### PR TITLE
chore(app version) use version 1.26.2 PE-2025

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Secure, permanent storage
 
 publish_to: 'none'
 
-version: 1.26.1
+version: 1.26.2
 
 environment:
   sdk: '>=2.15.0 <3.0.0'


### PR DESCRIPTION
The commit message is incorrect. It is 1.26.2.