### PR TITLE
fix(drive_detail): fix changed state not updating data table PE-1084

### DIFF
--- a/lib/blocs/drive_detail/drive_detail_state.dart
+++ b/lib/blocs/drive_detail/drive_detail_state.dart
@@ -27,6 +27,7 @@ class DriveDetailLoadSuccess extends DriveDetailState {
 
   final int rowsPerPage;
   final List<int> availableRowsPerPage;
+  final int _equatableBust = DateTime.now().millisecondsSinceEpoch;
 
   DriveDetailLoadSuccess({
     required this.currentDrive,
@@ -79,6 +80,7 @@ class DriveDetailLoadSuccess extends DriveDetailState {
         rowsPerPage,
         availableRowsPerPage,
         maybeSelectedItem,
+        _equatableBust,
       ];
 
   bool isViewingRootFolder() =>

--- a/lib/pages/drive_detail/components/drive_detail_data_table.dart
+++ b/lib/pages/drive_detail/components/drive_detail_data_table.dart
@@ -2,6 +2,7 @@ part of '../drive_detail_page.dart';
 
 Widget _buildDataTable(BuildContext context, DriveDetailLoadSuccess state) {
   return DriveDataTable(
+    key: ObjectKey(state),
     driveDetailState: state,
     context: context,
   );


### PR DESCRIPTION
Adds equatable bust to the drive detail load state for the drive table object key to compare equality.

A widget will only re-render if the key is different.