### PR TITLE
fix: revisions weren't optimistically added for tracking

### DIFF
--- a/lib/blocs/drive_create/drive_create_cubit.dart
+++ b/lib/blocs/drive_create/drive_create_cubit.dart
@@ -92,10 +92,10 @@ class DriveCreateCubit extends Cubit<DriveCreateState> {
       await _arweave.postTx(driveTx);
       await _arweave.postTx(rootFolderTx);
 
-      await _driveDao
-          .writeTransaction(rootFolderEntity.toTransactionCompanion());
-      await _driveDao.insertFolderRevision(
-          rootFolderEntity.toRevisionCompanion(RevisionAction.create));
+      rootFolderEntity.txId = rootFolderTx.id;
+
+      await _driveDao.insertFolderRevision(rootFolderEntity.toRevisionCompanion(
+          performedAction: RevisionAction.create));
 
       _drivesCubit.selectDrive(drive.id);
     } catch (err) {

--- a/lib/blocs/drive_create/drive_create_cubit.dart
+++ b/lib/blocs/drive_create/drive_create_cubit.dart
@@ -77,18 +77,23 @@ class DriveCreateCubit extends Cubit<DriveCreateState> {
       final driveTx =
           await _arweave.prepareEntityTx(drive, wallet, createRes.driveKey);
 
+      final rootFolderEntity = FolderEntity(
+        id: drive.rootFolderId,
+        driveId: drive.id,
+        name: driveName,
+      );
+
       final rootFolderTx = await _arweave.prepareEntityTx(
-        FolderEntity(
-          id: drive.rootFolderId,
-          driveId: drive.id,
-          name: driveName,
-        ),
+        rootFolderEntity,
         wallet,
         createRes.driveKey,
       );
 
       await _arweave.postTx(driveTx);
       await _arweave.postTx(rootFolderTx);
+
+      await _driveDao.insertFolderRevision(
+          rootFolderEntity.toRevisionCompanion(RevisionAction.create));
 
       _drivesCubit.selectDrive(drive.id);
     } catch (err) {

--- a/lib/blocs/drive_create/drive_create_cubit.dart
+++ b/lib/blocs/drive_create/drive_create_cubit.dart
@@ -92,6 +92,8 @@ class DriveCreateCubit extends Cubit<DriveCreateState> {
       await _arweave.postTx(driveTx);
       await _arweave.postTx(rootFolderTx);
 
+      await _driveDao
+          .writeTransaction(rootFolderEntity.toTransactionCompanion());
       await _driveDao.insertFolderRevision(
           rootFolderEntity.toRevisionCompanion(RevisionAction.create));
 

--- a/lib/blocs/folder_create/folder_create_cubit.dart
+++ b/lib/blocs/folder_create/folder_create_cubit.dart
@@ -93,6 +93,7 @@ class FolderCreateCubit extends Cubit<FolderCreateState> {
 
         await _arweave.postTx(folderTx);
 
+        await _driveDao.writeTransaction(folderEntity.toTransactionCompanion());
         await _driveDao.insertFolderRevision(
             folderEntity.toRevisionCompanion(RevisionAction.create));
       });

--- a/lib/blocs/folder_create/folder_create_cubit.dart
+++ b/lib/blocs/folder_create/folder_create_cubit.dart
@@ -78,18 +78,23 @@ class FolderCreateCubit extends Cubit<FolderCreateState> {
           path: '${targetFolder.path}/${folderName}',
         );
 
+        final folderEntity = FolderEntity(
+          id: newFolderId,
+          driveId: targetFolder.driveId,
+          parentFolderId: targetFolder.id,
+          name: folderName,
+        );
+
         final folderTx = await _arweave.prepareEntityTx(
-          FolderEntity(
-            id: newFolderId,
-            driveId: targetFolder.driveId,
-            parentFolderId: targetFolder.id,
-            name: folderName,
-          ),
+          folderEntity,
           profile.wallet,
           driveKey,
         );
 
         await _arweave.postTx(folderTx);
+
+        await _driveDao.insertFolderRevision(
+            folderEntity.toRevisionCompanion(RevisionAction.create));
       });
     } catch (err) {
       addError(err);

--- a/lib/blocs/folder_create/folder_create_cubit.dart
+++ b/lib/blocs/folder_create/folder_create_cubit.dart
@@ -93,9 +93,10 @@ class FolderCreateCubit extends Cubit<FolderCreateState> {
 
         await _arweave.postTx(folderTx);
 
-        await _driveDao.writeTransaction(folderEntity.toTransactionCompanion());
-        await _driveDao.insertFolderRevision(
-            folderEntity.toRevisionCompanion(RevisionAction.create));
+        folderEntity.txId = folderTx.id;
+
+        await _driveDao.insertFolderRevision(folderEntity.toRevisionCompanion(
+            performedAction: RevisionAction.create));
       });
     } catch (err) {
       addError(err);

--- a/lib/blocs/fs_entry_move/fs_entry_move_cubit.dart
+++ b/lib/blocs/fs_entry_move/fs_entry_move_cubit.dart
@@ -84,11 +84,16 @@ class FsEntryMoveCubit extends Cubit<FsEntryMoveState> {
               path: '${parentFolder.path}/${folder.name}',
               lastUpdated: DateTime.now());
 
+          final folderEntity = folder.asEntity();
+
           final folderTx = await _arweave.prepareEntityTx(
-              folder.asEntity(), profile.wallet, driveKey);
+              folderEntity, profile.wallet, driveKey);
 
           await _arweave.postTx(folderTx);
           await _driveDao.writeToFolder(folder);
