### PR TITLE
task: update folders in folder query PE-626

### DIFF
--- a/lib/models/queries/drive_queries.moor
+++ b/lib/models/queries/drive_queries.moor
@@ -39,10 +39,16 @@ foldersInFolder ($order = ''):
     SELECT * FROM folder_entries
     WHERE driveId = :driveId AND parentFolderId = :parentFolderId
     ORDER BY $order;
+
 foldersInFolderAtPath ($order = ''):
     SELECT * FROM folder_entries
-    WHERE driveId = :driveId AND path LIKE :path || '/%' AND path NOT LIKE :path || '/%/%'
+    WHERE parentFolderId IN (
+        SELECT id FROM folder_entries
+        WHERE driveId = :driveId AND path = :path 
+        LIMIT 1
+    ) 
     ORDER BY $order;
+
 foldersInFolderWithName:
     SELECT * FROM folder_entries
     WHERE driveId = :driveId AND parentFolderId = :parentFolderId AND name = :name;


### PR DESCRIPTION
Reworks the query that fetches folders based on paths. While previously it would do a wildcard search for folders inside a folder, now it gets the parent folder id and uses that to fetch the folders inside instead. This is more accurate and doesn't result in looping paths and weird folder hierarchy.