### PR TITLE
feat(survey feedback modal): set the pref on dontRemindMe() PE-1773

### DIFF
--- a/lib/blocs/feedback_survey/feedback_survey_cubit.dart
+++ b/lib/blocs/feedback_survey/feedback_survey_cubit.dart
@@ -43,12 +43,12 @@ class FeedbackSurveyCubit extends Cubit<FeedbackSurveyState> {
     emit(FeedbackSurveyDontRemindMe(isOpen: false));
   }
 
-  void dontRemindMe() {
+  Future<void> dontRemindMe() async {
+    await (await _store).putBool(dontRemindMeAgainKey, true);
     emit(FeedbackSurveyDontRemindMe(isOpen: true));
   }
 
-  Future<void> closeDontRemindMe() async {
-    await (await _store).putBool(dontRemindMeAgainKey, true);
+  void closeDontRemindMe() {
     emit(FeedbackSurveyDontRemindMe(isOpen: false));
   }
 }


### PR DESCRIPTION
The preference was previously set after the second view of the modal: you first clicked "don't remind me again" and nothing happened, then you clicked "Got it" and the flag was set after.
Now the flag is set when clicking the first button.