### PR TITLE
feat: prevent uploads of files too large for browser memory

### DIFF
--- a/lib/blocs/upload/upload_cubit.dart
+++ b/lib/blocs/upload/upload_cubit.dart
@@ -112,9 +112,14 @@ class UploadCubit extends Cubit<UploadState> {
       return;
     }
 
-    for (final file in files) {
-      final uploadHandle = await prepareFileUpload(file);
-      _fileUploadHandles[uploadHandle.entity.id] = uploadHandle;
+    try {
+      for (final file in files) {
+        final uploadHandle = await prepareFileUpload(file);
+        _fileUploadHandles[uploadHandle.entity.id] = uploadHandle;
+      }
+    } catch (err) {
+      addError(err);
+      return;
     }
 
     final uploadCost = _fileUploadHandles.values
@@ -282,5 +287,11 @@ class UploadCubit extends Cubit<UploadState> {
     }
 
     return uploadHandle;
+  }
+
+  @override
+  void onError(Object error, StackTrace stackTrace) {
+    emit(UploadFailure());
+    super.onError(error, stackTrace);
   }
 }

--- a/lib/blocs/upload/upload_cubit.dart
+++ b/lib/blocs/upload/upload_cubit.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:ardrive/entities/entities.dart';
 import 'package:ardrive/models/models.dart';
@@ -100,6 +101,16 @@ class UploadCubit extends Cubit<UploadState> {
     final profile = _profileCubit.state as ProfileLoggedIn;
 
     emit(UploadPreparationInProgress());
+
+    final tooLargeFiles = [
+      for (final file in files)
+        if (await file.length() > 1.25 * math.pow(10, 9)) file.name
+    ];
+
+    if (tooLargeFiles.isNotEmpty) {
+      emit(UploadFileTooLarge(tooLargeFileNames: tooLargeFiles));
+      return;
+    }
 
     for (final file in files) {
       final uploadHandle = await prepareFileUpload(file);

--- a/lib/blocs/upload/upload_state.dart
+++ b/lib/blocs/upload/upload_state.dart
@@ -19,6 +19,15 @@ class UploadFileConflict extends UploadState {
   List<Object> get props => [conflictingFileNames];
 }
 
+class UploadFileTooLarge extends UploadState {
+  final List<String> tooLargeFileNames;
+
+  UploadFileTooLarge({@required this.tooLargeFileNames});
+
+  @override
+  List<Object> get props => [tooLargeFileNames];
+}
+
 /// [UploadReady] means that the upload is ready to be performed and is awaiting confirmation from the user.
 class UploadReady extends UploadState {
   /// The cost to upload the data, in AR.

--- a/lib/components/upload_form.dart
+++ b/lib/components/upload_form.dart
@@ -83,6 +83,31 @@ class UploadForm extends StatelessWidget {
                 ),
               ],
             );
+          } else if (state is UploadFileTooLarge) {
+            return AppDialog(
+              title: '${state.tooLargeFileNames.length} file(s) too large',
+              content: SizedBox(
+                width: kMediumDialogWidth,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                        'ArDrive on web currently only supports file uploads smaller than 1.25 GB.'),
+                    const SizedBox(height: 16),
+                    Text('Too large for upload:'),
+                    const SizedBox(height: 8),
+                    Text(state.tooLargeFileNames.join(', ')),
+                  ],
+                ),
+              ),
+              actions: <Widget>[
+                TextButton(
+                  child: Text('OK'),
+                  onPressed: () => Navigator.of(context).pop(false),
+                ),
+              ],
+            );
           } else if (state is UploadPreparationInProgress) {
             return AppDialog(
               title: 'Preparing upload...',


### PR DESCRIPTION
This PR prevents uploads for files larger than 1.25 GB which can cause browser buffer allocation issues.