### PR TITLE
fix(file revision): Pass dataContentType on rename and move actions PE-1110

### DIFF
--- a/lib/models/file_entry.dart
+++ b/lib/models/file_entry.dart
@@ -11,5 +11,6 @@ extension FileEntryExtensions on FileEntry {
         dataTxId: dataTxId,
         size: size,
         lastModifiedDate: lastModifiedDate,
+        dataContentType: dataContentType,
       );
 }


### PR DESCRIPTION
This PR preserves the `dataContentType` field on files when performing rename / move actions