### PR TITLE
refactor: add tableKey property to CustomDataTable PE-1109

### DIFF
--- a/lib/pages/drive_detail/components/custom_paginated_data_table.dart
+++ b/lib/pages/drive_detail/components/custom_paginated_data_table.dart
@@ -28,6 +28,7 @@ class CustomPaginatedDataTable extends StatefulWidget {
     this.arrowHeadColor,
     required this.source,
     this.checkboxHorizontalMargin,
+    this.tableKey,
   })  : assert(columns.isNotEmpty),
         assert(sortColumnIndex == null ||
             (sortColumnIndex >= 0 && sortColumnIndex < columns.length)),
@@ -47,6 +48,8 @@ class CustomPaginatedDataTable extends StatefulWidget {
   ///
   /// See [DataTable.sortColumnIndex].
   final int? sortColumnIndex;
+
+  final Key? tableKey;
 
   /// Whether the column mentioned in [sortColumnIndex], if any, is sorted
   /// in ascending order.
@@ -276,8 +279,6 @@ class CustomPaginatedDataTableState extends State<CustomPaginatedDataTable> {
       !_rowCountApproximate &&
       (_firstRowIndex + widget.rowsPerPage >= _rowCount);
 
-  final GlobalKey _tableKey = GlobalKey();
-
   final pageButtonStyle = TextButton.styleFrom(
     padding: EdgeInsets.zero,
     minimumSize: Size(10, 10),
@@ -477,7 +478,7 @@ class CustomPaginatedDataTableState extends State<CustomPaginatedDataTable> {
             ConstrainedBox(
               constraints: BoxConstraints(minWidth: double.infinity),
               child: DataTable(
-                key: _tableKey,
+                key: widget.tableKey,
                 columns: widget.columns,
                 showCheckboxColumn: false,
                 sortColumnIndex: widget.sortColumnIndex,

--- a/lib/pages/drive_detail/components/drive_detail_data_table.dart
+++ b/lib/pages/drive_detail/components/drive_detail_data_table.dart
@@ -2,7 +2,6 @@ part of '../drive_detail_page.dart';
 
 Widget _buildDataTable(BuildContext context, DriveDetailLoadSuccess state) {
   return DriveDataTable(
-    key: ObjectKey(state),
     driveDetailState: state,
     context: context,
   );
@@ -25,6 +24,7 @@ class _DriveDataTableState extends State<DriveDataTable> {
   @override
   Widget build(BuildContext context) {
     return CustomPaginatedDataTable(
+      tableKey: ObjectKey(widget.driveDetailState.folderInView),
       columns: _buildTableColumns(context),
       sortColumnIndex:
           DriveOrder.values.indexOf(widget.driveDetailState.contentOrderBy),

--- a/lib/pages/drive_detail/components/drive_detail_data_table.dart
+++ b/lib/pages/drive_detail/components/drive_detail_data_table.dart
@@ -24,6 +24,9 @@ class _DriveDataTableState extends State<DriveDataTable> {
   @override
   Widget build(BuildContext context) {
     return CustomPaginatedDataTable(
+      // The key is used to rerender the data table whenever the folderInView is
+      // updated. This includes revisions on the containing files and folders,
+      // transaction status updates, renames and moves.
       tableKey: ObjectKey(widget.driveDetailState.folderInView),
       columns: _buildTableColumns(context),
       sortColumnIndex:

--- a/lib/pages/drive_detail/drive_detail_page.dart
+++ b/lib/pages/drive_detail/drive_detail_page.dart
@@ -46,7 +46,6 @@ class DriveDetailPage extends StatelessWidget {
                 desktop: Stack(
                   children: [
                     Row(
-                      key: ObjectKey(state.folderInView.folder.id),
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Expanded(


### PR DESCRIPTION
Uses a key only in the CustomDataTable widget to avoid scroll and page reset. Removes all other keys from the drive data table.