### PR TITLE
PE-1919: Refactor custom Arweave Gateway URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ This will trigger a GitHub Action that will deploy `master` to production.
 
 ## Using a custom Arweave Gateway URL
 
-You can use a custom gateway URL by setting the `flutter.arweaveGatewayUrl` item in your local storage.
+You can use a custom gateway URL by setting the `flutter.arweaveGatewayUrl` key in your browser's Local Storage.
 
-In web you can use this example in the JavaScript console of your browser:
+With the web app opened you can access the browser's JavaScript console to run the follow examples:
 
 ```js
 // To set the item

--- a/README.md
+++ b/README.md
@@ -56,3 +56,19 @@ All changes made to `dev` will be continuously deployed to [staging.ardrive.io](
 To create a release to [app.ardrive.io](https://app.ardrive.io), first merge any changes from `dev` into `master` that are required, and publish a new release through the GitHub UI with the tag name matching the pattern `v*` eg. `v1.0.1`.
 
 This will trigger a GitHub Action that will deploy `master` to production.
+
+## Using a custom Arweave Gateway URL
+
+You can use a custom gateway URL by setting the `flutter.arweaveGatewayUrl` item in your local storage.
+
+In web you can use this example in the JavaScript console of your browser:
+
+```js
+// To set the item
+localStorage.setItem('flutter.arweaveGatewayUrl', 'https://my.custom.url');
+
+// To remove it (set the default)
+localStorage.removeItem('flutter.arweaveGatewayUrl');
+```
+
+You may need to reload to apply the change.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:ardrive/blocs/activity/activity_cubit.dart';
 import 'package:ardrive/blocs/feedback_survey/feedback_survey_cubit.dart';
 import 'package:ardrive/utils/html/html_util.dart';
+import 'package:ardrive/utils/local_key_value_store.dart';
 import 'package:arweave/arweave.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -21,7 +22,9 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   configService = ConfigService();
-  config = await configService.getConfig();
+  config = await configService.getConfig(
+    localStore: await LocalKeyValueStore.getInstance(),
+  );
 
   arweave = ArweaveService(
       Arweave(gatewayUrl: Uri.parse(config.defaultArweaveGatewayUrl!)));

--- a/lib/services/config/config_service.dart
+++ b/lib/services/config/config_service.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import 'package:cooky/cooky.dart' as cookie;
+import 'package:ardrive/utils/local_key_value_store.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
@@ -11,14 +11,15 @@ class ConfigService {
 
   Future<AppConfig> getConfig() async {
     if (_config == null) {
-      final environment = kReleaseMode ? 'prod' : 'dev';
+      const environment = kReleaseMode ? 'prod' : 'dev';
       final configContent =
           await rootBundle.loadString('assets/config/$environment.json');
 
-      final gatewayCookie = cookie.get('arweaveGatewayUrl');
+      final localStorage = await LocalKeyValueStore.getInstance();
+      final gatewayUrl = localStorage.getString('arweaveGatewayUrl');
 
-      _config = AppConfig.fromJson(gatewayCookie != null
-          ? {'defaultArweaveGatewayUrl': gatewayCookie}
+      _config = AppConfig.fromJson(gatewayUrl != null
+          ? {'defaultArweaveGatewayUrl': gatewayUrl}
           : json.decode(configContent));
     }
 

--- a/lib/services/config/config_service.dart
+++ b/lib/services/config/config_service.dart
@@ -9,14 +9,13 @@ import 'config.dart';
 class ConfigService {
   AppConfig? _config;
 
-  Future<AppConfig> getConfig() async {
+  Future<AppConfig> getConfig({required LocalKeyValueStore localStore}) async {
     if (_config == null) {
       const environment = kReleaseMode ? 'prod' : 'dev';
       final configContent =
           await rootBundle.loadString('assets/config/$environment.json');
 
-      final localStorage = await LocalKeyValueStore.getInstance();
-      final gatewayUrl = localStorage.getString('arweaveGatewayUrl');
+      final gatewayUrl = localStore.getString('arweaveGatewayUrl');
 
       _config = AppConfig.fromJson(gatewayUrl != null
           ? {'defaultArweaveGatewayUrl': gatewayUrl}

--- a/lib/utils/key_value_store.dart
+++ b/lib/utils/key_value_store.dart
@@ -1,5 +1,8 @@
 abstract class KeyValueStore {
   Future<bool> putBool(String key, bool value);
   bool? getBool(String key);
+  Future<bool> putString(String key, String value);
+  String? getString(String key);
   Future<bool> remove(String key);
+  Set<String> getKeys();
 }

--- a/lib/utils/local_key_value_store.dart
+++ b/lib/utils/local_key_value_store.dart
@@ -32,7 +32,22 @@ class LocalKeyValueStore implements KeyValueStore {
   }
 
   @override
+  Future<bool> putString(String key, String value) {
+    return _preferences.setString(key, value);
+  }
+
+  @override
+  String? getString(String key) {
+    return _preferences.getString(key);
+  }
+
+  @override
   Future<bool> remove(String key) {
     return _preferences.remove(key);
+  }
+
+  @override
+  Set<String> getKeys() {
+    return _preferences.getKeys();
   }
 }

--- a/lib/utils/local_key_value_store.dart
+++ b/lib/utils/local_key_value_store.dart
@@ -6,7 +6,7 @@ class LocalKeyValueStore implements KeyValueStore {
 
   LocalKeyValueStore._create();
 
-  static Future<KeyValueStore> getInstance({
+  static Future<LocalKeyValueStore> getInstance({
     /// takes a SharedPreferences for testing purposes
     SharedPreferences? prefs,
   }) async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -206,13 +206,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
-  cooky:
-    dependency: "direct main"
-    description:
-      name: cooky
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
   coverage:
     dependency: transitive
     description:
@@ -572,6 +565,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: "direct overridden"
     description:
@@ -732,7 +732,7 @@ packages:
       name: platform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.2"
+    version: "3.1.0"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -1017,21 +1017,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.17.12"
+    version: "1.19.5"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.9"
   timeago:
     dependency: "direct main"
     description:
@@ -1115,7 +1115,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.3.0"
+    version: "7.5.0"
   watcher:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -565,13 +565,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
-  material_color_utilities:
-    dependency: transitive
-    description:
-      name: material_color_utilities
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.3"
   meta:
     dependency: "direct overridden"
     description:
@@ -732,7 +725,7 @@ packages:
       name: platform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "3.0.2"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -1017,21 +1010,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.19.5"
+    version: "1.17.12"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
+    version: "0.4.3"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.2"
   timeago:
     dependency: "direct main"
     description:
@@ -1115,7 +1108,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.5.0"
+    version: "7.3.0"
   watcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,7 +47,6 @@ dependencies:
   csv: 5.0.0
   stash_memory: 4.0.1
   percent_indicator: ^4.0.0
-  cooky: ^2.0.0
   flutter_lints: ^1.0.4
   retry: ^3.1.0
   shared_preferences: ^2.0.15

--- a/test/blocs/drive_create_cubit_test.dart
+++ b/test/blocs/drive_create_cubit_test.dart
@@ -2,6 +2,7 @@ import 'package:ardrive/blocs/blocs.dart';
 import 'package:ardrive/entities/entities.dart';
 import 'package:ardrive/models/models.dart';
 import 'package:ardrive/services/services.dart';
+import 'package:ardrive/utils/local_key_value_store.dart';
 import 'package:arweave/arweave.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:cryptography/cryptography.dart';
@@ -32,7 +33,9 @@ void main() {
       db = getTestDb();
       driveDao = db.driveDao;
       final configService = ConfigService();
-      final config = await configService.getConfig();
+      final config = await configService.getConfig(
+        localStore: await LocalKeyValueStore.getInstance(),
+      );
 
       arweave = ArweaveService(
           Arweave(gatewayUrl: Uri.parse(config.defaultArweaveGatewayUrl!)));

--- a/test/blocs/folder_create_cubit_test.dart
+++ b/test/blocs/folder_create_cubit_test.dart
@@ -1,6 +1,7 @@
 import 'package:ardrive/blocs/blocs.dart';
 import 'package:ardrive/models/models.dart';
 import 'package:ardrive/services/services.dart';
+import 'package:ardrive/utils/local_key_value_store.dart';
 import 'package:arweave/arweave.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -25,7 +26,9 @@ void main() {
       driveDao = db.driveDao;
 
       final configService = ConfigService();
-      final config = await configService.getConfig();
+      final config = await configService.getConfig(
+        localStore: await LocalKeyValueStore.getInstance(),
+      );
 
       arweave = ArweaveService(
           Arweave(gatewayUrl: Uri.parse(config.defaultArweaveGatewayUrl!)));

--- a/test/utils/key_value_store_test.dart
+++ b/test/utils/key_value_store_test.dart
@@ -8,7 +8,10 @@ void main() {
     late KeyValueStore store;
 
     setUp(() async {
-      Map<String, Object> values = <String, Object>{'isItTrue': false};
+      Map<String, Object> values = <String, Object>{
+        'isItTrue': false,
+        'aStringValue': 'IM THE STRING!',
+      };
       SharedPreferences.setMockInitialValues(values);
       final fakePrefs = await SharedPreferences.getInstance();
       store = await LocalKeyValueStore.getInstance(prefs: fakePrefs);
@@ -24,14 +27,28 @@ void main() {
       });
     });
 
+    group('putString method', () {
+      test('replaces the previous value', () async {
+        var currentValue = store.getString('aStringValue');
+        expect(currentValue, 'IM THE STRING!');
+        await store.putString('aStringValue', 'DIFFERENT STRING!');
+        currentValue = store.getString('aStringValue');
+        expect(currentValue, 'DIFFERENT STRING!');
+      });
+    });
+
     group('remove method', () {
       test(
         'returns true when sucessfully removed and the value turns null',
         () async {
-          final success = await store.remove('isItTrue');
-          expect(success, true);
-          var currentValue = store.getBool('isItTrue');
-          expect(currentValue, null);
+          final successBoolean = await store.remove('isItTrue');
+          final successString = await store.remove('aStringValue');
+          expect(successBoolean, true);
+          expect(successString, true);
+          var currentBoolValue = store.getBool('isItTrue');
+          var currentStringValue = store.getBool('aStringValue');
+          expect(currentBoolValue, null);
+          expect(currentStringValue, null);
         },
       );
     });
@@ -39,6 +56,13 @@ void main() {
     group('getBool method', () {
       test('returns null if the key is not present', () async {
         var currentValue = store.getBool('isItTrue');
+        expect(currentValue, null);
+      });
+    });
+
+    group('getString method', () {
+      test('returns null if the key is not present', () async {
+        var currentValue = store.getString('aStringValue');
         expect(currentValue, null);
       });
     });

--- a/test/utils/key_value_store_test.dart
+++ b/test/utils/key_value_store_test.dart
@@ -17,6 +17,13 @@ void main() {
       store = await LocalKeyValueStore.getInstance(prefs: fakePrefs);
     });
 
+    group('getKeys method', () {
+      test('lists all non-null item\'s keys', () async {
+        final allKeys = store.getKeys();
+        expect(allKeys, ['isItTrue', 'aStringValue']);
+      });
+    });
+
     group('putBool method', () {
       test('replaces the previous value', () async {
         var currentValue = store.getBool('isItTrue');


### PR DESCRIPTION
Changes

- Uses `LocalKeyValueStore` instead of a cookie to hold the custom URL
- Removes the `cooky` dep
  - ~FIXME: Some versions were unintentionally updated~
- Adds an entry to the README.md explaining the new behavior