### PR TITLE
fix: Fix folder name overlap PE-22

### DIFF
--- a/lib/pages/drive_detail/components/drive_detail_data_table.dart
+++ b/lib/pages/drive_detail/components/drive_detail_data_table.dart
@@ -1,7 +1,5 @@
 part of '../drive_detail_page.dart';
 
-final fileNameWidth = 700.0;
-
 Widget _buildDataTable(BuildContext context, DriveDetailLoadSuccess state) =>
     Scrollbar(
       child: ListView(
@@ -82,13 +80,15 @@ List<DataColumn> _buildTableColumns(BuildContext context) {
 
 String trimName({required String name, required BuildContext context}) {
   final width = MediaQuery.of(context).size.width;
-  final stringLength = width > 1000
-      ? 75
-      : width > 700
+  final stringLength = width > 1500
+      ? 100
+      : width > 1200
           ? 50
           : 35;
 
-  return name.substring(0, stringLength) + '.....' + name.split('.').last;
+  return name.length > stringLength
+      ? name.substring(0, stringLength) + '.....' + name.split('.').last
+      : name;
 }
 
 DataRow _buildFolderRow({
@@ -109,7 +109,7 @@ DataRow _buildFolderRow({
               child: const Icon(Icons.folder),
             ),
             Text(
-              folder.name,
+              trimName(name: folder.name, context: context),
             ),
           ],
         ),
@@ -140,13 +140,8 @@ DataRow _buildFileRow({
                 file.dataContentType,
               ),
             ),
-            Container(
-              width: fileNameWidth,
-              child: Text(
-                file.name,
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
-              ),
+            Text(
+              trimName(name: file.name, context: context),
             ),
           ],
         ),

--- a/lib/pages/drive_detail/components/drive_detail_data_table.dart
+++ b/lib/pages/drive_detail/components/drive_detail_data_table.dart
@@ -79,7 +79,7 @@ List<DataColumn> _buildTableColumns(BuildContext context) {
 }
 
 String trimName({required String name, required BuildContext context}) {
-  const endBuffer = 10;
+  const endBuffer = 8;
   final width = MediaQuery.of(context).size.width;
   // No better way to do this. Lerping is too gradual and causes overlap.
   final stringLength = width > 1600
@@ -91,7 +91,7 @@ String trimName({required String name, required BuildContext context}) {
               : 30;
   return name.length > stringLength
       ? name.substring(0, stringLength - endBuffer) +
-          '...' +
+          ' ... ' +
           name.substring(name.length - endBuffer)
       : name;
 }

--- a/lib/pages/drive_detail/components/drive_detail_data_table.dart
+++ b/lib/pages/drive_detail/components/drive_detail_data_table.dart
@@ -87,9 +87,8 @@ String trimName({required String name, required BuildContext context}) {
       : width > 700
           ? 50
           : 35;
-  
 
-  return '';
+  return name.substring(0, stringLength) + '.....' + name.split('.').last;
 }
 
 DataRow _buildFolderRow({

--- a/lib/pages/drive_detail/components/drive_detail_data_table.dart
+++ b/lib/pages/drive_detail/components/drive_detail_data_table.dart
@@ -95,7 +95,14 @@ DataRow _buildFolderRow({
                 padding: const EdgeInsetsDirectional.only(end: 8.0),
                 child: const Icon(Icons.folder),
               ),
-              Text(folder.name),
+              Container(
+                width: MediaQuery.of(context).size.width / 1.7,
+                child: Text(
+                  folder.name,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
             ],
           ),
         ),

--- a/lib/pages/drive_detail/components/drive_detail_data_table.dart
+++ b/lib/pages/drive_detail/components/drive_detail_data_table.dart
@@ -1,5 +1,7 @@
 part of '../drive_detail_page.dart';
 
+final fileNameWidth = 700.0;
+
 Widget _buildDataTable(BuildContext context, DriveDetailLoadSuccess state) =>
     Scrollbar(
       child: ListView(
@@ -96,7 +98,7 @@ DataRow _buildFolderRow({
                 child: const Icon(Icons.folder),
               ),
               Container(
-                width: MediaQuery.of(context).size.width / 1.7,
+                width: fileNameWidth,
                 child: Text(
                   folder.name,
                   maxLines: 2,
@@ -132,7 +134,7 @@ DataRow _buildFileRow({
               ),
             ),
             Container(
-              width: MediaQuery.of(context).size.width / 1.7,
+              width: fileNameWidth,
               child: Text(
                 file.name,
                 maxLines: 2,

--- a/lib/pages/drive_detail/components/drive_detail_data_table.dart
+++ b/lib/pages/drive_detail/components/drive_detail_data_table.dart
@@ -80,38 +80,46 @@ List<DataColumn> _buildTableColumns(BuildContext context) {
   ];
 }
 
+String trimName({required String name, required BuildContext context}) {
+  final width = MediaQuery.of(context).size.width;
+  final stringLength = width > 1000
+      ? 75
+      : width > 700
+          ? 50
+          : 35;
+  
+
+  return '';
+}
+
 DataRow _buildFolderRow({
   required BuildContext context,
   required FolderEntry folder,
   bool selected = false,
   required Function onPressed,
-}) =>
-    DataRow(
-      onSelectChanged: (_) => onPressed(),
-      selected: selected,
-      cells: [
-        DataCell(
-          Row(
-            children: [
-              Padding(
-                padding: const EdgeInsetsDirectional.only(end: 8.0),
-                child: const Icon(Icons.folder),
-              ),
-              Container(
-                width: fileNameWidth,
-                child: Text(
-                  folder.name,
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-            ],
-          ),
+}) {
+  return DataRow(
+    onSelectChanged: (_) => onPressed(),
+    selected: selected,
+    cells: [
+      DataCell(
+        Row(
+          children: [
+            Padding(
+              padding: const EdgeInsetsDirectional.only(end: 8.0),
+              child: const Icon(Icons.folder),
+            ),
+            Text(
+              folder.name,
+            ),
+          ],
         ),
-        DataCell(Text('-')),
-        DataCell(Text('-')),
-      ],
-    );
+      ),
+      DataCell(Text('-')),
+      DataCell(Text('-')),
+    ],
+  );
+}
 
 DataRow _buildFileRow({
   required BuildContext context,

--- a/lib/pages/drive_detail/components/drive_detail_data_table.dart
+++ b/lib/pages/drive_detail/components/drive_detail_data_table.dart
@@ -82,13 +82,20 @@ String trimName({required String name, required BuildContext context}) {
   const endBuffer = 8;
   final width = MediaQuery.of(context).size.width;
   // No better way to do this. Lerping is too gradual and causes overlap.
-  final stringLength = width > 1600
+  var stringLength = width > 1600
       ? 75
       : width > 1400
           ? 50
           : width > 1200
               ? 35
-              : 30;
+              : 20;
+
+  // If info sidebar is closed increase the width
+  final driveState = context.read<DriveDetailCubit>().state;
+  if (driveState is DriveDetailLoadSuccess &&
+      !driveState.showSelectedItemDetails) {
+    stringLength += 20;
+  }
   return name.length > stringLength
       ? name.substring(0, stringLength - endBuffer) +
           ' ... ' +

--- a/lib/pages/drive_detail/components/drive_detail_data_table.dart
+++ b/lib/pages/drive_detail/components/drive_detail_data_table.dart
@@ -79,15 +79,20 @@ List<DataColumn> _buildTableColumns(BuildContext context) {
 }
 
 String trimName({required String name, required BuildContext context}) {
+  const endBuffer = 10;
   final width = MediaQuery.of(context).size.width;
-  final stringLength = width > 1500
-      ? 100
-      : width > 1200
+  // No better way to do this. Lerping is too gradual and causes overlap.
+  final stringLength = width > 1600
+      ? 75
+      : width > 1400
           ? 50
-          : 35;
-
+          : width > 1200
+              ? 35
+              : 30;
   return name.length > stringLength
-      ? name.substring(0, stringLength) + '.....' + name.split('.').last
+      ? name.substring(0, stringLength - endBuffer) +
+          '...' +
+          name.substring(name.length - endBuffer)
       : name;
 }
 

--- a/lib/pages/drive_detail/drive_detail_page.dart
+++ b/lib/pages/drive_detail/drive_detail_page.dart
@@ -48,23 +48,24 @@ class DriveDetailPage extends StatelessWidget {
                             child: Column(
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
-                                ConstrainedBox(
-                                  constraints: BoxConstraints(minWidth: 100),
-                                  child: Row(
-                                    mainAxisAlignment:
-                                        MainAxisAlignment.spaceBetween,
-                                    children: [
-                                      Expanded(
+                                Row(
+                                  mainAxisAlignment:
+                                      MainAxisAlignment.spaceBetween,
+                                  children: [
+                                    Expanded(
+                                      child: Container(
+                                        width: 400,
                                         child: Text(
                                           state.currentDrive.name,
                                           style: Theme.of(context)
                                               .textTheme
                                               .headline5,
+                                          overflow: TextOverflow.ellipsis,
                                         ),
                                       ),
-                                      DriveDetailActionRow(),
-                                    ],
-                                  ),
+                                    ),
+                                    DriveDetailActionRow(),
+                                  ],
                                 ),
                                 DriveDetailBreadcrumbRow(
                                   path: state.currentFolder.folder?.path ??

--- a/lib/pages/drive_detail/drive_detail_page.dart
+++ b/lib/pages/drive_detail/drive_detail_page.dart
@@ -1,4 +1,5 @@
 import 'dart:math';
+import 'dart:ui';
 
 import 'package:ardrive/blocs/blocs.dart';
 import 'package:ardrive/components/components.dart';
@@ -47,17 +48,23 @@ class DriveDetailPage extends StatelessWidget {
                             child: Column(
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
-                                Row(
-                                  mainAxisAlignment:
-                                      MainAxisAlignment.spaceBetween,
-                                  children: [
-                                    Text(
-                                      state.currentDrive.name,
-                                      style:
-                                          Theme.of(context).textTheme.headline5,
-                                    ),
-                                    DriveDetailActionRow(),
-                                  ],
+                                ConstrainedBox(
+                                  constraints: BoxConstraints(minWidth: 100),
+                                  child: Row(
+                                    mainAxisAlignment:
+                                        MainAxisAlignment.spaceBetween,
+                                    children: [
+                                      Expanded(
+                                        child: Text(
+                                          state.currentDrive.name,
+                                          style: Theme.of(context)
+                                              .textTheme
+                                              .headline5,
+                                        ),
+                                      ),
+                                      DriveDetailActionRow(),
+                                    ],
+                                  ),
                                 ),
                                 DriveDetailBreadcrumbRow(
                                   path: state.currentFolder.folder?.path ??


### PR DESCRIPTION
UI tweaks to prevent folder and file names from overlapping with other columns of the data table.