### PR TITLE
fix: user not being redirected to sign in when logging out

### DIFF
--- a/lib/blocs/profile/profile_state.dart
+++ b/lib/blocs/profile/profile_state.dart
@@ -15,7 +15,7 @@ class ProfileCheckingAvailability extends ProfileState {}
 abstract class ProfileAvailable extends ProfileState {}
 
 /// [ProfileUnavailable] is a superclass state that indicates that
-/// the user no profile that can/has been logged into.
+/// the user has no profile to log into.
 abstract class ProfileUnavailable extends ProfileState {}
 
 class ProfilePromptLogIn extends ProfileAvailable {}

--- a/lib/components/profile_overlay.dart
+++ b/lib/components/profile_overlay.dart
@@ -43,16 +43,11 @@ class ProfileOverlay extends StatelessWidget {
                               ),
                             ],
                           ),
-                          trailing: Link(
-                            uri: Uri(path: '/sign-in'),
-                            builder: (context, redirectToSignIn) => IconButton(
-                              icon: const Icon(Icons.logout),
-                              tooltip: 'Logout',
-                              onPressed: () {
-                                redirectToSignIn();
-                                context.read<ProfileCubit>().logoutProfile();
-                              },
-                            ),
+                          trailing: IconButton(
+                            icon: const Icon(Icons.logout),
+                            tooltip: 'Logout',
+                            onPressed: () =>
+                                context.read<ProfileCubit>().logoutProfile(),
                           ),
                         )
                       : ListTile(

--- a/lib/components/profile_overlay.dart
+++ b/lib/components/profile_overlay.dart
@@ -43,11 +43,16 @@ class ProfileOverlay extends StatelessWidget {
                               ),
                             ],
                           ),
-                          trailing: IconButton(
-                            icon: const Icon(Icons.logout),
-                            tooltip: 'Logout',
-                            onPressed: () =>
-                                context.read<ProfileCubit>().logoutProfile(),
+                          trailing: Link(
+                            uri: Uri(path: '/sign-in'),
+                            builder: (context, redirectToSignIn) => IconButton(
+                              icon: const Icon(Icons.logout),
+                              tooltip: 'Logout',
+                              onPressed: () {
+                                redirectToSignIn();
+                                context.read<ProfileCubit>().logoutProfile();
+                              },
+                            ),
                           ),
                         )
                       : ListTile(
@@ -56,7 +61,7 @@ class ProfileOverlay extends StatelessWidget {
                           subtitle: Text(
                               'Log in to experience all of ArDrive\'s features!'),
                           trailing: Link(
-                            uri: Uri(path: '/'),
+                            uri: Uri(path: '/sign-in'),
                             builder: (context, onPressed) => IconButton(
                               icon: const Icon(Icons.login),
                               tooltip: 'Login',

--- a/lib/pages/app_route_information_parser.dart
+++ b/lib/pages/app_route_information_parser.dart
@@ -17,6 +17,8 @@ class AppRouteInformationParser extends RouteInformationParser<AppRoutePath> {
     }
 
     switch (uri.pathSegments.first) {
+      case 'sign-in':
+        return AppRoutePath.signIn();
       case 'drives':
         if (uri.pathSegments.length > 1) {
           final driveId = uri.pathSegments[1];
@@ -60,7 +62,9 @@ class AppRouteInformationParser extends RouteInformationParser<AppRoutePath> {
 
   @override
   RouteInformation restoreRouteInformation(AppRoutePath path) {
-    if (path.driveId != null) {
+    if (path.signingIn) {
+      return RouteInformation(location: '/sign-in');
+    } else if (path.driveId != null) {
       return path.driveFolderId == null
           ? RouteInformation(location: '/drives/${path.driveId}')
           : RouteInformation(

--- a/lib/pages/app_route_path.dart
+++ b/lib/pages/app_route_path.dart
@@ -4,6 +4,9 @@ import 'package:moor/moor.dart';
 
 @immutable
 class AppRoutePath {
+  /// Whether or not the user is trying to sign in.
+  final bool signingIn;
+
   final String driveId;
   final String driveFolderId;
 
@@ -16,12 +19,16 @@ class AppRoutePath {
   final String sharedRawFileKey;
 
   AppRoutePath({
+    this.signingIn = false,
     this.driveId,
     this.driveFolderId,
     this.sharedFileId,
     this.sharedFileKey,
     this.sharedRawFileKey,
   });
+
+  /// Creates a route that lets the user sign in.
+  factory AppRoutePath.signIn() => AppRoutePath(signingIn: true);
 
   /// Creates a route that points to a particular drive.
   factory AppRoutePath.driveDetail({@required String driveId}) =>

--- a/lib/pages/app_router_delegate.dart
+++ b/lib/pages/app_router_delegate.dart
@@ -29,6 +29,7 @@ class AppRouterDelegate extends RouterDelegate<AppRoutePath>
 
   @override
   AppRoutePath get currentConfiguration => AppRoutePath(
+        signingIn: signingIn,
         driveId: driveId,
         driveFolderId: driveFolderId,
         sharedFileId: sharedFileId,


### PR DESCRIPTION
This PR adds an explicit path for a user to sign in with at `/sign-in` and also fixes a bug with the user not being redirected to sign in when logging out.