### PR TITLE
Fix: Handle negative numbers getting the current block height

### DIFF
--- a/lib/blocs/sync/sync_cubit.dart
+++ b/lib/blocs/sync/sync_cubit.dart
@@ -17,6 +17,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 import 'package:moor/moor.dart';
+import 'package:retry/retry.dart';
 
 part 'sync_state.dart';
 
@@ -237,9 +238,16 @@ class SyncCubit extends Cubit<SyncState> {
         return;
       }
 
+      final currentBlockHeight = await retry(
+          () async => await getCurrentBlockHeight(), onRetry: (exception) {
+        print(
+          'Retrying for get the current block height on exception ${exception.toString()}',
+        );
+      });
+
       _syncProgress = _syncProgress.copyWith(drivesCount: drives.length);
 
-      final currentBlockHeight = await arweave.getCurrentBlockHeight();
+      print('Current block height number $currentBlockHeight');
 
       final driveSyncProcesses = drives.map((drive) => _syncDrive(
             drive.id,
@@ -293,6 +301,16 @@ class SyncCubit extends Cubit<SyncState> {
     } else {
       return max(lastBlockHeight - kBlockHeightLookBack, 0);
     }
+  }
+
+  Future<int> getCurrentBlockHeight() async {
+    final currentBlockHeight = await arweave.getCurrentBlockHeight();
+
+    if (currentBlockHeight < 0) {
+      throw Exception(
+          'The current block height is negative. It should be equal or greater than 0.');
+    }
+    return currentBlockHeight;
   }
 
   Future<void> createGhosts({String? ownerAddress}) async {

--- a/lib/blocs/sync/sync_cubit.dart
+++ b/lib/blocs/sync/sync_cubit.dart
@@ -308,7 +308,7 @@ class SyncCubit extends Cubit<SyncState> {
 
     if (currentBlockHeight < 0) {
       throw Exception(
-          'The current block height is negative. It should be equal or greater than 0.');
+          'The current block height $currentBlockHeight is negative. It should be equal or greater than 0.');
     }
     return currentBlockHeight;
   }


### PR DESCRIPTION
UI Crashes and enters an infinite loop on negative blockheights.

For unknown reasons if the query to Arweave for the latest blockheight fails, we could end with a negative blockheight to be used during sync, which crashes the Sync progress UI and leads to an infinite loop.