### PR TITLE
PE-1195: corrects text with wrong placeholder

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -437,7 +437,7 @@
       }
     }
   },
-  "folderWasRenamed": "This folder was renamed to {folderName}.",
+  "folderWasRenamed": "This folder was renamed to {driveName}.",
   "@folderWasRenamed": {
     "description": "Folder activity (journal): renamed",
     "placeholders": {
@@ -465,7 +465,7 @@
       }
     }
   },
-  "fileWasRenamed": "This file was renamed to {fileName}.",
+  "fileWasRenamed": "This file was renamed to {driveName}.",
   "@fileWasRenamed": {
     "description": "File activity (journal): renamed",
     "placeholders": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -437,11 +437,11 @@
       }
     }
   },
-  "folderWasRenamed": "This folder was renamed to {driveName}.",
+  "folderWasRenamed": "This folder was renamed to {folderName}.",
   "@folderWasRenamed": {
     "description": "Folder activity (journal): renamed",
     "placeholders": {
-      "driveName": {
+      "folderName": {
         "type": "String",
         "example": "folder name"
       }
@@ -465,11 +465,11 @@
       }
     }
   },
-  "fileWasRenamed": "This file was renamed to {driveName}.",
+  "fileWasRenamed": "This file was renamed to {fileName}.",
   "@fileWasRenamed": {
     "description": "File activity (journal): renamed",
     "placeholders": {
-      "driveName": {
+      "fileName": {
         "type": "String",
         "example": "file name"
       }


### PR DESCRIPTION
Text at the activity section for `Folder` and `File` now uses the correct placeholder