### PR TITLE
PE-1774: Fixes a crash on the ProfileCubit

### DIFF
--- a/lib/blocs/profile/profile_cubit.dart
+++ b/lib/blocs/profile/profile_cubit.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:ardrive/blocs/feedback_survey/feedback_survey_cubit.dart';
 import 'package:ardrive/entities/profileTypes.dart';
 import 'package:ardrive/models/models.dart';
 import 'package:ardrive/services/arconnect/arconnect_wallet.dart';
@@ -20,17 +19,14 @@ class ProfileCubit extends Cubit<ProfileState> {
   final ArweaveService _arweave;
   final ProfileDao _profileDao;
   final Database _db;
-  final FeedbackSurveyCubit _feedbackSurveyCubit;
 
   ProfileCubit({
     required ArweaveService arweave,
     required ProfileDao profileDao,
     required Database db,
-    required FeedbackSurveyCubit feedbackSurveyCubit,
   })  : _arweave = arweave,
         _profileDao = profileDao,
         _db = db,
-        _feedbackSurveyCubit = feedbackSurveyCubit,
         super(ProfileCheckingAvailability()) {
     promptToAuthenticate();
   }
@@ -165,8 +161,6 @@ class ProfileCubit extends Cubit<ProfileState> {
   Future<void> logoutProfile() async {
     final profile = await _profileDao.defaultProfile().getSingleOrNull();
     final arconnect = ArConnectService();
-
-    _feedbackSurveyCubit.reset();
 
     if (profile != null && profile.profileType == ProfileType.ArConnect.index) {
       try {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -57,7 +57,6 @@ class _AppState extends State<App> {
                 arweave: context.read<ArweaveService>(),
                 profileDao: context.read<ProfileDao>(),
                 db: context.read<Database>(),
-                feedbackSurveyCubit: context.read<FeedbackSurveyCubit>(),
               ),
             ),
             BlocProvider(

--- a/lib/pages/app_router_delegate.dart
+++ b/lib/pages/app_router_delegate.dart
@@ -175,6 +175,13 @@ class AppRouterDelegate extends RouterDelegate<AppRoutePath>
                           }
                         },
                       ),
+                      BlocListener<ProfileCubit, ProfileState>(
+                        listener: ((context, state) {
+                          if (state is ProfileLoggingOut) {
+                            context.read<FeedbackSurveyCubit>().reset();
+                          }
+                        }),
+                      ),
                     ],
                     child: AppShell(page: shellPage),
                   ),

--- a/test/blocs/feedback_survey_cubit_test.dart
+++ b/test/blocs/feedback_survey_cubit_test.dart
@@ -65,7 +65,7 @@ void main() {
     blocTest<FeedbackSurveyCubit, FeedbackSurveyState>(
       'no thanks! dont remind me again',
       build: () => feedbackCubit,
-      act: (bloc) async => await bloc.closeDontRemindMe(),
+      act: (bloc) async => bloc.closeDontRemindMe(),
       expect: () => [
         FeedbackSurveyDontRemindMe(isOpen: false),
       ],


### PR DESCRIPTION
It seemed that there was a crash I didn't have when developing; it was related to a comment regarding #563 (the comment is on [Slack](https://ardrive.slack.com/archives/C01CTS2Q9DM/p1656437774437569?thread_ts=1656433184.207689&cid=C01CTS2Q9DM)).
Also removes an extra await in the tests.

At `lib/pages/app_router_delegate.dart` and `lib/main.dart` you'll find the relevant changes.