### PR TITLE
PE-2570: add card component

### DIFF
--- a/packages/ardrive_ui_library/lib/src/components.dart
+++ b/packages/ardrive_ui_library/lib/src/components.dart
@@ -1,2 +1,3 @@
 export 'components/button.dart';
+export 'components/card.dart';
 export 'components/toggle.dart';

--- a/packages/ardrive_ui_library/lib/src/components/card.dart
+++ b/packages/ardrive_ui_library/lib/src/components/card.dart
@@ -33,7 +33,7 @@ class ArDriveCard extends StatelessWidget {
       decoration: BoxDecoration(
         color: backgroundColor ??
             ArDriveTheme.of(context).themeData.colors.themeBgSurface,
-        borderRadius: BorderRadius.circular(borderRadius ?? 10),
+        borderRadius: BorderRadius.circular(borderRadius ?? 8),
         boxShadow: [_getBoxShadow(boxShadow, context)],
       ),
       child: Padding(

--- a/packages/ardrive_ui_library/lib/src/components/card.dart
+++ b/packages/ardrive_ui_library/lib/src/components/card.dart
@@ -1,0 +1,44 @@
+import 'package:ardrive_ui_library/src/styles/theme/themes.dart';
+import 'package:flutter/material.dart';
+
+class ArDriveCard extends StatelessWidget {
+  const ArDriveCard({
+    super.key,
+    this.backgroundColor,
+    this.borderRadius,
+    this.elevation = 4.0,
+    required this.content,
+    this.contentPadding = const EdgeInsets.all(8),
+    this.height,
+    this.width,
+  });
+
+  final Color? backgroundColor;
+  final double? borderRadius;
+  final double elevation;
+  final EdgeInsets contentPadding;
+  final Widget content;
+  final double? height;
+  final double? width;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: height,
+      width: width,
+      child: Card(
+        color: backgroundColor ??
+            ArDriveTheme.of(context).themeData.colors.themeBgSurface,
+        elevation: elevation,
+        shadowColor: ArDriveTheme.of(context).themeData.colors.themeBgSurface,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(borderRadius ?? 10),
+        ),
+        child: Padding(
+          padding: contentPadding,
+          child: content,
+        ),
+      ),
+    );
+  }
+}

--- a/packages/ardrive_ui_library/lib/src/components/card.dart
+++ b/packages/ardrive_ui_library/lib/src/components/card.dart
@@ -1,6 +1,8 @@
 import 'package:ardrive_ui_library/src/styles/theme/themes.dart';
 import 'package:flutter/material.dart';
 
