### PR TITLE
documentation(typo): Adds missing flutter command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ flutter pub get
 ```
 Install script runner to have access to pubspec scripts
 ```
-pub global activate script_runner
+flutter pub global activate script_runner
 ```
+
+Make sure to add scr to your path with ``export``
 
 In order to run them we need to use ``scr`` plus a ``pubspec.yaml`` script
 


### PR DESCRIPTION
Adds missing leading `flutter` command
Adds mention to `export` to path