### PR TITLE
fix: fix incorrect files and folders under parent PE-882

### DIFF
--- a/lib/models/database/database.dart
+++ b/lib/models/database/database.dart
@@ -15,7 +15,7 @@ class Database extends _$Database {
   Database([QueryExecutor? e]) : super(e ?? openConnection());
 
   @override
-  int get schemaVersion => 15;
+  int get schemaVersion => 16;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(

--- a/lib/models/queries/drive_queries.moor
+++ b/lib/models/queries/drive_queries.moor
@@ -14,7 +14,7 @@ driveById: SELECT * FROM drives WHERE id = :driveId;
 oldestDriveRevisionByDriveId:
     SELECT * FROM drive_revisions
     WHERE driveId = :driveId
-    ORDER BY dateCreated ASC 
+    ORDER BY dateCreated ASC
     LIMIT 1;
 latestDriveRevisionByDriveId:
     SELECT * FROM drive_revisions
@@ -32,7 +32,7 @@ folderById:
     WHERE driveId = :driveId AND id = :folderId;
 folderWithPath:
     SELECT * FROM folder_entries
-    WHERE driveId = :driveId AND path = :path 
+    WHERE driveId = :driveId AND path = :path
     LIMIT 1;
 
 foldersInFolder ($order = ''):
@@ -44,9 +44,9 @@ foldersInFolderAtPath ($order = ''):
     SELECT * FROM folder_entries
     WHERE parentFolderId IN (
         SELECT id FROM folder_entries
-        WHERE driveId = :driveId AND path = :path 
+        WHERE driveId = :driveId AND path = :path
         LIMIT 1
-    ) 
+    )
     ORDER BY $order;
 
 ghostFolders:
@@ -60,7 +60,7 @@ foldersInFolderWithName:
 oldestFolderRevisionByFolderId:
     SELECT * FROM folder_revisions
     WHERE driveId = :driveId AND folderId = :folderId
-    ORDER BY dateCreated ASC 
+    ORDER BY dateCreated ASC
     LIMIT 1;
 latestFolderRevisionByFolderId:
     SELECT * FROM folder_revisions
@@ -90,7 +90,11 @@ filesInFolderWithName:
     WHERE driveId = :driveId AND parentFolderId = :parentFolderId AND name = :name;
 filesInFolderAtPath ($order = ''):
     SELECT * FROM file_entries
-    WHERE driveId = :driveId AND path LIKE :path || '/%' AND path NOT LIKE :path || '/%/%'
+    WHERE parentFolderId IN (
+        SELECT id FROM folder_entries
+        WHERE driveId = :driveId AND path = :path
+        LIMIT 1
+    )
     ORDER BY $order;
 
 filesInFolderWithRevisionTransactions ($order = '') AS FileWithLatestRevisionTransactions:
@@ -119,7 +123,11 @@ filesInFolderAtPathWithRevisionTransactions ($order = '') AS FileWithLatestRevis
         WHERE driveId = :driveId AND fileId = file_entries.id
         ORDER BY rev.dateCreated DESC
         LIMIT 1)
-    WHERE driveId = :driveId AND path LIKE :path || '/%' AND path NOT LIKE :path || '/%/%'
+     WHERE parentFolderId IN (
+        SELECT id FROM folder_entries
+        WHERE driveId = :driveId AND path = :path
+        LIMIT 1
+    )
     ORDER BY $order;
 
 filesInDriveWithRevisionTransactions ($order = '') AS FileWithLatestRevisionTransactions:


### PR DESCRIPTION
Updates the filesAtPath query to use a subquery instead of like comparison.