### PR TITLE
PE 978/Dont reset rows per page on sync

### DIFF
--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -103,7 +103,6 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
                 currentFolder: folderContents,
                 contentOrderBy: contentOrderBy,
                 contentOrderingMode: contentOrderingMode,
-                rowsPerPage: availableRowsPerPage.first,
                 availableRowsPerPage: availableRowsPerPage,
               ),
             );

--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -104,6 +104,9 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
                 contentOrderBy: contentOrderBy,
                 contentOrderingMode: contentOrderingMode,
                 availableRowsPerPage: availableRowsPerPage,
+                rowsPerPage: availableRowsPerPage.contains(state.rowsPerPage)
+                    ? state.rowsPerPage
+                    : availableRowsPerPage.first,
               ),
             );
           } else {

--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -104,6 +104,8 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
                 contentOrderBy: contentOrderBy,
                 contentOrderingMode: contentOrderingMode,
                 availableRowsPerPage: availableRowsPerPage,
+                // In case sync hasn't populated the drive yet,
+                // set a default rows per page
                 rowsPerPage: availableRowsPerPage.contains(state.rowsPerPage)
                     ? state.rowsPerPage
                     : availableRowsPerPage.first,

--- a/lib/components/app_drawer/app_drawer.dart
+++ b/lib/components/app_drawer/app_drawer.dart
@@ -145,7 +145,7 @@ class AppDrawer extends StatelessWidget {
                                 ),
                               );
                             } else {
-                              return Container();
+                              return SizedBox(height: 32, width: 32);
                             }
                           },
                         ),


### PR DESCRIPTION
Stops sync from resetting the current rows per page option.

Also took the opportunity to update the placeholder widget for version, which stops the widgets on top from jumping around.