### PR TITLE
fix(image preview): Align image preview on top PE-1484

### DIFF
--- a/lib/pages/drive_detail/components/fs_entry_side_sheet.dart
+++ b/lib/pages/drive_detail/components/fs_entry_side_sheet.dart
@@ -83,7 +83,10 @@ class _FsEntrySideSheetState extends State<FsEntrySideSheet> {
                               child: TabBarView(
                                 children: [
                                   if (previewState is FsEntryPreviewSuccess)
-                                    FsEntryPreviewWidget(state: previewState),
+                                    Align(
+                                        alignment: Alignment.topCenter,
+                                        child: FsEntryPreviewWidget(
+                                            state: previewState)),
                                   Column(
                                     crossAxisAlignment:
                                         CrossAxisAlignment.stretch,


### PR DESCRIPTION
Today the image preview shows the image in the center of the tab bar. We want to show on top.