### PR TITLE
Pe 1121 fix buttons alignment

### DIFF
--- a/lib/components/upload_form.dart
+++ b/lib/components/upload_form.dart
@@ -83,6 +83,9 @@ class UploadForm extends StatelessWidget {
               actions: <Widget>[
                 if (!state.isAllFilesConflicting)
                   TextButton(
+                    style: ButtonStyle(
+                        fixedSize:
+                            MaterialStateProperty.all(Size.fromWidth(140))),
                     onPressed: () => context
                         .read<UploadCubit>()
                         .prepareUploadPlanAndCostEstimates(
@@ -90,10 +93,16 @@ class UploadForm extends StatelessWidget {
                     child: Text('SKIP'),
                   ),
                 TextButton(
+                  style: ButtonStyle(
+                      fixedSize:
+                          MaterialStateProperty.all(Size.fromWidth(140))),
                   onPressed: () => Navigator.of(context).pop(false),
                   child: Text('CANCEL'),
                 ),
                 TextButton(
+                    style: ButtonStyle(
+                        fixedSize:
+                            MaterialStateProperty.all(Size.fromWidth(140))),
                     onPressed: () => context
                         .read<UploadCubit>()
                         .prepareUploadPlanAndCostEstimates(


### PR DESCRIPTION
Align the buttons SKIP - CANCEL - REPLACE.

The TextButton width depends directly on the text inside. So, to align we need to pass a fixed width. 

Before:
![image](https://user-images.githubusercontent.com/32248947/158660100-10bbbac2-8fd0-4c4b-991a-def271b93ed8.png)

Now:
![image](https://user-images.githubusercontent.com/32248947/158660123-62dba9cf-1a58-4abd-993f-2ca33c25797c.png)

Thanks, @agsuy 