### PR TITLE
fix: fix public drive share link PE-1120

### DIFF
--- a/lib/components/drive_share_dialog.dart
+++ b/lib/components/drive_share_dialog.dart
@@ -34,12 +34,7 @@ class _DriveShareDialogState extends State<DriveShareDialog> {
 
   @override
   Widget build(BuildContext context) =>
-      BlocConsumer<DriveShareCubit, DriveShareState>(
-        listener: (context, state) {
-          if (state is DriveShareLoadSuccess) {
-            shareLinkController.text = state.driveShareLink.toString();
-          }
-        },
+      BlocBuilder<DriveShareCubit, DriveShareState>(
         builder: (context, state) => AppDialog(
           title: 'Share drive with others',
           content: SizedBox(
@@ -60,7 +55,8 @@ class _DriveShareDialogState extends State<DriveShareDialog> {
                     children: [
                       Expanded(
                         child: TextField(
-                          controller: shareLinkController,
+                          controller: shareLinkController
+                            ..text = state.driveShareLink.toString(),
                           readOnly: true,
                         ),
                       ),


### PR DESCRIPTION
Fixes the public drive share link generation. 
While working on the private drive sharing we made the generate link function for the public drives synchronous (not async), causing the BlocListener to not fire when the link was generated and the state emitted.
In this fix, we set the share link on the controller in the builder instead.