### PR TITLE
PE-2196 Fix revision used in shared file widget

### DIFF
--- a/lib/pages/shared_file/shared_file_page.dart
+++ b/lib/pages/shared_file/shared_file_page.dart
@@ -81,9 +81,9 @@ class SharedFilePage extends StatelessWidget {
                           ListTile(
                             contentPadding: EdgeInsets.zero,
                             leading: const Icon(Icons.text_snippet),
-                            title: Text(state.fileRevisions.last.name),
+                            title: Text(state.fileRevisions.first.name),
                             subtitle:
-                                Text(filesize(state.fileRevisions.last.size)),
+                                Text(filesize(state.fileRevisions.first.size)),
                           ),
                           const SizedBox(height: 24),
                           ElevatedButton.icon(
@@ -91,7 +91,7 @@ class SharedFilePage extends StatelessWidget {
                             label: Text(appLocalizationsOf(context).download),
                             onPressed: () => promptToDownloadSharedFile(
                               context: context,
-                              fileId: state.fileRevisions.last.fileId,
+                              fileId: state.fileRevisions.first.fileId,
                               fileKey: state.fileKey,
                             ),
                           ),


### PR DESCRIPTION
Uses the first revision (i.e; latest) instead of the last for information.