### PR TITLE
PE 1621/select other drive after detach

### DIFF
--- a/lib/blocs/drives/drives_cubit.dart
+++ b/lib/blocs/drives/drives_cubit.dart
@@ -92,15 +92,16 @@ class DrivesCubit extends Cubit<DrivesState> {
               : null;
       if (firstOrNullDrive != null) {
         emit(state.copyWith(selectedDriveId: firstOrNullDrive));
+        return;
       }
     }
     emit(DrivesLoadedWithNoDrivesFound(canCreateNewDrive: canCreateNewDrive));
   }
 
   Future<void> detachDrive(DriveID driveId) async {
-    await _driveDao.deleteDriveById(driveId: driveId);
     _resetDriveSelection(driveId);
-    emit(state);
+    await Future.delayed(const Duration(seconds: 1));
+    await _driveDao.deleteDriveById(driveId: driveId);
   }
 
   @override


### PR DESCRIPTION
Fixes contents of detached drive remaining on the drive view.
Also fixes the uncaught console error.