### PR TITLE
format the flutter installation link correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ After installing lefthook you need to enable it by running:
 lefthook install
 ```
 
-If your environment is using homebrew, install the Flutter SDK with its cask as shown below. Alternatively, visit the [Flutter Installation Instructions][https://flutter.dev/docs/get-started/install] to get the Flutter SDK up and running for your OS / local setup.
+If your environment is using homebrew, install the Flutter SDK with its cask as shown below. Alternatively, visit the [Flutter Installation Instructions](https://flutter.dev/docs/get-started/install) to get the Flutter SDK up and running for your OS / local setup.
 
 ```shell
 # with homebrew


### PR DESCRIPTION
Format the Flutter installation link correctly.

Before:
[Flutter Installation Instructions][https://flutter.dev/docs/get-started/install]

now:
[Flutter Installation Instructions](https://flutter.dev/docs/get-started/install)