### PR TITLE
PE-1221: Missing Spanish translations

### DIFF
--- a/lib/components/app_drawer/app_drawer.dart
+++ b/lib/components/app_drawer/app_drawer.dart
@@ -292,7 +292,7 @@ class AppDrawer extends StatelessWidget {
                         Padding(
                           padding: const EdgeInsets.all(8.0),
                           child: Text(
-                            R.insufficientARWarning,
+                            appLocalizationsOf(context).insufficientARWarning,
                             style: Theme.of(context)
                                 .textTheme
                                 .caption!

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -144,6 +144,10 @@
   "@aggreeToTerms_body": {
     "description": "Checkbox for agreeing the terms of of service and privacy policy"
   },
+  "aggreeToTerms_main": "I agree to the ",
+  "@aggreeToTerms_main": {
+    "description": "Checkbox for agreeing the terms of of service and privacy policy"
+  },
   "aggreeToTerms_link": "ArDrive terms of service and privacy policy",
   "@aggreeToTerms_link": {
     "description": "Segment of text representing a link to the legal documents"
@@ -1168,5 +1172,30 @@
   "validationNameUnchanged": "This name is identical to the current name",
   "@validationNameUnchanged": {
     "description": "Input validation error: The given name is exactly the same"
+  },
+  "insufficientARWarning": "Insufficient Funds",
+  "@insufficientARWarning": {
+    "description": "Warns the user that the wallet balance is less than minimum AR required to make a transaction"
+  },
+  "displayedPaginatedData": "{from} - {to} of {total}",
+  "@displayedPaginatedData": {
+    "description": "Indicates the user what items of a list are being displayed. Example: 1 - 25 of 100",
+    "placeholders": {
+      "from": {
+        "type": "int",
+        "format": "decimalPattern",
+        "example": "1"
+      },
+      "to": {
+        "type": "int",
+        "format": "decimalPattern",
+        "example": "25"
+      },
+      "total": {
+        "type": "int",
+        "format": "decimalPattern",
+        "example": "100"
+      }
+    }
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1091,7 +1091,7 @@
   },
   "conflictingNameFoundChooseNewName": "An entity with that name already exists at this location. Please choose a new name.",
   "@conflictingNameFoundChooseNewName": {
-    "description": "The user must type a non-conflicting name"
+    "description": "The given name is conflicting with some entity, the user must type a non-conflicting name"
   },
   "conflictingManifestFound": "Conflicting manifest was found",
   "@conflictingManifestFound": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -371,7 +371,7 @@
   "@driveTxID": {
     "description": "The transaction ID of the drive"
   },
-  "copyDriveTxID": "Copiar la ID de la transacción del disco",
+  "copyDriveTxID": "Copiar la ID de la transacción de la unidad",
   "@copyDriveTxID": {
     "description": "Copy transaction ID of Drive tooltip"
   },
@@ -1047,31 +1047,31 @@
       }
     }
   },
-  "uploadingManifestEmphasized": "CARGANDO MANIFESTO...",
+  "uploadingManifestEmphasized": "CARGANDO MANIFIESTO...",
   "@uploadingManifestEmphasized": {
     "description": "The manifest is being uploaded"
   },
-  "preparingManifestEmphasized": "PREPARANDO MANIFESTO...",
+  "preparingManifestEmphasized": "PREPARANDO MANIFIESTO...",
   "@preparingManifestEmphasized": {
     "description": "The manifest is being prepared for the upload"
   },
-  "manifestName": "Nombre del manifesto",
+  "manifestName": "Nombre del manifiesto",
   "@manifestName": {
     "description": "The name of the manifest"
   },
-  "failedToCreateManifestEmphasized": "LA CREACIÓN DEL MANIFESTO HA FALLADO",
+  "failedToCreateManifestEmphasized": "LA CREACIÓN DEL MANIFIESTO HA FALLADO",
   "@failedToCreateManifestEmphasized": {
     "description": "The manifest could not be created"
   },
-  "walletChangedDuringManifestCreation": "El monedero que estabas usando cambió mientras se creaba el manifesto...",
+  "walletChangedDuringManifestCreation": "El monedero que estabas usando cambió mientras se creaba el manifiesto...",
   "@walletChangedDuringManifestCreation": {
     "description": "The wallet has been changed while the creation of the manifest was in process"
   },
-  "manifestTransactionUnexpectedlyFailed": "La transacción del manifesto ha fallado inesperadamente mientras se cargaba a la red de Arweave...",
+  "manifestTransactionUnexpectedlyFailed": "La transacción del manifiesto ha fallado inesperadamente mientras se cargaba a la red de Arweave...",
   "@manifestTransactionUnexpectedlyFailed": {
     "description": "The manifest transaction did not succeed being uploaded"
   },
-  "insufficientBalanceForManifest": "El balance de {walletBalance} AR es insuficiente para esta transacción de manifesto que cuesta: {totalCost} AR...",
+  "insufficientBalanceForManifest": "El balance de {walletBalance} AR es insuficiente para esta transacción de manifiesto que cuesta: {totalCost} AR...",
   "@insufficientBalanceForManifest": {
     "description": "The ammount of AR the wallet has is not enough to upload the manifest transaction",
     "placeholders": {
@@ -1091,21 +1091,21 @@
   },
   "conflictingNameFoundChooseNewName": "Una entidad con ese nombre ya existe en este lugar. Por favor, elige un nombre diferente.",
   "@conflictingNameFoundChooseNewName": {
-    "description": "The user must type a non-conflicting name"
+    "description": "The given name is conflicting with some entity, the user must type a non-conflicting name"
   },
-  "conflictingManifestFound": "El manifesto ya existe",
+  "conflictingManifestFound": "El manifiesto ya existe",
   "@conflictingManifestFound": {
     "description": "There is an on-chain entity with the same name"
   },
-  "conflictingManifestFoundChooseNewName": "Ya hay un manifesto con ese nombre aquí. ¿Quieres continuar y cargar este manifesto como una nueva revisión?",
+  "conflictingManifestFoundChooseNewName": "Ya hay un manifiesto con ese nombre aquí. ¿Quieres continuar y cargar este manifiesto como una nueva revisión?",
   "@conflictingManifestFoundChooseNewName": {
     "description": "A manifest with the same name already exists. Ask the user for confirmation about uploading it as a new revision"
   },
-  "addnewManifestEmphasized": "AÑADIR NUEVO MANIFESTO",
+  "addnewManifestEmphasized": "AÑADIR NUEVO MANIFIESTO",
   "@addnewManifestEmphasized": {
     "description": "There is a non-manifest entity with the same name"
   },
-  "aManifestIsASpecialKindOfFile": "Un manifesto es un tipo especial de archivos que relaciona cualquier cantidad de transacciones Arweave con direcciones amigable.",
+  "aManifestIsASpecialKindOfFile": "Un manifiesto es un tipo especial de archivo que relaciona transacciones Arweave con rutas perzonalizadas.",
   "@aManifestIsASpecialKindOfFile": {
     "description": "Simple explanation of what a manifest is"
   },
@@ -1113,11 +1113,11 @@
   "@learnMore": {
     "description": "Link to a document explaining manifests in detail"
   },
-  "createManifestEmphasized": "CREAR MANIFESTO",
+  "createManifestEmphasized": "CREAR MANIFIESTO",
   "@createManifestEmphasized": {
     "description": "To create a manifest"
   },
-  "filesWillBePermanentlyPublicWarning": "Todos los archivos cargados aquí serán permanentemente públicos para cualquiera en el internet. Asegúrate de estar haciendo la información pública a propósito.",
+  "filesWillBePermanentlyPublicWarning": "Todos los archivos cargados aquí serán públicos por siempre para cualquiera en el internet. Asegúrate de que quieres que esta información sea pública.",
   "@filesWillBePermanentlyPublicWarning": {
     "description": "Make the user aware that it is uploading permanent data publicly"
   },
@@ -1157,19 +1157,19 @@
   "@validationInvalidKey": {
     "description": "Input validation error: The given drive key is wrong"
   },
-  "validationAttachUserLoggedOut": "Debes iniciar sesión para vincular discos privados.",
+  "validationAttachUserLoggedOut": "Debes iniciar sesión para vincular unidades privadas.",
   "@validationAttachUserLoggedOut": {
     "description": "Input validation error: the user cannot attach a drive when not logged in"
   },
-  "validationEntityNameAlreadyPresent": "Una carpeta o archivo con el mismo nombre ya existe aquí.",
+  "validationEntityNameAlreadyPresent": "Ya existe una carpeta o archivo con el mismo nombre.",
   "@validationEntityNameAlreadyPresent": {
     "description": "Input validation error: The given name is already in use by some exising entity"
   },
-  "validationDriveNameAlreadyPresent": "Un disco con el mismo nombre ya existe aquí.",
+  "validationDriveNameAlreadyPresent": "Una unidad con el mismo nombre ya existe aquí.",
   "@validationDriveNameAlreadyPresent": {
     "description": "Input validation error: The given name is already in use by some exising drive"
   },
-  "validationNameUnchanged": "Este nombre es el idéntico al nombre original",
+  "validationNameUnchanged": "Este nombre es idéntico al nombre original",
   "@validationNameUnchanged": {
     "description": "Input validation error: The given name is exactly the same"
   },

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -823,7 +823,7 @@
   "@upload": {
     "description": "The action of uploading certain item"
   },
-  "uploadEmphasized": "UPLOAD",
+  "uploadEmphasized": "CARGAR",
   "@uploadEmphasized": {
     "description": "The action of uploading certain item"
   },

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -28,7 +28,7 @@
   "@welcomeToThePermawebEmphasized": {
     "description": "Welcoming message at the onboarding screen. Emphasized with upper case"
   },
-  "ardriveIsntJustAnotherCloudSyncApp": "ArDrive no es sólo otra aplicacion de almacenamiento en la nube. Es el comienzo de un disco duro permanente.",
+  "ardriveIsntJustAnotherCloudSyncApp": "ArDrive no es sólo otra aplicación de almacenamiento en la nube. Es el comienzo de un disco duro permanente.",
   "@ardriveIsntJustAnotherCloudSyncApp": {
     "description": "Description about the permanence and uniqueness of ArDrive"
   },
@@ -144,6 +144,10 @@
   "@aggreeToTerms_body": {
     "description": "Checkbox for agreeing the terms of of service and privacy policy"
   },
+  "aggreeToTerms_main": "Acepto ",
+  "@aggreeToTerms_main": {
+    "description": "Checkbox for agreeing the terms of of service and privacy policy"
+  },
   "aggreeToTerms_link": "los términos de servicio y la política de privacidad de ArDrive",
   "@aggreeToTerms_link": {
     "description": "Segment of text representing a link to the legal documents"
@@ -209,6 +213,10 @@
   "next": "Siguiente",
   "@next": {
     "description": "Action of going to the next page"
+  },
+  "nextEmphasized": "NEXT",
+  "@nextEmphasized": {
+    "description": "Next step"
   },
   "goToLast": "Ir al final",
   "@goToLast": {
@@ -441,7 +449,7 @@
   "@folderWasRenamed": {
     "description": "Folder activity (journal): renamed",
     "placeholders": {
-      "driveName": {
+      "folderName": {
         "type": "String",
         "example": "folder name"
       }
@@ -469,7 +477,7 @@
   "@fileWasRenamed": {
     "description": "File activity (journal): renamed",
     "placeholders": {
-      "driveName": {
+      "fileName": {
         "type": "String",
         "example": "file name"
       }
@@ -765,6 +773,10 @@
   "@back": {
     "description": "Go back"
   },
+  "backEmphasized": "BACK",
+  "@backEmphasized": {
+    "description": "Go back. Emphasized with upper case"
+  },
   "logout": "Cerrar sesión",
   "@logout": {
     "description": "The logout process"
@@ -781,11 +793,11 @@
   "@login": {
     "description": "The login process"
   },
-  "conflictingFilesFound": "{numberOfConflicts,plural, =0{No se encontró ningún conflicto} =1{Se encontró un conflicto} =other{Se encontraron {numberOfConflicts} conflictos}}",
-  "@conflictingFilesFound": {
+  "duplicateFiles": "{numberOfDuplicateFiles,plural, =0{No hay ningún archivo duplicado} =1{Se encontró un archivo duplicado} =other{Se encontraron {numberOfDuplicateFiles} archivos duplicados}}",
+  "@duplicateFiles": {
     "description": "Count of conflicting items",
     "placeholders": {
-      "numberOfConflicts": {
+      "numberOfDuplicateFiles": {
         "type": "int",
         "format": "decimalPattern",
         "example": "0"
@@ -809,6 +821,10 @@
   },
   "upload": "Cargar",
   "@upload": {
+    "description": "The action of uploading certain item"
+  },
+  "uploadEmphasized": "UPLOAD",
+  "@uploadEmphasized": {
     "description": "The action of uploading certain item"
   },
   "continueEmphasized": "CONTINUAR",
@@ -1028,6 +1044,157 @@
       "fileCountString": {
         "type": "String",
         "example": "10 files"
+      }
+    }
+  },
+  "uploadingManifestEmphasized": "CARGANDO MANIFESTO...",
+  "@uploadingManifestEmphasized": {
+    "description": "The manifest is being uploaded"
+  },
+  "preparingManifestEmphasized": "PREPARANDO MANIFESTO...",
+  "@preparingManifestEmphasized": {
+    "description": "The manifest is being prepared for the upload"
+  },
+  "manifestName": "Nombre del manifesto",
+  "@manifestName": {
+    "description": "The name of the manifest"
+  },
+  "failedToCreateManifestEmphasized": "LA CREACIÓN DEL MANIFESTO HA FALLADO",
+  "@failedToCreateManifestEmphasized": {
+    "description": "The manifest could not be created"
+  },
+  "walletChangedDuringManifestCreation": "El monedero que estabas usando cambió mientras se creaba el manifesto...",
+  "@walletChangedDuringManifestCreation": {
+    "description": "The wallet has been changed while the creation of the manifest was in process"
+  },
+  "manifestTransactionUnexpectedlyFailed": "La transacción del manifesto ha fallado inesperadamente mientras se cargaba a la red de Arweave...",
+  "@manifestTransactionUnexpectedlyFailed": {
+    "description": "The manifest transaction did not succeed being uploaded"
+  },
+  "insufficientBalanceForManifest": "El balance de {walletBalance} AR es insuficiente para esta transacción de manifesto que cuesta: {totalCost} AR...",
+  "@insufficientBalanceForManifest": {
+    "description": "The ammount of AR the wallet has is not enough to upload the manifest transaction",
+    "placeholders": {
+      "walletBalance": {
+        "type": "String",
+        "example": "0"
+      },
+      "totalCost": {
+        "type": "String",
+        "example": "1.2"
+      }
+    }
+  },
+  "conflictingNameFound": "Se encontró un conflicto de nombres",
+  "@conflictingNameFound": {
+    "description": "There is a non-manifest entity with the same name"
+  },
+  "conflictingNameFoundChooseNewName": "Una entidad con ese nombre ya existe en este lugar. Por favor, elige un nombre diferente.",
+  "@conflictingNameFoundChooseNewName": {
+    "description": "The user must type a non-conflicting name"
+  },
+  "conflictingManifestFound": "El manifesto ya existe",
+  "@conflictingManifestFound": {
+    "description": "There is an on-chain entity with the same name"
+  },
+  "conflictingManifestFoundChooseNewName": "Ya hay un manifesto con ese nombre aquí. ¿Quieres continuar y cargar este manifesto como una nueva revisión?",
+  "@conflictingManifestFoundChooseNewName": {
+    "description": "A manifest with the same name already exists. Ask the user for confirmation about uploading it as a new revision"
+  },
+  "addnewManifestEmphasized": "AÑADIR NUEVO MANIFESTO",
+  "@addnewManifestEmphasized": {
+    "description": "There is a non-manifest entity with the same name"
+  },
+  "aManifestIsASpecialKindOfFile": "Un manifesto es un tipo especial de archivos que relaciona cualquier cantidad de transacciones Arweave con direcciones amigable.",
+  "@aManifestIsASpecialKindOfFile": {
+    "description": "Simple explanation of what a manifest is"
+  },
+  "learnMore": "Conocer más",
+  "@learnMore": {
+    "description": "Link to a document explaining manifests in detail"
+  },
+  "createManifestEmphasized": "CREAR MANIFESTO",
+  "@createManifestEmphasized": {
+    "description": "To create a manifest"
+  },
+  "filesWillBePermanentlyPublicWarning": "Todos los archivos cargados aquí serán permanentemente públicos para cualquiera en el internet. Asegúrate de estar haciendo la información pública a propósito.",
+  "@filesWillBePermanentlyPublicWarning": {
+    "description": "Make the user aware that it is uploading permanent data publicly"
+  },
+  "createHereEmphasized": "CREAR AQUÍ",
+  "@createHereEmphasized": {
+    "description": "Create the manifest in the current selected folder"
+  },
+  "confirmEmphasized": "CONFIRMAR",
+  "@confirmEmphasized": {
+    "description": "Confirm the prompted question"
+  },
+  "skipEmphasized": "OMITIR",
+  "@skipEmphasized": {
+    "description": "Example: to SKIP a conflict"
+  },
+  "replaceEmphasized": "REEMPLAZAR",
+  "@replaceEmphasized": {
+    "description": "Example: to REPLACE an entity"
+  },
+  "validationRequired": "Este campo es requerido.",
+  "@validationRequired": {
+    "description": "Input validation error: the field is empty, but it's required"
+  },
+  "validationInvalid": "Información inválida.",
+  "@validationInvalid": {
+    "description": "Input validation error: the field has invalid data"
+  },
+  "validationPasswordIncorrect": "Contraseña incorrecta.",
+  "@validationPasswordIncorrect": {
+    "description": "Input validation error: the given password is wrong"
+  },
+  "validationAttachDriveCouldNotBeFound": "No se encontró la unidad especificada.",
+  "@validationAttachDriveCouldNotBeFound": {
+    "description": "Input validation error: The given drive ID does not exist"
+  },
+  "validationInvalidKey": "Clave de la unidad inválida.",
+  "@validationInvalidKey": {
+    "description": "Input validation error: The given drive key is wrong"
+  },
+  "validationAttachUserLoggedOut": "Debes iniciar sesión para vincular discos privados.",
+  "@validationAttachUserLoggedOut": {
+    "description": "Input validation error: the user cannot attach a drive when not logged in"
+  },
+  "validationEntityNameAlreadyPresent": "Una carpeta o archivo con el mismo nombre ya existe aquí.",
+  "@validationEntityNameAlreadyPresent": {
+    "description": "Input validation error: The given name is already in use by some exising entity"
+  },
+  "validationDriveNameAlreadyPresent": "Un disco con el mismo nombre ya existe aquí.",
+  "@validationDriveNameAlreadyPresent": {
+    "description": "Input validation error: The given name is already in use by some exising drive"
+  },
+  "validationNameUnchanged": "Este nombre es el idéntico al nombre original",
+  "@validationNameUnchanged": {
+    "description": "Input validation error: The given name is exactly the same"
+  },
+  "insufficientARWarning": "Balance insuficiente",
+  "@insufficientARWarning": {
+    "description": "Warns the user that the wallet balance is less than minimum AR required to make a transaction"
+  },
+  "displayedPaginatedData": "{from} - {to} de {total}",
+  "@displayedPaginatedData": {
+    "description": "Indicates the user what items of a list are being displayed. Example: 1 - 25 of 100",
+    "placeholders": {
+      "from": {
+        "type": "int",
+        "format": "decimalPattern",
+        "example": "1"
+      },
+      "to": {
+        "type": "int",
+        "format": "decimalPattern",
+        "example": "25"
+      },
+      "total": {
+        "type": "int",
+        "format": "decimalPattern",
+        "example": "100"
       }
     }
   }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -214,7 +214,7 @@
   "@next": {
     "description": "Action of going to the next page"
   },
-  "nextEmphasized": "NEXT",
+  "nextEmphasized": "SIGUIENTE",
   "@nextEmphasized": {
     "description": "Next step"
   },
@@ -773,7 +773,7 @@
   "@back": {
     "description": "Go back"
   },
-  "backEmphasized": "BACK",
+  "backEmphasized": "ANTERIOR",
   "@backEmphasized": {
     "description": "Go back. Emphasized with upper case"
   },

--- a/lib/misc/resources.dart
+++ b/lib/misc/resources.dart
@@ -1,6 +1,5 @@
 class R {
   static final images = Images();
-  static final insufficientARWarning = 'Insufficient Funds';
   static final arHelpLink =
       'https://ardrive.io/questions/where-do-i-get-additional-arweave-tokens/';
   static final manifestLearnMoreLink =

--- a/lib/pages/drive_detail/components/custom_paginated_data_table.dart
+++ b/lib/pages/drive_detail/components/custom_paginated_data_table.dart
@@ -416,7 +416,11 @@ class CustomPaginatedDataTableState extends State<CustomPaginatedDataTable> {
     footerWidgets.addAll(<Widget>[
       Container(width: 32.0),
       Text(
-        '${_firstRowIndex + 1} - ${_firstRowIndex + widget.rowsPerPage} of $_rowCount',
+        appLocalizationsOf(context).displayedPaginatedData(
+          _firstRowIndex + 1,
+          _firstRowIndex + widget.rowsPerPage,
+          _rowCount,
+        ),
       ),
       Container(width: 32.0),
       if (widget.showFirstLastButtons)

--- a/lib/pages/profile_auth/components/profile_auth_add_screen.dart
+++ b/lib/pages/profile_auth/components/profile_auth_add_screen.dart
@@ -109,10 +109,15 @@ class ProfileAuthAddScreen extends StatelessWidget {
                                   child: Text.rich(
                                     TextSpan(
                                       children: [
-                                        TextSpan(text: 'I agree to the '),
                                         TextSpan(
-                                          text:
-                                              'ArDrive terms of service and privacy policy',
+                                          // TODO replace at PE-1125
+                                          text: appLocalizationsOf(context)
+                                              .aggreeToTerms_main,
+                                        ),
+                                        TextSpan(
+                                          // TODO replace at PE-1125
+                                          text: appLocalizationsOf(context)
+                                              .aggreeToTerms_link,
                                           style: TextStyle(
                                             decoration:
                                                 TextDecoration.underline,

--- a/lib/pages/profile_auth/components/profile_auth_prompt_wallet_screen.dart
+++ b/lib/pages/profile_auth/components/profile_auth_prompt_wallet_screen.dart
@@ -20,13 +20,15 @@ class ProfileAuthPromptWalletScreen extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             Text(
-              'WELCOME TO',
+              // TODO replace at PE-1125
+              appLocalizationsOf(context).welcomeTo_main,
               textAlign: TextAlign.center,
               style: Theme.of(context).textTheme.headline5,
             ),
             const SizedBox(height: 32),
             Text(
-              'Your private and secure, decentralized, pay-as-you-go, censorship-resistant and permanent hard drive.',
+              // TODO replace at PE-1125
+              appLocalizationsOf(context).welcomeTo_description,
               textAlign: TextAlign.center,
               style: Theme.of(context).textTheme.headline6,
             ),

--- a/web/index.html
+++ b/web/index.html
@@ -37,7 +37,7 @@
   <script defer src="avsc.min.js"></script>
   <script defer src="js/tagparser.js"></script>
   <script defer src="sql-wasm.js"></script>
-  <script src="main.dart.js?version=73" type="application/javascript"></script>
+  <script src="main.dart.js?version=74" type="application/javascript"></script>
   
 </body>
 


### PR DESCRIPTION
**This PR...**
- Adds the missing keys at app_es.arb
  - So the Back and Next buttons on the onboarding page are translated
  - The form validation messages are translated 
  - The manifest creation form is fully translated
- Fixes a Spanish typo: "Aplicación" at the onboarding page
- Declares insufficientARWarning and displayedPaginatedData keys in both ARB files
  - So the "Insufficient Funds" warning is translated
  - The paginated data count is translated: {from} - {to} of {total}
- Temporarily adds the keys aggreeToTerms_main, aggreeToTerms_link, welcomeTo_main, and welcomeTo_description directly in the code as those has a direct order relationship (1 to 1) between en and es. That will be dynamically handled in a [following-up work PE-1125](https://ardrive.atlassian.net/browse/PE-1125) when required for other languages.

