### PR TITLE
fix(drive_detail): fix folder info metadata tx not being shown PE-1093

### DIFF
--- a/lib/pages/drive_detail/components/fs_entry_side_sheet.dart
+++ b/lib/pages/drive_detail/components/fs_entry_side_sheet.dart
@@ -250,8 +250,7 @@ class FsEntrySideSheet extends StatelessWidget {
                             ),
                           ),
                         ]),
-                    } else if (infoState
-                        is FsEntryInfoSuccess<FolderEntry>) ...{
+                    } else if (infoState is FsEntryInfoSuccess<FolderNode>) ...{
                       DataRow(cells: [
                         DataCell(Text('Metadata Tx ID')),
                         DataCell(


### PR DESCRIPTION
Corrects the type used in the folder info state.