### PR TITLE
PE-2559 button component

### DIFF
--- a/packages/ardrive_ui_library/lib/src/components.dart
+++ b/packages/ardrive_ui_library/lib/src/components.dart
@@ -1,1 +1,2 @@
+export 'components/button.dart';
 export 'components/toggle.dart';

--- a/packages/ardrive_ui_library/lib/src/components/button.dart
+++ b/packages/ardrive_ui_library/lib/src/components/button.dart
@@ -1,0 +1,158 @@
+import 'package:ardrive_ui_library/ardrive_ui_library.dart';
+import 'package:flutter/material.dart';
+
+enum ArDriveButtonStyle { primary, secondary, tertiary }
+
+class ArDriveButton extends StatefulWidget {
+  const ArDriveButton({
+    super.key,
+    required this.text,
+    required this.onPressed,
+    this.style = ArDriveButtonStyle.primary,
+  });
+
+  final String text;
+  final Function() onPressed;
+  final ArDriveButtonStyle style;
+
+  @override
+  State<ArDriveButton> createState() => _ArDriveButtonState();
+}
+
+class _ArDriveButtonState extends State<ArDriveButton> {
+  @override
+  Widget build(BuildContext context) {
+    switch (widget.style) {
+      case ArDriveButtonStyle.primary:
+        return ElevatedButton(
+          style: ButtonStyle(
+            maximumSize: _maxSize,
+            minimumSize: _minimumSize,
+            shape: _shape,
+            padding: _padding,
+            alignment: Alignment.center,
+          ),
+          onPressed: widget.onPressed,
+          child: Text(
+            widget.text,
+            style: ArDriveTypography.headline.headline5Bold(
+              color: ArDriveTheme.of(context).themeData.colors.themeFgOnAccent,
+            ),
+          ),
+        );
+      case ArDriveButtonStyle.secondary:
+        return OutlinedButton(
+          onPressed: widget.onPressed,
+          style: ButtonStyle(
+            maximumSize: _maxSize,
+            minimumSize: _minimumSize,
+            shape: _shapeOutlined,
+            side: _borderSise,
+            padding: _padding,
+          ),
+          child: Text(
+            widget.text,
+            style: ArDriveTypography.headline.headline5Bold(
+              color: ArDriveTheme.of(context).themeData.colors.themeFgDefault,
+            ),
+          ),
+        );
+      case ArDriveButtonStyle.tertiary:
+        return ArDriveTextButton(
+          text: widget.text,
+          onPressed: widget.onPressed,
+        );
+    }
+  }
+
+  MaterialStateProperty<OutlinedBorder> get _shape =>
+      MaterialStateProperty.resolveWith<OutlinedBorder>(
+        (Set<MaterialState> states) {
+          return RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(6),
+          );
+        },
+      );
+  MaterialStateProperty<OutlinedBorder> get _shapeOutlined =>
+      MaterialStateProperty.resolveWith<OutlinedBorder>(
+        (Set<MaterialState> states) {
+          return RoundedRectangleBorder(
+            side: BorderSide(
+              width: 3,
+              style: BorderStyle.solid,
+              color: ArDriveTheme.of(context).themeData.colors.themeFgDefault,
+            ),
+            borderRadius: BorderRadius.circular(6),
+          );
+        },
+      );
+  MaterialStateProperty<BorderSide?> get _borderSise =>
+      MaterialStateProperty.resolveWith<BorderSide?>(
+        (Set<MaterialState> states) {
+          return BorderSide(
+            width: 1,
+            style: BorderStyle.solid,
+            color: ArDriveTheme.of(context).themeData.colors.themeFgDefault,
+          );
+        },
+      );
+
+  MaterialStateProperty<EdgeInsets> get _padding =>
+      MaterialStateProperty.resolveWith<EdgeInsets>(
+        (Set<MaterialState> states) {
+          return const EdgeInsets.symmetric(vertical: 12, horizontal: 12);
+        },
+      );
+  MaterialStateProperty<Size> get _maxSize =>
+      MaterialStateProperty.resolveWith<Size>(
+        (Set<MaterialState> states) {
+          return const Size(368, 56);
+        },
+      );
+
+  MaterialStateProperty<Size> get _minimumSize {
+    late double width;
+    if (MediaQuery.of(context).size.width * 0.8 > 368 + 16) {
+      width = 368;
+    } else {
+      width = MediaQuery.of(context).size.width * 0.8;
+    }
+    return MaterialStateProperty.resolveWith<Size>(
+      (Set<MaterialState> states) {
+        return Size(width, 56);
+      },
+    );
+  }
+}
+
+class ArDriveTextButton extends StatelessWidget {
+  const ArDriveTextButton({
+    super.key,
+    required this.text,
+    required this.onPressed,
+  });
+  final String text;
+  final Function() onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton(
+      style: ButtonStyle(overlayColor: _hoverColor),
+      onPressed: onPressed,
+      child: Text(
+        text,
+        style: ArDriveTypography.body.smallRegular().copyWith(
+              decoration: TextDecoration.underline,
+              color: ArDriveTheme.of(context).themeData.colors.themeFgDefault,
+            ),
+      ),
+    );
+  }
+
+  MaterialStateProperty<Color?> get _hoverColor =>
+      MaterialStateProperty.resolveWith<Color?>(
+        (Set<MaterialState> states) {
+          return Colors.transparent;
+        },
+      );
+}

