### PR TITLE
refactor: move transactions into their own database table

### DIFF
--- a/lib/blocs/fs_entry_activity/fs_entry_activity_cubit.dart
+++ b/lib/blocs/fs_entry_activity/fs_entry_activity_cubit.dart
@@ -25,13 +25,13 @@ class FsEntryActivityCubit extends Cubit<FsEntryActivityState> {
         super(FsEntryActivityInitial()) {
     if (folderId != null) {
       _entrySubscription = _driveDao
-          .latestFolderRevisionsByFolderId(driveId, folderId)
+          .latestFolderRevisionsByFolderIdWithStatus(driveId, folderId)
           .watch()
           .listen((r) =>
               emit(FsEntryActivitySuccess<FolderRevision>(revisions: r)));
     } else if (fileId != null) {
       _entrySubscription = _driveDao
-          .latestFileRevisionsByFileId(driveId, fileId)
+          .latestFileRevisionsByFileIdWithStatus(driveId, fileId)
           .watch()
           .listen(
               (r) => emit(FsEntryActivitySuccess<FileRevision>(revisions: r)));

--- a/lib/blocs/fs_entry_activity/fs_entry_activity_cubit.dart
+++ b/lib/blocs/fs_entry_activity/fs_entry_activity_cubit.dart
@@ -25,16 +25,18 @@ class FsEntryActivityCubit extends Cubit<FsEntryActivityState> {
         super(FsEntryActivityInitial()) {
     if (folderId != null) {
       _entrySubscription = _driveDao
-          .latestFolderRevisionsByFolderIdWithStatus(driveId, folderId)
+          .latestFolderRevisionsByFolderIdWithTransactions(driveId, folderId)
           .watch()
-          .listen((r) =>
-              emit(FsEntryActivitySuccess<FolderRevision>(revisions: r)));
+          .listen((r) => emit(
+              FsEntryActivitySuccess<FolderRevisionWithTransaction>(
+                  revisions: r)));
     } else if (fileId != null) {
       _entrySubscription = _driveDao
-          .latestFileRevisionsByFileIdWithStatus(driveId, fileId)
+          .latestFileRevisionsByFileIdWithTransactions(driveId, fileId)
           .watch()
-          .listen(
-              (r) => emit(FsEntryActivitySuccess<FileRevision>(revisions: r)));
+          .listen((r) => emit(
+              FsEntryActivitySuccess<FileRevisionWithTransactions>(
+                  revisions: r)));
     }
   }
 

--- a/lib/blocs/sync/sync_cubit.dart
+++ b/lib/blocs/sync/sync_cubit.dart
@@ -401,7 +401,7 @@ class SyncCubit extends Cubit<SyncState> {
           }
         }
 
-        await _driveDao.writeToTransactions(
+        await _driveDao.writeToTransaction(
           NetworkTransactionsCompanion(
             id: Value(txId),
             status: Value(txStatus),

--- a/lib/blocs/sync/sync_cubit.dart
+++ b/lib/blocs/sync/sync_cubit.dart
@@ -183,7 +183,6 @@ class SyncCubit extends Cubit<SyncState> {
       }
 
       final revision = FileRevisionsCompanion.insert(
-        id: entity.txId,
         fileId: entity.id,
         driveId: entity.driveId,
         name: entity.name,
@@ -347,9 +346,9 @@ class SyncCubit extends Cubit<SyncState> {
 
   Future<void> _updateRevisionTransactionStatuses(String driveId) async {
     final unconfirmedFolderRevisions =
-        await _driveDao.pendingFolderRevisionsInDrive(driveId).get();
+        await _driveDao.pendingFolderRevisionsInDriveWithStatus(driveId).get();
     final unconfirmedFileRevisions =
-        await _driveDao.pendingFileRevisionsInDrive(driveId).get();
+        await _driveDao.pendingFileRevisionsInDriveWithStatus(driveId).get();
 
     // Construct a list of revisions with transactions that are unconfirmed,
     // filtering out ones that are already confirmed.
@@ -357,10 +356,10 @@ class SyncCubit extends Cubit<SyncState> {
         unconfirmedFolderRevisions
             .map((r) => MapEntry<String, Object>(r.metadataTxId, r))
             .followedBy(unconfirmedFileRevisions
-                .where((r) => r.metadataTxStatus == TransactionStatus.pending)
+                .where((r) => r.metadataTx.status == TransactionStatus.pending)
                 .map((r) => MapEntry<String, Object>(r.metadataTxId, r)))
             .followedBy(unconfirmedFileRevisions
-                .where((r) => r.dataTxStatus == TransactionStatus.pending)
+                .where((r) => r.dataTx.status == TransactionStatus.pending)
                 .map((r) => MapEntry<String, Object>(r.dataTxId, r))));
 
     final txConfirmations = await _arweave

--- a/lib/models/daos/drive_dao/drive_dao.dart
+++ b/lib/models/daos/drive_dao/drive_dao.dart
@@ -339,8 +339,7 @@ class DriveDao extends DatabaseAccessor<Database> with _$DriveDaoMixin {
     );
   }
 
-  Future<void> writeToTransactions(
-          Insertable<NetworkTransaction> transaction) =>
+  Future<void> writeToTransaction(Insertable<NetworkTransaction> transaction) =>
       (update(networkTransactions)..whereSamePrimaryKey(transaction))
           .write(transaction);
 }

--- a/lib/models/daos/drive_dao/drive_dao.dart
+++ b/lib/models/daos/drive_dao/drive_dao.dart
@@ -339,12 +339,8 @@ class DriveDao extends DatabaseAccessor<Database> with _$DriveDaoMixin {
     );
   }
 
-  Future<void> writeToFolderRevision(
-          Insertable<FolderRevision> folderRevision) =>
-      (update(folderRevisions)..whereSamePrimaryKey(folderRevision))
-          .write(folderRevision);
-
-  Future<void> writeToFileRevision(Insertable<FileRevision> fileRevision) =>
-      (update(fileRevisions)..whereSamePrimaryKey(fileRevision))
-          .write(fileRevision);
+  Future<void> writeToTransactions(
+          Insertable<NetworkTransaction> transaction) =>
+      (update(networkTransactions)..whereSamePrimaryKey(transaction))
+          .write(transaction);
 }

--- a/lib/models/file_revision.dart
+++ b/lib/models/file_revision.dart
@@ -2,13 +2,14 @@ import 'package:ardrive/entities/entities.dart';
 
 import 'models.dart';
 
-extension FileRevisionExtensions on FileRevision {
+extension FileRevisionWithTransactionsExtensions
+    on FileRevisionWithTransactions {
   String get confirmationStatus {
-    if (metadataTxStatus == TransactionStatus.failed ||
-        dataTxStatus == TransactionStatus.failed) {
+    if (metadataTx.status == TransactionStatus.failed ||
+        dataTx.status == TransactionStatus.failed) {
       return TransactionStatus.failed;
-    } else if (metadataTxStatus == TransactionStatus.pending ||
-        dataTxStatus == TransactionStatus.pending) {
+    } else if (metadataTx.status == TransactionStatus.pending ||
+        dataTx.status == TransactionStatus.pending) {
       return TransactionStatus.pending;
     } else {
       return TransactionStatus.confirmed;

--- a/lib/models/folder_revision.dart
+++ b/lib/models/folder_revision.dart
@@ -2,8 +2,9 @@ import 'package:ardrive/entities/entities.dart';
 
 import 'models.dart';
 
-extension FolderRevisionExtensions on FolderRevision {
-  String get confirmationStatus => metadataTxStatus;
+extension FolderRevisionWithTransactionExtensions
+    on FolderRevisionWithTransaction {
+  String get confirmationStatus => metadataTx.status;
 }
 
 extension FolderRevisionCompanionExtensions on FolderRevisionsCompanion {

--- a/lib/models/queries/drive_queries.moor
+++ b/lib/models/queries/drive_queries.moor
@@ -3,6 +3,7 @@ import '../tables/folder_entries.moor';
 import '../tables/folder_revisions.moor';
 import '../tables/file_entries.moor';
 import '../tables/file_revisions.moor';
+import '../tables/network_transactions.moor';
 
 allDrives: SELECT * FROM drives;
 driveById: SELECT * FROM drives WHERE id = :driveId;
@@ -21,17 +22,19 @@ oldestFolderRevisionByFolderId:
     SELECT * FROM folder_revisions
     WHERE driveId = :driveId AND folderId = :folderId
     ORDER BY dateCreated ASC LIMIT 1;
-latestFolderRevisionsByFolderId:
-    SELECT * FROM folder_revisions
-    WHERE driveId = :driveId AND folderId = :folderId
-    ORDER BY dateCreated DESC;
 latestFolderRevisionByFolderId:
     SELECT * FROM folder_revisions
     WHERE driveId = :driveId AND folderId = :folderId
     ORDER BY dateCreated DESC LIMIT 1;
-pendingFolderRevisionsInDrive:
-    SELECT * FROM folder_revisions
-    WHERE driveId = :driveId AND metadataTxStatus = 'pending';
+latestFolderRevisionsByFolderIdWithStatus:
+    SELECT rev.*, metadataTx.** FROM folder_revisions rev
+    INNER JOIN network_transactions metadataTx ON metadataTx.id = rev.metadataTxId
+    WHERE driveId = :driveId AND folderId = :folderId
+    ORDER BY dateCreated DESC;
+pendingFolderRevisionsInDriveWithStatus:
+    SELECT rev.*, metadataTx.** FROM folder_revisions rev
+    INNER JOIN network_transactions metadataTx ON metadataTx.id = rev.metadataTxId
+    WHERE rev.driveId = :driveId AND metadataTx.status = 'pending';
 
 fileById:
     SELECT * FROM file_entries
@@ -47,14 +50,18 @@ oldestFileRevisionByFileId:
     SELECT * FROM file_revisions
     WHERE driveId = :driveId AND fileId = :fileId
     ORDER BY dateCreated ASC LIMIT 1;
-latestFileRevisionsByFileId:
-    SELECT * FROM file_revisions
-    WHERE driveId = :driveId AND fileId = :fileId
-    ORDER BY dateCreated DESC;
 latestFileRevisionByFileId:
     SELECT * FROM file_revisions
     WHERE driveId = :driveId AND fileId = :fileId
     ORDER BY dateCreated DESC LIMIT 1;
-pendingFileRevisionsInDrive:
-    SELECT * FROM file_revisions
-    WHERE driveId = :driveId AND (metadataTxStatus = 'pending' OR dataTxStatus = 'pending');
+latestFileRevisionsByFileIdWithStatus:
+    SELECT rev.*, metadataTx.**, dataTx.** FROM file_revisions rev
+    INNER JOIN network_transactions metadataTx ON metadataTx.id = rev.metadataTxId
+    INNER JOIN network_transactions dataTx ON dataTx.id = rev.dataTxId
+    WHERE driveId = :driveId AND fileId = :fileId
+    ORDER BY dateCreated DESC;
+pendingFileRevisionsInDriveWithStatus:
+    SELECT rev.*, metadataTx.**, dataTx.** FROM file_revisions rev
+    INNER JOIN network_transactions metadataTx ON metadataTx.id = rev.metadataTxId
+    INNER JOIN network_transactions dataTx ON dataTx.id = rev.dataTxId
+    WHERE rev.driveId = :driveId AND (metadataTx.status = 'pending' OR dataTx.status = 'pending');

--- a/lib/models/queries/drive_queries.moor
+++ b/lib/models/queries/drive_queries.moor
@@ -26,15 +26,11 @@ latestFolderRevisionByFolderId:
     SELECT * FROM folder_revisions
     WHERE driveId = :driveId AND folderId = :folderId
     ORDER BY dateCreated DESC LIMIT 1;
-latestFolderRevisionsByFolderIdWithStatus:
+latestFolderRevisionsByFolderIdWithTransactions AS FolderRevisionWithTransaction:
     SELECT rev.*, metadataTx.** FROM folder_revisions rev
     INNER JOIN network_transactions metadataTx ON metadataTx.id = rev.metadataTxId
     WHERE driveId = :driveId AND folderId = :folderId
-    ORDER BY dateCreated DESC;
-pendingFolderRevisionsInDriveWithStatus:
-    SELECT rev.*, metadataTx.** FROM folder_revisions rev
-    INNER JOIN network_transactions metadataTx ON metadataTx.id = rev.metadataTxId
-    WHERE rev.driveId = :driveId AND metadataTx.status = 'pending';
+    ORDER BY rev.dateCreated DESC;
 
 fileById:
     SELECT * FROM file_entries
@@ -54,14 +50,13 @@ latestFileRevisionByFileId:
     SELECT * FROM file_revisions
     WHERE driveId = :driveId AND fileId = :fileId
     ORDER BY dateCreated DESC LIMIT 1;
-latestFileRevisionsByFileIdWithStatus:
+latestFileRevisionsByFileIdWithTransactions AS FileRevisionWithTransactions:
     SELECT rev.*, metadataTx.**, dataTx.** FROM file_revisions rev
     INNER JOIN network_transactions metadataTx ON metadataTx.id = rev.metadataTxId
     INNER JOIN network_transactions dataTx ON dataTx.id = rev.dataTxId
     WHERE driveId = :driveId AND fileId = :fileId
-    ORDER BY dateCreated DESC;
-pendingFileRevisionsInDriveWithStatus:
-    SELECT rev.*, metadataTx.**, dataTx.** FROM file_revisions rev
-    INNER JOIN network_transactions metadataTx ON metadataTx.id = rev.metadataTxId
-    INNER JOIN network_transactions dataTx ON dataTx.id = rev.dataTxId
-    WHERE rev.driveId = :driveId AND (metadataTx.status = 'pending' OR dataTx.status = 'pending');
+    ORDER BY rev.dateCreated DESC;
+
+pendingTransactions:
+    SELECT * FROM network_transactions
+    WHERE status = 'pending';

--- a/lib/models/tables/all.moor
+++ b/lib/models/tables/all.moor
@@ -4,3 +4,4 @@ import 'file_revisions.moor';
 import 'folder_entries.moor';
 import 'folder_revisions.moor';
 import 'profiles.moor';
+import 'network_transactions.moor';

--- a/lib/models/tables/drives.moor
+++ b/lib/models/tables/drives.moor
@@ -13,6 +13,6 @@ CREATE TABLE drives (
     encryptedKey BLOB,
     keyEncryptionIv BLOB,
 
-    dateCreated DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    lastUpdated DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+    dateCreated DATETIME NOT NULL DEFAULT (strftime('%s','now')),
+    lastUpdated DATETIME NOT NULL DEFAULT (strftime('%s','now'))
 );

--- a/lib/models/tables/file_entries.moor
+++ b/lib/models/tables/file_entries.moor
@@ -11,8 +11,8 @@ CREATE TABLE file_entries (
 
     dataTxId TEXT NOT NULL,
 
-    dateCreated DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    lastUpdated DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    dateCreated DATETIME NOT NULL DEFAULT (strftime('%s','now')),
+    lastUpdated DATETIME NOT NULL DEFAULT (strftime('%s','now')),
 
     PRIMARY KEY (id, driveId)
 ) AS FileEntry;

--- a/lib/models/tables/file_revisions.moor
+++ b/lib/models/tables/file_revisions.moor
@@ -12,7 +12,7 @@ CREATE TABLE file_revisions (
     metadataTxId TEXT NOT NULL,
     dataTxId TEXT NOT NULL,
 
-    dateCreated DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    dateCreated DATETIME NOT NULL DEFAULT (strftime('%s','now')),
     
     [action] TEXT NOT NULL,
 

--- a/lib/models/tables/file_revisions.moor
+++ b/lib/models/tables/file_revisions.moor
@@ -1,6 +1,6 @@
-CREATE TABLE file_revisions (
-    id TEXT NOT NULL PRIMARY KEY,
+import 'network_transactions.moor';
 
+CREATE TABLE file_revisions (
     fileId TEXT NOT NULL,
     driveId TEXT NOT NULL,
 
@@ -10,12 +10,13 @@ CREATE TABLE file_revisions (
     lastModifiedDate DATETIME NOT NULL,
 
     metadataTxId TEXT NOT NULL,
-    metadataTxStatus TEXT NOT NULL DEFAULT 'pending',
-
     dataTxId TEXT NOT NULL,
-    dataTxStatus TEXT NOT NULL DEFAULT 'pending',
 
     dateCreated DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     
-    [action] TEXT NOT NULL
+    [action] TEXT NOT NULL,
+
+    PRIMARY KEY (fileId, driveId, dateCreated),
+    FOREIGN KEY (metadataTxId) REFERENCES network_transactions(id),
+    FOREIGN KEY (dataTxId) REFERENCES network_transactions(id)
 );

--- a/lib/models/tables/folder_entries.moor
+++ b/lib/models/tables/folder_entries.moor
@@ -6,8 +6,8 @@ CREATE TABLE folder_entries (
     parentFolderId TEXT,
     path TEXT NOT NULL,
 
-    dateCreated DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    lastUpdated DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    dateCreated DATETIME NOT NULL DEFAULT (strftime('%s','now')),
+    lastUpdated DATETIME NOT NULL DEFAULT (strftime('%s','now')),
 
     PRIMARY KEY (id, driveId)
 ) As FolderEntry;

--- a/lib/models/tables/folder_revisions.moor
+++ b/lib/models/tables/folder_revisions.moor
@@ -9,7 +9,7 @@ CREATE TABLE folder_revisions (
 
     metadataTxId TEXT NOT NULL,
 
-    dateCreated DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    dateCreated DATETIME NOT NULL DEFAULT (strftime('%s','now')),
     
     [action] TEXT NOT NULL,
 

--- a/lib/models/tables/folder_revisions.moor
+++ b/lib/models/tables/folder_revisions.moor
@@ -1,6 +1,6 @@
-CREATE TABLE folder_revisions (
-    id TEXT NOT NULL PRIMARY KEY,
+import 'network_transactions.moor';
 
+CREATE TABLE folder_revisions (
     folderId TEXT NOT NULL,
     driveId TEXT NOT NULL,
 
@@ -8,9 +8,11 @@ CREATE TABLE folder_revisions (
     parentFolderId TEXT,
 
     metadataTxId TEXT NOT NULL,
-    metadataTxStatus TEXT NOT NULL DEFAULT 'pending',
 
     dateCreated DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     
-    [action] TEXT NOT NULL
+    [action] TEXT NOT NULL,
+
+    PRIMARY KEY (folderId, driveId, dateCreated),
+    FOREIGN KEY (metadataTxId) REFERENCES network_transactions(id)
 );

--- a/lib/models/tables/network_transactions.moor
+++ b/lib/models/tables/network_transactions.moor
@@ -3,5 +3,5 @@ CREATE TABLE network_transactions (
 
     status TEXT NOT NULL DEFAULT 'pending',
 
-    dateCreated DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+    dateCreated DATETIME NOT NULL DEFAULT (strftime('%s','now'))
 );

--- a/lib/models/tables/network_transactions.moor
+++ b/lib/models/tables/network_transactions.moor
@@ -1,0 +1,7 @@
+CREATE TABLE network_transactions (
+    id TEXT NOT NULL PRIMARY KEY,
+
+    status TEXT NOT NULL DEFAULT 'pending',
+
+    dateCreated DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/lib/pages/drive_detail/components/fs_entry_side_sheet.dart
+++ b/lib/pages/drive_detail/components/fs_entry_side_sheet.dart
@@ -133,7 +133,7 @@ class FsEntrySideSheet extends StatelessWidget {
                           Widget dateCreatedSubtitle;
                           String revisionConfirmationStatus;
 
-                          if (revision is FolderRevision) {
+                          if (revision is FolderRevisionWithTransaction) {
                             switch (revision.action) {
                               case RevisionAction.create:
                                 content = Text(
@@ -155,7 +155,7 @@ class FsEntrySideSheet extends StatelessWidget {
 
                             revisionConfirmationStatus =
                                 revision.confirmationStatus;
-                          } else if (revision is FileRevision) {
+                          } else if (revision is FileRevisionWithTransactions) {
                             switch (revision.action) {
                               case RevisionAction.create:
                                 content = Text(


### PR DESCRIPTION
This PR moves the status of revision transaction into their own model in the database which simplifies queries and reduces code duplication.