### PR TITLE
ux: optimistically calculate wallet balance

### DIFF
--- a/lib/blocs/profile/profile_cubit.dart
+++ b/lib/blocs/profile/profile_cubit.dart
@@ -63,7 +63,10 @@ class ProfileCubit extends Cubit<ProfileState> {
     final profile = state as ProfileLoggedIn;
 
     final walletAddress = await profile.wallet.getAddress();
-    final walletBalance = await _arweave.getWalletBalance(walletAddress);
+    final walletBalance = await Future.wait([
+      _arweave.getWalletBalance(walletAddress),
+      _arweave.getPendingTxFees(walletAddress),
+    ]).then((res) => res[0] - res[1]);
 
     emit(profile.copyWith(walletBalance: walletBalance));
   }

--- a/lib/blocs/profile/profile_state.dart
+++ b/lib/blocs/profile/profile_state.dart
@@ -62,7 +62,8 @@ class ProfileLoggedIn extends ProfileAvailable {
       );
 
   @override
-  List<Object> get props => [username, password, wallet, cipherKey];
+  List<Object> get props =>
+      [username, password, wallet, walletAddress, walletBalance, cipherKey];
 }
 
 class ProfilePromptAdd extends ProfileUnavailable {}

--- a/lib/blocs/sync/sync_cubit.dart
+++ b/lib/blocs/sync/sync_cubit.dart
@@ -63,7 +63,10 @@ class SyncCubit extends Cubit<SyncState> {
       final driveSyncProcesses = driveIds.map((driveId) => _syncDrive(driveId));
       await Future.wait(driveSyncProcesses);
 
-      await _updateTransactionStatuses();
+      await Future.wait([
+        _profileCubit.refreshBalance(),
+        _updateTransactionStatuses(),
+      ]);
     } catch (err) {
       addError(err);
     }

--- a/lib/blocs/upload/upload_cubit.dart
+++ b/lib/blocs/upload/upload_cubit.dart
@@ -163,6 +163,8 @@ class UploadCubit extends Cubit<UploadState> {
       }
     });
 
+    unawaited(_profileCubit.refreshBalance());
+
     emit(UploadComplete());
   }
 

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -13,9 +13,24 @@ class ArweaveService {
   ArweaveService(this.client)
       : _gql = ArtemisClient('${client.api.gatewayUrl.origin}/graphql');
 
+  /// Returns the onchain balance of the specified address.
   Future<BigInt> getWalletBalance(String address) => client.api
       .get('wallet/$address/balance')
       .then((res) => BigInt.parse(res.body));
+
+  /// Returns the pending transaction fees of the specified address that is not reflected by `getWalletBalance()`.
+  Future<BigInt> getPendingTxFees(String address) async {
+    final query = await _gql.execute(PendingTxFeesQuery(
+        variables: PendingTxFeesArguments(walletAddress: address)));
+
+    return query.data.transactions.edges
+        .map((edge) => edge.node)
+        .where((node) => node.block == null)
+        .fold<BigInt>(
+          BigInt.zero,
+          (totalFees, node) => totalFees + BigInt.parse(node.fee.winston),
+        );
+  }
 
   Future<TransactionCommonMixin> getTransactionDetails(String txId) async {
     final query = await _gql.execute(TransactionDetailsQuery(

--- a/lib/services/arweave/graphql/queries/PendingTxFees.graphql
+++ b/lib/services/arweave/graphql/queries/PendingTxFees.graphql
@@ -1,0 +1,14 @@
+query PendingTxFees($walletAddress: String!) {
+  transactions(owners: [$walletAddress], sort: HEIGHT_DESC, first: 100) {
+    edges {
+      node {
+        fee {
+          winston
+        }
+        block {
+          id
+        }
+      }
+    }
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -958,4 +958,4 @@ packages:
     version: "2.2.1"
 sdks:
   dart: ">=2.12.0-29 <3.0.0"
-  flutter: ">=1.22.0 <2.0.0"
+  flutter: ">=1.22.0"


### PR DESCRIPTION
This PR makes the wallet balance displayed in the app account for any pending transaction fees as opposed to just the wallet balance which isn't accurate if there are unconfirmed transactions.

It also makes it so that the balance is refreshed on every sync and after every upload.