### PR TITLE
PE-2309: fix: previous versions cannot be downloaded in sharing landing page mode

### DIFF
--- a/lib/blocs/file_download/file_download_cubit.dart
+++ b/lib/blocs/file_download/file_download_cubit.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:developer';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:ardrive/blocs/blocs.dart';
 import 'package:ardrive/entities/entities.dart';

--- a/lib/blocs/file_download/file_download_cubit.dart
+++ b/lib/blocs/file_download/file_download_cubit.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
+import 'dart:developer';
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:ardrive/blocs/blocs.dart';
 import 'package:ardrive/entities/entities.dart';
@@ -9,7 +9,6 @@ import 'package:ardrive/models/models.dart';
 import 'package:ardrive/services/services.dart';
 import 'package:ardrive_io/ardrive_io.dart';
 import 'package:cryptography/cryptography.dart';
-import 'package:drift/drift.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';

--- a/lib/components/file_download_dialog.dart
+++ b/lib/components/file_download_dialog.dart
@@ -62,14 +62,14 @@ Future<void> promptToDownloadFileRevision({
 
 Future<void> promptToDownloadSharedFile({
   required BuildContext context,
-  required String fileId,
   SecretKey? fileKey,
+  required FileRevision revision,
 }) =>
     showDialog(
       context: context,
       builder: (_) => BlocProvider<FileDownloadCubit>(
         create: (_) => SharedFileDownloadCubit(
-          fileId: fileId,
+          revision: revision,
           fileKey: fileKey,
           arweave: context.read<ArweaveService>(),
         ),

--- a/lib/pages/shared_file/shared_file_page.dart
+++ b/lib/pages/shared_file/shared_file_page.dart
@@ -90,8 +90,8 @@ class SharedFilePage extends StatelessWidget {
                             icon: const Icon(Icons.file_download),
                             label: Text(appLocalizationsOf(context).download),
                             onPressed: () => promptToDownloadSharedFile(
+                              revision: state.fileRevisions.first,
                               context: context,
-                              fileId: state.fileRevisions.first.fileId,
                               fileKey: state.fileKey,
                             ),
                           ),

--- a/lib/pages/shared_file/shared_file_side_sheet/shared_file_side_sheet.dart
+++ b/lib/pages/shared_file/shared_file_side_sheet/shared_file_side_sheet.dart
@@ -1,3 +1,5 @@
+import 'dart:developer';
+
 import 'package:ardrive/blocs/shared_file/shared_file_cubit.dart';
 import 'package:ardrive/components/components.dart';
 import 'package:ardrive/entities/entities.dart';
@@ -283,9 +285,14 @@ void downloadOrPreviewRevision({
   required FileRevision revision,
   SecretKey? fileKey,
 }) {
+  log(revision.toJsonString());
+
   if (drivePrivacy == DrivePrivacy.private) {
     promptToDownloadSharedFile(
-        context: context, fileId: revision.fileId, fileKey: fileKey);
+      context: context,
+      revision: revision,
+      fileKey: fileKey,
+    );
   } else {
     context.read<SharedFileCubit>().launchPreview(revision.dataTxId);
   }


### PR DESCRIPTION
If we access a shared file from a private drive and paste it in a new tab, it is not possible to download any revision of the file from the 'Details' and 'Activity' panel.

Now we are using the `FileRevision` to download the file.

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/4b2dr4krpceh8
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/5a2i81bjemppg