### PR TITLE
Update help link PE-1560

### DIFF
--- a/lib/components/app_drawer/app_drawer.dart
+++ b/lib/components/app_drawer/app_drawer.dart
@@ -126,8 +126,8 @@ class AppDrawer extends StatelessWidget {
                           child: FloatingActionButton(
                             elevation: 0,
                             tooltip: appLocalizationsOf(context).help,
-                            onPressed: () => launch(
-                                'https://ardrive.typeform.com/to/pGeAVvtg'),
+                            onPressed: () =>
+                                launch('https://ardrive.zendesk.com/'),
                             child: const Icon(Icons.help_outline),
                           ),
                         ),


### PR DESCRIPTION
In the bottom left of ArDrive Web is a “Help” button.  It currently points to 

https://ardrive.typeform.com/to/pGeAVvtg 

This link must be updated to point to the new ArDrive Zendesk Help Center

https://ardrive.zendesk.com/