### PR TITLE
fix: fully sync the user's drives when first logging in

### DIFF
--- a/lib/blocs/sync/sync_cubit.dart
+++ b/lib/blocs/sync/sync_cubit.dart
@@ -64,8 +64,9 @@ class SyncCubit extends Cubit<SyncState> {
       // Sync the contents of each drive attached in the app.
       final driveIds =
           await _drivesDao.selectAllDrives().map((d) => d.id).get();
-      final driveSyncProcesses = driveIds.map((driveId) => _syncDrive(driveId));
-      await Future.wait(driveSyncProcesses);
+      for (final driveId in driveIds) {
+        await _syncDrive(driveId).catchError((_) {});
+      }
     } catch (err) {
       addError(err);
     }

--- a/lib/services/arweave/graphql/fragments/TransactionConnectionPageInfo.graphql
+++ b/lib/services/arweave/graphql/fragments/TransactionConnectionPageInfo.graphql
@@ -1,0 +1,5 @@
+fragment TransactionConnectionPageInfo on TransactionConnection {
+  pageInfo {
+    hasNextPage
+  }
+}

--- a/lib/services/arweave/graphql/queries/DriveEntityHistory.graphql
+++ b/lib/services/arweave/graphql/queries/DriveEntityHistory.graphql
@@ -1,4 +1,8 @@
-query DriveEntityHistory($driveId: String!, $startingBlockHeight: Int) {
+query DriveEntityHistory(
+  $driveId: String!
+  $after: String
+  $startingBlockHeight: Int
+) {
   transactions(
     first: 100
     sort: HEIGHT_ASC
@@ -6,12 +10,15 @@ query DriveEntityHistory($driveId: String!, $startingBlockHeight: Int) {
       { name: "ArFS", values: ["0.10", "0.11"] }
       { name: "Drive-Id", values: [$driveId] }
     ]
+    after: $after
     block: { min: $startingBlockHeight }
   ) {
     edges {
       node {
         ...TransactionCommon
       }
+      cursor
     }
+    ...TransactionConnectionPageInfo
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -639,7 +639,7 @@ packages:
     source: hosted
     version: "0.1.7"
   quiver:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: quiver
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   moor: ^3.3.1
   path_provider: ^1.6.11
   pedantic: ^1.9.2
+  quiver: ^2.1.5
   reactive_forms: ^7.3.0
   rxdart: ^0.25.0
   timeago: ^2.0.28


### PR DESCRIPTION
Previously, drive syncs would only be performed up to the first 100 entities of a user's drives making it seem as though some content were missing. We now sync all of the user's drive's entities.