### PR TITLE
fix: Allow attaching drives on empty wallets without drives

### DIFF
--- a/lib/components/app_drawer/app_drawer.dart
+++ b/lib/components/app_drawer/app_drawer.dart
@@ -274,6 +274,7 @@ class AppDrawer extends StatelessWidget {
   PopupMenuEntry<Function> _buildNewFolderItem(
       context, DriveDetailLoadSuccess state, bool hasMinimumWalletBalance) {
     return _buildMenuItemTile(
+      context: context,
       isEnabled: state.hasWritePermissions && hasMinimumWalletBalance,
       itemTitle: appLocalizationsOf(context).newFolder,
       message: hasMinimumWalletBalance
@@ -290,6 +291,7 @@ class AppDrawer extends StatelessWidget {
   PopupMenuEntry<Function> _buildUploadFileItem(
       context, DriveDetailLoadSuccess state, bool hasMinimumWalletBalance) {
     return _buildMenuItemTile(
+      context: context,
       isEnabled: state.hasWritePermissions && hasMinimumWalletBalance,
       message: hasMinimumWalletBalance
           ? null
@@ -307,6 +309,7 @@ class AppDrawer extends StatelessWidget {
   PopupMenuEntry<Function> _buildUploadFolderItem(
       context, DriveDetailLoadSuccess state, bool hasMinimumWalletBalance) {
     return _buildMenuItemTile(
+      context: context,
       isEnabled: state.hasWritePermissions && hasMinimumWalletBalance,
       itemTitle: appLocalizationsOf(context).uploadFolder,
       message: hasMinimumWalletBalance
@@ -333,6 +336,7 @@ class AppDrawer extends StatelessWidget {
   PopupMenuEntry<Function> _buildCreateDrive(BuildContext context,
       DrivesLoadSuccess drivesState, bool hasMinimumWalletBalance) {
     return _buildMenuItemTile(
+      context: context,
       isEnabled: drivesState.canCreateNewDrive && hasMinimumWalletBalance,
       itemTitle: appLocalizationsOf(context).newDrive,
       message: hasMinimumWalletBalance
@@ -362,6 +366,7 @@ class AppDrawer extends StatelessWidget {
   PopupMenuEntry<Function> _buildCreateManifestItem(BuildContext context,
       DriveDetailLoadSuccess state, bool hasMinimumWalletBalance) {
     return _buildMenuItemTile(
+      context: context,
       isEnabled: !state.driveIsEmpty,
       itemTitle: appLocalizationsOf(context).createManifest,
       message: hasMinimumWalletBalance
@@ -376,13 +381,16 @@ class AppDrawer extends StatelessWidget {
       {required bool isEnabled,
       Future<void> Function(dynamic)? value,
       String? message,
-      required String itemTitle}) {
+      required String itemTitle,
+      required BuildContext context}) {
     return PopupMenuItem(
       value: value,
       enabled: isEnabled,
       child: Tooltip(
         message: message ?? '',
         child: ListTile(
+          textColor:
+              isEnabled ? ListTileTheme.of(context).textColor : Colors.grey,
           title: Text(
             itemTitle,
           ),

--- a/lib/components/app_drawer/app_drawer.dart
+++ b/lib/components/app_drawer/app_drawer.dart
@@ -179,6 +179,7 @@ class AppDrawer extends StatelessWidget {
 
     if (profileState.runtimeType == ProfileLoggedIn) {
       final profile = profileState as ProfileLoggedIn;
+      final hasMinBalance = profile.walletBalance >= minimumWalletBalance;
       return Column(
         children: [
           ListTileTheme(
@@ -194,24 +195,19 @@ class AppDrawer extends StatelessWidget {
                     onSelected: (callback) => callback(context),
                     itemBuilder: (context) => [
                       if (state is DriveDetailLoadSuccess) ...{
-                        _buildNewFolderItem(context, state,
-                            profile.walletBalance >= minimumWalletBalance),
+                        _buildNewFolderItem(context, state, hasMinBalance),
                         PopupMenuDivider(),
-                        _buildUploadFileItem(context, state,
-                            profile.walletBalance >= minimumWalletBalance),
-                        _buildUploadFolderItem(context, state,
-                            profile.walletBalance >= minimumWalletBalance),
+                        _buildUploadFileItem(context, state, hasMinBalance),
+                        _buildUploadFolderItem(context, state, hasMinBalance),
                         PopupMenuDivider(),
                       },
                       if (drivesState is DrivesLoadSuccess) ...{
-                        _buildCreateDrive(context, drivesState,
-                            profile.walletBalance >= minimumWalletBalance),
+                        _buildCreateDrive(context, drivesState, hasMinBalance),
                         _buildAttachDrive(context)
                       },
                       if (state is DriveDetailLoadSuccess &&
                           state.currentDrive.privacy == 'public') ...{
-                        _buildCreateManifestItem(context, state,
-                            profile.walletBalance >= minimumWalletBalance)
+                        _buildCreateManifestItem(context, state, hasMinBalance)
                       },
                     ],
                     child: _buildNewButton(context),
@@ -220,7 +216,7 @@ class AppDrawer extends StatelessWidget {
               ),
             ),
           ),
-          if (profile.walletBalance < minimumWalletBalance) ...{
+          if (!hasMinBalance) ...{
             Padding(
               padding: const EdgeInsets.all(8.0),
               child: Text(
@@ -272,12 +268,12 @@ class AppDrawer extends StatelessWidget {
   }
 
   PopupMenuEntry<Function> _buildNewFolderItem(
-      context, DriveDetailLoadSuccess state, bool hasMinimumWalletBalance) {
+      context, DriveDetailLoadSuccess state, bool hasMinBalance) {
     return _buildMenuItemTile(
       context: context,
-      isEnabled: state.hasWritePermissions && hasMinimumWalletBalance,
+      isEnabled: state.hasWritePermissions && hasMinBalance,
       itemTitle: appLocalizationsOf(context).newFolder,
-      message: hasMinimumWalletBalance
+      message: hasMinBalance
           ? null
           : appLocalizationsOf(context).insufficientFundsForCreateAFolder,
       value: (context) => promptToCreateFolder(
@@ -289,11 +285,11 @@ class AppDrawer extends StatelessWidget {
   }
 
   PopupMenuEntry<Function> _buildUploadFileItem(
-      context, DriveDetailLoadSuccess state, bool hasMinimumWalletBalance) {
+      context, DriveDetailLoadSuccess state, bool hasMinBalance) {
     return _buildMenuItemTile(
       context: context,
-      isEnabled: state.hasWritePermissions && hasMinimumWalletBalance,
-      message: hasMinimumWalletBalance
+      isEnabled: state.hasWritePermissions && hasMinBalance,
+      message: hasMinBalance
           ? null
           : appLocalizationsOf(context).insufficientFundsForUploadFiles,
       itemTitle: appLocalizationsOf(context).uploadFiles,
@@ -307,12 +303,12 @@ class AppDrawer extends StatelessWidget {
   }
 
   PopupMenuEntry<Function> _buildUploadFolderItem(
-      context, DriveDetailLoadSuccess state, bool hasMinimumWalletBalance) {
+      context, DriveDetailLoadSuccess state, bool hasMinBalance) {
     return _buildMenuItemTile(
       context: context,
-      isEnabled: state.hasWritePermissions && hasMinimumWalletBalance,
+      isEnabled: state.hasWritePermissions && hasMinBalance,
       itemTitle: appLocalizationsOf(context).uploadFolder,
-      message: hasMinimumWalletBalance
+      message: hasMinBalance
           ? null
           : appLocalizationsOf(context).insufficientFundsForUploadFolders,
       value: (context) => promptToUpload(
@@ -334,12 +330,12 @@ class AppDrawer extends StatelessWidget {
   }
 
   PopupMenuEntry<Function> _buildCreateDrive(BuildContext context,
-      DrivesLoadSuccess drivesState, bool hasMinimumWalletBalance) {
+      DrivesLoadSuccess drivesState, bool hasMinBalance) {
     return _buildMenuItemTile(
       context: context,
-      isEnabled: drivesState.canCreateNewDrive && hasMinimumWalletBalance,
+      isEnabled: drivesState.canCreateNewDrive && hasMinBalance,
       itemTitle: appLocalizationsOf(context).newDrive,
-      message: hasMinimumWalletBalance
+      message: hasMinBalance
           ? null
           : appLocalizationsOf(context).insufficientFundsForCreateADrive,
       value: (context) => promptToCreateDrive(context),
@@ -364,12 +360,12 @@ class AppDrawer extends StatelessWidget {
   }
 
   PopupMenuEntry<Function> _buildCreateManifestItem(BuildContext context,
-      DriveDetailLoadSuccess state, bool hasMinimumWalletBalance) {
+      DriveDetailLoadSuccess state, bool hasMinBalance) {
     return _buildMenuItemTile(
       context: context,
       isEnabled: !state.driveIsEmpty,
       itemTitle: appLocalizationsOf(context).createManifest,
-      message: hasMinimumWalletBalance
+      message: hasMinBalance
           ? null
           : appLocalizationsOf(context).insufficientFundsForCreateAManifest,
       value: (context) =>

--- a/lib/components/app_drawer/app_drawer.dart
+++ b/lib/components/app_drawer/app_drawer.dart
@@ -273,69 +273,50 @@ class AppDrawer extends StatelessWidget {
 
   PopupMenuEntry<Function> _buildNewFolderItem(
       context, DriveDetailLoadSuccess state, bool hasMinimumWalletBalance) {
-    return PopupMenuItem(
-      enabled: state.hasWritePermissions,
+    return _buildMenuItemTile(
+      isEnabled: state.hasWritePermissions && hasMinimumWalletBalance,
+      itemTitle: appLocalizationsOf(context).newFolder,
+      message: hasMinimumWalletBalance
+          ? null
+          : appLocalizationsOf(context).insufficientFundsForCreateAFolder,
       value: (context) => promptToCreateFolder(
         context,
         driveId: state.currentDrive.id,
         parentFolderId: state.folderInView.folder.id,
-      ),
-      child: Tooltip(
-        message: hasMinimumWalletBalance
-            ? ''
-            : appLocalizationsOf(context).insufficientFundsForCreateAFolder,
-        child: ListTile(
-          enabled: state.hasWritePermissions && hasMinimumWalletBalance,
-          title: Text(appLocalizationsOf(context).newFolder),
-        ),
       ),
     );
   }
 
   PopupMenuEntry<Function> _buildUploadFileItem(
       context, DriveDetailLoadSuccess state, bool hasMinimumWalletBalance) {
-    return PopupMenuItem(
-      enabled: state.hasWritePermissions,
+    return _buildMenuItemTile(
+      isEnabled: state.hasWritePermissions && hasMinimumWalletBalance,
+      message: hasMinimumWalletBalance
+          ? null
+          : appLocalizationsOf(context).insufficientFundsForUploadFiles,
+      itemTitle: appLocalizationsOf(context).uploadFiles,
       value: (context) => promptToUpload(
         context,
         driveId: state.currentDrive.id,
         folderId: state.folderInView.folder.id,
         isFolderUpload: false,
       ),
-      child: Tooltip(
-        message: hasMinimumWalletBalance
-            ? ''
-            : appLocalizationsOf(context).insufficientFundsForUploadFiles,
-        child: ListTile(
-          enabled: state.hasWritePermissions && hasMinimumWalletBalance,
-          title: Text(
-            appLocalizationsOf(context).uploadFiles,
-          ),
-        ),
-      ),
     );
   }
 
   PopupMenuEntry<Function> _buildUploadFolderItem(
       context, DriveDetailLoadSuccess state, bool hasMinimumWalletBalance) {
-    return PopupMenuItem(
-      enabled: state.hasWritePermissions,
+    return _buildMenuItemTile(
+      isEnabled: state.hasWritePermissions && hasMinimumWalletBalance,
+      itemTitle: appLocalizationsOf(context).uploadFolder,
+      message: hasMinimumWalletBalance
+          ? null
+          : appLocalizationsOf(context).insufficientFundsForUploadFolders,
       value: (context) => promptToUpload(
         context,
         driveId: state.currentDrive.id,
         folderId: state.folderInView.folder.id,
         isFolderUpload: true,
-      ),
-      child: Tooltip(
-        message: hasMinimumWalletBalance
-            ? ''
-            : appLocalizationsOf(context).insufficientFundsForUploadFolders,
-        child: ListTile(
-          enabled: state.hasWritePermissions && hasMinimumWalletBalance,
-          title: Text(
-            appLocalizationsOf(context).uploadFolder,
-          ),
-        ),
       ),
     );
   }
@@ -351,21 +332,13 @@ class AppDrawer extends StatelessWidget {
 
   PopupMenuEntry<Function> _buildCreateDrive(BuildContext context,
       DrivesLoadSuccess drivesState, bool hasMinimumWalletBalance) {
-    return PopupMenuItem(
-      enabled: drivesState.canCreateNewDrive && hasMinimumWalletBalance,
+    return _buildMenuItemTile(
+      isEnabled: drivesState.canCreateNewDrive && hasMinimumWalletBalance,
+      itemTitle: appLocalizationsOf(context).newDrive,
+      message: hasMinimumWalletBalance
+          ? null
+          : appLocalizationsOf(context).insufficientFundsForCreateADrive,
       value: (context) => promptToCreateDrive(context),
-      child: Tooltip(
-        message: hasMinimumWalletBalance
-            ? ''
-            : appLocalizationsOf(context).insufficientFundsForCreateADrive,
-        child: ListTile(
-          textColor: hasMinimumWalletBalance
-              ? ListTileTheme.of(context).textColor
-              : Colors.grey,
-          enabled: drivesState.canCreateNewDrive && hasMinimumWalletBalance,
-          title: Text(appLocalizationsOf(context).newDrive),
-        ),
-      ),
     );
   }
 
@@ -388,19 +361,32 @@ class AppDrawer extends StatelessWidget {
 
   PopupMenuEntry<Function> _buildCreateManifestItem(BuildContext context,
       DriveDetailLoadSuccess state, bool hasMinimumWalletBalance) {
-    return PopupMenuItem(
+    return _buildMenuItemTile(
+      isEnabled: !state.driveIsEmpty,
+      itemTitle: appLocalizationsOf(context).createManifest,
+      message: hasMinimumWalletBalance
+          ? null
+          : appLocalizationsOf(context).insufficientFundsForCreateAManifest,
       value: (context) =>
           promptToCreateManifest(context, drive: state.currentDrive),
-      enabled: !state.driveIsEmpty,
+    );
+  }
+
+  PopupMenuEntry<Function> _buildMenuItemTile(
+      {required bool isEnabled,
+      Future<void> Function(dynamic)? value,
+      String? message,
+      required String itemTitle}) {
+    return PopupMenuItem(
+      value: value,
+      enabled: isEnabled,
       child: Tooltip(
-        message: hasMinimumWalletBalance
-            ? ''
-            : appLocalizationsOf(context).insufficientFundsForCreateAManifest,
+        message: message ?? '',
         child: ListTile(
           title: Text(
-            appLocalizationsOf(context).createManifest,
+            itemTitle,
           ),
-          enabled: !state.driveIsEmpty,
+          enabled: isEnabled,
         ),
       ),
     );

--- a/lib/components/app_drawer/app_drawer.dart
+++ b/lib/components/app_drawer/app_drawer.dart
@@ -179,159 +179,75 @@ class AppDrawer extends StatelessWidget {
 
     if (profileState.runtimeType == ProfileLoggedIn) {
       final profile = profileState as ProfileLoggedIn;
-      return ListTileTheme(
-        textColor: theme.textTheme.bodyText1!.color,
-        iconColor: theme.iconTheme.color,
-        child: Align(
-          alignment: Alignment.center,
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 16),
-            child: BlocBuilder<DriveDetailCubit, DriveDetailState>(
-              builder: (context, state) => profile.walletBalance >=
-                      minimumWalletBalance
-                  ? PopupMenuButton<Function>(
-                      onSelected: (callback) => callback(context),
-                      itemBuilder: (context) => [
-                        if (state is DriveDetailLoadSuccess) ...{
-                          PopupMenuItem(
-                            enabled: state.hasWritePermissions,
-                            value: (context) => promptToCreateFolder(
-                              context,
-                              driveId: state.currentDrive.id,
-                              parentFolderId: state.folderInView.folder.id,
-                            ),
-                            child: ListTile(
-                              enabled: state.hasWritePermissions,
-                              title:
-                                  Text(appLocalizationsOf(context).newFolder),
-                            ),
-                          ),
-                          PopupMenuDivider(),
-                          PopupMenuItem(
-                            enabled: state.hasWritePermissions,
-                            value: (context) => promptToUpload(
-                              context,
-                              driveId: state.currentDrive.id,
-                              folderId: state.folderInView.folder.id,
-                              isFolderUpload: false,
-                            ),
-                            child: ListTile(
-                              enabled: state.hasWritePermissions,
-                              title: Text(
-                                appLocalizationsOf(context).uploadFiles,
-                              ),
-                            ),
-                          ),
-                          PopupMenuItem(
-                            enabled: state.hasWritePermissions,
-                            value: (context) => promptToUpload(
-                              context,
-                              driveId: state.currentDrive.id,
-                              folderId: state.folderInView.folder.id,
-                              isFolderUpload: true,
-                            ),
-                            child: ListTile(
-                              enabled: state.hasWritePermissions,
-                              title: Text(
-                                appLocalizationsOf(context).uploadFolder,
-                              ),
-                            ),
-                          ),
-                          PopupMenuDivider(),
-                        },
-                        if (drivesState is DrivesLoadSuccess) ...{
-                          PopupMenuItem(
-                            enabled: drivesState.canCreateNewDrive,
-                            value: (context) => promptToCreateDrive(context),
-                            child: ListTile(
-                              enabled: drivesState.canCreateNewDrive,
-                              title: Text(appLocalizationsOf(context).newDrive),
-                            ),
-                          ),
-                          PopupMenuItem(
-                            value: (context) => attachDrive(context: context),
-                            child: ListTile(
-                              title:
-                                  Text(appLocalizationsOf(context).attachDrive),
-                            ),
-                          ),
-                        },
-                        if (state is DriveDetailLoadSuccess &&
-                            state.currentDrive.privacy == 'public') ...{
-                          PopupMenuItem(
-                            value: (context) => promptToCreateManifest(context,
-                                drive: state.currentDrive),
-                            enabled: !state.driveIsEmpty,
-                            child: ListTile(
-                              title: Text(
-                                appLocalizationsOf(context).createManifest,
-                              ),
-                              enabled: !state.driveIsEmpty,
-                            ),
-                          ),
-                        },
-                      ],
-                      child: SizedBox(
-                        width: 164,
-                        height: 36,
-                        child: FloatingActionButton.extended(
-                          onPressed: null,
-                          shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(10)),
-                          label: Text(
-                            appLocalizationsOf(context).newStringEmphasized,
-                            style: TextStyle(
-                              fontWeight: FontWeight.bold,
-                            ),
-                          ),
-                        ),
-                      ),
-                    )
-                  : Column(
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        SizedBox(
-                          width: 164,
-                          height: 36,
-                          child: FloatingActionButton.extended(
-                            onPressed: null,
-                            backgroundColor: Colors.grey,
-                            shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(10)),
-                            label: Text(
-                              appLocalizationsOf(context).newStringEmphasized,
-                              style: TextStyle(
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
-                          ),
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.all(8.0),
-                          child: Text(
-                            appLocalizationsOf(context).insufficientARWarning,
-                            style: Theme.of(context)
-                                .textTheme
-                                .caption!
-                                .copyWith(color: Colors.grey),
-                          ),
-                        ),
-                        TextButton(
-                          onPressed: () => launch(R.arHelpLink),
-                          child: Text(
-                            appLocalizationsOf(context).howDoIGetAR,
-                            style: TextStyle(
-                              color: Colors.grey,
-                              decoration: TextDecoration.underline,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
+      return Column(
+        children: [
+          ListTileTheme(
+            textColor: theme.textTheme.bodyText1!.color,
+            iconColor: theme.iconTheme.color,
+            child: Align(
+              alignment: Alignment.center,
+              child: Padding(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 8, vertical: 16),
+                child: BlocBuilder<DriveDetailCubit, DriveDetailState>(
+                  builder: (context, state) => PopupMenuButton<Function>(
+                    onSelected: (callback) => callback(context),
+                    itemBuilder: (context) => [
+                      if (state is DriveDetailLoadSuccess) ...{
+                        // TODO(@thiagocarvalhodev): add the tooltip and `hasMinimumWalletBalance` validation
+
+                        _buildNewFolderItem(context, state,
+                            profile.walletBalance >= minimumWalletBalance),
+                        PopupMenuDivider(),
+                        _buildUploadFileItem(context, state,
+                            profile.walletBalance >= minimumWalletBalance),
+                        _buildUploadFolderItem(context, state,
+                            profile.walletBalance >= minimumWalletBalance),
+                        PopupMenuDivider(),
+                      },
+                      if (drivesState is DrivesLoadSuccess) ...{
+                        // TODO(@thiagocarvalhodev): add the tooltip and `hasMinimumWalletBalance` validation
+
+                        _buildCreateDrive(context, drivesState,
+                            profile.walletBalance >= minimumWalletBalance),
+                        _buildAttachDrive(context)
+                      },
+                      if (state is DriveDetailLoadSuccess &&
+                          state.currentDrive.privacy == 'public') ...{
+                        // TODO(@thiagocarvalhodev): add the tooltip and `hasMinimumWalletBalance` validation
+
+                        _buildCreateManifestItem(state, context)
+                      },
+                    ],
+                    child: _buildNewButton(context),
+                  ),
+                ),
+              ),
             ),
           ),
-        ),
+          if (profile.walletBalance < minimumWalletBalance) ...{
+            Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Text(
+                appLocalizationsOf(context).insufficientARWarning,
+                style: Theme.of(context)
+                    .textTheme
+                    .caption!
+                    .copyWith(color: Colors.grey),
+              ),
+            ),
+            TextButton(
+              onPressed: () => launch(R.arHelpLink),
+              child: Text(
+                appLocalizationsOf(context).howDoIGetAR,
+                style: TextStyle(
+                  color: Colors.grey,
+                  decoration: TextDecoration.underline,
+                ),
+              ),
+            ),
+          }
+        ],
       );
     } else {
       return ListTileTheme(
@@ -342,36 +258,139 @@ class AppDrawer extends StatelessWidget {
           child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 16),
               child: PopupMenuButton<Function>(
-                onSelected: (callback) => callback(context),
-                itemBuilder: (context) => [
-                  if (drivesState is DrivesLoadSuccess) ...{
-                    PopupMenuItem(
-                      value: (context) => attachDrive(context: context),
-                      child: ListTile(
-                        title: Text(appLocalizationsOf(context).attachDrive),
-                      ),
-                    ),
-                  }
-                ],
-                child: SizedBox(
-                  width: 164,
-                  height: 36,
-                  child: FloatingActionButton.extended(
-                    onPressed: null,
-                    shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(10)),
-                    label: Text(
-                      appLocalizationsOf(context).newStringEmphasized,
-                      style: TextStyle(
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                  ),
-                ),
-              )),
+                  onSelected: (callback) => callback(context),
+                  itemBuilder: (context) => [
+                        if (drivesState is DrivesLoadSuccess) ...{
+                          PopupMenuItem(
+                            value: (context) => attachDrive(context: context),
+                            child: ListTile(
+                              title:
+                                  Text(appLocalizationsOf(context).attachDrive),
+                            ),
+                          ),
+                        }
+                      ],
+                  child: _buildNewButton(context))),
         ),
       );
     }
+  }
+
+  PopupMenuEntry<Function> _buildNewFolderItem(
+      context, DriveDetailLoadSuccess state, bool hasMinimumWalletBalance) {
+    return PopupMenuItem(
+      enabled: state.hasWritePermissions,
+      value: (context) => promptToCreateFolder(
+        context,
+        driveId: state.currentDrive.id,
+        parentFolderId: state.folderInView.folder.id,
+      ),
+      child: ListTile(
+        enabled: state.hasWritePermissions && hasMinimumWalletBalance,
+        title: Text(appLocalizationsOf(context).newFolder),
+      ),
+    );
+  }
+
+  PopupMenuEntry<Function> _buildUploadFileItem(
+      context, DriveDetailLoadSuccess state, bool hasMinimumWalletBalance) {
+    return PopupMenuItem(
+      enabled: state.hasWritePermissions,
+      value: (context) => promptToUpload(
+        context,
+        driveId: state.currentDrive.id,
+        folderId: state.folderInView.folder.id,
+        isFolderUpload: false,
+      ),
+      // TODO(@thiagocarvalhodev): add the tooltip and `hasMinimumWalletBalance` validation
+
+      child: ListTile(
+        enabled: state.hasWritePermissions,
+        title: Text(
+          appLocalizationsOf(context).uploadFiles,
+        ),
+      ),
+    );
+  }
+
+  PopupMenuEntry<Function> _buildUploadFolderItem(
+      context, DriveDetailLoadSuccess state, bool hasMinimumWalletBalance) {
+    return PopupMenuItem(
+      enabled: state.hasWritePermissions,
+      value: (context) => promptToUpload(
+        context,
+        driveId: state.currentDrive.id,
+        folderId: state.folderInView.folder.id,
+        isFolderUpload: true,
+      ),
+      // TODO(@thiagocarvalhodev): add the tooltip and `hasMinimumWalletBalance` validation
+      child: ListTile(
+        enabled: state.hasWritePermissions,
+        title: Text(
+          appLocalizationsOf(context).uploadFolder,
+        ),
+      ),
+    );
+  }
+
+  PopupMenuEntry<Function> _buildAttachDrive(BuildContext context) {
+    return PopupMenuItem(
+      value: (context) => attachDrive(context: context),
+      child: ListTile(
+        title: Text(appLocalizationsOf(context).attachDrive),
+      ),
+    );
+  }
+
+  PopupMenuEntry<Function> _buildCreateDrive(BuildContext context,
+      DrivesLoadSuccess drivesState, bool hasMinimumWalletBalance) {
+    return PopupMenuItem(
+      enabled: drivesState.canCreateNewDrive && hasMinimumWalletBalance,
+      value: (context) => promptToCreateDrive(context),
+      child: Tooltip(
+        message: hasMinimumWalletBalance
+            ? ''
+            : 'Only wallets with AR can create New Drives',
+        child: ListTile(
+          textColor: hasMinimumWalletBalance
+              ? ListTileTheme.of(context).textColor
+              : Colors.grey,
+          enabled: drivesState.canCreateNewDrive,
+          title: Text(appLocalizationsOf(context).newDrive),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildNewButton(BuildContext context) {
+    return SizedBox(
+      width: 164,
+      height: 36,
+      child: FloatingActionButton.extended(
+        onPressed: null,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+        label: Text(
+          appLocalizationsOf(context).newStringEmphasized,
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ),
+    );
+  }
+
+  PopupMenuEntry<Function> _buildCreateManifestItem(context, state) {
+    return PopupMenuItem(
+      value: (context) =>
+          promptToCreateManifest(context, drive: state.currentDrive),
+      enabled: !state.driveIsEmpty,
+      child: ListTile(
+        title: Text(
+          appLocalizationsOf(context).createManifest,
+        ),
+        enabled: !state.driveIsEmpty,
+      ),
+    );
   }
 
   Widget _buildSyncButton() => BlocBuilder<SyncCubit, SyncState>(

--- a/lib/components/app_drawer/app_drawer.dart
+++ b/lib/components/app_drawer/app_drawer.dart
@@ -194,8 +194,6 @@ class AppDrawer extends StatelessWidget {
                     onSelected: (callback) => callback(context),
                     itemBuilder: (context) => [
                       if (state is DriveDetailLoadSuccess) ...{
-                        // TODO(@thiagocarvalhodev): add the tooltip and `hasMinimumWalletBalance` validation
-
                         _buildNewFolderItem(context, state,
                             profile.walletBalance >= minimumWalletBalance),
                         PopupMenuDivider(),
@@ -206,17 +204,14 @@ class AppDrawer extends StatelessWidget {
                         PopupMenuDivider(),
                       },
                       if (drivesState is DrivesLoadSuccess) ...{
-                        // TODO(@thiagocarvalhodev): add the tooltip and `hasMinimumWalletBalance` validation
-
                         _buildCreateDrive(context, drivesState,
                             profile.walletBalance >= minimumWalletBalance),
                         _buildAttachDrive(context)
                       },
                       if (state is DriveDetailLoadSuccess &&
                           state.currentDrive.privacy == 'public') ...{
-                        // TODO(@thiagocarvalhodev): add the tooltip and `hasMinimumWalletBalance` validation
-
-                        _buildCreateManifestItem(state, context)
+                        _buildCreateManifestItem(context, state,
+                            profile.walletBalance >= minimumWalletBalance)
                       },
                     ],
                     child: _buildNewButton(context),
@@ -285,9 +280,14 @@ class AppDrawer extends StatelessWidget {
         driveId: state.currentDrive.id,
         parentFolderId: state.folderInView.folder.id,
       ),
-      child: ListTile(
-        enabled: state.hasWritePermissions && hasMinimumWalletBalance,
-        title: Text(appLocalizationsOf(context).newFolder),
+      child: Tooltip(
+        message: hasMinimumWalletBalance
+            ? ''
+            : appLocalizationsOf(context).insufficientFundsForCreateAFolder,
+        child: ListTile(
+          enabled: state.hasWritePermissions && hasMinimumWalletBalance,
+          title: Text(appLocalizationsOf(context).newFolder),
+        ),
       ),
     );
   }
@@ -302,12 +302,15 @@ class AppDrawer extends StatelessWidget {
         folderId: state.folderInView.folder.id,
         isFolderUpload: false,
       ),
-      // TODO(@thiagocarvalhodev): add the tooltip and `hasMinimumWalletBalance` validation
-
-      child: ListTile(
-        enabled: state.hasWritePermissions,
-        title: Text(
-          appLocalizationsOf(context).uploadFiles,
+      child: Tooltip(
+        message: hasMinimumWalletBalance
+            ? ''
+            : appLocalizationsOf(context).insufficientFundsForUploadFiles,
+        child: ListTile(
+          enabled: state.hasWritePermissions && hasMinimumWalletBalance,
+          title: Text(
+            appLocalizationsOf(context).uploadFiles,
+          ),
         ),
       ),
     );
@@ -323,11 +326,15 @@ class AppDrawer extends StatelessWidget {
         folderId: state.folderInView.folder.id,
         isFolderUpload: true,
       ),
-      // TODO(@thiagocarvalhodev): add the tooltip and `hasMinimumWalletBalance` validation
-      child: ListTile(
-        enabled: state.hasWritePermissions,
-        title: Text(
-          appLocalizationsOf(context).uploadFolder,
+      child: Tooltip(
+        message: hasMinimumWalletBalance
+            ? ''
+            : appLocalizationsOf(context).insufficientFundsForUploadFolders,
+        child: ListTile(
+          enabled: state.hasWritePermissions && hasMinimumWalletBalance,
+          title: Text(
+            appLocalizationsOf(context).uploadFolder,
+          ),
         ),
       ),
     );
@@ -350,12 +357,12 @@ class AppDrawer extends StatelessWidget {
       child: Tooltip(
         message: hasMinimumWalletBalance
             ? ''
-            : 'Only wallets with AR can create New Drives',
+            : appLocalizationsOf(context).insufficientFundsForCreateADrive,
         child: ListTile(
           textColor: hasMinimumWalletBalance
               ? ListTileTheme.of(context).textColor
               : Colors.grey,
-          enabled: drivesState.canCreateNewDrive,
+          enabled: drivesState.canCreateNewDrive && hasMinimumWalletBalance,
           title: Text(appLocalizationsOf(context).newDrive),
         ),
       ),
@@ -379,16 +386,22 @@ class AppDrawer extends StatelessWidget {
     );
   }
 
-  PopupMenuEntry<Function> _buildCreateManifestItem(context, state) {
+  PopupMenuEntry<Function> _buildCreateManifestItem(BuildContext context,
+      DriveDetailLoadSuccess state, bool hasMinimumWalletBalance) {
     return PopupMenuItem(
       value: (context) =>
           promptToCreateManifest(context, drive: state.currentDrive),
       enabled: !state.driveIsEmpty,
-      child: ListTile(
-        title: Text(
-          appLocalizationsOf(context).createManifest,
+      child: Tooltip(
+        message: hasMinimumWalletBalance
+            ? ''
+            : appLocalizationsOf(context).insufficientFundsForCreateAManifest,
+        child: ListTile(
+          title: Text(
+            appLocalizationsOf(context).createManifest,
+          ),
+          enabled: !state.driveIsEmpty,
         ),
-        enabled: !state.driveIsEmpty,
       ),
     );
   }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1115,6 +1115,26 @@
       }
     }
   },
+  "insufficientFundsForCreateADrive": "You do not have sufficient funds to create a Drive at this time. Please go to the top up page to add funds to your account.",
+  "@insufficientFundsForCreateADrive": {
+    "description": "Show that needs funds to create a Drive"
+  },
+  "insufficientFundsForCreateAFolder": "You do not have sufficient funds to create a Folder at this time. Please go to the top up page to add funds to your account.",
+  "@insufficientFundsForCreateADrive": {
+    "description": "Show that needs funds to create a Folder"
+  },
+  "insufficientFundsForCreateAManifest": "You do not have sufficient funds to create a Manifest at this time. Please go to the top up page to add funds to your account.",
+  "@insufficientFundsForCreateAManifest": {
+    "description": "Show that needs funds to create a Manifest"
+  },
+  "insufficientFundsForUploadFiles": "You do not have sufficient funds to upload Files at this time. Please go to the top up page to add funds to your account.",
+  "@insufficientFundsForUploadFiles": {
+    "description": "Show that needs funds to upload files"
+  },
+  "insufficientFundsForUploadFolders": "You do not have sufficient funds to upload Folders at this time. Please go to the top up page to add funds to your account.",
+  "@insufficientFundsForUploadFolders": {
+    "description": "Show that needs funds to upload folders"
+  },
   "conflictingNameFound": "Conflicting name was found",
   "@conflictingNameFound": {
     "description": "There is a non-manifest entity with the same name"


### PR DESCRIPTION
If the user has no funds the button, `NEW` will be disabled and he won't be capable of attaching drives public drives. 

As no fund is required to do that, the button `NEW` will be enabled but the dropdown's options that are required to have funds will be disabled and will show a helpful message.

The disabled items:

- Create Drive 
- Create Folder
- Create Manifest
- Upload Files
- Upload Folder