+enum BoxShadowCard { shadow20, shadow40, shadow60, shadow80, shadow100 }
+
 class ArDriveCard extends StatelessWidget {
   const ArDriveCard({
     super.key,
@@ -11,6 +13,7 @@ class ArDriveCard extends StatelessWidget {
     this.contentPadding = const EdgeInsets.all(8),
     this.height,
     this.width,
+    this.boxShadow,
   });
 
   final Color? backgroundColor;
@@ -20,25 +23,45 @@ class ArDriveCard extends StatelessWidget {
   final Widget content;
   final double? height;
   final double? width;
+  final BoxShadowCard? boxShadow;
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
+    return Container(
       height: height,
       width: width,
-      child: Card(
+      decoration: BoxDecoration(
         color: backgroundColor ??
             ArDriveTheme.of(context).themeData.colors.themeBgSurface,
-        elevation: elevation,
-        shadowColor: ArDriveTheme.of(context).themeData.colors.themeBgSurface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(borderRadius ?? 10),
-        ),
-        child: Padding(
-          padding: contentPadding,
-          child: content,
-        ),
+        borderRadius: BorderRadius.circular(borderRadius ?? 10),
+        boxShadow: [_getBoxShadow(boxShadow, context)],
+      ),
+      child: Padding(
+        padding: contentPadding,
+        child: content,
       ),
     );
+  }
+
+  BoxShadow _getBoxShadow(BoxShadowCard? boxShadowCard, BuildContext context) {
+    switch (boxShadowCard) {
+      case BoxShadowCard.shadow20:
+        return ArDriveTheme.of(context).themeData.shadows.boxShadow20();
+
+      case BoxShadowCard.shadow40:
+        return ArDriveTheme.of(context).themeData.shadows.boxShadow40();
+
+      case BoxShadowCard.shadow60:
+        return ArDriveTheme.of(context).themeData.shadows.boxShadow60();
+
+      case BoxShadowCard.shadow80:
+        return ArDriveTheme.of(context).themeData.shadows.boxShadow80();
+
+      case BoxShadowCard.shadow100:
+        return ArDriveTheme.of(context).themeData.shadows.boxShadow100();
+
+      default:
+        return ArDriveTheme.of(context).themeData.shadows.boxShadow20();
+    }
   }
 }

--- a/packages/ardrive_ui_library/lib/src/styles.dart
+++ b/packages/ardrive_ui_library/lib/src/styles.dart
@@ -1,3 +1,4 @@
 export 'styles/colors/sematic_colors.dart';
 export 'styles/fonts/typography.dart';
+export 'styles/shadows/shadows.dart';
 export 'styles/theme/themes.dart';

--- a/packages/ardrive_ui_library/lib/src/styles/colors/global_colors.dart
+++ b/packages/ardrive_ui_library/lib/src/styles/colors/global_colors.dart
@@ -9,6 +9,8 @@ const MaterialColor red = MaterialColor(0xffFE0230, _red);
 const MaterialColor grey = MaterialColor(0xff9E9E9E, _grey);
 const Color white = Colors.white;
 const Color black = Colors.black;
+final Color shadowColor = const Color(0xff0D0D0D).withOpacity(0.9);
+final Color shadowColorLight = const Color(0xff303133).withOpacity(0.1);
 
 const Map<int, Color> _blue = {
   50: Color(0xffECEEFE),

--- a/packages/ardrive_ui_library/lib/src/styles/colors/sematic_colors.dart
+++ b/packages/ardrive_ui_library/lib/src/styles/colors/sematic_colors.dart
@@ -10,7 +10,7 @@ class ArDriveColors {
     Color? themeFgOnDisabled,
     Color? themeFgDisabled,
     Color? themeBgSurface,
-    Color? themeGbmuted,
+    Color? themeGbMuted,
     Color? themeBgSubtle,
     Color? themeBgCanvas,
     Color? themeAccentBrand,
@@ -44,6 +44,7 @@ class ArDriveColors {
     Color? themeAccentDefault,
     Color? themeAccentDisabled,
     Color? themeAccentSubtle,
+    Color? shadow,
   }) {
     this.themeFgDefault = themeFgDefault ?? white;
     this.themeFgMuted = themeFgMuted ?? grey.shade100;
@@ -52,7 +53,7 @@ class ArDriveColors {
     this.themeFgOnDisabled = themeFgOnDisabled ?? grey.shade300;
     this.themeFgDisabled = themeFgDisabled ?? grey.shade600;
     this.themeBgSurface = themeBgSurface ?? grey.shade900;
-    this.themeGbmuted = themeGbmuted ?? grey.shade600;
+    this.themeGbMuted = themeGbMuted ?? grey.shade600;
     this.themeBgSubtle = themeBgSubtle ?? grey.shade900;
     this.themeBgCanvas = themeBgCanvas ?? black;
     this.themeAccentBrand = themeAccentBrand ?? red.shade500;
@@ -86,6 +87,7 @@ class ArDriveColors {
     this.themeAccentDefault = blue;
     this.themeAccentDisabled = grey.shade600;
     this.themeAccentSubtle = themeAccentSubtle ?? blue.withOpacity(0.95);
+    this.shadow = shadow ?? shadowColor;
   }
 
   factory ArDriveColors.light() => ArDriveColors(
@@ -96,7 +98,7 @@ class ArDriveColors {
         themeFgOnDisabled: grey.shade600,
         themeFgDisabled: grey.shade400,
         themeBgSurface: white,
-        themeGbmuted: grey.shade300,
+        themeGbMuted: grey.shade300,
         themeBgSubtle: grey.shade200,
         themeBgCanvas: grey.shade50,
         themeWarningFg: yellow.shade600,
@@ -111,6 +113,7 @@ class ArDriveColors {
         themeOverlayBackground: black,
         themeAccentDefault: grey.shade400,
         themeAccentSubtle: blue.shade50,
+        shadow: shadowColorLight,
       );
 
   factory ArDriveColors.dark() => ArDriveColors();
@@ -125,7 +128,7 @@ class ArDriveColors {
 
   /// Background
   late Color themeBgSurface;
-  late Color themeGbmuted;
+  late Color themeGbMuted;
   late Color themeBgSubtle;
   late Color themeBgCanvas;
 
@@ -175,4 +178,7 @@ class ArDriveColors {
 
   /// Overlay
   late Color themeOverlayBackground;
+
+  /// Shadow
+  late Color shadow;
 }

--- a/packages/ardrive_ui_library/lib/src/styles/shadows/shadows.dart
+++ b/packages/ardrive_ui_library/lib/src/styles/shadows/shadows.dart
@@ -1,0 +1,40 @@
+import 'package:ardrive_ui_library/ardrive_ui_library.dart';
+import 'package:flutter/material.dart';
+
+BoxShadow _boxShadow20(ArDriveColors colors) => BoxShadow(
+      color: colors.shadow,
+      offset: const Offset(0, 0),
+      blurRadius: 1,
+    );
+BoxShadow _boxShadow40(ArDriveColors colors) => BoxShadow(
+      color: colors.shadow,
+      offset: const Offset(0, 2),
+      blurRadius: 4,
+    );
+BoxShadow _boxShadow60(ArDriveColors colors) => BoxShadow(
+      color: colors.shadow,
+      offset: const Offset(0, 4),
+      blurRadius: 8,
+    );
+BoxShadow _boxShadow80(ArDriveColors colors) => BoxShadow(
+      color: colors.shadow,
+      offset: const Offset(0, 8),
+      blurRadius: 16,
+    );
+BoxShadow _boxShadow100(ArDriveColors colors) => BoxShadow(
+      color: colors.shadow,
+      offset: const Offset(0, 16),
+      blurRadius: 24,
+    );
+
+class ArDriveShadows {
+  ArDriveShadows(this.colors);
+
+  final ArDriveColors colors;
+
+  BoxShadow boxShadow20() => _boxShadow20(colors);
+  BoxShadow boxShadow40() => _boxShadow40(colors);
+  BoxShadow boxShadow60() => _boxShadow60(colors);
+  BoxShadow boxShadow80() => _boxShadow80(colors);
+  BoxShadow boxShadow100() => _boxShadow100(colors);
+}

--- a/packages/ardrive_ui_library/lib/src/styles/theme/themes.dart
+++ b/packages/ardrive_ui_library/lib/src/styles/theme/themes.dart
@@ -87,6 +87,7 @@ ArDriveThemeData lightTheme() {
   ArDriveColors colors = ArDriveColors.light();
 
   return ArDriveThemeData(
+    backgroundColor: colors.themeBgSurface,
     colors: colors,
     materialThemeData: lightMaterialTheme(),
     name: 'light',

--- a/packages/ardrive_ui_library/lib/src/styles/theme/themes.dart
+++ b/packages/ardrive_ui_library/lib/src/styles/theme/themes.dart
@@ -34,8 +34,10 @@ class ArDriveThemeData {
     ThemeData? materialThemeData,
     String? name,
     ArDriveColors? colors,
+    ArDriveShadows? shadows,
   }) {
     this.colors = colors ?? ArDriveColors();
+    this.shadows = shadows ?? ArDriveShadows(this.colors);
 
     this.toggleTheme = toggleTheme ??
         ArDriveToggleTheme(
@@ -59,6 +61,7 @@ class ArDriveThemeData {
   late ThemeData materialThemeData;
   late String name;
   late ArDriveColors colors;
+  late ArDriveShadows shadows;
 }
 
 ThemeData lightMaterialTheme() {

--- a/packages/ardrive_ui_library/lib/src/styles/theme/themes.dart
+++ b/packages/ardrive_ui_library/lib/src/styles/theme/themes.dart
@@ -100,7 +100,6 @@ class ArDriveTheme extends InheritedWidget {
     required super.child,
     super.key,
   }) {
-    print(themeData?.name);
     this.themeData = themeData ?? ArDriveThemeData();
   }
 

--- a/packages/ardrive_ui_library/storybook/lib/src/button.dart
+++ b/packages/ardrive_ui_library/storybook/lib/src/button.dart
@@ -1,0 +1,89 @@
+import 'package:ardrive_ui_library/ardrive_ui_library.dart';
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+WidgetbookCategory button() {
+  return WidgetbookCategory(name: 'Button', widgets: [
+    WidgetbookComponent(name: 'Button', useCases: [
+      WidgetbookUseCase(
+        name: 'Primary',
+        builder: (context) {
+          return Center(
+            child: ArDriveButton(
+              onPressed: () {
+                debugPrint('Primary Button pressed');
+              },
+              text: 'Add Profile',
+            ),
+          );
+        },
+      ),
+      WidgetbookUseCase(
+        name: 'Secundary Light',
+        builder: (context) {
+          return Center(
+            child: ArDriveTheme(
+              themeData: lightTheme(),
+              child: ArDriveButton(
+                style: ArDriveButtonStyle.secondary,
+                onPressed: () {
+                  debugPrint('Secundary Light Button pressed');
+                },
+                text: 'Add Profile',
+              ),
+            ),
+          );
+        },
+      ),
+      WidgetbookUseCase(
+        name: 'Secundary Dark',
+        builder: (context) {
+          return Center(
+            child: ArDriveTheme(
+              child: ArDriveButton(
+                style: ArDriveButtonStyle.secondary,
+                onPressed: () {
+                  debugPrint('Secundary Dark Button pressed');
+                },
+                text: 'Add Profile',
+              ),
+            ),
+          );
+        },
+      ),
+      WidgetbookUseCase(
+        name: 'Tertiary Dark',
+        builder: (context) {
+          return Center(
+            child: ArDriveTheme(
+              child: ArDriveButton(
+                style: ArDriveButtonStyle.tertiary,
+                onPressed: () {
+                  debugPrint('Tertiary Dark Button pressed');
+                },
+                text: 'Add Profile',
+              ),
+            ),
+          );
+        },
+      ),
+      WidgetbookUseCase(
+        name: 'Tertiary Light',
+        builder: (context) {
+          return Center(
+            child: ArDriveTheme(
+              themeData: lightTheme(),
+              child: ArDriveButton(
+                style: ArDriveButtonStyle.tertiary,
+                onPressed: () {
+                  debugPrint('Tertiary Light Button pressed');
+                },
+                text: 'Add Profile',
+              ),
+            ),
+          );
+        },
+      ),
+    ])
+  ]);
+}

--- a/packages/ardrive_ui_library/storybook/lib/src/card.dart
+++ b/packages/ardrive_ui_library/storybook/lib/src/card.dart
@@ -1,0 +1,58 @@
+import 'package:ardrive_ui_library/ardrive_ui_library.dart';
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+WidgetbookCategory card() {
+  return WidgetbookCategory(name: 'Card', widgets: [
+    WidgetbookComponent(name: 'Card', useCases: [
+      WidgetbookUseCase(
+          name: 'Light',
+          builder: (context) {
+            return Center(
+              child: ArDriveTheme(
+                themeData: lightTheme(),
+                child: _card(),
+              ),
+            );
+          }),
+      WidgetbookUseCase(
+          name: 'Dark',
+          builder: (context) {
+            return Center(
+              child: ArDriveTheme(
+                child: _card(),
+              ),
+            );
+          })
+    ]),
+  ]);
+}
+
+Widget _card() {
+  return ArDriveCard(
+    contentPadding: const EdgeInsets.all(16),
+    content: Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              'Success',
+              style: ArDriveTypography.body.smallBold(),
+            ),
+            SizedBox(
+              height: 8,
+            ),
+            Text(
+              'You created a new drive',
+              style: ArDriveTypography.body.captionRegular(),
+            ),
+          ],
+        ),
+        Icon(Icons.close)
+      ],
+    ),
+  );
+}

--- a/packages/ardrive_ui_library/storybook/lib/src/card.dart
+++ b/packages/ardrive_ui_library/storybook/lib/src/card.dart
@@ -4,31 +4,33 @@ import 'package:widgetbook/widgetbook.dart';
 
 WidgetbookCategory card() {
   return WidgetbookCategory(name: 'Card', widgets: [
-    WidgetbookComponent(name: 'Card', useCases: [
+    WidgetbookComponent(name: 'Card Dark', useCases: [
       WidgetbookUseCase(
-          name: 'Light',
+          name: 'With content',
+          builder: (context) {
+            return Center(
+              child: ArDriveTheme(
+                child: _cardWithContent(),
+              ),
+            );
+          }),
+    ]),
+    WidgetbookComponent(name: 'Card Light', useCases: [
+      WidgetbookUseCase(
+          name: 'With content',
           builder: (context) {
             return Center(
               child: ArDriveTheme(
                 themeData: lightTheme(),
-                child: _card(),
+                child: _cardWithContent(),
               ),
             );
           }),
-      WidgetbookUseCase(
-          name: 'Dark',
-          builder: (context) {
-            return Center(
-              child: ArDriveTheme(
-                child: _card(),
-              ),
-            );
-          })
     ]),
   ]);
 }
-
-Widget _card() {
+ 
+Widget _cardWithContent() {
   return ArDriveCard(
     contentPadding: const EdgeInsets.all(16),
     content: Row(
@@ -42,7 +44,7 @@ Widget _card() {
               'Success',
               style: ArDriveTypography.body.smallBold(),
             ),
-            SizedBox(
+            const SizedBox(
               height: 8,
             ),
             Text(
@@ -51,7 +53,7 @@ Widget _card() {
             ),
           ],
         ),
-        Icon(Icons.close)
+        const Icon(Icons.close)
       ],
     ),
   );

--- a/packages/ardrive_ui_library/storybook/lib/src/colors.dart
+++ b/packages/ardrive_ui_library/storybook/lib/src/colors.dart
@@ -54,8 +54,8 @@ WidgetbookCategory getTypographyCategory(bool isDark) {
           builder: (context) => _getContainer(colors.themeBgSurface),
         ),
         WidgetbookUseCase(
-          name: 'themeGbmuted',
-          builder: (context) => _getContainer(colors.themeGbmuted),
+          name: 'themeGbMuted',
+          builder: (context) => _getContainer(colors.themeGbMuted),
         ),
         WidgetbookUseCase(
           name: 'themeBgSubtle',
@@ -252,5 +252,6 @@ WidgetbookCategory getTypographyCategory(bool isDark) {
         getInputColors(),
         getSuccessColors(),
         getOverlayColors(),
+        getAccentColors(),
       ]);
 }

--- a/packages/ardrive_ui_library/storybook/lib/src/shadows.dart
+++ b/packages/ardrive_ui_library/storybook/lib/src/shadows.dart
@@ -1,0 +1,142 @@
+import 'package:ardrive_ui_library/ardrive_ui_library.dart';
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+WidgetbookCategory shadows() {
+  return WidgetbookCategory(name: 'Shadows', widgets: [
+    WidgetbookComponent(name: 'Shadows Dark', useCases: [
+      WidgetbookUseCase(
+          name: '20%',
+          builder: (context) {
+            return ArDriveTheme(
+              child: _Container(
+                shadow:
+                    ArDriveShadows(ArDriveTheme.of(context).themeData.colors)
+                        .boxShadow20(),
+              ),
+            );
+          }),
+      WidgetbookUseCase(
+          name: '40%',
+          builder: (context) {
+            return ArDriveTheme(
+              child: _Container(
+                shadow:
+                    ArDriveShadows(ArDriveTheme.of(context).themeData.colors)
+                        .boxShadow40(),
+              ),
+            );
+          }),
+      WidgetbookUseCase(
+          name: '60%',
+          builder: (context) {
+            return ArDriveTheme(
+              child: _Container(
+                shadow:
+                    ArDriveShadows(ArDriveTheme.of(context).themeData.colors)
+                        .boxShadow60(),
+              ),
+            );
+          }),
+      WidgetbookUseCase(
+          name: '80%',
+          builder: (context) {
+            return ArDriveTheme(
+              child: _Container(
+                shadow:
+                    ArDriveShadows(ArDriveTheme.of(context).themeData.colors)
+                        .boxShadow80(),
+              ),
+            );
+          }),
+      WidgetbookUseCase(
+          name: '100%',
+          builder: (context) {
+            return ArDriveTheme(
+              child: _Container(
+                shadow:
+                    ArDriveShadows(ArDriveTheme.of(context).themeData.colors)
+                        .boxShadow100(),
+              ),
+            );
+          })
+    ]),
+    WidgetbookComponent(name: 'Shadows Light', useCases: [
+      WidgetbookUseCase(
+          name: '20%',
+          builder: (context) {
+            return ArDriveTheme(
+              themeData: lightTheme(),
+              child: _Container(
+                shadow: ArDriveShadows(lightTheme().colors).boxShadow20(),
+              ),
+            );
+          }),
+      WidgetbookUseCase(
+          name: '40%',
+          builder: (context) {
+            return ArDriveTheme(
+              themeData: lightTheme(),
+              child: _Container(
+                shadow: ArDriveShadows(lightTheme().colors).boxShadow40(),
+              ),
+            );
+          }),
+      WidgetbookUseCase(
+          name: '60%',
+          builder: (context) {
+            return ArDriveTheme(
+              themeData: lightTheme(),
+              child: _Container(
+                shadow: ArDriveShadows(lightTheme().colors).boxShadow60(),
+              ),
+            );
+          }),
+      WidgetbookUseCase(
+          name: '80%',
+          builder: (context) {
+            return ArDriveTheme(
+              themeData: lightTheme(),
+              child: _Container(
+                shadow: ArDriveShadows(lightTheme().colors).boxShadow80(),
+              ),
+            );
+          }),
+      WidgetbookUseCase(
+          name: '100%',
+          builder: (context) {
+            return ArDriveTheme(
+              themeData: lightTheme(),
+              child: _Container(
+                shadow: ArDriveShadows(lightTheme().colors).boxShadow100(),
+              ),
+            );
+          })
+    ])
+  ]);
+}
+
+class _Container extends StatelessWidget {
+  const _Container({
+    super.key,
+    required this.shadow,
+  });
+  final BoxShadow shadow;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Container(
+        height: 200,
+        width: 200,
+        decoration: BoxDecoration(
+          color: ArDriveTheme.of(context).themeData.backgroundColor,
+          boxShadow: [shadow],
+          borderRadius: BorderRadius.circular(
+            12,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/ardrive_ui_library/storybook/lib/src/story_book.dart
+++ b/packages/ardrive_ui_library/storybook/lib/src/story_book.dart
@@ -1,6 +1,7 @@
 import 'package:ardrive_ui_library/ardrive_ui_library.dart';
 import 'package:flutter/material.dart';
 import 'package:storybook/src/button.dart';
+import 'package:storybook/src/shadows.dart';
 import 'package:storybook/src/toggle.dart';
 import 'package:widgetbook/widgetbook.dart';
 
@@ -29,6 +30,7 @@ class StoryBook extends StatelessWidget {
             toggle(),
             getTypographyCategory(true),
             getTypographyCategory(false),
+            shadows(),
             button(),
             card(),
           ]),

--- a/packages/ardrive_ui_library/storybook/lib/src/story_book.dart
+++ b/packages/ardrive_ui_library/storybook/lib/src/story_book.dart
@@ -1,7 +1,10 @@
 import 'package:ardrive_ui_library/ardrive_ui_library.dart';
 import 'package:flutter/material.dart';
+import 'package:storybook/src/button.dart';
+import 'package:storybook/src/toggle.dart';
 import 'package:widgetbook/widgetbook.dart';
 
+import 'card.dart';
 import 'colors.dart';
 
 class StoryBook extends StatelessWidget {
@@ -10,7 +13,7 @@ class StoryBook extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ArDriveApp(
-      builder: (context) => Widgetbook(
+      builder: (context) => Widgetbook.material(
           themes: [
             WidgetbookTheme(
               name: 'Dark',
@@ -23,165 +26,11 @@ class StoryBook extends StatelessWidget {
           ],
           appInfo: AppInfo(name: 'ArDrive StoryBook'),
           categories: [
+            toggle(),
             getTypographyCategory(true),
             getTypographyCategory(false),
-            WidgetbookCategory(name: 'Toggle', widgets: [
-              WidgetbookComponent(name: 'Toggle Dark', useCases: [
-                WidgetbookUseCase(
-                  name: 'On',
-                  builder: (context) {
-                    return const Center(
-                      child: ArDriveToggle(
-                        initialState: ToggleState.on,
-                      ),
-                    );
-                  },
-                ),
-                WidgetbookUseCase(
-                  name: 'Off',
-                  builder: (context) {
-                    return const Center(
-                      child: ArDriveToggle(
-                        initialState: ToggleState.off,
-                      ),
-                    );
-                  },
-                ),
-                WidgetbookUseCase(
-                  name: 'disabled',
-                  builder: (context) {
-                    return const Center(
-                      child: ArDriveToggle(
-                        initialState: ToggleState.disabled,
-                      ),
-                    );
-                  },
-                )
-              ]),
-              WidgetbookComponent(name: 'Toggle Light', useCases: [
-                WidgetbookUseCase(
-                  name: 'On',
-                  builder: (context) {
-                    return Center(
-                      child: ArDriveTheme(
-                        themeData: lightTheme(),
-                        child: const ArDriveToggle(
-                          initialState: ToggleState.on,
-                        ),
-                      ),
-                    );
-                  },
-                ),
-                WidgetbookUseCase(
-                  name: 'Off',
-                  builder: (context) {
-                    return Center(
-                      child: ArDriveTheme(
-                        themeData: lightTheme(),
-                        child: const ArDriveToggle(
-                          initialState: ToggleState.off,
-                        ),
-                      ),
-                    );
-                  },
-                ),
-                WidgetbookUseCase(
-                  name: 'disabled',
-                  builder: (context) {
-                    return Center(
-                        child: ArDriveTheme(
-                      themeData: lightTheme(),
-                      child: const ArDriveToggle(
-                        initialState: ToggleState.disabled,
-                      ),
-                    ));
-                  },
-                )
-              ])
-            ]),
-            WidgetbookCategory(name: 'Button', widgets: [
-              WidgetbookComponent(name: 'Button', useCases: [
-                WidgetbookUseCase(
-                  name: 'Primary',
-                  builder: (context) {
-                    return Center(
-                      child: ArDriveButton(
-                        onPressed: () {
-                          debugPrint('Primary Button pressed');
-                        },
-                        text: 'Add Profile',
-                      ),
-                    );
-                  },
-                ),
-                WidgetbookUseCase(
-                  name: 'Secundary Light',
-                  builder: (context) {
-                    return Center(
-                      child: ArDriveTheme(
-                        themeData: lightTheme(),
-                        child: ArDriveButton(
-                          style: ArDriveButtonStyle.secondary,
-                          onPressed: () {
-                            debugPrint('Secundary Light Button pressed');
-                          },
-                          text: 'Add Profile',
-                        ),
-                      ),
-                    );
-                  },
-                ),
-                WidgetbookUseCase(
-                  name: 'Secundary Dark',
-                  builder: (context) {
-                    return Center(
-                      child: ArDriveTheme(
-                        child: ArDriveButton(
-                          style: ArDriveButtonStyle.secondary,
-                          onPressed: () {
-                            debugPrint('Secundary Dark Button pressed');
-                          },
-                          text: 'Add Profile',
-                        ),
-                      ),
-                    );
-                  },
-                ),
-                WidgetbookUseCase(
-                  name: 'Tertiary Dark',
-                  builder: (context) {
-                    return Center(
-                      child: ArDriveTheme(
-                        child: ArDriveButton(
-                          style: ArDriveButtonStyle.tertiary,
-                          onPressed: () {
-                            debugPrint('Tertiary Dark Button pressed');
-                          },
-                          text: 'Add Profile',
-                        ),
-                      ),
-                    );
-                  },
-                ),
-                WidgetbookUseCase(
-                  name: 'Tertiary Light',
-                  builder: (context) {
-                    return Center(
-                      child: ArDriveTheme(
-                        themeData: lightTheme(),
-                        child: ArDriveButton(
-                          style: ArDriveButtonStyle.tertiary,
-                          onPressed: () {
-                            debugPrint('Tertiary Light Button pressed');
-                          },
-                          text: 'Add Profile',
-                        ),
-                      ),
-                    );
-                  },
-                ),
-              ])
-            ])
+            button(),
+            card(),
           ]),
     );
   }

--- a/packages/ardrive_ui_library/storybook/lib/src/toggle.dart
+++ b/packages/ardrive_ui_library/storybook/lib/src/toggle.dart
@@ -1,0 +1,80 @@
+import 'package:ardrive_ui_library/ardrive_ui_library.dart';
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+WidgetbookCategory toggle() {
+  return WidgetbookCategory(name: 'Toggle', widgets: [
+    WidgetbookComponent(name: 'Toggle Dark', useCases: [
+      WidgetbookUseCase(
+        name: 'On',
+        builder: (context) {
+          return const Center(
+            child: ArDriveToggle(
+              initialState: ToggleState.on,
+            ),
+          );
+        },
+      ),
+      WidgetbookUseCase(
+        name: 'Off',
+        builder: (context) {
+          return const Center(
+            child: ArDriveToggle(
+              initialState: ToggleState.off,
+            ),
+          );
+        },
+      ),
+      WidgetbookUseCase(
+        name: 'disabled',
+        builder: (context) {
+          return const Center(
+            child: ArDriveToggle(
+              initialState: ToggleState.disabled,
+            ),
+          );
+        },
+      )
+    ]),
+    WidgetbookComponent(name: 'Toggle Light', useCases: [
+      WidgetbookUseCase(
+        name: 'On',
+        builder: (context) {
+          return Center(
+            child: ArDriveTheme(
+              themeData: lightTheme(),
+              child: const ArDriveToggle(
+                initialState: ToggleState.on,
+              ),
+            ),
+          );
+        },
+      ),
+      WidgetbookUseCase(
+        name: 'Off',
+        builder: (context) {
+          return Center(
+            child: ArDriveTheme(
+              themeData: lightTheme(),
+              child: const ArDriveToggle(
+                initialState: ToggleState.off,
+              ),
+            ),
+          );
+        },
+      ),
+      WidgetbookUseCase(
+        name: 'disabled',
+        builder: (context) {
+          return Center(
+              child: ArDriveTheme(
+            themeData: lightTheme(),
+            child: const ArDriveToggle(
+              initialState: ToggleState.disabled,
+            ),
+          ));
+        },
+      )
+    ])
+  ]);
+}

--- a/packages/ardrive_ui_library/test/src/components/card_test.dart
+++ b/packages/ardrive_ui_library/test/src/components/card_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('Test if Card renders and if renders its content',
+  testWidgets('Card widget and its contents render',
       (tester) async {
     const card = ArDriveCard(
       content: Text('Some widget'),

--- a/packages/ardrive_ui_library/test/src/components/card_test.dart
+++ b/packages/ardrive_ui_library/test/src/components/card_test.dart
@@ -1,0 +1,20 @@
+import 'package:ardrive_ui_library/ardrive_ui_library.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Test if Card renders and if renders its content',
+      (tester) async {
+    const card = ArDriveCard(
+      content: Text('Some widget'),
+    );
+    await tester.pumpWidget(ArDriveApp(
+      builder: (context) => const MaterialApp(
+        home: card,
+      ),
+    ));
+
+    expect(find.byWidget(card), findsOneWidget);
+    expect(find.text('Some widget'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Adds the `ArDriveCard` component. This component is the basic `Card` component.

Adds the `ArDriveShadows` design tokens and some missing Colors.

Examples in the Storybook - Widgetbook:

<img width="414" alt="Screenshot 2022-11-15 at 16 41 59" src="https://user-images.githubusercontent.com/32248947/202010917-ab3aa00b-27f8-4169-b410-3208f03eebe6.png">
<img width="426" alt="Screenshot 2022-11-15 at 16 41 41" src="https://user-images.githubusercontent.com/32248947/202010922-407035be-a7c6-4788-89c9-67e95354894b.png">


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/4jfafkpu3soa8
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/2mc65847a2d3g