+
+          await _driveDao.insertFolderRevision(
+              folderEntity.toRevisionCompanion(RevisionAction.move));
         });
 
         emit(FolderEntryMoveSuccess());
@@ -107,11 +112,16 @@ class FsEntryMoveCubit extends Cubit<FsEntryMoveState> {
           final fileKey =
               driveKey != null ? await deriveFileKey(driveKey, file.id) : null;
 
+          final fileEntity = file.asEntity();
+
           final fileTx = await _arweave.prepareEntityTx(
-              file.asEntity(), profile.wallet, fileKey);
+              fileEntity, profile.wallet, fileKey);
 
           await _arweave.postTx(fileTx);
           await _driveDao.writeToFile(file);
+
+          await _driveDao.insertFileRevision(
+              fileEntity.toRevisionCompanion(RevisionAction.move));
         });
 
         emit(FileEntryMoveSuccess());

--- a/lib/blocs/fs_entry_move/fs_entry_move_cubit.dart
+++ b/lib/blocs/fs_entry_move/fs_entry_move_cubit.dart
@@ -92,6 +92,8 @@ class FsEntryMoveCubit extends Cubit<FsEntryMoveState> {
           await _arweave.postTx(folderTx);
           await _driveDao.writeToFolder(folder);
 
+          await _driveDao
+              .writeTransaction(folderEntity.toTransactionCompanion());
           await _driveDao.insertFolderRevision(
               folderEntity.toRevisionCompanion(RevisionAction.move));
         });
@@ -120,6 +122,9 @@ class FsEntryMoveCubit extends Cubit<FsEntryMoveState> {
           await _arweave.postTx(fileTx);
           await _driveDao.writeToFile(file);
 
+          await Future.wait(fileEntity
+              .toTransactionCompanions()
+              .map((tx) => _driveDao.writeTransaction(tx)));
           await _driveDao.insertFileRevision(
               fileEntity.toRevisionCompanion(RevisionAction.move));
         });

--- a/lib/blocs/fs_entry_move/fs_entry_move_cubit.dart
+++ b/lib/blocs/fs_entry_move/fs_entry_move_cubit.dart
@@ -92,10 +92,10 @@ class FsEntryMoveCubit extends Cubit<FsEntryMoveState> {
           await _arweave.postTx(folderTx);
           await _driveDao.writeToFolder(folder);
 
-          await _driveDao
-              .writeTransaction(folderEntity.toTransactionCompanion());
-          await _driveDao.insertFolderRevision(
-              folderEntity.toRevisionCompanion(RevisionAction.move));
+          folderEntity.txId = folderTx.id;
+
+          await _driveDao.insertFolderRevision(folderEntity.toRevisionCompanion(
+              performedAction: RevisionAction.move));
         });
 
         emit(FolderEntryMoveSuccess());
