### PR TITLE
fix(drive_detail): show txs from correct revision PE-905

### DIFF
--- a/lib/pages/drive_detail/components/fs_entry_side_sheet.dart
+++ b/lib/pages/drive_detail/components/fs_entry_side_sheet.dart
@@ -210,7 +210,7 @@ class FsEntrySideSheet extends StatelessWidget {
           builder: (context, state) {
             if (state is FsEntryActivitySuccess) {
               if (state.revisions.isNotEmpty) {
-                final revision = state.revisions.last;
+                final revision = state.revisions.first;
                 return DataTable(
                   // Hide the data table header.
 


### PR DESCRIPTION
Fixes a bug where the incorrect metadata, data and bundle tx ids were shown in the info panel.