### PR TITLE
Properly handle a missing parent folder

### DIFF
--- a/lib/blocs/sync/sync_cubit.dart
+++ b/lib/blocs/sync/sync_cubit.dart
@@ -435,10 +435,13 @@ class SyncCubit extends Cubit<SyncState> {
             .folderById(
                 driveId: driveId, folderId: treeRoot.folder.parentFolderId)
             .map((f) => f.path)
-            .getSingle();
+            .getSingleOrNull();
       }
 
-      await updateFolderTree(treeRoot, parentPath);
+      if (parentPath == null)
+        print('Missing parent folder: ' + treeRoot.folder.parentFolderId);
+      else
+        await updateFolderTree(treeRoot, parentPath);
     }
 
     // Update paths of files whose parent folders were not updated.


### PR DESCRIPTION
During sync, gracefully handle the situation that an entity's parent folder is missing.  This can happen temporarily while we are still retrieving data, for instance.  Without this change, the sync will abort and fail, even if the parent folder is actually there and would be added in later.