### PR TITLE
nit: print errors passed to cubit onError()

### DIFF
--- a/lib/blocs/drive_attach/drive_attach_cubit.dart
+++ b/lib/blocs/drive_attach/drive_attach_cubit.dart
@@ -119,5 +119,7 @@ class DriveAttachCubit extends Cubit<DriveAttachState> {
   void onError(Object error, StackTrace stackTrace) {
     emit(DriveAttachFailure());
     super.onError(error, stackTrace);
+
+    print('Failed to attach drive: $error $stackTrace');
   }
 }

--- a/lib/blocs/drive_create/drive_create_cubit.dart
+++ b/lib/blocs/drive_create/drive_create_cubit.dart
@@ -110,5 +110,7 @@ class DriveCreateCubit extends Cubit<DriveCreateState> {
   void onError(Object error, StackTrace stackTrace) {
     emit(DriveCreateFailure());
     super.onError(error, stackTrace);
+
+    print('Failed to create drive: $error $stackTrace');
   }
 }

--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -137,9 +137,4 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
     _folderSubscription?.cancel();
     return super.close();
   }
-
-  @override
-  void onError(Object error, StackTrace stackTrace) {
-    super.onError(error, stackTrace);
-  }
 }

--- a/lib/blocs/file_download/personal_file_download_cubit.dart
+++ b/lib/blocs/file_download/personal_file_download_cubit.dart
@@ -72,5 +72,7 @@ class ProfileFileDownloadCubit extends FileDownloadCubit {
   void onError(Object error, StackTrace stackTrace) {
     emit(FileDownloadFailure());
     super.onError(error, stackTrace);
+
+    print('Failed to download personal file: $error $stackTrace');
   }
 }

--- a/lib/blocs/file_download/shared_file_download_cubit.dart
+++ b/lib/blocs/file_download/shared_file_download_cubit.dart
@@ -57,5 +57,7 @@ class SharedFileDownloadCubit extends FileDownloadCubit {
   void onError(Object error, StackTrace stackTrace) {
     emit(FileDownloadFailure());
     super.onError(error, stackTrace);
+
+    print('Failed to download shared file: $error $stackTrace');
   }
 }

--- a/lib/blocs/folder_create/folder_create_cubit.dart
+++ b/lib/blocs/folder_create/folder_create_cubit.dart
@@ -129,5 +129,7 @@ class FolderCreateCubit extends Cubit<FolderCreateState> {
   void onError(Object error, StackTrace stackTrace) {
     emit(FolderCreateFailure());
     super.onError(error, stackTrace);
+
+    print('Failed to create folder: $error $stackTrace');
   }
 }

--- a/lib/blocs/fs_entry_activity/fs_entry_activity_cubit.dart
+++ b/lib/blocs/fs_entry_activity/fs_entry_activity_cubit.dart
@@ -46,6 +46,8 @@ class FsEntryActivityCubit extends Cubit<FsEntryActivityState> {
   void onError(Object error, StackTrace stackTrace) {
     emit(FsEntryActivityFailure());
     super.onError(error, stackTrace);
+
+    print('Failed to load entity activity: $error $stackTrace');
   }
 
   @override

--- a/lib/blocs/fs_entry_info/fs_entry_info_cubit.dart
+++ b/lib/blocs/fs_entry_info/fs_entry_info_cubit.dart
@@ -71,6 +71,8 @@ class FsEntryInfoCubit extends Cubit<FsEntryInfoState> {
   void onError(Object error, StackTrace stackTrace) {
     emit(FsEntryInfoFailure());
     super.onError(error, stackTrace);
+
+    print('Failed to load entity info: $error $stackTrace');
   }
 
   @override

--- a/lib/blocs/fs_entry_move/fs_entry_move_cubit.dart
+++ b/lib/blocs/fs_entry_move/fs_entry_move_cubit.dart
@@ -151,8 +151,10 @@ class FsEntryMoveCubit extends Cubit<FsEntryMoveState> {
   void onError(Object error, StackTrace stackTrace) {
     if (_isMovingFolder) {
       emit(FolderEntryMoveFailure());
+      print('Failed to move folder: $error $stackTrace');
     } else {
       emit(FileEntryMoveFailure());
+      print('Failed to move file: $error $stackTrace');
     }
 
     super.onError(error, stackTrace);

--- a/lib/blocs/fs_entry_rename/fs_entry_rename_cubit.dart
+++ b/lib/blocs/fs_entry_rename/fs_entry_rename_cubit.dart
@@ -200,8 +200,10 @@ class FsEntryRenameCubit extends Cubit<FsEntryRenameState> {
   void onError(Object error, StackTrace stackTrace) {
     if (_isRenamingFolder) {
       emit(FolderEntryRenameFailure());
+      print('Failed to rename folder: $error $stackTrace');
     } else {
       emit(FileEntryRenameFailure());
+      print('Failed to rename file: $error $stackTrace');
     }
 
     super.onError(error, stackTrace);

--- a/lib/blocs/sync/sync_cubit.dart
+++ b/lib/blocs/sync/sync_cubit.dart
@@ -413,6 +413,8 @@ class SyncCubit extends Cubit<SyncState> {
     emit(SyncFailure());
     super.onError(error, stackTrace);
     emit(SyncIdle());
+
+    print('Failed to sync: $error $stackTrace');
   }
 
   @override

--- a/lib/blocs/upload/upload_cubit.dart
+++ b/lib/blocs/upload/upload_cubit.dart
@@ -293,5 +293,7 @@ class UploadCubit extends Cubit<UploadState> {
   void onError(Object error, StackTrace stackTrace) {
     emit(UploadFailure());
     super.onError(error, stackTrace);
+
+    print('Failed to upload file: $error $stackTrace');
   }
 }


### PR DESCRIPTION
This PR prints errors caught and passed to the onError() function of cubits as `bloc` does not do this for us, making it so that errors are simply swallowed.