### PR TITLE
Pe-1003 skip file conflicts on upload

### DIFF
--- a/lib/blocs/upload/enums/conflicting_files_actions.dart
+++ b/lib/blocs/upload/enums/conflicting_files_actions.dart
@@ -1,0 +1,6 @@
+/// Actions that the user can take to handle conflicting files.
+///
+/// `Skip` Will ignore the files and don't upload them.
+///
+/// `Replace` will upload the conflicting file and replace the existent.
+enum ConflictingFileActions { Skip, Replace }

--- a/lib/blocs/upload/upload_cubit.dart
+++ b/lib/blocs/upload/upload_cubit.dart
@@ -2,25 +2,19 @@ import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:ardrive/blocs/upload/cost_estimate.dart';
-import 'package:ardrive/blocs/upload/data_item_upload_handle.dart';
 import 'package:ardrive/blocs/upload/upload_plan.dart';
-import 'package:ardrive/entities/entities.dart';
 import 'package:ardrive/models/models.dart';
 import 'package:ardrive/services/services.dart';
 import 'package:ardrive/utils/upload_plan_utils.dart';
-import 'package:arweave/arweave.dart';
 import 'package:bloc/bloc.dart';
-import 'package:cryptography/cryptography.dart';
 import 'package:equatable/equatable.dart';
 import 'package:file_selector/file_selector.dart';
 import 'package:meta/meta.dart';
-import 'package:mime/mime.dart';
 import 'package:pedantic/pedantic.dart';
 import 'package:uuid/uuid.dart';
 
 import '../blocs.dart';
 import 'enums/conflicting_files_actions.dart';
-import 'file_upload_handle.dart';
 
 part 'upload_state.dart';
 
