### PR TITLE
Use data bundles and implement multi-file uploads

### DIFF
--- a/assets/config/dev.json
+++ b/assets/config/dev.json
@@ -1,3 +1,3 @@
 {
-  "defaultArweaveGatewayUrl": "https://arweave.dev"
+  "defaultArweaveGatewayUrl": "https://arweave.net"
 }

--- a/lib/blocs/drive_create/drive_create_cubit.dart
+++ b/lib/blocs/drive_create/drive_create_cubit.dart
@@ -81,9 +81,6 @@ class DriveCreateCubit extends Cubit<DriveCreateState> {
         createRes.driveKey,
       );
 
-      await driveDataItem.sign(wallet);
-      await rootFolderDataItem.sign(wallet);
-
       final createTx = await _arweave.prepareDataBundleTx(
           DataBundle(items: [driveDataItem, rootFolderDataItem]), wallet);
 

--- a/lib/blocs/drive_create/drive_create_cubit.dart
+++ b/lib/blocs/drive_create/drive_create_cubit.dart
@@ -2,6 +2,7 @@ import 'package:ardrive/blocs/blocs.dart';
 import 'package:ardrive/entities/entities.dart';
 import 'package:ardrive/models/models.dart';
 import 'package:ardrive/services/services.dart';
+import 'package:arweave/arweave.dart';
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:meta/meta.dart';
@@ -67,10 +68,10 @@ class DriveCreateCubit extends Cubit<DriveCreateState> {
             : null,
       );
 
-      final driveTx =
-          await _arweave.prepareEntityTx(drive, wallet, createRes.driveKey);
+      final driveDataItem = await _arweave.prepareEntityDataItem(
+          drive, wallet, createRes.driveKey);
 
