### PR TITLE
PE-1772: Open Feedback Modal after Share Dialog is dismissed by clicking the screen behind

### DIFF
--- a/lib/components/app_dialog.dart
+++ b/lib/components/app_dialog.dart
@@ -25,9 +25,7 @@ class AppDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) => WillPopScope(
         onWillPop: () async {
-          if (onWillPopCallback is Function) {
-            await onWillPopCallback!();
-          }
+          await onWillPopCallback?.call();
           return dismissable;
         },
         child: AlertDialog(

--- a/lib/components/app_dialog.dart
+++ b/lib/components/app_dialog.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:ardrive/theme/theme.dart';
 import 'package:flutter/material.dart';
 
@@ -6,7 +8,7 @@ class AppDialog extends StatelessWidget {
   final EdgeInsetsGeometry contentPadding;
   final Widget content;
   final List<Widget> actions;
-  final Future<void> Function()? onWillPopCallback;
+  final FutureOr<void> Function()? onWillPopCallback;
 
   final bool dismissable;
 

--- a/lib/components/app_dialog.dart
+++ b/lib/components/app_dialog.dart
@@ -19,7 +19,8 @@ class AppDialog extends StatelessWidget {
     this.onWillPopCallback,
     this.actions = const [],
     this.dismissable = true,
-  });
+    Key? key,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) => WillPopScope(

--- a/lib/components/app_dialog.dart
+++ b/lib/components/app_dialog.dart
@@ -6,6 +6,7 @@ class AppDialog extends StatelessWidget {
   final EdgeInsetsGeometry contentPadding;
   final Widget content;
   final List<Widget> actions;
+  final Future<void> Function()? onWillPopCallback;
 
   final bool dismissable;
 
@@ -13,13 +14,19 @@ class AppDialog extends StatelessWidget {
     required this.title,
     this.contentPadding = const EdgeInsets.fromLTRB(24, 20, 24, 24),
     required this.content,
+    this.onWillPopCallback,
     this.actions = const [],
     this.dismissable = true,
   });
 
   @override
   Widget build(BuildContext context) => WillPopScope(
-        onWillPop: () async => dismissable,
+        onWillPop: () async {
+          if (onWillPopCallback is Function) {
+            await onWillPopCallback!();
+          }
+          return dismissable;
+        },
         child: AlertDialog(
           titlePadding: EdgeInsets.zero,
           title: Container(

--- a/lib/components/file_share_dialog.dart
+++ b/lib/components/file_share_dialog.dart
@@ -45,6 +45,9 @@ class _FileShareDialogState extends State<FileShareDialog> {
           }
         },
         builder: (context, state) => AppDialog(
+          onWillPopCallback: () async {
+            context.read<FeedbackSurveyCubit>().openRemindMe();
+          },
           title: appLocalizationsOf(context).shareFileWithOthers,
           content: SizedBox(
             width: kLargeDialogWidth,

--- a/lib/components/file_share_dialog.dart
+++ b/lib/components/file_share_dialog.dart
@@ -45,7 +45,7 @@ class _FileShareDialogState extends State<FileShareDialog> {
           }
         },
         builder: (context, state) => AppDialog(
-          onWillPopCallback: () async {
+          onWillPopCallback: () {
             context.read<FeedbackSurveyCubit>().openRemindMe();
           },
           title: appLocalizationsOf(context).shareFileWithOthers,


### PR DESCRIPTION
Changes:
- Makes AppDialog to take an extra onWillPopCallback function.
- Pass the callback at the Share Dialog to open the Feedback Modal.