### PR TITLE
fix: save drive state locally

### DIFF
--- a/lib/blocs/sync/sync_cubit.dart
+++ b/lib/blocs/sync/sync_cubit.dart
@@ -284,12 +284,6 @@ class SyncCubit extends Cubit<SyncState> {
 
       _syncProgress = _syncProgress.copyWith(drivesCount: drives.length);
 
-      syncFormatedPrint('Current block height number $currentBlockHeight');
-
-      drives.forEach((drive) {
-        syncFormatedPrint('Drive last block height: ${drive.lastBlockHeight!}');
-      });
-
       final driveSyncProcesses = drives.map((drive) => _syncDrive(
             drive.id,
             lastBlockHeight: calculateSyncLastBlockHeight(
@@ -564,8 +558,6 @@ class SyncCubit extends Cubit<SyncState> {
         200 ~/ (_syncProgress.drivesCount - _syncProgress.drivesSynced);
     var currentDriveEntitiesSynced = 0;
     var driveSyncProgress = 0.0;
-    syncFormatedPrint('_syncSecondPhase: $currentBlockHeight');
-
     syncFormatedPrint(
         'number of drives at get metadata phase : ${_syncProgress.numberOfDrivesAtGetMetadataPhase}');
 
@@ -628,8 +620,6 @@ class SyncCubit extends Cubit<SyncState> {
 
           // Handle the last page of newEntities, i.e; There's nothing more to sync
           if (newEntities.length < pageCount) {
-            syncFormatedPrint(
-                'Saving last block height at _paginateProcess. $currentBlockHeight');
             // Reset the sync cursor after every sync to pick up files from other instances of the app.
             // (Different tab, different window, mobile, desktop etc)
             await _driveDao.writeToDrive(DrivesCompanion(

--- a/lib/blocs/sync/sync_cubit.dart
+++ b/lib/blocs/sync/sync_cubit.dart
@@ -286,6 +286,10 @@ class SyncCubit extends Cubit<SyncState> {
 
       syncFormatedPrint('Current block height number $currentBlockHeight');
 
+      drives.forEach((drive) {
+        syncFormatedPrint('Drive last block height: ${drive.lastBlockHeight!}');
+      });
+
       final driveSyncProcesses = drives.map((drive) => _syncDrive(
             drive.id,
             lastBlockHeight: calculateSyncLastBlockHeight(
@@ -560,6 +564,7 @@ class SyncCubit extends Cubit<SyncState> {
         200 ~/ (_syncProgress.drivesCount - _syncProgress.drivesSynced);
     var currentDriveEntitiesSynced = 0;
     var driveSyncProgress = 0.0;
+    syncFormatedPrint('_syncSecondPhase: $currentBlockHeight');
 
     syncFormatedPrint(
         'number of drives at get metadata phase : ${_syncProgress.numberOfDrivesAtGetMetadataPhase}');
@@ -623,6 +628,8 @@ class SyncCubit extends Cubit<SyncState> {
 
           // Handle the last page of newEntities, i.e; There's nothing more to sync
           if (newEntities.length < pageCount) {
+            syncFormatedPrint(
+                'Saving last block height at _paginateProcess. $currentBlockHeight');
             // Reset the sync cursor after every sync to pick up files from other instances of the app.
             // (Different tab, different window, mobile, desktop etc)
             await _driveDao.writeToDrive(DrivesCompanion(

--- a/lib/pages/app_router_delegate.dart
+++ b/lib/pages/app_router_delegate.dart
@@ -87,7 +87,6 @@ class AppRouterDelegate extends RouterDelegate<AppRoutePath>
           final lastLoggedInUser =
               state is ProfileLoggedIn ? state.walletAddress : null;
           if (lastLoggedInUser != null) {
-            print('deleteSharedPrivateDrives $lastLoggedInUser');
             context
                 .read<DriveDao>()
                 .deleteSharedPrivateDrives(lastLoggedInUser);

--- a/lib/pages/app_router_delegate.dart
+++ b/lib/pages/app_router_delegate.dart
@@ -86,7 +86,12 @@ class AppRouterDelegate extends RouterDelegate<AppRoutePath>
           // TODO: Find a better place to do this
           final lastLoggedInUser =
               state is ProfileLoggedIn ? state.walletAddress : null;
-          context.read<DriveDao>().deleteSharedPrivateDrives(lastLoggedInUser);
+          if (lastLoggedInUser != null) {
+            print('deleteSharedPrivateDrives $lastLoggedInUser');
+            context
+                .read<DriveDao>()
+                .deleteSharedPrivateDrives(lastLoggedInUser);
+          }
         },
         builder: (context, state) {
           Widget? shell;


### PR DESCRIPTION
### Overview
Synchronization begins at block 0 after unlocking the session, resulting in a full sync again.
Further incremental syncs work as expected.

After logging back in from a locked state, the drive state should resume synchronizing from the block height where it last left off.