### PR TITLE
refactor: validate file status before share PE-1797

### DIFF
--- a/lib/blocs/file_share/file_share_state.dart
+++ b/lib/blocs/file_share/file_share_state.dart
@@ -11,6 +11,10 @@ abstract class FileShareState extends Equatable {
 /// [FileShareLoadInProgress] means that the file share details are being loaded.
 class FileShareLoadInProgress extends FileShareState {}
 
+class FileShareLoadedPendingFile extends FileShareState {}
+
+class FileShareLoadedFailedFile extends FileShareState {}
+
 /// [FileShareLoadSuccess] provides details for the user to share the file with.
 class FileShareLoadSuccess extends FileShareState {
   final String fileName;

--- a/lib/components/file_share_dialog.dart
+++ b/lib/components/file_share_dialog.dart
@@ -23,12 +23,14 @@ Future<void> promptToShareFile({
           profileCubit: context.read<ProfileCubit>(),
           driveDao: context.read<DriveDao>(),
         ),
-        child: FileShareDialog(),
+        child: const FileShareDialog(),
       ),
     );
 
 /// Depends on a provided [FileShareCubit] for business logic.
 class FileShareDialog extends StatefulWidget {
+  const FileShareDialog({Key? key}) : super(key: key);
+
   @override
   _FileShareDialogState createState() => _FileShareDialogState();
 }
@@ -57,6 +59,10 @@ class _FileShareDialogState extends State<FileShareDialog> {
               children: [
                 if (state is FileShareLoadInProgress)
                   const Center(child: CircularProgressIndicator())
+                else if (state is FileShareLoadedFailedFile)
+                  Text(appLocalizationsOf(context).shareFailedFile)
+                else if (state is FileShareLoadedPendingFile)
+                  Text(appLocalizationsOf(context).sharePendingFile)
                 else if (state is FileShareLoadSuccess) ...{
                   ListTile(
                     title: Text(state.fileName),
@@ -107,6 +113,14 @@ class _FileShareDialogState extends State<FileShareDialog> {
                   context.read<FeedbackSurveyCubit>().openRemindMe();
                 },
                 child: Text(appLocalizationsOf(context).doneEmphasized),
+              )
+            else if (state is FileShareLoadedFailedFile ||
+                state is FileShareLoadedPendingFile)
+              TextButton(
+                onPressed: () {
+                  Navigator.pop(context);
+                },
+                child: Text(appLocalizationsOf(context).ok),
               ),
           ],
         ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -665,6 +665,14 @@
   "@shareFile": {
     "description": "The action of sharing a file link"
   },
+  "sharePendingFile": "The file you are trying to share is currently pending and can’t be shared at this time.",
+  "@sharePendingFile": {
+    "description": "Pending file share dialog text"
+  },
+  "shareFailedFile": "The file you are attempting to share is invalid and cannot be shared.",
+  "@shareFailedFile": {
+    "description": "Failed file share dialog text"
+  },
   "shareFileWithOthers": "Share file with others",
   "@shareFileWithOthers": {
     "description": "To share a file link"


### PR DESCRIPTION
Checks for transaction status of the dataTx before sharing a file.