### PR TITLE
PE 1062/Attach private drives

### DIFF
--- a/lib/blocs/drive_attach/drive_attach_cubit.dart
+++ b/lib/blocs/drive_attach/drive_attach_cubit.dart
@@ -1,5 +1,6 @@
 import 'package:ardrive/blocs/blocs.dart';
 import 'package:ardrive/entities/entities.dart';
+import 'package:ardrive/entities/string_types.dart';
 import 'package:ardrive/l11n/validation_messages.dart';
 import 'package:ardrive/misc/misc.dart';
 import 'package:ardrive/models/models.dart';
@@ -27,9 +28,9 @@ class DriveAttachCubit extends Cubit<DriveAttachState> {
   late SecretKey? _driveKey;
 
   DriveAttachCubit({
-    String? driveId,
-    String? driveName,
-    SecretKey? driveKey,
+    DriveID? initialDriveId,
+    String? initialDriveName,
+    SecretKey? initialDriveKey,
     required ArweaveService arweave,
     required DriveDao driveDao,
     required SyncCubit syncBloc,
@@ -42,9 +43,9 @@ class DriveAttachCubit extends Cubit<DriveAttachState> {
         _profileCubit = profileCubit,
         super(DriveAttachInitial()) {
     initializeForm(
-      driveId: driveId,
-      driveName: driveName,
-      driveKey: driveKey,
+      driveId: initialDriveId,
+      driveName: initialDriveName,
+      driveKey: initialDriveKey,
     );
   }
 

--- a/lib/blocs/drive_attach/drive_attach_cubit.dart
+++ b/lib/blocs/drive_attach/drive_attach_cubit.dart
@@ -1,9 +1,12 @@
 import 'package:ardrive/blocs/blocs.dart';
+import 'package:ardrive/entities/entities.dart';
 import 'package:ardrive/l11n/validation_messages.dart';
 import 'package:ardrive/misc/misc.dart';
 import 'package:ardrive/models/models.dart';
 import 'package:ardrive/services/services.dart';
+import 'package:arweave/utils.dart';
 import 'package:bloc/bloc.dart';
+import 'package:cryptography/cryptography.dart';
 import 'package:equatable/equatable.dart';
 import 'package:meta/meta.dart';
 import 'package:pedantic/pedantic.dart';
@@ -19,24 +22,47 @@ class DriveAttachCubit extends Cubit<DriveAttachState> {
   final DriveDao _driveDao;
   final SyncCubit _syncBloc;
   final DrivesCubit _drivesBloc;
+  final ProfileCubit _profileCubit;
+
+  final SecretKey? _driveKey;
 
   DriveAttachCubit({
-    String? initialDriveId,
+    String? driveId,
     String? driveName,
+    SecretKey? driveKey,
     required ArweaveService arweave,
     required DriveDao driveDao,
     required SyncCubit syncBloc,
     required DrivesCubit drivesBloc,
+    required ProfileCubit profileCubit,
   })  : _arweave = arweave,
         _driveDao = driveDao,
         _syncBloc = syncBloc,
         _drivesBloc = drivesBloc,
+        _profileCubit = profileCubit,
+        _driveKey = driveKey,
         super(DriveAttachInitial()) {
+    initializeForm(
+      driveId: driveId,
+      driveName: driveName,
+      driveKey: driveKey,
+    );
+  }
+
+  Future<void> initializeForm({
+    String? driveId,
+    String? driveName,
+    SecretKey? driveKey,
+  }) async {
+    if (_driveKey != null && _profileCubit.state is! ProfileLoggedIn) {
+      emit(DriveAttachPrivateNotLoggedIn());
+      return;
+    }
     form = FormGroup(
       {
         'driveId': FormControl<String>(
           validators: [Validators.required],
-          asyncValidators: [_driveNameLoader],
+          asyncValidators: [_drivePrivacyLoader, _driveNameLoader],
           // Debounce drive name loading by 500ms.
           asyncValidatorsDebounceTime: 500,
         ),
@@ -51,14 +77,14 @@ class DriveAttachCubit extends Cubit<DriveAttachState> {
     );
 
     // Add the initial drive id in a microtask to properly trigger the drive name loader.
-    Future.microtask(() {
-      if (initialDriveId != null) {
-        form.control('driveId').updateValue(initialDriveId);
+    await Future.microtask(() {
+      if (driveId != null) {
+        form.control('driveId').updateValue(driveId);
       }
     });
+
     if (driveName != null && driveName.isNotEmpty) {
-      form.control('driveId').value = initialDriveId;
-      form.control('name').value = driveName;
+      form.control('name').updateValue(driveName);
       submit();
     }
   }
@@ -67,6 +93,7 @@ class DriveAttachCubit extends Cubit<DriveAttachState> {
     form.markAllAsTouched();
 
     if (form.invalid) {
+      emit(DriveAttachFailure());
       return;
     }
 
@@ -75,26 +102,50 @@ class DriveAttachCubit extends Cubit<DriveAttachState> {
     try {
       final String driveId = form.control('driveId').value;
       final driveName = form.control('name').value.toString().trim();
-
-      final driveEntity = await _arweave.getLatestDriveEntityWithId(driveId);
-
+      final driveKey = await getDriveKey();
+      final driveEntity = await _arweave.getLatestDriveEntityWithId(
+        driveId,
+        driveKey,
+      );
       if (driveEntity == null) {
         form
             .control('driveId')
-            .setErrors({AppValidationMessage.driveNotFound: true});
+            .setErrors({AppValidationMessage.driveAttachDriveNotFound: true});
         emit(DriveAttachFailure());
         return;
       }
 
-      await _driveDao.writeDriveEntity(name: driveName, entity: driveEntity);
+      await _driveDao.writeDriveEntity(
+        name: driveName,
+        entity: driveEntity,
+        driveKey: driveKey,
+        profileKey: (_profileCubit.state as ProfileLoggedIn).cipherKey,
+      );
 
       _drivesBloc.selectDrive(driveId);
+      emit(DriveAttachSuccess());
       unawaited(_syncBloc.startSync());
     } catch (err) {
       addError(err);
     }
+  }
 
-    emit(DriveAttachSuccess());
+  Future<SecretKey?> getDriveKey() async {
+    final String? driveKeyBytes = form.controls.containsKey('driveKey')
+        ? form.control('driveKey').value
+        : null;
+    var driveKey = _driveKey;
+    if (driveKeyBytes != null) {
+      try {
+        driveKey = SecretKey(decodeBase64ToBytes(driveKeyBytes));
+      } catch (e) {
+        form.control('driveKey').setErrors({
+          AppValidationMessage.driveAttachInvalidDriveKey: true,
+        });
+        emit(DriveAttachFailure());
+      }
+    }
+    return driveKey;
   }
 
   Future<Map<String, dynamic>?> _driveNameLoader(
@@ -107,13 +158,51 @@ class DriveAttachCubit extends Cubit<DriveAttachState> {
     if (driveId == null) {
       return null;
     }
-    final drive = await _arweave.getLatestDriveEntityWithId(driveId);
+
+    final driveKey = await getDriveKey();
+
+    final drive = await _arweave.getLatestDriveEntityWithId(driveId, driveKey);
 
     if (drive == null) {
       return null;
     }
 
     form.control('name').updateValue(drive.name);
+
+    return null;
+  }
+
+  Future<Map<String, dynamic>?> _drivePrivacyLoader(
+      AbstractControl<dynamic> driveIdControl) async {
+    if ((driveIdControl as AbstractControl<String?>).isNull) {
+      return null;
+    }
+
+    final driveId = driveIdControl.value;
+    if (driveId == null) {
+      return null;
+    }
+    final drivePrivacy = await _arweave.getDrivePrivacyForId(driveId);
+
+    switch (drivePrivacy) {
+      case DrivePrivacy.private:
+        emit(DriveAttachPrivate());
+        form.addAll({
+          'driveKey': FormControl<String>(
+            validators: [
+              Validators.required,
+            ],
+            asyncValidators: [_driveNameLoader],
+          ),
+        });
+
+        break;
+      case null:
+        emit(DriveAttachDriveNotFound());
+        break;
+      default:
+        return null;
+    }
 
     return null;
   }

--- a/lib/blocs/drive_attach/drive_attach_cubit.dart
+++ b/lib/blocs/drive_attach/drive_attach_cubit.dart
@@ -176,7 +176,7 @@ class DriveAttachCubit extends Cubit<DriveAttachState> {
     return null;
   }
 
-  Future<Map<String, dynamic>?> _drivKeyValidatorr(
+  Future<Map<String, dynamic>?> _driveKeyValidator(
       AbstractControl<dynamic> driveKeyControl) async {
     final driveId = form.control('driveId').value;
 
@@ -219,7 +219,7 @@ class DriveAttachCubit extends Cubit<DriveAttachState> {
               Validators.required,
             ],
             asyncValidatorsDebounceTime: 1000,
-            asyncValidators: [_drivKeyValidatorr],
+            asyncValidators: [_driveKeyValidator],
           ),
         });
 

--- a/lib/blocs/drive_attach/drive_attach_cubit.dart
+++ b/lib/blocs/drive_attach/drive_attach_cubit.dart
@@ -93,7 +93,6 @@ class DriveAttachCubit extends Cubit<DriveAttachState> {
     form.markAllAsTouched();
 
     if (form.invalid) {
-      emit(DriveAttachFailure());
       return;
     }
 
@@ -111,7 +110,7 @@ class DriveAttachCubit extends Cubit<DriveAttachState> {
         form
             .control('driveId')
             .setErrors({AppValidationMessage.driveAttachDriveNotFound: true});
-        emit(DriveAttachFailure());
+        emit(DriveAttachInitial());
         return;
       }
 
@@ -119,7 +118,9 @@ class DriveAttachCubit extends Cubit<DriveAttachState> {
         name: driveName,
         entity: driveEntity,
         driveKey: driveKey,
-        profileKey: (_profileCubit.state as ProfileLoggedIn).cipherKey,
+        profileKey: driveKey != null
+            ? (_profileCubit.state as ProfileLoggedIn).cipherKey
+            : null,
       );
 
       _drivesBloc.selectDrive(driveId);

--- a/lib/blocs/drive_attach/drive_attach_state.dart
+++ b/lib/blocs/drive_attach/drive_attach_state.dart
@@ -8,6 +8,12 @@ abstract class DriveAttachState extends Equatable {
 
 class DriveAttachInitial extends DriveAttachState {}
 
+class DriveAttachPrivate extends DriveAttachState {}
+
+class DriveAttachPrivateNotLoggedIn extends DriveAttachState {}
+
+class DriveAttachDriveNotFound extends DriveAttachState {}
+
 class DriveAttachInProgress extends DriveAttachState {}
 
 class DriveAttachSuccess extends DriveAttachState {}

--- a/lib/components/drive_attach_form.dart
+++ b/lib/components/drive_attach_form.dart
@@ -1,4 +1,5 @@
 import 'package:ardrive/blocs/blocs.dart';
+import 'package:ardrive/entities/string_types.dart';
 import 'package:ardrive/l11n/l11n.dart';
 import 'package:ardrive/models/models.dart';
 import 'package:ardrive/pages/user_interaction_wrapper.dart';
@@ -16,7 +17,7 @@ import 'components.dart';
 
 Future<void> attachDrive({
   required BuildContext context,
-  String? driveId,
+  DriveID? driveId,
   String? driveName,
   SecretKey? driveKey,
 }) =>

--- a/lib/components/drive_attach_form.dart
+++ b/lib/components/drive_attach_form.dart
@@ -4,6 +4,7 @@ import 'package:ardrive/models/models.dart';
 import 'package:ardrive/pages/user_interaction_wrapper.dart';
 import 'package:ardrive/services/services.dart';
 import 'package:ardrive/theme/theme.dart';
+import 'package:cryptography/cryptography.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -13,22 +14,26 @@ import 'package:reactive_forms/reactive_forms.dart';
 
 import 'components.dart';
 
-Future<void> attachDrive(
-        {required BuildContext context,
-        String? initialDriveId,
-        String? driveName}) =>
+Future<void> attachDrive({
+  required BuildContext context,
+  String? driveId,
+  String? driveName,
+  SecretKey? driveKey,
+}) =>
     showModalDialog(
       context,
       () => showDialog(
         context: context,
         builder: (BuildContext context) => BlocProvider<DriveAttachCubit>(
           create: (context) => DriveAttachCubit(
-            initialDriveId: initialDriveId,
+            driveId: driveId,
             driveName: driveName,
+            driveKey: driveKey,
             arweave: context.read<ArweaveService>(),
             driveDao: context.read<DriveDao>(),
             syncBloc: context.read<SyncCubit>(),
             drivesBloc: context.read<DrivesCubit>(),
+            profileCubit: context.read<ProfileCubit>(),
           ),
           child: BlocListener<DriveAttachCubit, DriveAttachState>(
             listener: (context, state) {
@@ -39,11 +44,7 @@ Future<void> attachDrive(
                 Navigator.pop(context);
               }
             },
-            child: driveName != null
-                ? ProgressDialog(
-                    title: 'ATTACHING DRIVE...',
-                  )
-                : DriveAttachForm(),
+            child: DriveAttachForm(),
           ),
         ),
       ),
@@ -52,9 +53,31 @@ Future<void> attachDrive(
 /// Depends on a provided [DriveAttachCubit] for business logic.
 class DriveAttachForm extends StatelessWidget {
   @override
-  Widget build(BuildContext context) =>
-      BlocBuilder<DriveAttachCubit, DriveAttachState>(
-        builder: (context, state) => AppDialog(
+  Widget build(BuildContext context) {
+    return BlocBuilder<DriveAttachCubit, DriveAttachState>(
+      builder: (context, state) {
+        if (state is DriveAttachInProgress) {
+          return ProgressDialog(
+            title: 'ATTACHING DRIVE...',
+          );
+        }
+        if (state is DriveAttachPrivateNotLoggedIn) {
+          return AppDialog(
+            dismissable: false,
+            title: 'Drive attach failed',
+            content: SizedBox(
+              width: kMediumDialogWidth,
+              child: Text('Please log in to attach private drives.'),
+            ),
+            actions: [
+              ElevatedButton(
+                onPressed: () => Navigator.pop(context),
+                child: Text('OK'),
+              ),
+            ],
+          );
+        }
+        return AppDialog(
           title: 'ATTACH DRIVE',
           content: SizedBox(
             width: kMediumDialogWidth,
@@ -69,6 +92,19 @@ class DriveAttachForm extends StatelessWidget {
                     decoration: InputDecoration(labelText: 'Drive ID'),
                     validationMessages: (_) => kValidationMessages,
                   ),
+                  const SizedBox(height: 16),
+                  if (state is DriveAttachPrivate)
+                    ReactiveTextField(
+                      formControlName: 'driveKey',
+                      autofocus: true,
+                      obscureText: true,
+                      decoration: InputDecoration(labelText: 'Drive Key'),
+                      validationMessages: (_) => kValidationMessages,
+                      onEditingComplete: () => context
+                          .read<DriveAttachCubit>()
+                          .form
+                          .updateValueAndValidity(),
+                    ),
                   const SizedBox(height: 16),
                   ReactiveTextField(
                     formControlName: 'name',
@@ -118,6 +154,8 @@ class DriveAttachForm extends StatelessWidget {
               child: Text(AppLocalizations.of(context)!.attach.toUpperCase()),
             ),
           ],
-        ),
-      );
+        );
+      },
+    );
+  }
 }

--- a/lib/components/drive_attach_form.dart
+++ b/lib/components/drive_attach_form.dart
@@ -26,9 +26,9 @@ Future<void> attachDrive({
         context: context,
         builder: (BuildContext context) => BlocProvider<DriveAttachCubit>(
           create: (context) => DriveAttachCubit(
-            driveId: driveId,
-            driveName: driveName,
-            driveKey: driveKey,
+            initialDriveId: driveId,
+            initialDriveName: driveName,
+            initialDriveKey: driveKey,
             arweave: context.read<ArweaveService>(),
             driveDao: context.read<DriveDao>(),
             syncBloc: context.read<SyncCubit>(),

--- a/lib/l11n/validation_messages.dart
+++ b/lib/l11n/validation_messages.dart
@@ -4,7 +4,11 @@ const kValidationMessages = {
   ValidationMessage.required: 'This field is required.',
   ValidationMessage.pattern: 'This field is invalid.',
   AppValidationMessage.passwordIncorrect: 'This password is incorrect.',
-  AppValidationMessage.driveNotFound: 'The specified drive could not be found.',
+  AppValidationMessage.driveAttachDriveNotFound:
+      'The specified drive could not be found.',
+  AppValidationMessage.driveAttachInvalidDriveKey: 'Invalid drive key.',
+  AppValidationMessage.driveAttachUserLoggedOut:
+      'You need to be signed in to attach private drives.',
   AppValidationMessage.fsEntryNameAlreadyPresent:
       'A folder/file with this name is already present here.',
   AppValidationMessage.driveNameAlreadyPresent:
@@ -15,7 +19,10 @@ const kValidationMessages = {
 
 class AppValidationMessage {
   static const String passwordIncorrect = 'password-incorrect';
-  static const String driveNotFound = 'drive-not-found';
+  static const String driveAttachDriveNotFound = 'drive-not-found';
+  static const String driveAttachUserLoggedOut = 'drive-attach-user-logged-out';
+  static const String driveAttachInvalidDriveKey =
+      'drive-attach-invalid-drive-key';
   static const String fsEntryNameAlreadyPresent = 'name-already-present';
   static const String fsEntryNameUnchanged = 'name-unchanged';
   static const String driveNameAlreadyPresent = 'drive-name-already-present';

--- a/lib/models/daos/drive_dao/drive_dao.dart
+++ b/lib/models/daos/drive_dao/drive_dao.dart
@@ -111,10 +111,15 @@ class DriveDao extends DatabaseAccessor<Database> with _$DriveDaoMixin {
   Future<void> writeDriveEntity({
     required String name,
     required DriveEntity entity,
-  }) {
-    assert(entity.privacy == DrivePrivacy.public);
+    SecretKey? driveKey,
+    SecretKey? profileKey,
+  }) async {
+    if (driveKey != null && profileKey == null) {
+      //TODO: Support attaching private drives when not logged in
+      throw UnimplementedError();
+    }
 
-    final companion = DrivesCompanion.insert(
+    var companion = DrivesCompanion.insert(
       id: entity.id!,
       name: name,
       ownerAddress: entity.ownerAddress,
@@ -123,8 +128,14 @@ class DriveDao extends DatabaseAccessor<Database> with _$DriveDaoMixin {
       dateCreated: Value(entity.createdAt),
       lastUpdated: Value(entity.createdAt),
     );
-
-    return into(drives).insert(
+    if (entity.privacy == DrivePrivacy.private) {
+      companion = await _addDriveKeyToDriveCompanion(
+        companion,
+        profileKey!,
+        driveKey!,
+      );
+    }
+    await into(drives).insert(
       companion,
       onConflict: DoUpdate((_) => companion.copyWith(dateCreated: null)),
     );

--- a/lib/pages/app_route_path.dart
+++ b/lib/pages/app_route_path.dart
@@ -10,6 +10,9 @@ class AppRoutePath {
   final String? driveName;
   final String? driveFolderId;
 
+  final SecretKey? sharedDriveKey;
+  final String? sharedRawDriveKey;
+
   final String? sharedFileId;
 
   /// The private key of the corresponding shared file.
@@ -23,6 +26,8 @@ class AppRoutePath {
     this.driveId,
     this.driveName,
     this.driveFolderId,
+    this.sharedDriveKey,
+    this.sharedRawDriveKey,
     this.sharedFileId,
     this.sharedFileKey,
     this.sharedRawFileKey,
@@ -32,9 +37,18 @@ class AppRoutePath {
   factory AppRoutePath.signIn() => AppRoutePath(signingIn: true);
 
   /// Creates a route that points to a particular drive.
-  factory AppRoutePath.driveDetail(
-          {required String driveId, String? driveName}) =>
-      AppRoutePath(driveId: driveId, driveName: driveName);
+  factory AppRoutePath.driveDetail({
+    required String driveId,
+    String? driveName,
+    SecretKey? sharedDrivePk,
+    String? sharedRawDriveKey,
+  }) =>
+      AppRoutePath(
+        driveId: driveId,
+        driveName: driveName,
+        sharedDriveKey: sharedDrivePk,
+        sharedRawDriveKey: sharedRawDriveKey,
+      );
 
   /// Creates a route that points to a folder in a particular drive.
   factory AppRoutePath.folderDetail({

--- a/lib/pages/app_router_delegate.dart
+++ b/lib/pages/app_router_delegate.dart
@@ -19,6 +19,9 @@ class AppRouterDelegate extends RouterDelegate<AppRoutePath>
   String? driveName;
   String? driveFolderId;
 
+  SecretKey? sharedDriveKey;
+  String? sharedRawDriveKey;
+
   String? sharedFileId;
   SecretKey? sharedFileKey;
   String? sharedRawFileKey;
@@ -26,6 +29,7 @@ class AppRouterDelegate extends RouterDelegate<AppRoutePath>
   bool canAnonymouslyShowDriveDetail(ProfileState profileState) =>
       profileState is ProfileUnavailable && tryingToViewDrive;
   bool get tryingToViewDrive => driveId != null;
+  bool get tryingToViewSharedPrivateDrive => sharedDriveKey != null;
   bool get isViewingSharedFile => sharedFileId != null;
 
   @override
@@ -33,6 +37,8 @@ class AppRouterDelegate extends RouterDelegate<AppRoutePath>
         signingIn: signingIn,
         driveId: driveId,
         driveName: driveName,
+        sharedDriveKey: sharedDriveKey,
+        sharedRawDriveKey: sharedRawDriveKey,
         driveFolderId: driveFolderId,
         sharedFileId: sharedFileId,
         sharedFileKey: sharedFileKey,
@@ -132,11 +138,11 @@ class AppRouterDelegate extends RouterDelegate<AppRoutePath>
                           clearState();
                           return;
                         }
-
                         attachDrive(
                           context: context,
                           initialDriveId: driveId,
                           driveName: driveName,
+                          //sharedDriveKey: sharedDriveKey,
                         );
                       }
                     },
@@ -219,6 +225,8 @@ class AppRouterDelegate extends RouterDelegate<AppRoutePath>
     driveId = path.driveId;
     driveName = path.driveName;
     driveFolderId = path.driveFolderId;
+    sharedDriveKey = path.sharedDriveKey;
+    sharedRawDriveKey = path.sharedRawDriveKey;
     sharedFileId = path.sharedFileId;
     sharedFileKey = path.sharedFileKey;
     sharedRawFileKey = path.sharedRawFileKey;
@@ -229,6 +237,8 @@ class AppRouterDelegate extends RouterDelegate<AppRoutePath>
     driveId = null;
     driveName = null;
     driveFolderId = null;
+    sharedDriveKey = null;
+    sharedRawDriveKey = null;
     sharedFileId = null;
     sharedFileKey = null;
     sharedRawFileKey = null;

--- a/lib/pages/app_router_delegate.dart
+++ b/lib/pages/app_router_delegate.dart
@@ -140,9 +140,9 @@ class AppRouterDelegate extends RouterDelegate<AppRoutePath>
                         }
                         attachDrive(
                           context: context,
-                          initialDriveId: driveId,
+                          driveId: driveId,
                           driveName: driveName,
-                          //sharedDriveKey: sharedDriveKey,
+                          driveKey: sharedDriveKey,
                         );
                       }
                     },

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -358,14 +358,7 @@ class ArweaveService {
 
     final driveTx = queryEdges.first.node;
 
-    switch (driveTx.getTag(EntityTag.drivePrivacy)) {
-      case DrivePrivacy.public:
-        return DrivePrivacy.public;
-      case DrivePrivacy.private:
-        return DrivePrivacy.private;
-      default:
-        return null;
-    }
+    return driveTx.getTag(EntityTag.drivePrivacy);
   }
 
   /// Gets the owner of the drive sorted by blockheight.

--- a/test/blocs/drive_attach_cubit_test.dart
+++ b/test/blocs/drive_attach_cubit_test.dart
@@ -101,7 +101,7 @@ void main() {
     });
 
     blocTest<DriveAttachCubit, DriveAttachState>(
-      'attach drive, start sync and select the drive when given valid public drive details',
+      'attach drive should start sync and should select the drive when given valid public drive details',
       build: () => driveAttachCubit,
       setUp: () {},
       act: (bloc) {
@@ -201,7 +201,7 @@ void main() {
       );
 
       blocTest<DriveAttachCubit, DriveAttachState>(
-        'attach drive, start sync and select the drive when given valid private drive details',
+        'attach drive should start sync and should select the drive when given valid private drive details',
         build: () => DriveAttachCubit(
           arweave: arweave,
           driveDao: driveDao,

--- a/test/blocs/drive_attach_cubit_test.dart
+++ b/test/blocs/drive_attach_cubit_test.dart
@@ -16,6 +16,7 @@ void main() {
     late DriveDao driveDao;
     late SyncCubit syncBloc;
     late DrivesCubit drivesBloc;
+    late ProfileCubit profileCubit;
     late DriveAttachCubit driveAttachCubit;
 
     const validDriveId = 'valid-drive-id';
@@ -32,18 +33,19 @@ void main() {
       driveDao = MockDriveDao();
       syncBloc = MockSyncBloc();
       drivesBloc = MockDrivesCubit();
-
+      profileCubit = MockProfileCubit();
       when(() => arweave.getLatestDriveEntityWithId(validDriveId))
           .thenAnswer((_) => Future.value(DriveEntity()));
 
       when(() => arweave.getLatestDriveEntityWithId(notFoundDriveId))
           .thenAnswer((_) => Future.value(null));
-
+      profileCubit.emit(ProfileLoggingOut());
       driveAttachCubit = DriveAttachCubit(
         arweave: arweave,
         driveDao: driveDao,
         syncBloc: syncBloc,
         drivesBloc: drivesBloc,
+        profileCubit: profileCubit,
       );
     });
 
@@ -68,7 +70,7 @@ void main() {
     );
 
     blocTest<DriveAttachCubit, DriveAttachState>(
-      'set form "${AppValidationMessage.driveNotFound}" error when no valid drive could be found',
+      'set form "${AppValidationMessage.driveAttachDriveNotFound}" error when no valid drive could be found',
       build: () => driveAttachCubit,
       act: (bloc) {
         bloc.form.value = {

--- a/test/blocs/drive_attach_cubit_test.dart
+++ b/test/blocs/drive_attach_cubit_test.dart
@@ -1,9 +1,15 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:ardrive/blocs/blocs.dart';
 import 'package:ardrive/entities/entities.dart';
 import 'package:ardrive/l11n/l11n.dart';
 import 'package:ardrive/models/models.dart';
 import 'package:ardrive/services/services.dart';
+import 'package:arweave/utils.dart';
 import 'package:bloc_test/bloc_test.dart';
+import 'package:cryptography/cryptography.dart';
+import 'package:cryptography/helpers.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
@@ -19,6 +25,13 @@ void main() {
     late DrivesCubit drivesBloc;
     late ProfileCubit profileCubit;
     late DriveAttachCubit driveAttachCubit;
+
+    const validPrivateDriveId = 'valid-private-drive-id';
+    const validPrivateDriveKeyBase64 =
+        'a6U1qYiJNNNfX6RqhCUGpwOfRN3ZdAiQl7LHywqIJTk';
+    final validPrivateDriveKey = SecretKey(
+      decodeBase64ToBytes(validPrivateDriveKeyBase64),
+    );
 
     const validDriveId = 'valid-drive-id';
     const validDriveName = 'valid-drive-name';
@@ -50,12 +63,34 @@ void main() {
         ),
       );
 
+      when(() => arweave.getLatestDriveEntityWithId(
+            validPrivateDriveId,
+            validPrivateDriveKey,
+          )).thenAnswer(
+        (_) => Future.value(
+          DriveEntity(
+            id: validPrivateDriveId,
+            name: validDriveName,
+            privacy: DrivePrivacy.private,
+            rootFolderId: validRootFolderId,
+            authMode: DriveAuthMode.password,
+          )..ownerAddress = ownerAddress,
+        ),
+      );
+
+      when(() => arweave.getLatestDriveEntityWithId(validPrivateDriveId))
+          .thenAnswer((_) => Future.value(null));
+
       when(() => arweave.getLatestDriveEntityWithId(notFoundDriveId))
           .thenAnswer((_) => Future.value(null));
       when(() => arweave.getDrivePrivacyForId(validDriveId))
           .thenAnswer((_) => Future.value(DrivePrivacy.public));
+      when(() => arweave.getDrivePrivacyForId(validPrivateDriveId))
+          .thenAnswer((_) => Future.value(DrivePrivacy.private));
+
       when(() => syncBloc.startSync()).thenAnswer((_) => Future.value(null));
-      profileCubit.emit(ProfileLoggingOut());
+      when(() => profileCubit.state).thenAnswer((_) => ProfilePromptAdd());
+
       driveAttachCubit = DriveAttachCubit(
         arweave: arweave,
         driveDao: driveDao,
@@ -66,7 +101,7 @@ void main() {
     });
 
     blocTest<DriveAttachCubit, DriveAttachState>(
-      'attach drive and trigger actions when given valid details',
+      'attach drive and trigger actions when given valid public drive details',
       build: () => driveAttachCubit,
       setUp: () {},
       act: (bloc) {
@@ -85,6 +120,108 @@ void main() {
         verify(() => drivesBloc.selectDrive(validDriveId)).called(1);
       },
     );
+
+    blocTest<DriveAttachCubit, DriveAttachState>(
+      'driveKey field is added to form when private drive id is used',
+      build: () => driveAttachCubit,
+      setUp: () {},
+      act: (bloc) {
+        bloc.form.value = {
+          'driveId': validPrivateDriveId,
+        };
+        bloc.form.updateValueAndValidity();
+      },
+      wait: Duration(milliseconds: 1000),
+      verify: (bloc) {
+        expect(bloc.form.contains('driveKey'), isTrue);
+      },
+    );
+    blocTest<DriveAttachCubit, DriveAttachState>(
+      'initializeForm on attaching private drive while logged out emits correct states',
+      build: () => driveAttachCubit,
+      setUp: () {
+        when(() => profileCubit.state).thenAnswer((_) => ProfilePromptAdd());
+      },
+      act: (bloc) async {
+        await bloc.initializeForm(
+          driveId: validPrivateDriveId,
+          driveKey: validPrivateDriveKey,
+          driveName: validDriveName,
+        );
+      },
+      expect: () => [DriveAttachPrivateNotLoggedIn()],
+    );
+
+    group('attach private drive while logged in', () {
+      final invalidDriveKeyBase64 = base64Encode(Uint8List(32));
+      final invalidDriveKey = SecretKey(
+        decodeBase64ToBytes(invalidDriveKeyBase64),
+      );
+      setUp(() async {
+        final keyBytes = Uint8List(32);
+        fillBytesWithSecureRandom(keyBytes);
+        final wallet = getTestWallet();
+        when(() => profileCubit.state).thenReturn(
+          ProfileLoggedIn(
+            username: '',
+            password: '123',
+            wallet: wallet,
+            cipherKey: SecretKey(keyBytes),
+            walletAddress: await wallet.getAddress(),
+            walletBalance: BigInt.one,
+          ),
+        );
+        when(() => arweave.getLatestDriveEntityWithId(
+              validPrivateDriveId,
+              invalidDriveKey,
+            )).thenAnswer((_) => Future.value(null));
+      });
+      blocTest<DriveAttachCubit, DriveAttachState>(
+        'does nothing when submitted without valid drive key',
+        build: () => driveAttachCubit,
+        act: (bloc) async {
+          await Future.microtask(() {
+            bloc.form.control('driveId').updateValue(validPrivateDriveId);
+          });
+          await Future.delayed(Duration(milliseconds: 1000));
+          bloc.form.control('driveKey').updateValue(invalidDriveKeyBase64);
+          await Future.delayed(Duration(milliseconds: 1000));
+          bloc.submit();
+        },
+        expect: () => [
+          DriveAttachPrivate(),
+        ],
+        wait: Duration(milliseconds: 1200),
+        verify: (_) async {
+          verifyZeroInteractions(syncBloc);
+          verifyZeroInteractions(drivesBloc);
+        },
+      );
+      blocTest<DriveAttachCubit, DriveAttachState>(
+        'attach drive and trigger actions when given valid private drive details',
+        build: () => DriveAttachCubit(
+          arweave: arweave,
+          driveDao: driveDao,
+          syncBloc: syncBloc,
+          drivesBloc: drivesBloc,
+          profileCubit: profileCubit,
+          driveId: validPrivateDriveId,
+          driveName: validDriveName,
+          driveKey: validPrivateDriveKey,
+        ),
+        expect: () => [
+          DriveAttachInProgress(),
+          DriveAttachSuccess(),
+          // This state is here after DriveAttachSuccess due to debounced validation after drive attaches
+          DriveAttachPrivate(),
+        ],
+        wait: Duration(milliseconds: 1200),
+        verify: (_) async {
+          verify(() => syncBloc.startSync()).called(1);
+          verify(() => drivesBloc.selectDrive(validPrivateDriveId)).called(1);
+        },
+      );
+    });
 
     blocTest<DriveAttachCubit, DriveAttachState>(
       'set form "${AppValidationMessage.driveAttachDriveNotFound}" error when no valid drive could be found',

--- a/test/blocs/drive_attach_cubit_test.dart
+++ b/test/blocs/drive_attach_cubit_test.dart
@@ -157,6 +157,7 @@ void main() {
       final invalidDriveKey = SecretKey(
         decodeBase64ToBytes(invalidDriveKeyBase64),
       );
+
       setUp(() async {
         final keyBytes = Uint8List(32);
         fillBytesWithSecureRandom(keyBytes);
@@ -176,6 +177,7 @@ void main() {
               invalidDriveKey,
             )).thenAnswer((_) => Future.value(null));
       });
+
       blocTest<DriveAttachCubit, DriveAttachState>(
         'does nothing when submitted without valid drive key',
         build: () => driveAttachCubit,
@@ -197,6 +199,7 @@ void main() {
           verifyZeroInteractions(drivesBloc);
         },
       );
+
       blocTest<DriveAttachCubit, DriveAttachState>(
         'attach drive and trigger actions when given valid private drive details',
         build: () => DriveAttachCubit(

--- a/test/blocs/drive_attach_cubit_test.dart
+++ b/test/blocs/drive_attach_cubit_test.dart
@@ -101,7 +101,7 @@ void main() {
     });
 
     blocTest<DriveAttachCubit, DriveAttachState>(
-      'attach drive and trigger actions when given valid public drive details',
+      'attach drive, start sync and select the drive when given valid public drive details',
       build: () => driveAttachCubit,
       setUp: () {},
       act: (bloc) {
@@ -201,16 +201,16 @@ void main() {
       );
 
       blocTest<DriveAttachCubit, DriveAttachState>(
-        'attach drive and trigger actions when given valid private drive details',
+        'attach drive, start sync and select the drive when given valid private drive details',
         build: () => DriveAttachCubit(
           arweave: arweave,
           driveDao: driveDao,
           syncBloc: syncBloc,
           drivesBloc: drivesBloc,
           profileCubit: profileCubit,
-          driveId: validPrivateDriveId,
-          driveName: validDriveName,
-          driveKey: validPrivateDriveKey,
+          initialDriveId: validPrivateDriveId,
+          initialDriveName: validDriveName,
+          initialDriveKey: validPrivateDriveKey,
         ),
         expect: () => [
           DriveAttachInProgress(),


### PR DESCRIPTION
Adds support for attaching private drives both through the attach form and through a shared link.

Suggested Review Order:
1. drive_attach_cubit.dart
2. drive_dao.dart
(Added support for attaching private drives)
3. app_route_information_parser.dart, app_router_delegate.dart, app_route_path.dart 
(Updated routing to support driveKey)
5. drive_attach_cubit_test.dart
(Expanded drive attach cubit tests)

To support attaching private drives, the writeDriveEntity function was updated to take in a driveKey and to write private drives to the database. A getDrivePrivacyForId function was added to arweave_service to fetch the privacy tag value of a drive with the given drive id.

A new driveKey field was added to drive_attach_form and drive_attach_cubit which is only visible when the given drive id is private. To validate the drive id we try to decrypt the drive name for the provided drive. If incorrect the driveKey form will show a valdation error. If correct we encrypt and store the driveKey with the user's password, and then sync and attach the private drive. 