@@ -122,11 +122,10 @@ class FsEntryMoveCubit extends Cubit<FsEntryMoveState> {
           await _arweave.postTx(fileTx);
           await _driveDao.writeToFile(file);
 
-          await Future.wait(fileEntity
-              .toTransactionCompanions()
-              .map((tx) => _driveDao.writeTransaction(tx)));
-          await _driveDao.insertFileRevision(
-              fileEntity.toRevisionCompanion(RevisionAction.move));
+          fileEntity.txId = fileTx.id;
+
+          await _driveDao.insertFileRevision(fileEntity.toRevisionCompanion(
+              performedAction: RevisionAction.move));
         });
 
         emit(FileEntryMoveSuccess());

--- a/lib/blocs/fs_entry_rename/fs_entry_rename_cubit.dart
+++ b/lib/blocs/fs_entry_rename/fs_entry_rename_cubit.dart
@@ -97,10 +97,10 @@ class FsEntryRenameCubit extends Cubit<FsEntryRenameState> {
           await _arweave.postTx(folderTx);
           await _driveDao.writeToFolder(folder);
 
-          await _driveDao
-              .writeTransaction(folderEntity.toTransactionCompanion());
-          await _driveDao.insertFolderRevision(
-              folderEntity.toRevisionCompanion(RevisionAction.rename));
+          folderEntity.txId = folderTx.id;
+
+          await _driveDao.insertFolderRevision(folderEntity.toRevisionCompanion(
+              performedAction: RevisionAction.rename));
 
           final folderMap = {folder.id: folder.toCompanion(false)};
           await _syncCubit.generateFsEntryPaths(driveId, folderMap, {});
@@ -127,11 +127,10 @@ class FsEntryRenameCubit extends Cubit<FsEntryRenameState> {
           await _arweave.postTx(fileTx);
           await _driveDao.writeToFile(file);
 
-          await Future.wait(fileEntity
-              .toTransactionCompanions()
-              .map((tx) => _driveDao.writeTransaction(tx)));
-          await _driveDao.insertFileRevision(
-              fileEntity.toRevisionCompanion(RevisionAction.rename));
+          fileEntity.txId = fileTx.id;
+
+          await _driveDao.insertFileRevision(fileEntity.toRevisionCompanion(
+              performedAction: RevisionAction.rename));
         });
 
         emit(FileEntryRenameSuccess());

--- a/lib/blocs/fs_entry_rename/fs_entry_rename_cubit.dart
+++ b/lib/blocs/fs_entry_rename/fs_entry_rename_cubit.dart
@@ -97,6 +97,8 @@ class FsEntryRenameCubit extends Cubit<FsEntryRenameState> {
           await _arweave.postTx(folderTx);
           await _driveDao.writeToFolder(folder);
 
+          await _driveDao
+              .writeTransaction(folderEntity.toTransactionCompanion());
           await _driveDao.insertFolderRevision(
               folderEntity.toRevisionCompanion(RevisionAction.rename));
 
@@ -125,6 +127,9 @@ class FsEntryRenameCubit extends Cubit<FsEntryRenameState> {
           await _arweave.postTx(fileTx);
           await _driveDao.writeToFile(file);
 
+          await Future.wait(fileEntity
+              .toTransactionCompanions()
+              .map((tx) => _driveDao.writeTransaction(tx)));
           await _driveDao.insertFileRevision(
               fileEntity.toRevisionCompanion(RevisionAction.rename));
         });

