### PR TITLE
PE 1343 -Split getNewEntitiesForDrive function into smaller functions

### DIFF
--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -107,10 +107,9 @@ class ArweaveService {
   }) async {
     final transactionsEdges =
         <DriveEntityHistory$Query$TransactionConnection$TransactionEdge>[];
-    var finishProcess = false;
     var cursor = after;
 
-    while (!finishProcess) {
+    while (true) {
       // Get a page of 100 transactions
       final driveEntityHistoryQuery = await _gql.execute(
         DriveEntityHistoryQuery(
@@ -127,9 +126,8 @@ class ArweaveService {
 
       cursor = transactionsEdges.last.cursor;
 
-      if (driveEntityHistoryQuery.data!.transactions.edges.length <
-          kMaxNumberOfTransactionsPerPage) {
-        finishProcess = true;
+      if (!driveEntityHistoryQuery.data!.transactions.pageInfo.hasNextPage) {
+        break;
       }
     }
 

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -14,6 +14,8 @@ import '../services.dart';
 
 const byteCountPerChunk = 262144; // 256 KiB
 
+const kMaxNumberOfTransactionsPerPage = 100;
+
 class ArweaveService {
   final Arweave client;
 
@@ -125,7 +127,8 @@ class ArweaveService {
 
       cursor = transactionsEdges.last.cursor;
 
-      if (driveEntityHistoryQuery.data!.transactions.edges.length < 100) {
+      if (driveEntityHistoryQuery.data!.transactions.edges.length <
+          kMaxNumberOfTransactionsPerPage) {
         finishProcess = true;
       }
     }
@@ -238,7 +241,8 @@ class ArweaveService {
   }
 
   /// Gets the entity history for a particular drive starting from the specified block height.
-  @Deprecated('')
+  @Deprecated(
+      'Should use getAllTransactionsFromDrive and createDriveEntityHistoryFromTransactions to acomplish the same result.')
   Future<DriveEntityHistory> getNewEntitiesForDrive(
     String driveId, {
     String? after,

--- a/lib/services/arweave/graphql/queries/DriveEntityHistory.graphql
+++ b/lib/services/arweave/graphql/queries/DriveEntityHistory.graphql
@@ -9,6 +9,9 @@ query DriveEntityHistory($driveId: String!, $after: String, $lastBlockHeight: In
     after: $after,
     block: {min: $lastBlockHeight}
   ) {
+    pageInfo {
+      hasNextPage
+    }
     edges {
       node {
         ...TransactionCommon


### PR DESCRIPTION
Split the getNewEntitiesForDrive into smaller functions to change the sync algorithm order.

This function was split in two functions:

- getAllTransactionsFromDrive
- createDriveEntityHistoryFromTransactions

Most of the logic was reused.