### PR TITLE
Fix not properly show an attached public drive contents

### DIFF
--- a/lib/blocs/sync/sync_cubit.dart
+++ b/lib/blocs/sync/sync_cubit.dart
@@ -230,9 +230,6 @@ class SyncCubit extends Cubit<SyncState> {
 
         syncProgressController.add(_syncProgress);
 
-        // To show 100% loaded to the user
-        await Future.delayed(Duration(milliseconds: 1000));
-
         emit(SyncIdle());
 
         return;

--- a/lib/blocs/sync/sync_cubit.dart
+++ b/lib/blocs/sync/sync_cubit.dart
@@ -273,9 +273,6 @@ class SyncCubit extends Cubit<SyncState> {
 
       await createGhosts(ownerAddress: ownerAddress);
 
-      /// In order to have a smooth transition at the end.
-      await Future.delayed(const Duration(milliseconds: 1000));
-
       await Future.wait([
         if (profile is ProfileLoggedIn) _profileCubit.refreshBalance(),
         _updateTransactionStatuses(),


### PR DESCRIPTION
### Overview
Anytime that we try to attach a drive while syncing we'll have unexpected behavior. It can be achieved by following some steps:

1. Log in on ArDrive
2. After sync, choose a public drive of your preference and copy the id
3. Paste this id on app.ardrive.io/#/drives/$driveId
4. It will trigger the sync and the attach at the same time
5. Attach a drive before sync ends

Following those steps, you can see an empty page.

------- 

This PR will cover the following scenario:

For fresh pages, the current delay of 1s to finish the sync bar animation will be sufficient to win the race condition and not attach the drive properly. So, we'll remove those delays.