-      final rootFolderTx = await _arweave.prepareEntityTx(
+      final rootFolderDataItem = await _arweave.prepareEntityDataItem(
         FolderEntity(
           id: drive.rootFolderId,
           driveId: drive.id,
@@ -80,7 +81,13 @@ class DriveCreateCubit extends Cubit<DriveCreateState> {
         createRes.driveKey,
       );
 
-      await _arweave.batchPostTxs([driveTx, rootFolderTx]);
+      await driveDataItem.sign(wallet);
+      await rootFolderDataItem.sign(wallet);
+
+      final createTx = await _arweave.prepareDataBundleTx(
+          DataBundle(items: [driveDataItem, rootFolderDataItem]), wallet);
+
+      await _arweave.postTx(createTx);
 
       _drivesCubit.selectDrive(drive.id);
     } catch (err) {

--- a/lib/blocs/upload/file_upload_handle.dart
+++ b/lib/blocs/upload/file_upload_handle.dart
@@ -1,0 +1,68 @@
+import 'package:ardrive/entities/entities.dart';
+import 'package:ardrive/services/services.dart';
+import 'package:arweave/arweave.dart';
+import 'package:meta/meta.dart';
+
+class FileUploadHandle {
+  final FileEntity entity;
+  final String path;
+
+  BigInt get cost {
+    if (bundleTx != null) {
+      return bundleTx.reward;
+    } else {
+      return (entityTx as Transaction).reward + (dataTx as Transaction).reward;
+    }
+  }
+
+  int get uploadSize {
+    if (bundleTx != null) {
+      return int.parse(bundleTx.dataSize);
+    } else {
+      return int.parse((entityTx as Transaction).dataSize) +
+          int.parse((dataTx as Transaction).dataSize);
+    }
+  }
+
+  int uploadedSize = 0;
+
+  double get uploadProgress => uploadedSize / uploadSize;
+
+  Transaction bundleTx;
+
+  TransactionBase entityTx;
+  TransactionBase dataTx;
+
+  FileUploadHandle({
+    @required this.entity,
+    @required this.path,
+    this.bundleTx,
+    this.entityTx,
+    this.dataTx,
+  });
+
+  /// Uploads the file, emitting an event whenever the progress is updated.
+  Stream<Null> upload(ArweaveService arweave) async* {
+    if (bundleTx != null) {
+      final dataSize = int.parse(bundleTx.dataSize);
+
+      await for (final upload in arweave.client.transactions.upload(bundleTx)) {
+        uploadedSize = (dataSize * upload.progress).toInt();
+        yield null;
+      }
+    } else {
+      await arweave.postTx(entityTx);
+
+      final entitySize = int.parse((entityTx as Transaction).dataSize);
+      uploadedSize = entitySize;
+
+      yield null;
+
+      final dataSize = int.parse((dataTx as Transaction).dataSize);
+      await for (final upload in arweave.client.transactions.upload(dataTx)) {
+        uploadedSize = entitySize + (dataSize * upload.progress).toInt();
+        yield null;
+      }
+    }
+  }
+}

--- a/lib/blocs/upload/upload_cubit.dart
+++ b/lib/blocs/upload/upload_cubit.dart
@@ -160,13 +160,11 @@ class UploadCubit extends Cubit<UploadState> {
 
       await for (final upload
           in _arweave.client.transactions.upload(_uploadTx)) {
-        final uploadProgress = upload.percentageComplete / 100;
-
         emit(UploadFileInProgress(
           fileName: uploadHandle.entity.name,
           fileSize: uploadEntity.size,
-          uploadProgress: uploadProgress,
-          uploadedFileSize: (uploadEntity.size * uploadProgress).toInt(),
+          uploadProgress: upload.progress,
+          uploadedFileSize: (uploadEntity.size * upload.progress).toInt(),
         ));
       }
     }

--- a/lib/blocs/upload/upload_state.dart
+++ b/lib/blocs/upload/upload_state.dart
@@ -10,64 +10,40 @@ class UploadPreparationInProgress extends UploadState {}
 
 class UploadPreparationFailure extends UploadState {}
 
-class UploadFileAlreadyExists extends UploadState {
-  final String existingFileId;
-  final String existingFileName;
+class UploadFileConflict extends UploadState {
+  final List<String> conflictingFileNames;
 
-  UploadFileAlreadyExists({
-    @required this.existingFileId,
-    @required this.existingFileName,
-  });
+  UploadFileConflict({@required this.conflictingFileNames});
 
   @override
-  List<Object> get props => [existingFileId, existingFileName];
+  List<Object> get props => [conflictingFileNames];
 }
 
-class UploadFileReady extends UploadState {
-  final String fileName;
+class UploadReady extends UploadState {
   final BigInt uploadCost;
-  final int uploadSize;
-
   final bool insufficientArBalance;
+  final List<FileUploadHandle> files;
 
-  UploadFileReady({
-    @required this.fileName,
-    @required this.uploadCost,
-    @required this.uploadSize,
-    @required this.insufficientArBalance,
-  });
-
-  @override
-  List<Object> get props => [fileName, uploadCost, uploadSize];
-}
-
-class UploadFileInProgress extends UploadState {
-  final String fileName;
-  final int fileSize;
-
-  final double uploadProgress;
-  final int uploadedFileSize;
-
-  UploadFileInProgress({
-    @required this.fileName,
-    @required this.fileSize,
-    this.uploadProgress = 0,
-    this.uploadedFileSize = 0,
-  });
+  UploadReady(
+      {@required this.uploadCost,
+      @required this.insufficientArBalance,
+      @required this.files});
 
   @override
-  List<Object> get props => [fileName, uploadProgress];
+  List<Object> get props => [uploadCost, insufficientArBalance, files];
 }
 
-class UploadFileFailure extends UploadState {}
+class UploadInProgress extends UploadState {
+  final List<FileUploadHandle> files;
 
-class UploadFolderInProgress extends UploadState {
-  final List<UploadFileInProgress> fileUploads;
+  final int _equatableBust = DateTime.now().millisecondsSinceEpoch;
 
-  UploadFolderInProgress({@required this.fileUploads});
+  UploadInProgress({this.files});
 
   @override
-  List<Object> get props => [fileUploads];
+  List<Object> get props => [files, _equatableBust];
 }
+
+class UploadFailure extends UploadState {}
 
 class UploadComplete extends UploadState {}

--- a/lib/components/app_drawer/app_drawer.dart
+++ b/lib/components/app_drawer/app_drawer.dart
@@ -1,6 +1,5 @@
 import 'package:ardrive/blocs/blocs.dart';
 import 'package:ardrive/theme/theme.dart';
-import 'package:file_picker_cross/file_picker_cross.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -119,14 +118,15 @@ class AppDrawer extends StatelessWidget {
                   PopupMenuDivider(),
                   PopupMenuItem(
                     enabled: state.hasWritePermissions,
-                    value: (context) => _promptToUploadFile(
+                    value: (context) => promptToUploadFile(
                       context,
-                      state.currentDrive.id,
-                      state.currentFolder.folder.id,
+                      driveId: state.currentDrive.id,
+                      folderId: state.currentFolder.folder.id,
+                      allowSelectMultiple: true,
                     ),
                     child: ListTile(
                       enabled: state.hasWritePermissions,
-                      title: Text('Upload file'),
+                      title: Text('Upload file(s)'),
                     ),
                   ),
                   PopupMenuDivider(),
@@ -171,22 +171,4 @@ class AppDrawer extends StatelessWidget {
                 tooltip: 'Sync',
               ),
       );
-
-  void _promptToUploadFile(
-      BuildContext context, String targetDriveId, String targetFolderId) async {
-    try {
-      final fileChooseResult = await FilePickerCross.importFromStorage();
-
-      await promptToUpload(
-        context,
-        driveId: targetDriveId,
-        folderId: targetFolderId,
-        file: fileChooseResult,
-      );
-    } catch (err) {
-      if (err is! FileSelectionCanceledError) {
-        rethrow;
-      }
-    }
-  }
 }

--- a/lib/entities/drive_entity.dart
+++ b/lib/entities/drive_entity.dart
@@ -53,13 +53,7 @@ class DriveEntity extends Entity {
   }
 
   @override
-  Future<Transaction> asTransaction([SecretKey driveKey]) async {
-    assert(id != null && rootFolderId != null);
-
-    final tx = driveKey == null
-        ? Transaction.withJsonData(data: this)
-        : await createEncryptedEntityTransaction(this, driveKey);
-
+  T addEntityTagsToTransaction<T extends TransactionBase>(T tx) {
     tx
       ..addApplicationTags()
       ..addArFsTag()

--- a/lib/entities/drive_entity.dart
+++ b/lib/entities/drive_entity.dart
@@ -53,7 +53,9 @@ class DriveEntity extends Entity {
   }
 
   @override
-  T addEntityTagsToTransaction<T extends TransactionBase>(T tx) {
+  void addEntityTagsToTransaction<T extends TransactionBase>(T tx) {
+    assert(id != null && rootFolderId != null);
+
     tx
       ..addApplicationTags()
       ..addArFsTag()
@@ -64,8 +66,6 @@ class DriveEntity extends Entity {
     if (privacy == DrivePrivacy.private) {
       tx.addTag(EntityTag.driveAuthMode, authMode);
     }
-
-    return tx;
   }
 
   factory DriveEntity.fromJson(Map<String, dynamic> json) =>

--- a/lib/entities/entity.dart
+++ b/lib/entities/entity.dart
@@ -20,7 +20,9 @@ abstract class Entity {
         ? Transaction.withJsonData(data: this)
         : await createEncryptedEntityTransaction(this, key);
 
-    return addEntityTagsToTransaction(tx);
+    addEntityTagsToTransaction(tx);
+
+    return tx;
   }
 
   /// Returns a [DataItem] with the entity's data along with the appropriate tags.
@@ -33,11 +35,13 @@ abstract class Entity {
         ? DataItem.withJsonData(data: this)
         : await createEncryptedEntityDataItem(this, key);
 
-    return addEntityTagsToTransaction(item);
+    addEntityTagsToTransaction(item);
+
+    return item;
   }
 
   @protected
-  T addEntityTagsToTransaction<T extends TransactionBase>(T tx);
+  void addEntityTagsToTransaction<T extends TransactionBase>(T tx);
 }
 
 class EntityTransactionParseException implements Exception {}

--- a/lib/entities/file_entity.dart
+++ b/lib/entities/file_entity.dart
@@ -80,27 +80,13 @@ class FileEntity extends Entity {
   }
 
   @override
-  Future<Transaction> asTransaction([SecretKey fileKey]) async {
-    assert(id != null &&
-        driveId != null &&
-        parentFolderId != null &&
-        name != null &&
-        size != null);
-
-    final tx = fileKey == null
-        ? Transaction.withJsonData(data: this)
-        : await createEncryptedEntityTransaction(this, fileKey);
-
-    tx
-      ..addApplicationTags()
-      ..addArFsTag()
-      ..addTag(EntityTag.entityType, EntityType.file)
-      ..addTag(EntityTag.driveId, driveId)
-      ..addTag(EntityTag.parentFolderId, parentFolderId)
-      ..addTag(EntityTag.fileId, id);
-
-    return tx;
-  }
+  T addEntityTagsToTransaction<T extends TransactionBase>(T tx) => tx
+    ..addApplicationTags()
+    ..addArFsTag()
+    ..addTag(EntityTag.entityType, EntityType.file)
+    ..addTag(EntityTag.driveId, driveId)
+    ..addTag(EntityTag.parentFolderId, parentFolderId)
+    ..addTag(EntityTag.fileId, id);
 
   factory FileEntity.fromJson(Map<String, dynamic> json) =>
       _$FileEntityFromJson(json);

--- a/lib/entities/file_entity.dart
+++ b/lib/entities/file_entity.dart
@@ -80,13 +80,21 @@ class FileEntity extends Entity {
   }
 
   @override
-  T addEntityTagsToTransaction<T extends TransactionBase>(T tx) => tx
-    ..addApplicationTags()
-    ..addArFsTag()
-    ..addTag(EntityTag.entityType, EntityType.file)
-    ..addTag(EntityTag.driveId, driveId)
-    ..addTag(EntityTag.parentFolderId, parentFolderId)
-    ..addTag(EntityTag.fileId, id);
+  void addEntityTagsToTransaction<T extends TransactionBase>(T tx) {
+    assert(id != null &&
+        driveId != null &&
+        parentFolderId != null &&
+        name != null &&
+        size != null);
+
+    tx
+      ..addApplicationTags()
+      ..addArFsTag()
+      ..addTag(EntityTag.entityType, EntityType.file)
+      ..addTag(EntityTag.driveId, driveId)
+      ..addTag(EntityTag.parentFolderId, parentFolderId)
+      ..addTag(EntityTag.fileId, id);
+  }
 
   factory FileEntity.fromJson(Map<String, dynamic> json) =>
       _$FileEntityFromJson(json);

--- a/lib/entities/folder_entity.dart
+++ b/lib/entities/folder_entity.dart
@@ -48,13 +48,7 @@ class FolderEntity extends Entity {
   }
 
   @override
-  Future<Transaction> asTransaction([SecretKey driveKey]) async {
-    assert(id != null && driveId != null && name != null);
-
-    final tx = driveKey == null
-        ? Transaction.withJsonData(data: this)
-        : await createEncryptedEntityTransaction(this, driveKey);
-
+  T addEntityTagsToTransaction<T extends TransactionBase>(T tx) {
     tx
       ..addApplicationTags()
       ..addArFsTag()

--- a/lib/entities/folder_entity.dart
+++ b/lib/entities/folder_entity.dart
@@ -48,7 +48,9 @@ class FolderEntity extends Entity {
   }
 
   @override
-  T addEntityTagsToTransaction<T extends TransactionBase>(T tx) {
+  void addEntityTagsToTransaction<T extends TransactionBase>(T tx) {
+    assert(id != null && driveId != null && name != null);
+
     tx
       ..addApplicationTags()
       ..addArFsTag()
@@ -59,8 +61,6 @@ class FolderEntity extends Entity {
     if (parentFolderId != null) {
       tx.addTag(EntityTag.parentFolderId, parentFolderId);
     }
-
-    return tx;
   }
 
   factory FolderEntity.fromJson(Map<String, dynamic> json) =>

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -234,7 +234,7 @@ class ArweaveService {
     Wallet wallet, [
     SecretKey key,
   ]) async {
-    final item = await entity.asDataItem();
+    final item = await entity.asDataItem(key);
     item.setOwner(wallet.owner);
 
     await item.sign(wallet);

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -208,9 +208,9 @@ class ArweaveService {
     );
   }
 
-  /// Creates and signs a transaction representing the provided entity.
+  /// Creates and signs a [Transaction] representing the provided entity.
   ///
-  /// Optionally provide a [SecretKey] to encrypt the transaction data.
+  /// Optionally provide a [SecretKey] to encrypt the entity data.
   Future<Transaction> prepareEntityTx(
     Entity entity,
     Wallet wallet, [
@@ -224,6 +224,22 @@ class ArweaveService {
     await tx.sign(wallet);
 
     return tx;
+  }
+
+  /// Creates and signs a [DataItem] representing the provided entity.
+  ///
+  /// Optionally provide a [SecretKey] to encrypt the entity data.
+  Future<DataItem> prepareEntityDataItem(
+    Entity entity,
+    Wallet wallet, [
+    SecretKey key,
+  ]) async {
+    final item = await entity.asDataItem();
+    item.setOwner(wallet.owner);
+
+    await item.sign(wallet);
+
+    return item;
   }
 
   Future<void> postTx(Transaction transaction) =>

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -242,11 +242,21 @@ class ArweaveService {
     return item;
   }
 
+  /// Creates and signs a [Transaction] representing the provided [DataBundle].
+  Future<Transaction> prepareDataBundleTx(
+      DataBundle bundle, Wallet wallet) async {
+    final bundleTx = await client.transactions.prepare(
+      Transaction.withDataBundle(bundle: bundle),
+      wallet,
+    );
+
+    await bundleTx.sign(wallet);
+
+    return bundleTx;
+  }
+
   Future<void> postTx(Transaction transaction) =>
       client.transactions.post(transaction);
-
-  Future<void> batchPostTxs(List<Transaction> transactions) =>
-      Future.wait(transactions.map((tx) => client.transactions.post(tx)));
 }
 
 /// The entity history of a particular drive, chunked by block height.

--- a/lib/services/crypto/entities.dart
+++ b/lib/services/crypto/entities.dart
@@ -57,7 +57,11 @@ Future<Transaction> createEncryptedEntityTransaction(
         Entity entity, SecretKey key) =>
     createEncryptedTransaction(utf8.encode(json.encode(entity)), key);
 
-/// Creates a transaction with the provided data encrypted along with the appropriate cipher tags.
+/// Creates a data item with the provided entity's JSON data encrypted along with the appropriate cipher tags.
+Future<DataItem> createEncryptedEntityDataItem(Entity entity, SecretKey key) =>
+    createEncryptedDataItem(utf8.encode(json.encode(entity)), key);
+
+/// Creates a [Transaction] with the provided data encrypted along with the appropriate cipher tags.
 Future<Transaction> createEncryptedTransaction(
   Uint8List data,
   SecretKey key,
@@ -66,6 +70,23 @@ Future<Transaction> createEncryptedTransaction(
   final encryptedData = await aesGcm.encrypt(data, secretKey: key, nonce: iv);
 
   return Transaction.withBlobData(data: encryptedData)
+    ..addTag(EntityTag.contentType, ContentType.octetStream)
+    ..addTag(EntityTag.cipher, Cipher.aes256)
+    ..addTag(
+      EntityTag.cipherIv,
+      utils.encodeBytesToBase64(iv.bytes),
+    );
+}
+
+/// Creates a [DataItem] with the provided data encrypted along with the appropriate cipher tags.
+Future<DataItem> createEncryptedDataItem(
+  Uint8List data,
+  SecretKey key,
+) async {
+  final iv = Nonce.randomBytes(96 ~/ 8);
+  final encryptedData = await aesGcm.encrypt(data, secretKey: key, nonce: iv);
+
+  return DataItem.withBlobData(data: encryptedData)
     ..addTag(EntityTag.contentType, ContentType.octetStream)
     ..addTag(EntityTag.cipher, Cipher.aes256)
     ..addTag(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -40,8 +40,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "1bff9df5329bce01e8ebbba5e9f8e6689035c6f2"
-      resolved-ref: "1bff9df5329bce01e8ebbba5e9f8e6689035c6f2"
+      ref: "95835f1ab88f586eeadc52cec76cbb4bd8849844"
+      resolved-ref: "95835f1ab88f586eeadc52cec76cbb4bd8849844"
       url: "https://github.com/CDDelta/arweave-dart.git"
     source: git
     version: "0.1.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -40,8 +40,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "95835f1ab88f586eeadc52cec76cbb4bd8849844"
-      resolved-ref: "95835f1ab88f586eeadc52cec76cbb4bd8849844"
+      ref: ec941370d72619e2ee770866b72944e5a9df8e58
+      resolved-ref: ec941370d72619e2ee770866b72944e5a9df8e58
       url: "https://github.com/CDDelta/arweave-dart.git"
     source: git
     version: "0.1.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -908,7 +908,7 @@ packages:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.7.8"
+    version: "5.7.10"
   url_launcher_linux:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   arweave:
     git:
       url: https://github.com/CDDelta/arweave-dart.git
-      ref: 95835f1ab88f586eeadc52cec76cbb4bd8849844
+      ref: ec941370d72619e2ee770866b72944e5a9df8e58
   cryptography:
     git:
       url: https://github.com/CDDelta/cryptography.git

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,7 +50,7 @@ dependencies:
   reactive_forms: ^6.0.2
   rxdart: ^0.24.1
   timeago: ^2.0.28
-  url_launcher: ^5.7.8
+  url_launcher: ^5.7.10
   uuid: ^2.2.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   arweave:
     git:
       url: https://github.com/CDDelta/arweave-dart.git
-      ref: 1bff9df5329bce01e8ebbba5e9f8e6689035c6f2
+      ref: 95835f1ab88f586eeadc52cec76cbb4bd8849844
   cryptography:
     git:
       url: https://github.com/CDDelta/cryptography.git


### PR DESCRIPTION
By using data bundles for actions that require multiple transactions at once we can:
- Make said actions atomic and avoid problems with dropped transactions resulting in invalid state.
- Increase the throughput for the number of transactions we can perform on the network.
- Support multi-file uploads in a much simpler fashion.