### PR TITLE
PE-2471: biometric login enabled from profile, no fingerprint/face id request from lock screen

### DIFF
--- a/lib/blocs/profile_add/profile_add_cubit.dart
+++ b/lib/blocs/profile_add/profile_add_cubit.dart
@@ -6,6 +6,7 @@ import 'package:ardrive/models/models.dart';
 import 'package:ardrive/services/arconnect/arconnect_wallet.dart';
 import 'package:ardrive/services/authentication/biometric_authentication.dart';
 import 'package:ardrive/services/services.dart';
+import 'package:ardrive/utils/app_platform.dart';
 import 'package:ardrive/utils/key_value_store.dart';
 import 'package:ardrive/utils/secure_key_value_store.dart';
 import 'package:arweave/arweave.dart';
@@ -202,7 +203,9 @@ class ProfileAddCubit extends Cubit<ProfileAddState> {
 
       await _profileDao.addProfile(username, password, _wallet, _profileType);
 
-      if (await _biometricAuthentication.isEnabled()) {
+      final platform = SystemPlatform.platform;
+
+      if (platform == 'Android' || platform == 'iOS') {
         _savePasswordOnSecureStore(password);
       }
 


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/6u9ia4tu10f1g
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/5adg0amhh2rmo