### PR TITLE
PE-1105: Disallow empty manifest

### DIFF
--- a/lib/blocs/create_manifest/create_manifest_cubit.dart
+++ b/lib/blocs/create_manifest/create_manifest_cubit.dart
@@ -20,6 +20,7 @@ part 'create_manifest_state.dart';
 
 class CreateManifestCubit extends Cubit<CreateManifestState> {
   late FormGroup form;
+  late FolderNode rootFolderNode;
 
   final ProfileCubit _profileCubit;
   final Drive drive;
@@ -63,6 +64,9 @@ class CreateManifestCubit extends Cubit<CreateManifestState> {
     if (form.invalid) {
       return;
     }
+    rootFolderNode =
+        await _driveDao.getFolderTree(drive.id, drive.rootFolderId);
+
     await loadFolder(drive.rootFolderId);
   }
 
@@ -174,8 +178,8 @@ class CreateManifestCubit extends Cubit<CreateManifestState> {
     try {
       final parentFolder =
           (state as CreateManifestPreparingManifest).parentFolder;
-      final folderNode =
-          (await _driveDao.getFolderTree(drive.id, parentFolder.id));
+      final folderNode = rootFolderNode.searchForFolder(parentFolder.id)!;
+
       final arweaveManifest =
           ManifestData.fromFolderNode(folderNode: folderNode);
 

--- a/lib/blocs/create_manifest/create_manifest_cubit.dart
+++ b/lib/blocs/create_manifest/create_manifest_cubit.dart
@@ -178,10 +178,12 @@ class CreateManifestCubit extends Cubit<CreateManifestState> {
     try {
       final parentFolder =
           (state as CreateManifestPreparingManifest).parentFolder;
-      final folderNode = rootFolderNode.searchForFolder(parentFolder.id)!;
+      final folderNode = rootFolderNode.searchForFolder(parentFolder.id) ??
+          await _driveDao.getFolderTree(drive.id, parentFolder.id);
 
-      final arweaveManifest =
-          ManifestData.fromFolderNode(folderNode: folderNode);
+      final arweaveManifest = ManifestData.fromFolderNode(
+        folderNode: folderNode,
+      );
 
       final profile = _profileCubit.state as ProfileLoggedIn;
       final wallet = profile.wallet;

--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -96,6 +96,10 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
           folderContents.files.length + folderContents.subfolders.length,
         );
 
+        final rootFolderNode =
+            await _driveDao.getFolderTree(driveId, drive.rootFolderId);
+        final driveIsEmpty = rootFolderNode.getRecursiveFileCount() == 0;
+
         if (state != null) {
           emit(state.copyWith(
             currentDrive: drive,
@@ -119,6 +123,7 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
             rowsPerPage: availableRowsPerPage.first,
             availableRowsPerPage: availableRowsPerPage,
             maybeSelectedItem: maybeSelectedItem,
+            driveIsEmpty: driveIsEmpty,
           ));
         }
       },

--- a/lib/blocs/drive_detail/drive_detail_state.dart
+++ b/lib/blocs/drive_detail/drive_detail_state.dart
@@ -11,6 +11,7 @@ class DriveDetailLoadInProgress extends DriveDetailState {}
 class DriveDetailLoadSuccess extends DriveDetailState {
   final Drive currentDrive;
   final bool hasWritePermissions;
+  final bool driveIsEmpty;
 
   final FolderWithContents folderInView;
 
@@ -40,6 +41,7 @@ class DriveDetailLoadSuccess extends DriveDetailState {
     this.maybeSelectedItem,
     this.showSelectedItemDetails = false,
     this.selectedFilePreviewUrl,
+    required this.driveIsEmpty,
   });
 
   DriveDetailLoadSuccess copyWith({
@@ -53,6 +55,7 @@ class DriveDetailLoadSuccess extends DriveDetailState {
     Uri? selectedFilePreviewUrl,
     int? rowsPerPage,
     List<int>? availableRowsPerPage,
+    bool? driveIsEmpty,
   }) =>
       DriveDetailLoadSuccess(
         currentDrive: currentDrive ?? this.currentDrive,
@@ -67,6 +70,7 @@ class DriveDetailLoadSuccess extends DriveDetailState {
             selectedFilePreviewUrl ?? this.selectedFilePreviewUrl,
         availableRowsPerPage: availableRowsPerPage ?? this.availableRowsPerPage,
         rowsPerPage: rowsPerPage ?? this.rowsPerPage,
+        driveIsEmpty: driveIsEmpty ?? this.driveIsEmpty,
       );
 
   @override
@@ -81,6 +85,7 @@ class DriveDetailLoadSuccess extends DriveDetailState {
         availableRowsPerPage,
         maybeSelectedItem,
         _equatableBust,
+        driveIsEmpty,
       ];
 
   bool isViewingRootFolder() =>

--- a/lib/components/app_drawer/app_drawer.dart
+++ b/lib/components/app_drawer/app_drawer.dart
@@ -240,6 +240,7 @@ class AppDrawer extends StatelessWidget {
                                 drive: state.currentDrive),
                             child: ListTile(
                               title: Text('Create manifest'),
+                              enabled: state.driveIsEmpty,
                             ),
                           ),
                         },

--- a/lib/components/app_drawer/app_drawer.dart
+++ b/lib/components/app_drawer/app_drawer.dart
@@ -238,9 +238,10 @@ class AppDrawer extends StatelessWidget {
                           PopupMenuItem(
                             value: (context) => promptToCreateManifest(context,
                                 drive: state.currentDrive),
+                            enabled: !state.driveIsEmpty,
                             child: ListTile(
                               title: Text('Create manifest'),
-                              enabled: state.driveIsEmpty,
+                              enabled: !state.driveIsEmpty,
                             ),
                           ),
                         },

--- a/lib/components/create_manifest_form.dart
+++ b/lib/components/create_manifest_form.dart
@@ -281,7 +281,7 @@ class CreateManifestForm extends StatelessWidget {
 
         if (state is CreateManifestFolderLoadSuccess) {
           return AppDialog(
-            title: 'CREATE MANIFEST FROM',
+            title: 'CREATE MANIFEST',
             actions: [
               TextButton(
                 onPressed: () => readCubitContext.backToName(),
@@ -289,7 +289,7 @@ class CreateManifestForm extends StatelessWidget {
               ),
               ElevatedButton(
                 onPressed: () => readCubitContext.checkForConflicts(),
-                child: Text('CREATE'),
+                child: Text('CREATE HERE'),
               ),
             ],
             content: SizedBox(

--- a/lib/components/create_manifest_form.dart
+++ b/lib/components/create_manifest_form.dart
@@ -284,7 +284,12 @@ class CreateManifestForm extends StatelessWidget {
           /// Returns false if a folder does not contain any file entities
           bool isFolderEmpty(FolderID folderId) {
             final folderNode =
-                readCubitContext.rootFolderNode.searchForFolder(folderId)!;
+                readCubitContext.rootFolderNode.searchForFolder(folderId);
+
+            if (folderNode == null) {
+              return true;
+            }
+
             return folderNode.getRecursiveFileCount() == 0;
           }
 

--- a/lib/components/create_manifest_form.dart
+++ b/lib/components/create_manifest_form.dart
@@ -1,6 +1,7 @@
 import 'package:ardrive/blocs/blocs.dart';
 import 'package:ardrive/blocs/create_manifest/create_manifest_cubit.dart';
 import 'package:ardrive/entities/entities.dart';
+import 'package:ardrive/entities/string_types.dart';
 import 'package:ardrive/l11n/l11n.dart';
 import 'package:ardrive/misc/misc.dart';
 import 'package:ardrive/models/models.dart';
@@ -280,6 +281,13 @@ class CreateManifestForm extends StatelessWidget {
         }
 
         if (state is CreateManifestFolderLoadSuccess) {
+          /// Returns false if a folder does not contain any file entities
+          bool isFolderEmpty(FolderID folderId) {
+            final folderNode =
+                readCubitContext.rootFolderNode.searchForFolder(folderId)!;
+            return folderNode.getRecursiveFileCount() == 0;
+          }
+
           return AppDialog(
             title: 'CREATE MANIFEST',
             actions: [
@@ -333,6 +341,7 @@ class CreateManifestForm extends StatelessWidget {
                                   onTap: () =>
                                       readCubitContext.loadFolder(f.id),
                                   trailing: Icon(Icons.keyboard_arrow_right),
+                                  enabled: isFolderEmpty(f.id),
                                 ),
                               ),
                               ...state.viewingFolder.files

--- a/lib/components/create_manifest_form.dart
+++ b/lib/components/create_manifest_form.dart
@@ -341,7 +341,7 @@ class CreateManifestForm extends StatelessWidget {
                                   onTap: () =>
                                       readCubitContext.loadFolder(f.id),
                                   trailing: Icon(Icons.keyboard_arrow_right),
-                                  enabled: isFolderEmpty(f.id),
+                                  enabled: !isFolderEmpty(f.id),
                                 ),
                               ),
                               ...state.viewingFolder.files

--- a/lib/models/daos/drive_dao/folder_node.dart
+++ b/lib/models/daos/drive_dao/folder_node.dart
@@ -15,8 +15,13 @@ class FolderNode {
 
   FolderNode? searchForFolder(String folderId) {
     if (folder.id == folderId) return this;
+
     for (final subfolder in subfolders) {
-      return subfolder.searchForFolder(folderId);
+      final foundFolder = subfolder.searchForFolder(folderId);
+
+      if (foundFolder != null) {
+        return foundFolder;
+      }
     }
     return null;
   }


### PR DESCRIPTION
This PR :
- Disables create manifest button on drives that have no file entities
- Disables folders that have no file entities during folder selection
- Adjusts folder selection state's modal title and button text