### PR TITLE
feat: direct inferno icon to chinese rules PE-1808

### DIFF
--- a/lib/components/app_drawer/app_drawer.dart
+++ b/lib/components/app_drawer/app_drawer.dart
@@ -135,7 +135,7 @@ class AppDrawer extends StatelessWidget {
                               child: FloatingActionButton(
                                 elevation: 0,
                                 tooltip: appLocalizationsOf(context).help,
-                                onPressed: () => launch(R.helpLink),
+                                onPressed: () => launch(Resources.helpLink),
                                 child: const Icon(Icons.help_outline),
                               ),
                             ),
@@ -176,7 +176,8 @@ class AppDrawer extends StatelessWidget {
                                 ),
                               ),
                               onPressed: () {
-                                launchInfernoRulesURL(context);
+                                launchInfernoRulesURL(
+                                    appLocalizationsOf(context).localeName);
                               },
                               child: Tooltip(
                                 message: appLocalizationsOf(context)
@@ -184,7 +185,7 @@ class AppDrawer extends StatelessWidget {
                                 child: Column(
                                   children: [
                                     Image.asset(
-                                      R.images.inferno.fire,
+                                      Resources.images.inferno.fire,
                                       height: 50.0,
                                       width: 50.0,
                                       fit: BoxFit.contain,
@@ -223,7 +224,7 @@ class AppDrawer extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.all(16.0),
       child: Image.asset(
-        R.images.brand.logoHorizontalNoSubtitleDark,
+        Resources.images.brand.logoHorizontalNoSubtitleDark,
         height: 32,
         fit: BoxFit.contain,
       ),
@@ -286,7 +287,7 @@ class AppDrawer extends StatelessWidget {
               ),
             ),
             TextButton(
-              onPressed: () => launch(R.arHelpLink),
+              onPressed: () => launch(Resources.arHelpLink),
               child: Text(
                 appLocalizationsOf(context).howDoIGetAR,
                 style: const TextStyle(

--- a/lib/components/app_drawer/app_drawer.dart
+++ b/lib/components/app_drawer/app_drawer.dart
@@ -176,7 +176,7 @@ class AppDrawer extends StatelessWidget {
                                 ),
                               ),
                               onPressed: () {
-                                launchInfernoRulesURL();
+                                launchInfernoRulesURL(context);
                               },
                               child: Tooltip(
                                 message: appLocalizationsOf(context)

--- a/lib/components/create_manifest_form.dart
+++ b/lib/components/create_manifest_form.dart
@@ -224,8 +224,8 @@ class CreateManifestForm extends StatelessWidget {
                                     fontWeight: FontWeight.bold,
                                     decoration: TextDecoration.underline),
                                 recognizer: TapGestureRecognizer()
-                                  ..onTap =
-                                      () => launch(R.manifestLearnMoreLink)),
+                                  ..onTap = () =>
+                                      launch(Resources.manifestLearnMoreLink)),
                           ]),
                         ),
                         manifestNameForm()

--- a/lib/misc/resources.dart
+++ b/lib/misc/resources.dart
@@ -1,5 +1,5 @@
-class R {
-  static final images = Images();
+class Resources {
+  static const images = Images();
   static const arHelpLink =
       'https://ardrive.io/questions/where-do-i-get-additional-arweave-tokens/';
   static const manifestLearnMoreLink =

--- a/lib/misc/resources.dart
+++ b/lib/misc/resources.dart
@@ -4,7 +4,9 @@ class R {
       'https://ardrive.io/questions/where-do-i-get-additional-arweave-tokens/';
   static const manifestLearnMoreLink =
       'https://ardrive.atlassian.net/wiki/spaces/help/pages/359530513/Arweave+Manifests';
-  static const infernoRulesLink = 'https://ardrive.io/inferno/';
+  static const infernoRulesLinkEn = 'https://ardrive.io/inferno/';
+  static const infernoRulesLinkZh = 'https://cn.ardrive.io/inferno/';
+
   static const helpLink = 'https://ardrive.zendesk.com/';
 }
 

--- a/lib/pages/app_route_information_parser.dart
+++ b/lib/pages/app_route_information_parser.dart
@@ -74,8 +74,6 @@ class AppRouteInformationParser extends RouteInformationParser<AppRoutePath> {
 
   @override
   RouteInformation restoreRouteInformation(AppRoutePath path) {
-    print('AppRoutePath: ${path.driveId}');
-
     if (path.signingIn) {
       return const RouteInformation(location: '/sign-in');
     } else if (path.driveId != null) {

--- a/lib/pages/profile_auth/components/profile_auth_add_screen.dart
+++ b/lib/pages/profile_auth/components/profile_auth_add_screen.dart
@@ -16,7 +16,7 @@ class ProfileAuthAddScreen extends StatelessWidget {
         builder: (context, state) => state is ProfileAddPromptDetails
             ? ProfileAuthShell(
                 illustration: Image.asset(
-                  R.images.profile.profileAdd,
+                  Resources.images.profile.profileAdd,
                   fit: BoxFit.contain,
                 ),
                 contentWidthFactor: 0.5,

--- a/lib/pages/profile_auth/components/profile_auth_fail_screen.dart
+++ b/lib/pages/profile_auth/components/profile_auth_fail_screen.dart
@@ -11,7 +11,7 @@ class ProfileAuthFailScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) => ProfileAuthShell(
         illustration: Image.asset(
-          R.images.profile.profileWelcome,
+          Resources.images.profile.profileWelcome,
           fit: BoxFit.contain,
         ),
         contentWidthFactor: 0.5,

--- a/lib/pages/profile_auth/components/profile_auth_loading_screen.dart
+++ b/lib/pages/profile_auth/components/profile_auth_loading_screen.dart
@@ -12,7 +12,7 @@ class ProfileAuthLoadingScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) => ProfileAuthShell(
         illustration: Image.asset(
-          R.images.profile.profileUnlock,
+          Resources.images.profile.profileUnlock,
           fit: BoxFit.contain,
         ),
         content: Column(

--- a/lib/pages/profile_auth/components/profile_auth_onboarding_screen.dart
+++ b/lib/pages/profile_auth/components/profile_auth_onboarding_screen.dart
@@ -22,7 +22,7 @@ class _ProfileAuthOnboardingState extends State<ProfileAuthOnboarding> {
         return ProfileAuthShell(
           illustration: _buildIllustrationSection(
             Image.asset(
-              R.images.profile.newUserPermanent,
+              Resources.images.profile.newUserPermanent,
               fit: BoxFit.contain,
             ),
           ),
@@ -54,7 +54,7 @@ class _ProfileAuthOnboardingState extends State<ProfileAuthOnboarding> {
         return ProfileAuthShell(
           illustration: _buildIllustrationSection(
             Image.asset(
-              R.images.profile.newUserPayment,
+              Resources.images.profile.newUserPayment,
               fit: BoxFit.contain,
             ),
           ),
@@ -83,7 +83,7 @@ class _ProfileAuthOnboardingState extends State<ProfileAuthOnboarding> {
         return ProfileAuthShell(
           illustration: _buildIllustrationSection(
             Image.asset(
-              R.images.profile.newUserUpload,
+              Resources.images.profile.newUserUpload,
               fit: BoxFit.contain,
             ),
           ),
@@ -112,7 +112,7 @@ class _ProfileAuthOnboardingState extends State<ProfileAuthOnboarding> {
         return ProfileAuthShell(
           illustration: _buildIllustrationSection(
             Image.asset(
-              R.images.profile.newUserPrivate,
+              Resources.images.profile.newUserPrivate,
               fit: BoxFit.contain,
             ),
           ),
@@ -141,7 +141,7 @@ class _ProfileAuthOnboardingState extends State<ProfileAuthOnboarding> {
         return ProfileAuthShell(
           illustration: _buildIllustrationSection(
             Image.asset(
-              R.images.profile.newUserDelete,
+              Resources.images.profile.newUserDelete,
               fit: BoxFit.contain,
             ),
           ),

--- a/lib/pages/profile_auth/components/profile_auth_prompt_wallet_screen.dart
+++ b/lib/pages/profile_auth/components/profile_auth_prompt_wallet_screen.dart
@@ -12,7 +12,7 @@ class ProfileAuthPromptWalletScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) => ProfileAuthShell(
         illustration: Image.asset(
-          R.images.profile.profileWelcome,
+          Resources.images.profile.profileWelcome,
           fit: BoxFit.contain,
         ),
         contentWidthFactor: 0.5,

--- a/lib/pages/profile_auth/components/profile_auth_shell.dart
+++ b/lib/pages/profile_auth/components/profile_auth_shell.dart
@@ -29,7 +29,7 @@ class ProfileAuthShell extends StatelessWidget {
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   Image.asset(
-                    R.images.brand.logoHorizontalNoSubtitleLight,
+                    Resources.images.brand.logoHorizontalNoSubtitleLight,
                     height: 126,
                     fit: BoxFit.contain,
                   ),
@@ -52,7 +52,7 @@ class ProfileAuthShell extends StatelessWidget {
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Image.asset(R.images.profile.permahillsBg),
+                  Image.asset(Resources.images.profile.permahillsBg),
                   SizedBox(height: 128),
                 ],
               ),

--- a/lib/pages/profile_auth/components/profile_auth_unlock_screen.dart
+++ b/lib/pages/profile_auth/components/profile_auth_unlock_screen.dart
@@ -32,7 +32,7 @@ class _ProfileAuthUnlockScreenState extends State<ProfileAuthUnlockScreen> {
             } else {
               return ProfileAuthShell(
                 illustration: Image.asset(
-                  R.images.profile.profileUnlock,
+                  Resources.images.profile.profileUnlock,
                   fit: BoxFit.contain,
                 ),
                 contentWidthFactor: 0.5,

--- a/lib/pages/screen_not_supported/screen_not_supported_page.dart
+++ b/lib/pages/screen_not_supported/screen_not_supported_page.dart
@@ -17,7 +17,7 @@ class ScreenNotSupportedPage extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
                 Image.asset(
-                  R.images.brand.logoHorizontalNoSubtitleLight,
+                  Resources.images.brand.logoHorizontalNoSubtitleLight,
                   height: 126,
                   fit: BoxFit.contain,
                 ),

--- a/lib/pages/shared_file/shared_file_page.dart
+++ b/lib/pages/shared_file/shared_file_page.dart
@@ -31,7 +31,7 @@ class SharedFilePage extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
                   Image.asset(
-                    R.images.brand.logoHorizontalNoSubtitleLight,
+                    Resources.images.brand.logoHorizontalNoSubtitleLight,
                     height: 96,
                     fit: BoxFit.contain,
                   ),

--- a/lib/utils/launch_inferno_rules.dart
+++ b/lib/utils/launch_inferno_rules.dart
@@ -13,8 +13,13 @@ Future<void> launchInfernoRulesURL(BuildContext context) async {
 }
 
 String _getUrlForCurrentLocalization(BuildContext context) {
-  if (appLocalizationsOf(context).localeName == 'zh') {
-    return R.infernoRulesLinkZh;
-  }
-  return R.infernoRulesLinkEn;
+  final _infernoRulesLinkMap = {
+    'zh': R.infernoRulesLinkZh,
+    'en': R.infernoRulesLinkEn
+  };
+
+  final urlForCurrentLocalization =
+      _infernoRulesLinkMap[appLocalizationsOf(context).localeName];
+
+  return urlForCurrentLocalization ?? R.infernoRulesLinkEn;
 }

--- a/lib/utils/launch_inferno_rules.dart
+++ b/lib/utils/launch_inferno_rules.dart
@@ -1,11 +1,20 @@
 import 'package:ardrive/misc/resources.dart';
+import 'package:ardrive/utils/app_localizations_wrapper.dart';
+import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-Future<void> launchInfernoRulesURL() async {
-  const url = R.infernoRulesLink;
+Future<void> launchInfernoRulesURL(BuildContext context) async {
+  final url = _getUrlForCurrentLocalization(context);
   if (await canLaunch(url)) {
     await launch(url);
   } else {
     throw 'Could not launch $url';
   }
+}
+
+String _getUrlForCurrentLocalization(BuildContext context) {
+  if (appLocalizationsOf(context).localeName == 'zh') {
+    return R.infernoRulesLinkZh;
+  }
+  return R.infernoRulesLinkEn;
 }

--- a/lib/utils/launch_inferno_rules.dart
+++ b/lib/utils/launch_inferno_rules.dart
@@ -1,10 +1,8 @@
 import 'package:ardrive/misc/resources.dart';
-import 'package:ardrive/utils/app_localizations_wrapper.dart';
-import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-Future<void> launchInfernoRulesURL(BuildContext context) async {
-  final url = _getUrlForCurrentLocalization(context);
+Future<void> launchInfernoRulesURL(String localeName) async {
+  final url = getUrlForCurrentLocalization(localeName);
   if (await canLaunch(url)) {
     await launch(url);
   } else {
@@ -12,14 +10,13 @@ Future<void> launchInfernoRulesURL(BuildContext context) async {
   }
 }
 
-String _getUrlForCurrentLocalization(BuildContext context) {
+String getUrlForCurrentLocalization(String localeName) {
   final _infernoRulesLinkMap = {
-    'zh': R.infernoRulesLinkZh,
-    'en': R.infernoRulesLinkEn
+    'zh': Resources.infernoRulesLinkZh,
+    'en': Resources.infernoRulesLinkEn
   };
 
-  final urlForCurrentLocalization =
-      _infernoRulesLinkMap[appLocalizationsOf(context).localeName];
+  final urlForCurrentLocalization = _infernoRulesLinkMap[localeName];
 
-  return urlForCurrentLocalization ?? R.infernoRulesLinkEn;
+  return urlForCurrentLocalization ?? Resources.infernoRulesLinkEn;
 }

--- a/test/utils/launch_inferno_rules_test.dart
+++ b/test/utils/launch_inferno_rules_test.dart
@@ -1,0 +1,20 @@
+import 'package:ardrive/misc/resources.dart';
+import 'package:ardrive/utils/launch_inferno_rules.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('testing getUrlForCurrentLocalization function', () {
+    test('should return the zh rules page for zh locale', () {
+      expect(Resources.infernoRulesLinkZh, getUrlForCurrentLocalization('zh'));
+    });
+    test('should return the en rules page for zh locale', () {
+      expect(Resources.infernoRulesLinkEn, getUrlForCurrentLocalization('en'));
+    });
+
+    test(
+        'should return the en rules page for other localizations different of en and zh',
+        () {
+      expect(Resources.infernoRulesLinkEn, getUrlForCurrentLocalization('es'));
+    });
+  });
+}


### PR DESCRIPTION
The rules for Inferno are written in English and Chinese, yet the in-app fire icon only directs users to the English rules page. We need to ensure that users of the Chinese version of the app are redirected to the Chinese rules page.