### PR TITLE
fix: incorrect textfield label color RM-300

### DIFF
--- a/lib/theme/theme.dart
+++ b/lib/theme/theme.dart
@@ -4,7 +4,10 @@ import 'package:google_fonts/google_fonts.dart';
 part 'colors.dart';
 part 'constants.dart';
 
-final base = ThemeData.light();
+final ThemeData theme = ThemeData.light();
+final base = theme.copyWith(
+  colorScheme: theme.colorScheme.copyWith(primary: kPrimarySwatch.shade900),
+);
 
 ThemeData appTheme() {
   final textTheme = _buildTextTheme(base.textTheme);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -164,13 +164,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.0"
-  clock:
-    dependency: transitive
-    description:
-      name: clock
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.0"
   code_builder:
     dependency: transitive
     description:
@@ -241,13 +234,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.2.2"
-  fake_async:
-    dependency: transitive
-    description:
-      name: fake_async
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.0"
   ffi:
     dependency: "direct overridden"
     description:
@@ -344,11 +330,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.3.0"
-  flutter_test:
-    dependency: "direct dev"
-    description: flutter
-    source: sdk
-    version: "0.0.0"
   flutter_web_plugins:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,9 +53,6 @@ dependencies:
   package_info_plus: 0.6.4
 
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
-
   test: ^1.15.4
   bloc_test: ^7.1.0
   mockito: ^5.0.0-nullsafety.2


### PR DESCRIPTION
Incorrect colors caused by breaking change in ThemeData secondaryColor property. 
Use colorscheme instead of secondary color.