### PR TITLE
task(Web Analytics): Change from cloudflare to Plausible PE-1567

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -19,10 +19,9 @@
   <link rel="manifest" href="manifest.json" />
   <script defer src="js/arconnect.js"></script>
 
-  <!-- Cloudflare Web Analytics -->
-  <script defer src='https://static.cloudflareinsights.com/beacon.min.js'
-    data-cf-beacon='{"token": "590dc3369856495eadb700ec1975c29d"}'></script>
-  <!-- End Cloudflare Web Analytics -->
+  <!-- Plausible Web Analytics -->
+  <script defer data-domain="app.ardrive.io" src="https://plausible.io/js/plausible.js"></script>
+  <!-- End Plausible Web Analytics -->
 </head>
 
 <body>


### PR DESCRIPTION
We need to switch to Plausible, which is the web analytics service used for the Public Site, Price Calculator and Inferno Leaderboard.