@@ -221,68 +215,6 @@ class UploadCubit extends Cubit<UploadState> {
     unawaited(_profileCubit.refreshBalance());
 
     emit(UploadComplete());
-  }
-
-  Future<UploadPlan> xfilesToUploadPlan({
-    required List<XFile> files,
-    required SecretKey cipherKey,
-    required Wallet wallet,
-  }) async {
-    final _dataItemUploadHandles = <String, DataItemUploadHandle>{};
-    final _v2FileUploadHandles = <String, FileUploadHandle>{};
-    for (var file in files) {
-      final fileName = file.name;
-      final filePath = '${_targetFolder.path}/$fileName';
-      final fileSize = await file.length();
-      final fileEntity = FileEntity(
-        driveId: _targetDrive.id,
-        name: fileName,
-        size: fileSize,
-        lastModifiedDate: await file.lastModified(),
-        parentFolderId: _targetFolder.id,
-        dataContentType: lookupMimeType(fileName) ?? 'application/octet-stream',
-      );
-
-      // If this file conflicts with one that already exists in the target folder reuse the id of the conflicting file.
-      fileEntity.id = conflictingFiles[fileName] ?? _uuid.v4();
-
-      final private = _targetDrive.isPrivate;
-      final driveKey = private
-          ? await _driveDao.getDriveKey(_targetDrive.id, cipherKey)
-          : null;
-      final fileKey =
-          private ? await deriveFileKey(driveKey!, fileEntity.id!) : null;
-
-      final revisionAction = !conflictingFiles.containsKey(file.name)
-          ? RevisionAction.create
-          : RevisionAction.uploadNewVersion;
-
-      if (fileSize < bundleSizeLimit) {
-        _dataItemUploadHandles[fileEntity.id!] = DataItemUploadHandle(
-          entity: fileEntity,
-          path: filePath,
-          file: file,
-          driveKey: driveKey,
-          fileKey: fileKey,
-          arweave: _arweave,
-          wallet: wallet,
-          revisionAction: revisionAction,
-        );
-      } else {
-        _v2FileUploadHandles[fileEntity.id!] = FileUploadHandle(
-          entity: fileEntity,
-          path: filePath,
-          file: file,
-          driveKey: driveKey,
-          fileKey: fileKey,
-          revisionAction: revisionAction,
-        );
-      }
-    }
-    return UploadPlan.create(
-      v2FileUploadHandles: _v2FileUploadHandles,
-      dataItemUploadHandles: _dataItemUploadHandles,
-    );
   }
 
   void _removeConflictingFiles() {

--- a/lib/blocs/upload/upload_cubit.dart
+++ b/lib/blocs/upload/upload_cubit.dart
@@ -56,13 +56,13 @@ class UploadCubit extends Cubit<UploadState> {
         _uploadPlanUtils = uploadPlanUtils,
         super(UploadPreparationInProgress());
 
-  Future<void> initializeCubit() async {
+  Future<void> getDriveInformation() async {
     _targetDrive = await _driveDao.driveById(driveId: driveId).getSingle();
     _targetFolder = await _driveDao
         .folderById(driveId: driveId, folderId: folderId)
         .getSingle();
 
-    emit(UploadCubitInitialized());
+    emit(UploadPreparationInitialized());
   }
 
   /// Tries to find a files that conflict with the files in the target folder.

--- a/lib/blocs/upload/upload_cubit.dart
+++ b/lib/blocs/upload/upload_cubit.dart
@@ -11,7 +11,6 @@ import 'package:equatable/equatable.dart';
 import 'package:file_selector/file_selector.dart';
 import 'package:meta/meta.dart';
 import 'package:pedantic/pedantic.dart';
-import 'package:uuid/uuid.dart';
 
 import '../blocs.dart';
 import 'enums/conflicting_files_actions.dart';
@@ -19,7 +18,6 @@ import 'enums/conflicting_files_actions.dart';
 part 'upload_state.dart';
 
 final privateFileSizeLimit = 104857600;
-// The tests fails when we try to parse to int
 final publicFileSizeLimit = 1.25 * math.pow(10, 9);
 final minimumPstTip = BigInt.from(10000000);
 
@@ -28,7 +26,6 @@ class UploadCubit extends Cubit<UploadState> {
   final String folderId;
   final List<XFile> files;
 
-  final _uuid = Uuid();
   final ProfileCubit _profileCubit;
   final DriveDao _driveDao;
   final ArweaveService _arweave;

--- a/lib/blocs/upload/upload_cubit.dart
+++ b/lib/blocs/upload/upload_cubit.dart
@@ -56,12 +56,11 @@ class UploadCubit extends Cubit<UploadState> {
         _uploadPlanUtils = uploadPlanUtils,
         super(UploadPreparationInProgress());
 
-  Future<void> getDriveInformation() async {
+  Future<void> startUploadPreparation() async {
     _targetDrive = await _driveDao.driveById(driveId: driveId).getSingle();
     _targetFolder = await _driveDao
         .folderById(driveId: driveId, folderId: folderId)
         .getSingle();
-
     emit(UploadPreparationInitialized());
   }
 

--- a/lib/blocs/upload/upload_state.dart
+++ b/lib/blocs/upload/upload_state.dart
@@ -14,6 +14,8 @@ class UploadPreparationInProgress extends UploadState {
   List<Object> get props => [isArConnect];
 }
 
+class UploadCubitInitialized extends UploadState {}
+
 class UploadPreparationFailure extends UploadState {}
 
 class UploadSigningInProgress extends UploadState {

--- a/lib/blocs/upload/upload_state.dart
+++ b/lib/blocs/upload/upload_state.dart
@@ -31,9 +31,10 @@ class UploadFileConflict extends UploadState {
   final List<String> conflictingFileNames;
   final bool isAllFilesConflicting;
 
-  UploadFileConflict(
-      {required this.conflictingFileNames,
-      required this.isAllFilesConflicting});
+  UploadFileConflict({
+    required this.conflictingFileNames,
+    required this.isAllFilesConflicting,
+  });
 
   @override
   List<Object> get props => [conflictingFileNames];

--- a/lib/blocs/upload/upload_state.dart
+++ b/lib/blocs/upload/upload_state.dart
@@ -27,8 +27,11 @@ class UploadSigningInProgress extends UploadState {
 
 class UploadFileConflict extends UploadState {
   final List<String> conflictingFileNames;
+  final bool isAllFilesConflicting;
 
-  UploadFileConflict({required this.conflictingFileNames});
+  UploadFileConflict(
+      {required this.conflictingFileNames,
+      required this.isAllFilesConflicting});
 
   @override
   List<Object> get props => [conflictingFileNames];

--- a/lib/blocs/upload/upload_state.dart
+++ b/lib/blocs/upload/upload_state.dart
@@ -14,7 +14,7 @@ class UploadPreparationInProgress extends UploadState {
   List<Object> get props => [isArConnect];
 }
 
-class UploadCubitInitialized extends UploadState {}
+class UploadPreparationInitialized extends UploadState {}
 
 class UploadPreparationFailure extends UploadState {}
 

--- a/lib/components/upload_form.dart
+++ b/lib/components/upload_form.dart
@@ -1,4 +1,5 @@
 import 'package:ardrive/blocs/blocs.dart';
+import 'package:ardrive/blocs/upload/enums/conflicting_files_actions.dart';
 import 'package:ardrive/models/models.dart';
 import 'package:ardrive/pages/congestion_warning_wrapper.dart';
 import 'package:ardrive/services/services.dart';
@@ -80,12 +81,21 @@ class UploadForm extends StatelessWidget {
                   onPressed: () => Navigator.of(context).pop(false),
                   child: Text('CANCEL'),
                 ),
+                if (!state.isAllFilesConflicting)
+                  ElevatedButton(
+                    onPressed: () => context
+                        .read<UploadCubit>()
+                        .prepareUploadPlanAndCostEstimates(
+                            conflictingFileAction: ConflictingFileActions.Skip),
+                    child: Text('SKIP'),
+                  ),
                 ElevatedButton(
-                  onPressed: () => context
-                      .read<UploadCubit>()
-                      .prepareUploadPlanAndCostEstimates(),
-                  child: Text('CONTINUE'),
-                ),
+                    onPressed: () => context
+                        .read<UploadCubit>()
+                        .prepareUploadPlanAndCostEstimates(
+                            conflictingFileAction:
+                                ConflictingFileActions.Replace),
+                    child: Text('REPLACE')),
               ],
             );
           } else if (state is UploadFileTooLarge) {

--- a/lib/components/upload_form.dart
+++ b/lib/components/upload_form.dart
@@ -28,8 +28,9 @@ Future<void> promptToUploadFile(
       builder: (_) => BlocProvider<UploadCubit>(
         create: (context) => UploadCubit(
           uploadPlanUtils: UploadPlanUtils(
-              arweave: context.read<ArweaveService>(),
-              driveDao: context.read<DriveDao>()),
+            arweave: context.read<ArweaveService>(),
+            driveDao: context.read<DriveDao>(),
+          ),
           driveId: driveId,
           folderId: folderId,
           files: selectedFiles,

--- a/lib/components/upload_form.dart
+++ b/lib/components/upload_form.dart
@@ -37,7 +37,7 @@ Future<void> promptToUploadFile(
           arweave: context.read<ArweaveService>(),
           pst: context.read<PstService>(),
           driveDao: context.read<DriveDao>(),
-        )..initializeCubit(),
+        )..startUploadPreparation(),
         child: UploadForm(),
       ),
       barrierDismissible: false,
@@ -51,7 +51,7 @@ class UploadForm extends StatelessWidget {
         listener: (context, state) async {
           if (state is UploadComplete || state is UploadWalletMismatch) {
             Navigator.pop(context);
-          } else if (state is UploadCubitInitialized) {
+          } else if (state is UploadPreparationInitialized) {
             await context.read<UploadCubit>().checkConflictingFiles();
           }
           if (state is UploadWalletMismatch) {
@@ -59,7 +59,6 @@ class UploadForm extends StatelessWidget {
             await context.read<ProfileCubit>().logoutProfile();
           }
         },
-        // buildWhen: (_, currentState) => currentState is UploadCubitInitialized,
         builder: (context, state) {
           if (state is UploadFileConflict) {
             return AppDialog(
@@ -132,7 +131,8 @@ class UploadForm extends StatelessWidget {
                 ),
               ],
             );
-          } else if (state is UploadPreparationInProgress) {
+          } else if (state is UploadPreparationInProgress ||
+              state is UploadPreparationInitialized) {
             return AppDialog(
               title: 'Preparing upload...',
               content: SizedBox(
@@ -142,7 +142,8 @@ class UploadForm extends StatelessWidget {
                   children: <Widget>[
                     const CircularProgressIndicator(),
                     const SizedBox(height: 16),
-                    if (state.isArConnect)
+                    if (state is UploadPreparationInProgress &&
+                        state.isArConnect)
                       Text(
                         'CAUTION: Your Web3 wallet is signing your transactions. Please remain on this tab until it has completed.',
                       )

--- a/lib/pages/drive_detail/components/drive_file_drop_zone.dart
+++ b/lib/pages/drive_detail/components/drive_file_drop_zone.dart
@@ -2,6 +2,7 @@ import 'package:ardrive/blocs/blocs.dart';
 import 'package:ardrive/components/upload_form.dart';
 import 'package:ardrive/models/daos/drive_dao/drive_dao.dart';
 import 'package:ardrive/services/services.dart';
+import 'package:ardrive/utils/upload_plan_utils.dart';
 import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -111,6 +112,9 @@ class _DriveFileDropZoneState extends State<DriveFileDropZone> {
           context: context,
           builder: (_) => BlocProvider<UploadCubit>(
             create: (context) => UploadCubit(
+              uploadPlanUtils: UploadPlanUtils(
+                  arweave: context.read<ArweaveService>(),
+                  driveDao: context.read<DriveDao>()),
               driveId: driveId,
               folderId: folderId,
               files: selectedFiles,
@@ -118,7 +122,7 @@ class _DriveFileDropZoneState extends State<DriveFileDropZone> {
               pst: context.read<PstService>(),
               profileCubit: context.read<ProfileCubit>(),
               driveDao: context.read<DriveDao>(),
-            ),
+            )..initializeCubit(),
             child: UploadForm(),
           ),
           barrierDismissible: false,

--- a/lib/pages/drive_detail/components/drive_file_drop_zone.dart
+++ b/lib/pages/drive_detail/components/drive_file_drop_zone.dart
@@ -122,7 +122,7 @@ class _DriveFileDropZoneState extends State<DriveFileDropZone> {
               pst: context.read<PstService>(),
               profileCubit: context.read<ProfileCubit>(),
               driveDao: context.read<DriveDao>(),
-            )..initializeCubit(),
+            )..startUploadPreparation(),
             child: UploadForm(),
           ),
           barrierDismissible: false,

--- a/lib/pages/drive_detail/components/drive_file_drop_zone.dart
+++ b/lib/pages/drive_detail/components/drive_file_drop_zone.dart
@@ -113,8 +113,9 @@ class _DriveFileDropZoneState extends State<DriveFileDropZone> {
           builder: (_) => BlocProvider<UploadCubit>(
             create: (context) => UploadCubit(
               uploadPlanUtils: UploadPlanUtils(
-                  arweave: context.read<ArweaveService>(),
-                  driveDao: context.read<DriveDao>()),
+                arweave: context.read<ArweaveService>(),
+                driveDao: context.read<DriveDao>(),
+              ),
               driveId: driveId,
               folderId: folderId,
               files: selectedFiles,

--- a/lib/utils/upload_plan_utils.dart
+++ b/lib/utils/upload_plan_utils.dart
@@ -1,0 +1,88 @@
+import 'package:ardrive/blocs/upload/upload_plan.dart';
+import 'package:ardrive/models/daos/daos.dart';
+import 'package:ardrive/models/drive.dart';
+import 'package:ardrive/services/arweave/arweave.dart';
+import 'package:arweave/arweave.dart';
+import 'package:cryptography/cryptography.dart';
+import 'package:file_selector/file_selector.dart';
+import 'package:mime/mime.dart';
+import 'package:uuid/uuid.dart';
+
+import '../blocs/upload/data_item_upload_handle.dart';
+import '../blocs/upload/file_upload_handle.dart';
+import '../entities/file_entity.dart';
+import '../models/database/database.dart';
+import '../models/enums.dart';
+import '../services/crypto/keys.dart';
+
+class UploadPlanUtils {
+  UploadPlanUtils({required this.arweave, required this.driveDao});
+
+  final ArweaveService arweave;
+  final DriveDao driveDao;
+  final _uuid = Uuid();
+
+  Future<UploadPlan> xfilesToUploadPlan(
+      {required List<XFile> files,
+      required SecretKey cipherKey,
+      required Wallet wallet,
+      required Map<String, String> conflictingFiles,
+      required Drive targetDrive,
+      required FolderEntry folderEntry}) async {
+    final _dataItemUploadHandles = <String, DataItemUploadHandle>{};
+    final _v2FileUploadHandles = <String, FileUploadHandle>{};
+    for (var file in files) {
+      final fileName = file.name;
+      final filePath = '${folderEntry.path}/$fileName';
+      final fileSize = await file.length();
+      final fileEntity = FileEntity(
+        driveId: targetDrive.id,
+        name: fileName,
+        size: fileSize,
+        lastModifiedDate: await file.lastModified(),
+        parentFolderId: folderEntry.id,
+        dataContentType: lookupMimeType(fileName) ?? 'application/octet-stream',
+      );
+
+      // If this file conflicts with one that already exists in the target folder reuse the id of the conflicting file.
+      fileEntity.id = conflictingFiles[fileName] ?? _uuid.v4();
+
+      final private = targetDrive.isPrivate;
+      final driveKey = private
+          ? await driveDao.getDriveKey(targetDrive.id, cipherKey)
+          : null;
+      final fileKey =
+          private ? await deriveFileKey(driveKey!, fileEntity.id!) : null;
+
+      final revisionAction = !conflictingFiles.containsKey(file.name)
+          ? RevisionAction.create
+          : RevisionAction.uploadNewVersion;
+
+      if (fileSize < bundleSizeLimit) {
+        _dataItemUploadHandles[fileEntity.id!] = DataItemUploadHandle(
+          entity: fileEntity,
+          path: filePath,
+          file: file,
+          driveKey: driveKey,
+          fileKey: fileKey,
+          arweave: arweave,
+          wallet: wallet,
+          revisionAction: revisionAction,
+        );
+      } else {
+        _v2FileUploadHandles[fileEntity.id!] = FileUploadHandle(
+          entity: fileEntity,
+          path: filePath,
+          file: file,
+          driveKey: driveKey,
+          fileKey: fileKey,
+          revisionAction: revisionAction,
+        );
+      }
+    }
+    return UploadPlan.create(
+      v2FileUploadHandles: _v2FileUploadHandles,
+      dataItemUploadHandles: _dataItemUploadHandles,
+    );
+  }
+}

--- a/test/blocs/upload_cubit_test.dart
+++ b/test/blocs/upload_cubit_test.dart
@@ -1,0 +1,213 @@
+import 'dart:typed_data';
+
+import 'package:ardrive/blocs/blocs.dart';
+import 'package:ardrive/blocs/upload/upload_plan.dart';
+import 'package:ardrive/models/daos/drive_dao/drive_dao.dart';
+import 'package:ardrive/models/database/database.dart';
+import 'package:arweave/arweave.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:cryptography/cryptography.dart';
+import 'package:cryptography/helpers.dart';
+import 'package:file_selector/file_selector.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../test_utils/utils.dart';
+
+// TODO: Test prepareUploadPlanAndCostEstimates
+// TODO: Test startUpload
+void main() {
+  // Mocks
+  late DriveDao mockDriveDao;
+  late MockArweaveService mockArweave;
+  late MockPstService mockPst;
+  late MockUploadPlanUtils mockUploadPlanUtils;
+  MockProfileCubit? mockProfileCubit;
+
+  const tDriveId = 'drive_id';
+  const tRootFolderId = 'root-folder-id';
+  const tRootFolderFileCount = 5;
+
+  const tNestedFolderId = 'nested-folder-id';
+  const tNestedFolderFileCount = 5;
+
+  const tEmptyNestedFolderIdPrefix = 'empty-nested-folder-id';
+  const tEmptyNestedFolderCount = 5;
+
+  late Database db;
+  late List<XFile> allConflictingFiles;
+  late List<XFile> someConflictingFiles;
+  late List<XFile> noConflictingFiles;
+
+  final wallet = getTestWallet();
+  String? walletAddress;
+
+  final keyBytes = Uint8List(32);
+  fillBytesWithSecureRandom(keyBytes);
+
+  setUpAll(() {
+    registerFallbackValue(SecretKey([]));
+    registerFallbackValue(Wallet());
+    registerFallbackValue(FolderEntry(
+        id: '',
+        dateCreated: DateTime.now(),
+        driveId: '',
+        isGhost: false,
+        lastUpdated: DateTime.now(),
+        name: '',
+        parentFolderId: '',
+        path: ''));
+
+    registerFallbackValue(Drive(
+        id: '',
+        rootFolderId: '',
+        name: '',
+        ownerAddress: '',
+        dateCreated: DateTime.now(),
+        lastUpdated: DateTime.now(),
+        privacy: ''));
+  });
+
+  UploadCubit getUploadCubitInstanceWith(List<XFile> files) {
+    return UploadCubit(
+        uploadPlanUtils: mockUploadPlanUtils,
+        driveId: tDriveId,
+        folderId: tRootFolderId,
+        files: files,
+        profileCubit: mockProfileCubit!,
+        driveDao: mockDriveDao,
+        arweave: mockArweave,
+        pst: mockPst);
+  }
+
+  setUp(() async {
+    db = getTestDb();
+
+    final _testFile = XFile('assets/config/dev.json');
+
+    // the `addTestFilesToDb` will generate files with this path and name.
+    final conflictingFile = XFile(tRootFolderId + '1');
+
+    // Contains only conflicting files.
+    allConflictingFiles = <XFile>[conflictingFile];
+
+    /// This list contains conflicting and non conflicting files.
+    someConflictingFiles = <XFile>[conflictingFile, XFile('dumb_test_path')];
+
+    // This list doesn't has any conflicting files.
+    //
+    // We need a real file because in the UploadCubit we needs the size of the file.
+    // to know if the file is `tooLargeFiles`.
+    noConflictingFiles = <XFile>[_testFile];
+
+    // Initialize mocks
+    mockArweave = MockArweaveService();
+    mockPst = MockPstService();
+    mockDriveDao = db.driveDao;
+    mockProfileCubit = MockProfileCubit();
+    walletAddress = await wallet.getAddress();
+    mockUploadPlanUtils = MockUploadPlanUtils();
+
+    // Setup mock drive.
+    await addTestFilesToDb(
+      db,
+      driveId: tDriveId,
+      emptyNestedFolderCount: tEmptyNestedFolderCount,
+      emptyNestedFolderIdPrefix: tEmptyNestedFolderIdPrefix,
+      rootFolderId: tRootFolderId,
+      rootFolderFileCount: tRootFolderFileCount,
+      nestedFolderId: tNestedFolderId,
+      nestedFolderFileCount: tNestedFolderFileCount,
+    );
+  });
+  group('Testing checkConflictingFiles', () {
+    setUp(() {
+      when(() => mockProfileCubit!.state).thenReturn(
+        ProfileLoggedIn(
+          username: 'Test',
+          password: '123',
+          wallet: wallet,
+          walletAddress: walletAddress!,
+          walletBalance: BigInt.one,
+          cipherKey: SecretKey(keyBytes),
+        ),
+      );
+      when(() => mockProfileCubit!.checkIfWalletMismatch())
+          .thenAnswer((i) => Future.value(false));
+      when(() => mockProfileCubit!.isCurrentProfileArConnect())
+          .thenAnswer((i) => Future.value(false));
+      when(() => mockPst.getPSTFee(BigInt.zero))
+          .thenAnswer((invocation) => Future.value(BigInt.zero));
+      when(() => mockArweave.getArUsdConversionRate())
+          .thenAnswer((invocation) => Future.value(10));
+      when(() => mockUploadPlanUtils.xfilesToUploadPlan(
+              files: any(named: 'files'),
+              cipherKey: any(named: 'cipherKey'),
+              wallet: any(named: 'wallet'),
+              conflictingFiles: any(named: 'conflictingFiles'),
+              targetDrive: any(named: 'targetDrive'),
+              folderEntry: any<FolderEntry>(named: 'folderEntry')))
+          .thenAnswer((invocation) => Future.value(UploadPlan.create(
+              v2FileUploadHandles: {}, dataItemUploadHandles: {})));
+    });
+    blocTest<UploadCubit, UploadState>(
+        'Should emit UploadFileConflict with correctly file names and'
+        'isAllFilesConflicting true',
+        build: () {
+          return getUploadCubitInstanceWith(allConflictingFiles);
+        },
+        act: (cubit) async {
+          await cubit.initializeCubit();
+          await cubit.checkConflictingFiles();
+        },
+        tearDown: () async {
+          await db.close();
+        },
+        expect: () => <dynamic>[
+              TypeMatcher<UploadCubitInitialized>(),
+              TypeMatcher<UploadPreparationInProgress>(),
+              UploadFileConflict(
+                  isAllFilesConflicting: true,
+                  conflictingFileNames: [tRootFolderId + '1']),
+            ]);
+
+    blocTest<UploadCubit, UploadState>(
+        'Should emit UploadFileConflict with correctly file names '
+        'and isAllFilesConflicting false',
+        build: () {
+          return getUploadCubitInstanceWith(someConflictingFiles);
+        },
+        tearDown: () async {
+          await db.close();
+        },
+        act: (cubit) async {
+          await cubit.initializeCubit();
+          await cubit.checkConflictingFiles();
+        },
+        expect: () => <dynamic>[
+              TypeMatcher<UploadCubitInitialized>(),
+              TypeMatcher<UploadPreparationInProgress>(),
+              UploadFileConflict(
+                  isAllFilesConflicting: false,
+                  conflictingFileNames: [tRootFolderId + '1'])
+            ]);
+
+    blocTest<UploadCubit, UploadState>(
+        'Emits [UploadCubitInitialized,UploadPreparationInProgress, UploadReady] when there arent conflicting files.',
+        build: () {
+          return getUploadCubitInstanceWith(noConflictingFiles);
+        },
+        tearDown: () async {
+          await db.close();
+        },
+        act: (cubit) async {
+          await cubit.initializeCubit();
+          await cubit.checkConflictingFiles();
+        },
+        expect: () => <dynamic>[
+              TypeMatcher<UploadCubitInitialized>(),
+              TypeMatcher<UploadPreparationInProgress>(),
+              TypeMatcher<UploadReady>()
+            ]);
+  });
+}

--- a/test/test_utils/mocks.dart
+++ b/test/test_utils/mocks.dart
@@ -1,6 +1,7 @@
 import 'package:ardrive/blocs/blocs.dart';
 import 'package:ardrive/models/models.dart';
 import 'package:ardrive/services/services.dart';
+import 'package:ardrive/utils/upload_plan_utils.dart';
 import 'package:arweave/arweave.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/widgets.dart';
@@ -29,3 +30,7 @@ class MockProfileCubit extends MockCubit<ProfileState> implements ProfileCubit {
 }
 
 class MockUploadBloc extends MockCubit<UploadState> implements UploadCubit {}
+
+class MockPstService extends Mock implements PstService {}
+
+class MockUploadPlanUtils extends Mock implements UploadPlanUtils {}

--- a/web/index.html
+++ b/web/index.html
@@ -37,7 +37,7 @@
   <script defer src="avsc.min.js"></script>
   <script defer src="js/tagparser.js"></script>
   <script defer src="sql-wasm.js"></script>
-  <script src="main.dart.js?version=65" type="application/javascript"></script>
+  <script src="main.dart.js?version=66" type="application/javascript"></script>
   
 </body>
 


### PR DESCRIPTION
## Overview
When a user uploads files to a folder, a check is made to see if any existing file names conflict with the files being uploaded.  The user only has the option to replace the existing files and overwrite them with the new data.

Basically, it was added the `SKIP` button capability - it will ignore the conflicting files; And rename the `CONTINUE` button to `REPLACE` - this one still with the same behavior.

## Tests
This PR intends to implement the tests, specifically UploadCubit. To do so, I've needed to refactor some code:

#### UploadPlanUtils:
I moved the function `xfilesToUploadPlan` from `UploadCubit` to another class which was a hard function to mock. I called it UploadPlanUtils but I'm wondering about a better name.

#### UploadCubit:
I've changed the initialization of the object. Once we couldn't wait for the object initialization, it made weird behavior in the tests, like this:

<img width="602" alt="image" src="https://user-images.githubusercontent.com/32248947/157128367-6b658286-3423-4c16-a755-2ff5bb7cc6c9.png">

Instead, I move the object initialization to the `startUploadPreparation` function. To notify the page that the initialization was made, we could check by listening to the cubit and waiting for the `UploadCubitInitialized` state. It was implemented in the pages that use the UploadCubit.