### PR TITLE
PE-2615: ok button doesnt work in modal warning for private files on mobile

### DIFF
--- a/lib/blocs/file_download/personal_file_download_cubit.dart
+++ b/lib/blocs/file_download/personal_file_download_cubit.dart
@@ -176,7 +176,11 @@ class ProfileFileDownloadCubit extends FileDownloadCubit {
   @override
   Future<void> abortDownload() async {
     emit(FileDownloadAborted());
-    await _downloader.cancelDownload();
+    final drive = await _arfsRepository.getDriveById(_file.driveId);
+
+    if (drive.drivePrivacy == DrivePrivacy.private) {
+      await _downloader.cancelDownload();
+    }
   }
 
   @override

--- a/lib/components/file_download_dialog.dart
+++ b/lib/components/file_download_dialog.dart
@@ -198,7 +198,8 @@ class FileDownloadDialog extends StatelessWidget {
             final cipherKey =
                 profileState is ProfileLoggedIn ? profileState.cipherKey : null;
 
-            context.read<ProfileFileDownloadCubit>().download(cipherKey);
+            (context.read<FileDownloadCubit>() as ProfileFileDownloadCubit)
+                .download(cipherKey);
           },
           child: Text(appLocalizationsOf(context).ok),
         ),

--- a/test/blocs/personal_file_download_cubit_test.dart
+++ b/test/blocs/personal_file_download_cubit_test.dart
@@ -683,7 +683,7 @@ void main() {
               FileDownloadAborted(),
             ],
         verify: (bloc) {
-          verify(() => mockArDriveDownloader.cancelDownload());
+          verifyNever(() => mockArDriveDownloader.cancelDownload());
 
           /// public files on mobile should not call these functions
           verifyNever(() => mockDownloadService.download(any()));


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/76dcpdu60jjm8
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/20gfv4nnk5fp8