### PR TITLE
PE-1757: Put the flame icon

### DIFF
--- a/lib/components/app_drawer/app_drawer.dart
+++ b/lib/components/app_drawer/app_drawer.dart
@@ -32,11 +32,11 @@ class AppDrawer extends StatelessWidget {
                   Expanded(
                     child: Column(
                       children: [
-                        SizedBox(
+                        const SizedBox(
                           height: 32,
                         ),
                         _buildLogo(),
-                        SizedBox(
+                        const SizedBox(
                           height: 32,
                         ),
                         BlocBuilder<ProfileCubit, ProfileState>(
@@ -48,8 +48,10 @@ class AppDrawer extends StatelessWidget {
                           Expanded(
                             child: Scrollbar(
                               child: ListView(
-                                padding: EdgeInsets.all(21),
-                                key: PageStorageKey<String>('driveScrollView'),
+                                padding: const EdgeInsets.all(21),
+                                key: const PageStorageKey<String>(
+                                  'driveScrollView',
+                                ),
                                 children: [
                                   if (state.userDrives.isNotEmpty ||
                                       state.sharedDrives.isEmpty) ...{
@@ -116,45 +118,72 @@ class AppDrawer extends StatelessWidget {
                     ),
                   ),
                   Container(
-                    padding: EdgeInsets.all(21),
-                    alignment: Alignment.centerLeft,
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Padding(
-                          padding: const EdgeInsets.all(8.0),
-                          child: FloatingActionButton(
-                            elevation: 0,
-                            tooltip: appLocalizationsOf(context).help,
-                            onPressed: () =>
-                                launch('https://ardrive.zendesk.com/'),
-                            child: const Icon(Icons.help_outline),
-                          ),
-                        ),
-                        FutureBuilder(
-                          future: PackageInfo.fromPlatform(),
-                          builder: (BuildContext context,
-                              AsyncSnapshot<PackageInfo> snapshot) {
-                            if (snapshot.hasData) {
-                              return Padding(
+                      padding: const EdgeInsets.all(21),
+                      alignment: Alignment.centerLeft,
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Padding(
                                 padding: const EdgeInsets.all(8.0),
-                                child: Text(
-                                  appLocalizationsOf(context)
-                                      .appVersion(snapshot.data!.version),
-                                  style: Theme.of(context)
-                                      .textTheme
-                                      .caption!
-                                      .copyWith(color: Colors.grey),
+                                child: FloatingActionButton(
+                                  elevation: 0,
+                                  tooltip: appLocalizationsOf(context).help,
+                                  onPressed: () =>
+                                      launch('https://ardrive.zendesk.com/'),
+                                  child: const Icon(Icons.help_outline),
                                 ),
-                              );
-                            } else {
-                              return SizedBox(height: 32, width: 32);
-                            }
-                          },
-                        ),
-                      ],
-                    ),
-                  ),
+                              ),
+                              FutureBuilder(
+                                future: PackageInfo.fromPlatform(),
+                                builder: (BuildContext context,
+                                    AsyncSnapshot<PackageInfo> snapshot) {
+                                  if (snapshot.hasData) {
+                                    return Padding(
+                                      padding: const EdgeInsets.all(8.0),
+                                      child: Text(
+                                        appLocalizationsOf(context)
+                                            .appVersion(snapshot.data!.version),
+                                        style: Theme.of(context)
+                                            .textTheme
+                                            .caption!
+                                            .copyWith(color: Colors.grey),
+                                      ),
+                                    );
+                                  } else {
+                                    return const SizedBox(
+                                        height: 32, width: 32);
+                                  }
+                                },
+                              ),
+                            ],
+                          ),
+                          Column(
+                            mainAxisAlignment: MainAxisAlignment.start,
+                            children: [
+                              Padding(
+                                padding: const EdgeInsets.only(
+                                  top: 8.0,
+                                  right: 16.0,
+                                  left: 8.0,
+                                  bottom: 8.0,
+                                ),
+                                child: IconButton(
+                                  onPressed: () {
+                                    print('TODO: open inferno rules');
+                                  },
+                                  icon: const Icon(Icons.local_fire_department),
+                                  color: Colors.deepOrange,
+                                  iconSize: 50,
+                                ),
+                              ),
+                              const SizedBox(height: 32, width: 32),
+                            ],
+                          )
+                        ],
+                      )),
                 ],
               ),
             ),
@@ -196,10 +225,10 @@ class AppDrawer extends StatelessWidget {
                     itemBuilder: (context) => [
                       if (state is DriveDetailLoadSuccess) ...{
                         _buildNewFolderItem(context, state, hasMinBalance),
-                        PopupMenuDivider(),
+                        const PopupMenuDivider(key: Key('divider-1')),
                         _buildUploadFileItem(context, state, hasMinBalance),
                         _buildUploadFolderItem(context, state, hasMinBalance),
-                        PopupMenuDivider(),
+                        const PopupMenuDivider(key: Key('divider-2')),
                       },
                       if (drivesState is DrivesLoadSuccess) ...{
                         _buildCreateDrive(context, drivesState, hasMinBalance),
@@ -231,7 +260,7 @@ class AppDrawer extends StatelessWidget {
               onPressed: () => launch(R.arHelpLink),
               child: Text(
                 appLocalizationsOf(context).howDoIGetAR,
-                style: TextStyle(
+                style: const TextStyle(
                   color: Colors.grey,
                   decoration: TextDecoration.underline,
                 ),
@@ -351,7 +380,7 @@ class AppDrawer extends StatelessWidget {
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
         label: Text(
           appLocalizationsOf(context).newStringEmphasized,
-          style: TextStyle(
+          style: const TextStyle(
             fontWeight: FontWeight.bold,
           ),
         ),

--- a/lib/components/app_drawer/app_drawer.dart
+++ b/lib/components/app_drawer/app_drawer.dart
@@ -4,6 +4,7 @@ import 'package:ardrive/components/components.dart';
 import 'package:ardrive/misc/resources.dart';
 import 'package:ardrive/theme/theme.dart';
 import 'package:ardrive/utils/app_localizations_wrapper.dart';
+import 'package:ardrive/utils/launch_inferno_rules.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -172,7 +173,7 @@ class AppDrawer extends StatelessWidget {
                                 ),
                                 child: IconButton(
                                   onPressed: () {
-                                    print('TODO: open inferno rules');
+                                    launchInfernoRulesURL();
                                   },
                                   icon: const Icon(Icons.local_fire_department),
                                   color: Colors.deepOrange,

--- a/lib/components/app_drawer/app_drawer.dart
+++ b/lib/components/app_drawer/app_drawer.dart
@@ -132,8 +132,7 @@ class AppDrawer extends StatelessWidget {
                                 child: FloatingActionButton(
                                   elevation: 0,
                                   tooltip: appLocalizationsOf(context).help,
-                                  onPressed: () =>
-                                      launch('https://ardrive.zendesk.com/'),
+                                  onPressed: () => launch(R.helpLink),
                                   child: const Icon(Icons.help_outline),
                                 ),
                               ),

--- a/lib/components/app_drawer/app_drawer.dart
+++ b/lib/components/app_drawer/app_drawer.dart
@@ -172,6 +172,8 @@ class AppDrawer extends StatelessWidget {
                                   bottom: 8.0,
                                 ),
                                 child: IconButton(
+                                  tooltip: appLocalizationsOf(context)
+                                      .infernoIsInFullSwing,
                                   onPressed: () {
                                     launchInfernoRulesURL();
                                   },

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1291,5 +1291,9 @@
         "example": "Shared Drive A"
       }
     }
+  },
+  "infernoIsInFullSwing": "The Inferno Rewards Program is in full swing! Click here to check out the rules for participation!",
+  "@infernoIsInFullSwing": {
+    "description": "The text invites users to go read the Inferno rules"
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1294,6 +1294,6 @@
   },
   "infernoIsInFullSwing": "The Inferno Rewards Program is in full swing! Click here to check out the rules for participation!",
   "@infernoIsInFullSwing": {
-    "description": "The text invites users to go read the Inferno rules"
+    "description": "Text inviting the users to go read the Inferno rules"
   }
 }

--- a/lib/misc/resources.dart
+++ b/lib/misc/resources.dart
@@ -5,6 +5,7 @@ class R {
   static const manifestLearnMoreLink =
       'https://ardrive.atlassian.net/wiki/spaces/help/pages/359530513/Arweave+Manifests';
   static const infernoRulesLink = 'https://ardrive.io/inferno/';
+  static const helpLink = 'https://ardrive.zendesk.com/';
 }
 
 class Images {

--- a/lib/misc/resources.dart
+++ b/lib/misc/resources.dart
@@ -1,9 +1,10 @@
 class R {
   static final images = Images();
-  static final arHelpLink =
+  static const arHelpLink =
       'https://ardrive.io/questions/where-do-i-get-additional-arweave-tokens/';
-  static final manifestLearnMoreLink =
+  static const manifestLearnMoreLink =
       'https://ardrive.atlassian.net/wiki/spaces/help/pages/359530513/Arweave+Manifests';
+  static const infernoRulesLink = 'https://ardrive.io/inferno/';
 }
 
 class Images {

--- a/lib/utils/launch_inferno_rules.dart
+++ b/lib/utils/launch_inferno_rules.dart
@@ -1,0 +1,11 @@
+import 'package:ardrive/misc/resources.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+Future<void> launchInfernoRulesURL() async {
+  const url = R.infernoRulesLink;
+  if (await canLaunch(url)) {
+    await launch(url);
+  } else {
+    throw 'Could not launch $url';
+  }
+}


### PR DESCRIPTION
Changes:

- Adds a placeholder for the Flame 🔥 icon on its place.
- When the icon is clicked it opens the Inferno Rules.
- There's a tooltip wording: "The Inferno Rewards Program is in full swing! Click here to check out the rules for participation!"

TODO:

- Replace the placeholder with the actual design (surely addressed in another sub-task)


<img width="1440" alt="Screen Shot 2022-06-23 at 15 57 40" src="https://user-images.githubusercontent.com/22564541/175383994-06953b15-f900-4fae-94da-45fd7186e65e.png">