--- a/packages/ardrive_ui_library/lib/src/styles/fonts/typography.dart
+++ b/packages/ardrive_ui_library/lib/src/styles/fonts/typography.dart
@@ -440,6 +440,7 @@ class Headline {
       fontSize: fontSizeXL,
       fontWeight: FontWeight.w700,
       height: lineHeightsHeadlinesXl,
+      letterSpacing: letterSpacingHeadlines,
     );
   }
 
@@ -450,6 +451,7 @@ class Headline {
       package: _package,
       fontSize: fontSizeXL,
       fontWeight: FontWeight.w800,
+      letterSpacing: letterSpacingHeadlines,
       height: lineHeightsHeadlinesXl,
     );
   }
@@ -467,6 +469,8 @@ const double lineHeightsHeadlinesFefault = 1.1;
 const double lineHeightsHeadlinesSm = 1.3;
 const double lineHeightsBodyRelaxed = 1.75;
 const double lineHeightsBodyDefault = 1.5;
+
+const double letterSpacingHeadlines = -1;
 
 /// Font Sizes
 const double fontSizeBase = 16;

--- a/packages/ardrive_ui_library/storybook/lib/src/colors.dart
+++ b/packages/ardrive_ui_library/storybook/lib/src/colors.dart
@@ -12,245 +12,245 @@ Widget _getContainer(Color color) {
   );
 }
 
