### PR TITLE
fix: When create another Drive, change the Drive view to this one PE-1421

### DIFF
--- a/lib/blocs/drives/drives_cubit.dart
+++ b/lib/blocs/drives/drives_cubit.dart
@@ -72,6 +72,7 @@ class DrivesCubit extends Cubit<DrivesState> {
 
   void selectDrive(String driveId) {
     final canCreateNewDrive = _profileCubit.state is ProfileLoggedIn;
+
     final state = this.state is DrivesLoadSuccess
         ? (this.state as DrivesLoadSuccess).copyWith(selectedDriveId: driveId)
         : DrivesLoadSuccess(

--- a/lib/pages/app_router_delegate.dart
+++ b/lib/pages/app_router_delegate.dart
@@ -116,6 +116,7 @@ class AppRouterDelegate extends RouterDelegate<AppRoutePath>
                 if (state is DrivesLoadSuccess) {
                   shellPage =
                       !state.hasNoDrives ? DriveDetailPage() : NoDrivesPage();
+                  driveId = state.selectedDriveId;
                 }
 
                 shellPage ??= const SizedBox();


### PR DESCRIPTION
### Problem
While you’re creating a new Drive and there is another created drive , and finishing the creation of the drive. The drive selected won’t be the newly created one.

### Fix
When create another Drive, change the Drive view to this one

