### PR TITLE
task: skip sync when overlays are open PE-31

### DIFF
--- a/lib/blocs/profile/profile_cubit.dart
+++ b/lib/blocs/profile/profile_cubit.dart
@@ -21,6 +21,8 @@ class ProfileCubit extends Cubit<ProfileState> {
   final ProfileDao _profileDao;
   final Database _db;
 
+  bool _isOverlayOpen = false;
+
   ProfileCubit({
     required ArweaveService arweave,
     required ProfileDao profileDao,
@@ -40,6 +42,10 @@ class ProfileCubit extends Cubit<ProfileState> {
       return false;
     }
   }
+
+  bool isOverlayOpen() => _isOverlayOpen;
+
+  void setOverlayOpen(bool val) => _isOverlayOpen = val;
 
   Future<void> promptToAuthenticate() async {
     final profile = await _profileDao.defaultProfile().getSingleOrNull();

--- a/lib/blocs/sync/sync_cubit.dart
+++ b/lib/blocs/sync/sync_cubit.dart
@@ -74,6 +74,12 @@ class SyncCubit extends Cubit<SyncState> {
           return;
         }
 
+        if (_profileCubit.isOverlayOpen()) {
+          print('Overlay open, skipping sync...');
+          emit(SyncIdle());
+          return;
+        }
+
         if (await _profileCubit.logoutIfWalletMismatch()) {
           emit(SyncWalletMismatch());
           return;

--- a/lib/components/upload_form.dart
+++ b/lib/components/upload_form.dart
@@ -15,10 +15,13 @@ Future<void> promptToUploadFile(
   required String folderId,
   bool allowSelectMultiple = false,
 }) async {
+  final profleCubit = context.read<ProfileCubit>();
+  profleCubit.setOverlayOpen(true);
   final selectedFiles = allowSelectMultiple
       ? await file_selector.openFiles()
-      : [await file_selector.openFile()].where((file) => file != null) as List<file_selector.XFile>;
-
+      : [await file_selector.openFile()].where((file) => file != null)
+          as List<file_selector.XFile>;
+  profleCubit.setOverlayOpen(false);
   if (selectedFiles.isEmpty) {
     return;
   }
@@ -30,9 +33,9 @@ Future<void> promptToUploadFile(
         driveId: driveId,
         folderId: folderId,
         files: selectedFiles,
+        profileCubit: profleCubit,
         arweave: context.read<ArweaveService>(),
         pst: context.read<PstService>(),
-        profileCubit: context.read<ProfileCubit>(),
         driveDao: context.read<DriveDao>(),
       ),
       child: UploadForm(),


### PR DESCRIPTION
Adds an isOverlayOpen property to ProfileCubit which should be set when an overlay like the file picker is shown.
In this case it's set when the file picker is shown for file upload. We use the property then to skip sync so it doesn't interfere with uploads.