-WidgetbookFolder getForegroundColors() {
-  ArDriveColors colors = ArDriveColors.dark();
+WidgetbookCategory getTypographyCategory(bool isDark) {
+  ArDriveColors colors = isDark ? ArDriveColors.dark() : ArDriveColors.light();
 
-  return WidgetbookFolder(name: 'Foreground Colors', widgets: [
-    WidgetbookComponent(name: 'Colors', useCases: [
-      WidgetbookUseCase(
-        name: 'themeFgDefault',
-        builder: (context) => _getContainer(colors.themeFgDefault),
-      ),
-      WidgetbookUseCase(
-        name: 'themeFgMuted',
-        builder: (context) => _getContainer(colors.themeFgMuted),
-      ),
-      WidgetbookUseCase(
-        name: 'themeFgSubtle',
-        builder: (context) => _getContainer(colors.themeFgSubtle),
-      ),
-      WidgetbookUseCase(
-        name: 'themeFgOnAccent',
-        builder: (context) => _getContainer(colors.themeFgOnAccent),
-      ),
-      WidgetbookUseCase(
-        name: 'themeFgOnDisabled',
-        builder: (context) => _getContainer(colors.themeFgOnDisabled),
-      ),
-      WidgetbookUseCase(
-        name: 'themeFgDisabled',
-        builder: (context) => _getContainer(colors.themeFgDisabled),
-      ),
-    ])
-  ]);
-}
+  WidgetbookFolder getForegroundColors() {
+    return WidgetbookFolder(name: 'Foreground Colors', widgets: [
+      WidgetbookComponent(name: 'Colors', useCases: [
+        WidgetbookUseCase(
+          name: 'themeFgDefault',
+          builder: (context) => _getContainer(colors.themeFgDefault),
+        ),
+        WidgetbookUseCase(
+          name: 'themeFgMuted',
+          builder: (context) => _getContainer(colors.themeFgMuted),
+        ),
+        WidgetbookUseCase(
+          name: 'themeFgSubtle',
+          builder: (context) => _getContainer(colors.themeFgSubtle),
+        ),
+        WidgetbookUseCase(
+          name: 'themeFgOnAccent',
+          builder: (context) => _getContainer(colors.themeFgOnAccent),
+        ),
+        WidgetbookUseCase(
+          name: 'themeFgOnDisabled',
+          builder: (context) => _getContainer(colors.themeFgOnDisabled),
+        ),
+        WidgetbookUseCase(
+          name: 'themeFgDisabled',
+          builder: (context) => _getContainer(colors.themeFgDisabled),
+        ),
+      ])
+    ]);
+  }
 
-WidgetbookFolder getBackgroundColors() {
-  ArDriveColors colors = ArDriveColors.dark();
+  WidgetbookFolder getBackgroundColors() {
+    return WidgetbookFolder(name: 'Background Colors', widgets: [
+      WidgetbookComponent(name: 'Colors', useCases: [
+        WidgetbookUseCase(
+          name: 'themeBgSurface',
+          builder: (context) => _getContainer(colors.themeBgSurface),
+        ),
+        WidgetbookUseCase(
+          name: 'themeGbmuted',
+          builder: (context) => _getContainer(colors.themeGbmuted),
+        ),
+        WidgetbookUseCase(
+          name: 'themeBgSubtle',
+          builder: (context) => _getContainer(colors.themeBgSubtle),
+        ),
+        WidgetbookUseCase(
+          name: 'themeBgCanvas',
+          builder: (context) => _getContainer(colors.themeBgCanvas),
+        ),
+      ])
+    ]);
+  }
 
-  return WidgetbookFolder(name: 'Background Colors', widgets: [
-    WidgetbookComponent(name: 'Colors', useCases: [
-      WidgetbookUseCase(
-        name: 'themeBgSurface',
-        builder: (context) => _getContainer(colors.themeBgSurface),
-      ),
-      WidgetbookUseCase(
-        name: 'themeGbmuted',
-        builder: (context) => _getContainer(colors.themeGbmuted),
-      ),
-      WidgetbookUseCase(
-        name: 'themeBgSubtle',
-        builder: (context) => _getContainer(colors.themeBgSubtle),
-      ),
-      WidgetbookUseCase(
-        name: 'themeBgCanvas',
-        builder: (context) => _getContainer(colors.themeBgCanvas),
-      ),
-    ])
-  ]);
-}
+  WidgetbookFolder getAccentColors() {
+    return WidgetbookFolder(name: 'Accent colors', widgets: [
+      WidgetbookComponent(name: 'Colors', useCases: [
+        WidgetbookUseCase(
+          name: 'themeAccentBrand',
+          builder: (context) => _getContainer(colors.themeAccentBrand),
+        ),
+      ])
+    ]);
+  }
 
-WidgetbookFolder getAccentColors() {
-  ArDriveColors colors = ArDriveColors.dark();
+  WidgetbookFolder getWarningColors() {
+    return WidgetbookFolder(name: 'Warning colors', widgets: [
+      WidgetbookComponent(name: 'Colors', useCases: [
+        WidgetbookUseCase(
+          name: 'themeWarningFb',
+          builder: (context) => _getContainer(colors.themeWarningFg),
+        ),
+        WidgetbookUseCase(
+          name: 'themeWarningEmphasis',
+          builder: (context) => _getContainer(colors.themeWarningEmphasis),
+        ),
+        WidgetbookUseCase(
+          name: 'themeWarningMuted',
+          builder: (context) => _getContainer(colors.themeWarningMuted),
+        ),
+        WidgetbookUseCase(
+          name: 'themeWarningSubtle',
+          builder: (context) => _getContainer(colors.themeWarningSubtle),
+        ),
+        WidgetbookUseCase(
+          name: 'themeWarningOnWarning',
+          builder: (context) => _getContainer(colors.themeWarningOnWarning),
+        ),
+      ])
+    ]);
+  }
 
-  return WidgetbookFolder(name: 'Accent colors', widgets: [
-    WidgetbookComponent(name: 'Colors', useCases: [
-      WidgetbookUseCase(
-        name: 'themeAccentBrand',
-        builder: (context) => _getContainer(colors.themeAccentBrand),
-      ),
-    ])
-  ]);
-}
+  WidgetbookFolder getErrorColors() {
+    return WidgetbookFolder(name: 'Error colors', widgets: [
+      WidgetbookComponent(name: 'Colors', useCases: [
+        WidgetbookUseCase(
+          name: 'themeErrorFb',
+          builder: (context) => _getContainer(colors.themeErrorFg),
+        ),
+        WidgetbookUseCase(
+          name: 'themeErrorMuted',
+          builder: (context) => _getContainer(colors.themeErrorMuted),
+        ),
+        WidgetbookUseCase(
+          name: 'themeErrorSubtle',
+          builder: (context) => _getContainer(colors.themeErrorSubtle),
+        ),
+        WidgetbookUseCase(
+          name: 'themeErrorOnError',
+          builder: (context) => _getContainer(colors.themeErrorOnError),
+        ),
+      ])
+    ]);
+  }
 
-WidgetbookFolder getWarningColors() {
-  ArDriveColors colors = ArDriveColors.dark();
+  WidgetbookFolder getInfoColors() {
+    return WidgetbookFolder(name: 'Info colors', widgets: [
+      WidgetbookComponent(name: 'Colors', useCases: [
+        WidgetbookUseCase(
+          name: 'themeInfoFb',
+          builder: (context) => _getContainer(colors.themeInfoFb),
+        ),
+        WidgetbookUseCase(
+          name: 'themeInfoEmphasis',
+          builder: (context) => _getContainer(colors.themeInfoEmphasis),
+        ),
+        WidgetbookUseCase(
+          name: 'themeInfoMuted',
+          builder: (context) => _getContainer(colors.themeInfoMuted),
+        ),
+        WidgetbookUseCase(
+          name: 'themeInfoSubtle',
+          builder: (context) => _getContainer(colors.themeInfoSubtle),
+        ),
+        WidgetbookUseCase(
+          name: 'themeInfoOnInfo',
+          builder: (context) => _getContainer(colors.themeInfoOnInfo),
+        ),
+      ])
+    ]);
+  }
 
-  return WidgetbookFolder(name: 'Warning colors', widgets: [
-    WidgetbookComponent(name: 'Colors', useCases: [
-      WidgetbookUseCase(
-        name: 'themeWarningFb',
-        builder: (context) => _getContainer(colors.themeWarningFg),
-      ),
-      WidgetbookUseCase(
-        name: 'themeWarningEmphasis',
-        builder: (context) => _getContainer(colors.themeWarningEmphasis),
-      ),
-      WidgetbookUseCase(
-        name: 'themeWarningMuted',
-        builder: (context) => _getContainer(colors.themeWarningMuted),
-      ),
-      WidgetbookUseCase(
-        name: 'themeWarningSubtle',
-        builder: (context) => _getContainer(colors.themeWarningSubtle),
-      ),
-      WidgetbookUseCase(
-        name: 'themeWarningOnWarning',
-        builder: (context) => _getContainer(colors.themeWarningOnWarning),
-      ),
-    ])
-  ]);
-}
+  WidgetbookFolder getInputColors() {
+    return WidgetbookFolder(name: 'Input colors', widgets: [
+      WidgetbookComponent(name: 'Colors', useCases: [
+        WidgetbookUseCase(
+          name: 'themeInputBackground',
+          builder: (context) => _getContainer(colors.themeInputBackground),
+        ),
+        WidgetbookUseCase(
+          name: 'themeInputText',
+          builder: (context) => _getContainer(colors.themeInputText),
+        ),
+        WidgetbookUseCase(
+          name: 'themeInputPlaceholder',
+          builder: (context) => _getContainer(colors.themeInputPlaceholder),
+        ),
+        WidgetbookUseCase(
+          name: 'themeInputBorderDisabled',
+          builder: (context) => _getContainer(colors.themeInputBorderDisabled),
+        ),
+        WidgetbookUseCase(
+          name: 'themeInputFbDisabled',
+          builder: (context) => _getContainer(colors.themeInputFbDisabled),
+        ),
+        WidgetbookUseCase(
+          name: 'themeBorderDefault',
+          builder: (context) => _getContainer(colors.themeBorderDefault),
+        ),
+      ])
+    ]);
+  }
 
-WidgetbookFolder getErrorColors() {
-  ArDriveColors colors = ArDriveColors.dark();
+  WidgetbookFolder getSuccessColors() {
+    return WidgetbookFolder(name: 'Success Colors', widgets: [
+      WidgetbookComponent(name: 'Colors', useCases: [
+        WidgetbookUseCase(
+          name: 'themeSuccessFb',
+          builder: (context) => _getContainer(colors.themeSuccessFb),
+        ),
+        WidgetbookUseCase(
+          name: 'themeSuccessEmphasis',
+          builder: (context) => _getContainer(colors.themeSuccessEmphasis),
+        ),
+        WidgetbookUseCase(
+          name: 'themeSuccessMuted',
+          builder: (context) => _getContainer(colors.themeSuccessMuted),
+        ),
+        WidgetbookUseCase(
+          name: 'themeSuccessMuted',
+          builder: (context) => _getContainer(colors.themeSuccessMuted),
+        ),
+        WidgetbookUseCase(
+          name: 'themeSuccessSubtle',
+          builder: (context) => _getContainer(colors.themeSuccessSubtle),
+        ),
+        WidgetbookUseCase(
+          name: 'themeSuccessMuted',
+          builder: (context) => _getContainer(colors.themeSuccessMuted),
+        ),
+        WidgetbookUseCase(
+          name: 'themeSuccessOnSuccess',
+          builder: (context) => _getContainer(colors.themeSuccessOnSuccess),
+        ),
+      ])
+    ]);
+  }
 
-  return WidgetbookFolder(name: 'Error colors', widgets: [
-    WidgetbookComponent(name: 'Colors', useCases: [
-      WidgetbookUseCase(
-        name: 'themeErrorFb',
-        builder: (context) => _getContainer(colors.themeErrorFg),
-      ),
-      WidgetbookUseCase(
-        name: 'themeErrorMuted',
-        builder: (context) => _getContainer(colors.themeErrorMuted),
-      ),
-      WidgetbookUseCase(
-        name: 'themeErrorSubtle',
-        builder: (context) => _getContainer(colors.themeErrorSubtle),
-      ),
-      WidgetbookUseCase(
-        name: 'themeErrorOnError',
-        builder: (context) => _getContainer(colors.themeErrorOnError),
-      ),
-    ])
-  ]);
-}
+  WidgetbookFolder getOverlayColors() {
+    return WidgetbookFolder(
+      name: 'Overlay colors',
+      widgets: [
+        WidgetbookComponent(
+          name: 'Colors',
+          useCases: [
+            WidgetbookUseCase(
+              name: 'themeOverlayBackground',
+              builder: (context) =>
+                  _getContainer(colors.themeOverlayBackground),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
 
-WidgetbookFolder getInfoColors() {
-  ArDriveColors colors = ArDriveColors.dark();
-
-  return WidgetbookFolder(name: 'Info colors', widgets: [
-    WidgetbookComponent(name: 'Colors', useCases: [
-      WidgetbookUseCase(
-        name: 'themeInfoFb',
-        builder: (context) => _getContainer(colors.themeInfoFb),
-      ),
-      WidgetbookUseCase(
-        name: 'themeInfoEmphasis',
-        builder: (context) => _getContainer(colors.themeInfoEmphasis),
-      ),
-      WidgetbookUseCase(
-        name: 'themeInfoMuted',
-        builder: (context) => _getContainer(colors.themeInfoMuted),
-      ),
-      WidgetbookUseCase(
-        name: 'themeInfoSubtle',
-        builder: (context) => _getContainer(colors.themeInfoSubtle),
-      ),
-      WidgetbookUseCase(
-        name: 'themeInfoOnInfo',
-        builder: (context) => _getContainer(colors.themeInfoOnInfo),
-      ),
-    ])
-  ]);
-}
-
-WidgetbookFolder getInputColors() {
-  ArDriveColors colors = ArDriveColors.dark();
-
-  return WidgetbookFolder(name: 'Input colors', widgets: [
-    WidgetbookComponent(name: 'Colors', useCases: [
-      WidgetbookUseCase(
-        name: 'themeInputBackground',
-        builder: (context) => _getContainer(colors.themeInputBackground),
-      ),
-      WidgetbookUseCase(
-        name: 'themeInputText',
-        builder: (context) => _getContainer(colors.themeInputText),
-      ),
-      WidgetbookUseCase(
-        name: 'themeInputPlaceholder',
-        builder: (context) => _getContainer(colors.themeInputPlaceholder),
-      ),
-      WidgetbookUseCase(
-        name: 'themeInputBorderDisabled',
-        builder: (context) => _getContainer(colors.themeInputBorderDisabled),
-      ),
-      WidgetbookUseCase(
-        name: 'themeInputFbDisabled',
-        builder: (context) => _getContainer(colors.themeInputFbDisabled),
-      ),
-      WidgetbookUseCase(
-        name: 'themeBorderDefault',
-        builder: (context) => _getContainer(colors.themeBorderDefault),
-      ),
-    ])
-  ]);
-}
-
-WidgetbookFolder getSuccessColors() {
-  ArDriveColors colors = ArDriveColors.dark();
-
-  return WidgetbookFolder(name: 'Success Colors', widgets: [
-    WidgetbookComponent(name: 'Colors', useCases: [
-      WidgetbookUseCase(
-        name: 'themeSuccessFb',
-        builder: (context) => _getContainer(colors.themeSuccessFb),
-      ),
-      WidgetbookUseCase(
-        name: 'themeSuccessEmphasis',
-        builder: (context) => _getContainer(colors.themeSuccessEmphasis),
-      ),
-      WidgetbookUseCase(
-        name: 'themeSuccessMuted',
-        builder: (context) => _getContainer(colors.themeSuccessMuted),
-      ),
-      WidgetbookUseCase(
-        name: 'themeSuccessMuted',
-        builder: (context) => _getContainer(colors.themeSuccessMuted),
-      ),
-      WidgetbookUseCase(
-        name: 'themeSuccessSubtle',
-        builder: (context) => _getContainer(colors.themeSuccessSubtle),
-      ),
-      WidgetbookUseCase(
-        name: 'themeSuccessMuted',
-        builder: (context) => _getContainer(colors.themeSuccessMuted),
-      ),
-      WidgetbookUseCase(
-        name: 'themeSuccessOnSuccess',
-        builder: (context) => _getContainer(colors.themeSuccessOnSuccess),
-      ),
-    ])
-  ]);
-}
-
-WidgetbookFolder getOverlayColors() {
-  ArDriveColors colors = ArDriveColors.dark();
-
-  return WidgetbookFolder(
-    name: 'Overlay colors',
-    widgets: [
-      WidgetbookComponent(
-        name: 'Colors',
-        useCases: [
-          WidgetbookUseCase(
-            name: 'themeOverlayBackground',
-            builder: (context) => _getContainer(colors.themeOverlayBackground),
-          ),
-        ],
-      ),
-    ],
-  );
+  return WidgetbookCategory(
+      name: isDark ? 'Light Colors' : 'Dark Colors',
+      folders: [
+        getForegroundColors(),
+        getBackgroundColors(),
+        getWarningColors(),
+        getErrorColors(),
+        getInfoColors(),
+        getInputColors(),
+        getSuccessColors(),
+        getOverlayColors(),
+      ]);
 }

--- a/packages/ardrive_ui_library/storybook/lib/src/story_book.dart
+++ b/packages/ardrive_ui_library/storybook/lib/src/story_book.dart
@@ -23,16 +23,8 @@ class StoryBook extends StatelessWidget {
           ],
           appInfo: AppInfo(name: 'ArDrive StoryBook'),
           categories: [
-            WidgetbookCategory(name: 'Colors', folders: [
-              getForegroundColors(),
-              getBackgroundColors(),
-              getWarningColors(),
-              getErrorColors(),
-              getInfoColors(),
-              getInputColors(),
-              getSuccessColors(),
-              getOverlayColors(),
-            ]),
+            getTypographyCategory(true),
+            getTypographyCategory(false),
             WidgetbookCategory(name: 'Toggle', widgets: [
               WidgetbookComponent(name: 'Toggle Dark', useCases: [
                 WidgetbookUseCase(
@@ -105,6 +97,89 @@ class StoryBook extends StatelessWidget {
                     ));
                   },
                 )
+              ])
+            ]),
+            WidgetbookCategory(name: 'Button', widgets: [
+              WidgetbookComponent(name: 'Button', useCases: [
+                WidgetbookUseCase(
+                  name: 'Primary',
+                  builder: (context) {
+                    return Center(
+                      child: ArDriveButton(
+                        onPressed: () {
+                          debugPrint('Primary Button pressed');
+                        },
+                        text: 'Add Profile',
+                      ),
+                    );
+                  },
+                ),
+                WidgetbookUseCase(
+                  name: 'Secundary Light',
+                  builder: (context) {
+                    return Center(
+                      child: ArDriveTheme(
+                        themeData: lightTheme(),
+                        child: ArDriveButton(
+                          style: ArDriveButtonStyle.secondary,
+                          onPressed: () {
+                            debugPrint('Secundary Light Button pressed');
+                          },
+                          text: 'Add Profile',
+                        ),
+                      ),
+                    );
+                  },
+                ),
+                WidgetbookUseCase(
+                  name: 'Secundary Dark',
+                  builder: (context) {
+                    return Center(
+                      child: ArDriveTheme(
+                        child: ArDriveButton(
+                          style: ArDriveButtonStyle.secondary,
+                          onPressed: () {
+                            debugPrint('Secundary Dark Button pressed');
+                          },
+                          text: 'Add Profile',
+                        ),
+                      ),
+                    );
+                  },
+                ),
+                WidgetbookUseCase(
+                  name: 'Tertiary Dark',
+                  builder: (context) {
+                    return Center(
+                      child: ArDriveTheme(
+                        child: ArDriveButton(
+                          style: ArDriveButtonStyle.tertiary,
+                          onPressed: () {
+                            debugPrint('Tertiary Dark Button pressed');
+                          },
+                          text: 'Add Profile',
+                        ),
+                      ),
+                    );
+                  },
+                ),
+                WidgetbookUseCase(
+                  name: 'Tertiary Light',
+                  builder: (context) {
+                    return Center(
+                      child: ArDriveTheme(
+                        themeData: lightTheme(),
+                        child: ArDriveButton(
+                          style: ArDriveButtonStyle.tertiary,
+                          onPressed: () {
+                            debugPrint('Tertiary Light Button pressed');
+                          },
+                          text: 'Add Profile',
+                        ),
+                      ),
+                    );
+                  },
+                ),
               ])
             ])
           ]),

--- a/packages/ardrive_ui_library/test/src/components/button_test.dart
+++ b/packages/ardrive_ui_library/test/src/components/button_test.dart
@@ -1,0 +1,199 @@
+import 'package:ardrive_ui_library/ardrive_ui_library.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _Counter {
+  int count = 0;
+
+  void add() => ++count;
+}
+
+void main() {
+  testWidgets('Should click and update the counter class using in all styles',
+      (tester) async {
+    _Counter counterPrimary = _Counter();
+    _Counter counterSecondary = _Counter();
+    _Counter counterTertiary = _Counter();
+
+    final buttonPrimary = ArDriveButton(
+      style: ArDriveButtonStyle.primary,
+      text: 'Add',
+      onPressed: () {
+        return counterPrimary.add();
+      },
+    );
+    final buttonSecondary = ArDriveButton(
+      style: ArDriveButtonStyle.secondary,
+      text: 'Add',
+      onPressed: () {
+        return counterSecondary.add();
+      },
+    );
+    final buttonTertiary = ArDriveButton(
+      style: ArDriveButtonStyle.tertiary,
+      text: 'Add',
+      onPressed: () {
+        return counterTertiary.add();
+      },
+    );
+    await tester.pumpWidget(
+      ArDriveApp(
+        builder: (context) => MaterialApp(
+          home: buttonPrimary,
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(ArDriveButton));
+
+    expect(counterPrimary.count, 1);
+
+    /// Secondary
+    await tester.pumpWidget(
+      ArDriveApp(
+        builder: (context) => MaterialApp(
+          home: buttonSecondary,
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(ArDriveButton));
+
+    expect(counterSecondary.count, 1);
+
+    /// Tertiary
+    await tester.pumpWidget(
+      ArDriveApp(
+        builder: (context) => MaterialApp(
+          home: buttonTertiary,
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(ArDriveButton));
+
+    expect(counterTertiary.count, 1);
+  });
+
+  testWidgets('Test if button renders', (tester) async {
+    final button = ArDriveButton(
+      text: 'Add',
+      onPressed: () {},
+    );
+    await tester.pumpWidget(ArDriveApp(
+      builder: (context) => MaterialApp(
+        home: button,
+      ),
+    ));
+
+    expect(find.byWidget(button), findsOneWidget);
+  });
+  testWidgets('Test if the text is used correctly on primary', (tester) async {
+    final button = ArDriveButton(
+      text: 'Text',
+      onPressed: () {},
+    );
+    await tester.pumpWidget(ArDriveApp(
+      builder: (context) => MaterialApp(
+        home: button,
+      ),
+    ));
+
+    expect(find.text('Text'), findsOneWidget);
+  });
+
+  testWidgets('Test if the text is used correctly on Secondary',
+      (tester) async {
+    final button = ArDriveButton(
+      style: ArDriveButtonStyle.secondary,
+      text: 'Text',
+      onPressed: () {},
+    );
+    await tester.pumpWidget(ArDriveApp(
+      builder: (context) => MaterialApp(
+        home: button,
+      ),
+    ));
+
+    expect(find.text('Text'), findsOneWidget);
+  });
+
+  testWidgets('Test if the text is used correctly on Tertiary', (tester) async {
+    final button = ArDriveButton(
+      style: ArDriveButtonStyle.tertiary,
+      text: 'Text',
+      onPressed: () {},
+    );
+    await tester.pumpWidget(ArDriveApp(
+      builder: (context) => MaterialApp(
+        home: button,
+      ),
+    ));
+
+    expect(find.text('Text'), findsOneWidget);
+  });
+
+  testWidgets('Test if the text is used correctly on Tertiary', (tester) async {
+    final button = ArDriveButton(
+      style: ArDriveButtonStyle.tertiary,
+      text: 'Text',
+      onPressed: () {},
+    );
+
+    await tester.pumpWidget(ArDriveApp(
+      builder: (context) => MaterialApp(
+        home: button,
+      ),
+    ));
+
+    expect(find.text('Text'), findsOneWidget);
+  });
+
+  testWidgets('Test if ArDriveButton returns ElevatedButton when primary',
+      (tester) async {
+    final button = ArDriveButton(
+      text: 'Text',
+      onPressed: () {},
+    );
+
+    await tester.pumpWidget(ArDriveApp(
+      builder: (context) => MaterialApp(
+        home: button,
+      ),
+    ));
+
+    expect(find.bySubtype<ElevatedButton>(), findsOneWidget);
+  });
+  testWidgets('Test if ArDriveButton returns OutlinedButton when tertiary',
+      (tester) async {
+    final button = ArDriveButton(
+      style: ArDriveButtonStyle.secondary,
+      text: 'Text',
+      onPressed: () {},
+    );
+
+    await tester.pumpWidget(ArDriveApp(
+      builder: (context) => MaterialApp(
+        home: button,
+      ),
+    ));
+
+    expect(find.bySubtype<OutlinedButton>(), findsOneWidget);
+  });
+  testWidgets('Test if ArDriveButton returns ArDriveTextButton when tertiary',
+      (tester) async {
+    final button = ArDriveButton(
+      style: ArDriveButtonStyle.tertiary,
+      text: 'Text',
+      onPressed: () {},
+    );
+
+    await tester.pumpWidget(ArDriveApp(
+      builder: (context) => MaterialApp(
+        home: button,
+      ),
+    ));
+
+    expect(find.bySubtype<ArDriveTextButton>(), findsOneWidget);
+  });
+}


### PR DESCRIPTION
This PR is from the Theme branch which PR is open: #782. I suggest finishing the review there and then reviewing this.

### Overview
Adds the `ArDriveButton` component. This component has 3 styles: `primary`, `secondary`, and `tertiary`. It uses the `ArDriveTheme` and also the `Design tokens`.

Primary: 
![image](https://user-images.githubusercontent.com/32248947/201206241-9e04ebfd-1ad3-449a-a444-20fa02a72de3.png)

Secondary:
![image](https://user-images.githubusercontent.com/32248947/201206324-a5fc95fc-7e44-424a-b8fb-3d43a5bd4277.png)

Tertiary:
![image](https://user-images.githubusercontent.com/32248947/201206403-79fbfb5e-4636-470c-8a82-c1b61bee5b23.png)


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/56ohrs9f91e1g
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/0pt7e439ei5n0