### PR TITLE
PE-2365: Conditional platform tag

### DIFF
--- a/lib/entities/entity.dart
+++ b/lib/entities/entity.dart
@@ -92,8 +92,11 @@ extension TransactionUtils on TransactionBase {
     DateTime? unixTime,
     Platform platform = const LocalPlatform(),
   }) async {
+    final platformString = getPlatform(platform: platform);
     addTag(EntityTag.appName, 'ArDrive-App');
-    addTag(EntityTag.appPlatform, getPlatform(platform: platform));
+    if (platformString != null) {
+      addTag(EntityTag.appPlatform, platformString);
+    }
     addTag(EntityTag.appVersion, version);
     addTag(
         EntityTag.unixTime,

--- a/lib/utils/app_platform.dart
+++ b/lib/utils/app_platform.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:platform/platform.dart';
 
-String getPlatform({Platform platform = const LocalPlatform()}) {
+String? getPlatform({Platform platform = const LocalPlatform()}) {
   if (kIsWeb) {
     return 'Web';
   }
@@ -15,6 +15,6 @@ String getPlatform({Platform platform = const LocalPlatform()}) {
     case 'ios':
       return 'iOS';
     default:
-      throw Exception('Unsupported platform $operatingSystem!');
+      return null;
   }
 }

--- a/lib/utils/bundles/fake_tags.dart
+++ b/lib/utils/bundles/fake_tags.dart
@@ -16,6 +16,7 @@ final fakePrivateTags = [
 fakeApplicationTags({Platform platform = const LocalPlatform()}) async {
   final packageInfo = await PackageInfo.fromPlatform();
   final version = packageInfo.version;
+  final platformString = getPlatform(platform: platform);
 
   return <Tag>[
     Tag(EntityTag.appName, 'ArDrive-App'),
@@ -24,7 +25,7 @@ fakeApplicationTags({Platform platform = const LocalPlatform()}) async {
       EntityTag.unixTime,
       (DateTime.now().millisecondsSinceEpoch ~/ 1000).toString(),
     ),
-    Tag(EntityTag.appPlatform, getPlatform(platform: platform)),
+    if (platformString != null) Tag(EntityTag.appPlatform, platformString),
   ];
 }
 


### PR DESCRIPTION
Suggested changes to make the `App-Platform` tag to be conditional when the platform cannot be determined.

--- Releases ---
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/32gl2b62q2400