### PR TITLE
PE-402: tar.gz files get the wrong content-type

### DIFF
--- a/lib/blocs/file_download/file_download_cubit.dart
+++ b/lib/blocs/file_download/file_download_cubit.dart
@@ -6,12 +6,12 @@ import 'package:ardrive/entities/constants.dart';
 import 'package:ardrive/entities/string_types.dart';
 import 'package:ardrive/models/models.dart';
 import 'package:ardrive/services/services.dart';
+import 'package:ardrive/utils/mime_lookup.dart';
 import 'package:bloc/bloc.dart';
 import 'package:cryptography/cryptography.dart';
 import 'package:equatable/equatable.dart';
 import 'package:file_selector/file_selector.dart';
 import 'package:http/http.dart' as http;
-import 'package:mime/mime.dart';
 import 'package:moor/moor.dart';
 
 part 'file_download_state.dart';

--- a/lib/blocs/fs_entry_preview/fs_entry_preview_cubit.dart
+++ b/lib/blocs/fs_entry_preview/fs_entry_preview_cubit.dart
@@ -6,11 +6,11 @@ import 'package:ardrive/entities/entities.dart';
 import 'package:ardrive/models/models.dart';
 import 'package:ardrive/services/services.dart';
 import 'package:ardrive/utils/constants.dart';
+import 'package:ardrive/utils/mime_lookup.dart';
 import 'package:bloc/bloc.dart';
 import 'package:cryptography/cryptography.dart';
 import 'package:equatable/equatable.dart';
 import 'package:http/http.dart' as http;
-import 'package:mime/mime.dart';
 import 'package:moor/moor.dart';
 
 part 'fs_entry_preview_state.dart';

--- a/lib/utils/mime_lookup.dart
+++ b/lib/utils/mime_lookup.dart
@@ -1,14 +1,14 @@
 import 'package:mime/mime.dart' as mime;
 
-/// Matches all strings that ends with `.tar.gz` and has at least one character before that
-final tarGzRegexp = RegExp('.\\.tar\\.gz\$');
+/// Matches all strings that ends with `.gz` or `.tgz` and has at least one character before that
+final gZipRegExp = RegExp('.\\.(gz|tgz)\$');
 
-const applicationXTar = 'application/x-tar';
+const applicationGZip = 'application/gzip';
 
 String? lookupMimeType(String path, {List<int>? headerBytes}) {
-  final pathMatch = tarGzRegexp.firstMatch(path);
+  final pathMatch = gZipRegExp.firstMatch(path);
   if (pathMatch != null) {
-    return applicationXTar;
+    return applicationGZip;
   }
   return mime.lookupMimeType(path, headerBytes: headerBytes);
 }

--- a/lib/utils/mime_lookup.dart
+++ b/lib/utils/mime_lookup.dart
@@ -1,0 +1,14 @@
+import 'package:mime/mime.dart' as mime;
+
+/// Matches all strings that ends with `.tar.gz` and has at least one character before that
+final tarGzRegexp = RegExp('.\\.tar\\.gz\$');
+
+const applicationXTar = 'application/x-tar';
+
+String? lookupMimeType(String path, {List<int>? headerBytes}) {
+  final pathMatch = tarGzRegexp.firstMatch(path);
+  if (pathMatch != null) {
+    return applicationXTar;
+  }
+  return mime.lookupMimeType(path, headerBytes: headerBytes);
+}

--- a/lib/utils/upload_plan_utils.dart
+++ b/lib/utils/upload_plan_utils.dart
@@ -3,9 +3,9 @@ import 'package:ardrive/blocs/upload/upload_handles/handles.dart';
 import 'package:ardrive/entities/entities.dart';
 import 'package:ardrive/models/models.dart';
 import 'package:ardrive/services/services.dart';
+import 'package:ardrive/utils/mime_lookup.dart';
 import 'package:arweave/arweave.dart';
 import 'package:cryptography/cryptography.dart';
-import 'package:mime/mime.dart';
 import 'package:uuid/uuid.dart';
 
 class UploadPlanUtils {

--- a/test/utils/mime_lookup.dart
+++ b/test/utils/mime_lookup.dart
@@ -1,0 +1,25 @@
+import 'package:ardrive/utils/mime_lookup.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('lookupMimeType function', () {
+    const pathToMimeMapping = <String, String?>{
+      '.my.file.tar.gz': 'application/x-tar',
+      'abcdefghijklmnñopqrstuvwxyz.tar.gz': 'application/x-tar',
+      'path/to/my/file.tar.gz': 'application/x-tar',
+      'path/to/my/non tar/file.iso': 'application/x-iso9660-image',
+      'ardrive.png': 'image/png',
+      '.tar.gz': null,
+      'my.non.tar.gz.file': null,
+      'where\'s waldo.tar.gz.': null,
+    };
+
+    test('returns the expected mime type', () {
+      for (final path in pathToMimeMapping.keys) {
+        final expectedMime = pathToMimeMapping[path];
+        final mime = lookupMimeType(path);
+        expect(mime, expectedMime);
+      }
+    });
+  });
+}

--- a/test/utils/mime_lookup.dart
+++ b/test/utils/mime_lookup.dart
@@ -4,12 +4,14 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('lookupMimeType function', () {
     const pathToMimeMapping = <String, String?>{
-      '.my.file.tar.gz': 'application/x-tar',
-      'abcdefghijklmnñopqrstuvwxyz.tar.gz': 'application/x-tar',
-      'path/to/my/file.tar.gz': 'application/x-tar',
+      '.my.file.tar.gz': 'application/gzip',
+      'abcdefghijklmnñopqrstuvwxyz.tar.gz': 'application/gzip',
+      'path/to/my/file.tar.gz': 'application/gzip',
+      'path/to/my/file.gz': 'application/gzip',
+      'path/to/my/file.tgz': 'application/gzip',
       'path/to/my/non tar/file.iso': 'application/x-iso9660-image',
       'ardrive.png': 'image/png',
-      '.tar.gz': null,
+      '.tar.gz': 'application/gzip',
       'my.non.tar.gz.file': null,
       'where\'s waldo.tar.gz.': null,
     };


### PR DESCRIPTION
Implements a wrapper for the lookupMimeType function to support tar.gz files as well (**already reviewed at** #557).

This is the approach we've decided after noticing that the Dart PR might take some time to be delivered. See the pull request at: https://github.com/dart-lang/mime/pull/66