### PR TITLE
task: add validation message for identical name on rename PE-665

### DIFF
--- a/lib/blocs/fs_entry_rename/fs_entry_rename_cubit.dart
+++ b/lib/blocs/fs_entry_rename/fs_entry_rename_cubit.dart
@@ -150,7 +150,8 @@ class FsEntryRenameCubit extends Cubit<FsEntryRenameState> {
     final String newFolderName = control.value;
 
     if (newFolderName == folder.name) {
-      return null;
+      control.markAsTouched();
+      return {AppValidationMessage.fsEntryNameUnchanged: true};
     }
 
     // Check that the current folder does not already have a folder with the target file name.
@@ -177,7 +178,8 @@ class FsEntryRenameCubit extends Cubit<FsEntryRenameState> {
     final String newFileName = control.value;
 
     if (newFileName == file.name) {
-      return null;
+      control.markAsTouched();
+      return {AppValidationMessage.fsEntryNameUnchanged: true};
     }
 
     // Check that the current folder does not already have a file with the target file name.

--- a/lib/l11n/validation_messages.dart
+++ b/lib/l11n/validation_messages.dart
@@ -9,11 +9,14 @@ const kValidationMessages = {
       'A folder/file with this name is already present here.',
   AppValidationMessage.driveNameAlreadyPresent:
       'A drive with this name is already present.',
+  AppValidationMessage.fsEntryNameUnchanged:
+      'This name is identical to the current name.',
 };
 
 class AppValidationMessage {
   static const String passwordIncorrect = 'password-incorrect';
   static const String driveNotFound = 'drive-not-found';
   static const String fsEntryNameAlreadyPresent = 'name-already-present';
+  static const String fsEntryNameUnchanged = 'name-unchanged';
   static const String driveNameAlreadyPresent = 'drive-name-already-present';
 }


### PR DESCRIPTION
When renaming a file, we now enforce that the new name should be different from the current name.