--- a/lib/blocs/sync/sync_cubit.dart
+++ b/lib/blocs/sync/sync_cubit.dart
@@ -144,7 +144,8 @@ class SyncCubit extends Cubit<SyncState> {
 
       final revisionPerformedAction =
           entity.getPerformedRevisionAction(latestRevisions[entity.id]);
-      final revision = entity.toRevisionCompanion(revisionPerformedAction);
+      final revision =
+          entity.toRevisionCompanion(performedAction: revisionPerformedAction);
 
       if (revision.action.value == null) {
         continue;
@@ -189,7 +190,8 @@ class SyncCubit extends Cubit<SyncState> {
 
       final revisionPerformedAction =
           entity.getPerformedRevisionAction(latestRevisions[entity.id]);
-      final revision = entity.toRevisionCompanion(revisionPerformedAction);
+      final revision =
+          entity.toRevisionCompanion(performedAction: revisionPerformedAction);
 
       if (revision.action.value == null) {
         continue;

--- a/lib/blocs/sync/sync_cubit.dart
+++ b/lib/blocs/sync/sync_cubit.dart
@@ -142,15 +142,9 @@ class SyncCubit extends Cubit<SyncState> {
             .then((r) => r?.toCompanion(true));
       }
 
-      final revision = FolderRevisionsCompanion.insert(
-        folderId: entity.id,
-        driveId: entity.driveId,
-        name: entity.name,
-        parentFolderId: Value(entity.parentFolderId),
-        metadataTxId: entity.txId,
-        dateCreated: Value(entity.commitTime),
-        action: entity.getPerformedRevisionAction(latestRevisions[entity.id]),
-      );
+      final revisionPerformedAction =
+          entity.getPerformedRevisionAction(latestRevisions[entity.id]);
+      final revision = entity.toRevisionCompanion(revisionPerformedAction);
 
       if (revision.action.value == null) {
         continue;
@@ -193,18 +187,9 @@ class SyncCubit extends Cubit<SyncState> {
             .then((r) => r?.toCompanion(true));
       }
 
-      final revision = FileRevisionsCompanion.insert(
-        fileId: entity.id,
-        driveId: entity.driveId,
-        name: entity.name,
-        parentFolderId: entity.parentFolderId,
-        size: entity.size,
-        lastModifiedDate: entity.lastModifiedDate,
-        metadataTxId: entity.txId,
-        dataTxId: entity.dataTxId,
-        dateCreated: Value(entity.commitTime),
-        action: entity.getPerformedRevisionAction(latestRevisions[entity.id]),
-      );
+      final revisionPerformedAction =
+          entity.getPerformedRevisionAction(latestRevisions[entity.id]);
+      final revision = entity.toRevisionCompanion(revisionPerformedAction);
 
       if (revision.action.value == null) {
         continue;

--- a/lib/entities/drive_entity.dart
+++ b/lib/entities/drive_entity.dart
@@ -47,7 +47,7 @@ class DriveEntity extends Entity {
         ..authMode = transaction.getTag(EntityTag.driveAuthMode)
         ..txId = transaction.id
         ..ownerAddress = transaction.owner.address
-        ..commitTime = transaction.getCommitTime();
+        ..createdAt = transaction.getCommitTime();
     } catch (_) {
       throw EntityTransactionParseException();
     }
@@ -58,7 +58,7 @@ class DriveEntity extends Entity {
     assert(id != null && rootFolderId != null);
 
     tx
-      ..addApplicationTags()
+      ..addApplicationTags(unixTime: createdAt)
       ..addArFsTag()
       ..addTag(EntityTag.entityType, EntityType.drive)
       ..addTag(EntityTag.driveId, id)

--- a/lib/entities/entity.dart
+++ b/lib/entities/entity.dart
@@ -15,9 +15,9 @@ abstract class Entity {
   @JsonKey(ignore: true)
   String ownerAddress;
 
-  /// The time this entity was commited ie. its `Unix-Time`.
+  /// The time this entity was created at ie. its `Unix-Time`.
   @JsonKey(ignore: true)
-  DateTime commitTime;
+  DateTime createdAt = DateTime.now();
 
   /// Returns a [Transaction] with the entity's data along with the appropriate tags.
   ///
@@ -54,12 +54,14 @@ abstract class Entity {
 class EntityTransactionParseException implements Exception {}
 
 extension TransactionUtils on TransactionBase {
-  /// Tags this transaction with the app name, version, and current time.
-  void addApplicationTags() {
+  /// Tags this transaction with the app name, version, and the specified unix time.
+  void addApplicationTags({DateTime unixTime}) {
     addTag(EntityTag.appName, 'ArDrive-Web');
     addTag(EntityTag.appVersion, '0.1.0');
-    addTag(EntityTag.unixTime,
-        (DateTime.now().millisecondsSinceEpoch ~/ 1000).toString());
+    addTag(
+        EntityTag.unixTime,
+        ((unixTime ?? DateTime.now()).millisecondsSinceEpoch ~/ 1000)
+            .toString());
   }
 
   /// Tags this transaction with the ArFS version currently in use.

--- a/lib/entities/file_entity.dart
+++ b/lib/entities/file_entity.dart
@@ -78,7 +78,7 @@ class FileEntity extends Entity {
         ..lastModifiedDate ??= commitTime
         ..txId = transaction.id
         ..ownerAddress = transaction.owner.address
-        ..commitTime = commitTime;
+        ..createdAt = commitTime;
     } catch (_) {
       throw EntityTransactionParseException();
     }
@@ -93,7 +93,7 @@ class FileEntity extends Entity {
         size != null);
 
     tx
-      ..addApplicationTags()
+      ..addApplicationTags(unixTime: createdAt)
       ..addArFsTag()
       ..addTag(EntityTag.entityType, EntityType.file)
       ..addTag(EntityTag.driveId, driveId)

--- a/lib/entities/folder_entity.dart
+++ b/lib/entities/folder_entity.dart
@@ -42,7 +42,7 @@ class FolderEntity extends Entity {
         ..parentFolderId = transaction.getTag(EntityTag.parentFolderId)
         ..txId = transaction.id
         ..ownerAddress = transaction.owner.address
-        ..commitTime = transaction.getCommitTime();
+        ..createdAt = transaction.getCommitTime();
     } catch (_) {
       throw EntityTransactionParseException();
     }
@@ -53,7 +53,7 @@ class FolderEntity extends Entity {
     assert(id != null && driveId != null && name != null);
 
     tx
-      ..addApplicationTags()
+      ..addApplicationTags(unixTime: createdAt)
       ..addArFsTag()
       ..addTag(EntityTag.entityType, EntityType.folder)
       ..addTag(EntityTag.driveId, driveId)

--- a/lib/models/daos/drive_dao/drive_dao.dart
+++ b/lib/models/daos/drive_dao/drive_dao.dart
@@ -86,8 +86,8 @@ class DriveDao extends DatabaseAccessor<Database> with _$DriveDaoMixin {
             ownerAddress: entity.ownerAddress,
             rootFolderId: entity.rootFolderId,
             privacy: entity.privacy,
-            dateCreated: Value(entity.commitTime),
-            lastUpdated: Value(entity.commitTime),
+            dateCreated: Value(entity.createdAt),
+            lastUpdated: Value(entity.createdAt),
           );
 
           if (entity.privacy == DrivePrivacy.private) {
@@ -116,8 +116,8 @@ class DriveDao extends DatabaseAccessor<Database> with _$DriveDaoMixin {
       ownerAddress: entity.ownerAddress,
       rootFolderId: entity.rootFolderId,
       privacy: entity.privacy,
-      dateCreated: Value(entity.commitTime),
-      lastUpdated: Value(entity.commitTime),
+      dateCreated: Value(entity.createdAt),
+      lastUpdated: Value(entity.createdAt),
     );
 
     return into(drives).insert(
@@ -346,4 +346,10 @@ class DriveDao extends DatabaseAccessor<Database> with _$DriveDaoMixin {
   Future<void> writeToTransaction(Insertable<NetworkTransaction> transaction) =>
       (update(networkTransactions)..whereSamePrimaryKey(transaction))
           .write(transaction);
+
+  Future<void> insertFolderRevision(Insertable<FolderRevision> revision) =>
+      into(folderRevisions).insert(revision);
+
+  Future<void> insertFileRevision(Insertable<FileRevision> revision) =>
+      into(fileRevisions).insert(revision);
 }

--- a/lib/models/daos/drive_dao/drive_dao.dart
+++ b/lib/models/daos/drive_dao/drive_dao.dart
@@ -352,4 +352,7 @@ class DriveDao extends DatabaseAccessor<Database> with _$DriveDaoMixin {
 
   Future<void> insertFileRevision(Insertable<FileRevision> revision) =>
       into(fileRevisions).insert(revision);
+
+  Future<void> writeTransaction(Insertable<NetworkTransaction> transaction) =>
+      into(networkTransactions).insertOnConflictUpdate(transaction);
 }

--- a/lib/models/file_revision.dart
+++ b/lib/models/file_revision.dart
@@ -33,13 +33,23 @@ extension FileRevisionsCompanionExtensions on FileRevisionsCompanion {
         lastUpdated: dateCreated,
         lastModifiedDate: lastModifiedDate.value,
       );
+
+  /// Returns a list of [NetworkTransactionsCompanion] representing the metadata and data transactions
+  /// of this entity.
+  List<NetworkTransactionsCompanion> getTransactionCompanions() => [
+        NetworkTransactionsCompanion.insert(
+            id: metadataTxId.value, dateCreated: dateCreated),
+        NetworkTransactionsCompanion.insert(
+            id: dataTxId.value, dateCreated: dateCreated),
+      ];
 }
 
 extension FileEntityExtensions on FileEntity {
   /// Converts the entity to an instance of [FileRevisionsCompanion].
   ///
   /// This requires a `performedAction` to be specified.
-  FileRevisionsCompanion toRevisionCompanion(String performedAction) =>
+  FileRevisionsCompanion toRevisionCompanion(
+          {@required String performedAction}) =>
       FileRevisionsCompanion.insert(
         fileId: id,
         driveId: driveId,
@@ -52,15 +62,6 @@ extension FileEntityExtensions on FileEntity {
         dateCreated: Value(createdAt),
         action: performedAction,
       );
-
-  /// Returns a list of [NetworkTransactionsCompanion] representing the metadata and data transactions
-  /// of this entity.
-  List<NetworkTransactionsCompanion> toTransactionCompanions() => [
-        NetworkTransactionsCompanion.insert(
-            id: txId, dateCreated: Value(createdAt)),
-        NetworkTransactionsCompanion.insert(
-            id: dataTxId, dateCreated: Value(createdAt)),
-      ];
 
   /// Returns the action performed on the file that lead to the new revision.
   String getPerformedRevisionAction([FileRevisionsCompanion previousRevision]) {

--- a/lib/models/file_revision.dart
+++ b/lib/models/file_revision.dart
@@ -1,4 +1,5 @@
 import 'package:ardrive/entities/entities.dart';
+import 'package:moor/moor.dart';
 
 import 'models.dart';
 
@@ -35,6 +36,23 @@ extension FileRevisionsCompanionExtensions on FileRevisionsCompanion {
 }
 
 extension FileEntityExtensions on FileEntity {
+  /// Converts the entity to an instance of [FileRevisionsCompanion].
+  ///
+  /// This requires a `performedAction` to be specified.
+  FileRevisionsCompanion toRevisionCompanion(String performedAction) =>
+      FileRevisionsCompanion.insert(
+        fileId: id,
+        driveId: driveId,
+        name: name,
+        parentFolderId: parentFolderId,
+        size: size,
+        lastModifiedDate: lastModifiedDate,
+        metadataTxId: txId,
+        dataTxId: dataTxId,
+        dateCreated: Value(createdAt),
+        action: performedAction,
+      );
+
   /// Returns the action performed on the file that lead to the new revision.
   String getPerformedRevisionAction([FileRevisionsCompanion previousRevision]) {
     if (previousRevision == null) {

--- a/lib/models/file_revision.dart
+++ b/lib/models/file_revision.dart
@@ -53,6 +53,15 @@ extension FileEntityExtensions on FileEntity {
         action: performedAction,
       );
 
+  /// Returns a list of [NetworkTransactionsCompanion] representing the metadata and data transactions
+  /// of this entity.
+  List<NetworkTransactionsCompanion> toTransactionCompanions() => [
+        NetworkTransactionsCompanion.insert(
+            id: txId, dateCreated: Value(createdAt)),
+        NetworkTransactionsCompanion.insert(
+            id: dataTxId, dateCreated: Value(createdAt)),
+      ];
+
   /// Returns the action performed on the file that lead to the new revision.
   String getPerformedRevisionAction([FileRevisionsCompanion previousRevision]) {
     if (previousRevision == null) {

--- a/lib/models/folder_revision.dart
+++ b/lib/models/folder_revision.dart
@@ -20,13 +20,20 @@ extension FolderRevisionCompanionExtensions on FolderRevisionsCompanion {
         path: '',
         lastUpdated: dateCreated,
       );
+
+  /// Returns a [NetworkTransactionsCompanion] representing the metadata transaction
+  /// of this entity.
+  NetworkTransactionsCompanion getTransactionCompanion() =>
+      NetworkTransactionsCompanion.insert(
+          id: metadataTxId.value, dateCreated: dateCreated);
 }
 
 extension FolderEntityExtensions on FolderEntity {
   /// Converts the entity to an instance of [FolderRevisionsCompanion].
   ///
   /// This requires a `performedAction` to be specified.
-  FolderRevisionsCompanion toRevisionCompanion(String performedAction) =>
+  FolderRevisionsCompanion toRevisionCompanion(
+          {@required String performedAction}) =>
       FolderRevisionsCompanion.insert(
         folderId: id,
         driveId: driveId,
@@ -36,12 +43,6 @@ extension FolderEntityExtensions on FolderEntity {
         dateCreated: Value(createdAt),
         action: performedAction,
       );
-
-  /// Returns a [NetworkTransactionsCompanion] representing the metadata transaction
-  /// of this entity.
-  NetworkTransactionsCompanion toTransactionCompanion() =>
-      NetworkTransactionsCompanion.insert(
-          id: txId, dateCreated: Value(createdAt));
 
   /// Returns the action performed on the folder that lead to the new revision.
   String getPerformedRevisionAction(

--- a/lib/models/folder_revision.dart
+++ b/lib/models/folder_revision.dart
@@ -1,4 +1,5 @@
 import 'package:ardrive/entities/entities.dart';
+import 'package:moor/moor.dart';
 
 import 'models.dart';
 
@@ -22,6 +23,20 @@ extension FolderRevisionCompanionExtensions on FolderRevisionsCompanion {
 }
 
 extension FolderEntityExtensions on FolderEntity {
+  /// Converts the entity to an instance of [FolderRevisionsCompanion].
+  ///
+  /// This requires a `performedAction` to be specified.
+  FolderRevisionsCompanion toRevisionCompanion(String performedAction) =>
+      FolderRevisionsCompanion.insert(
+        folderId: id,
+        driveId: driveId,
+        name: name,
+        parentFolderId: Value(parentFolderId),
+        metadataTxId: txId,
+        dateCreated: Value(createdAt),
+        action: performedAction,
+      );
+
   /// Returns the action performed on the folder that lead to the new revision.
   String getPerformedRevisionAction(
       [FolderRevisionsCompanion previousRevision]) {

--- a/lib/models/folder_revision.dart
+++ b/lib/models/folder_revision.dart
@@ -37,6 +37,12 @@ extension FolderEntityExtensions on FolderEntity {
         action: performedAction,
       );
 
+  /// Returns a [NetworkTransactionsCompanion] representing the metadata transaction
+  /// of this entity.
+  NetworkTransactionsCompanion toTransactionCompanion() =>
+      NetworkTransactionsCompanion.insert(
+          id: txId, dateCreated: Value(createdAt));
+
   /// Returns the action performed on the folder that lead to the new revision.
   String getPerformedRevisionAction(
       [FolderRevisionsCompanion previousRevision]) {

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -86,7 +86,7 @@ class ArweaveService {
 
     // Sort the entities in each block by ascending commit time.
     for (final block in blockHistory) {
-      block.entities.sort((e1, e2) => e1.commitTime.compareTo(e2.commitTime));
+      block.entities.sort((e1, e2) => e1.createdAt.compareTo(e2.createdAt));
     }
 
     return DriveEntityHistory(


### PR DESCRIPTION
This PR makes it so that revisions made to folders/files are tracked before they are mined onto the network.

It does not optimistically add revisions for newly uploaded files.