### PR TITLE
PE-2632: Make use of the components for Quick Sync [Read-side]

### DIFF
--- a/lib/blocs/sync/sync_cubit.dart
+++ b/lib/blocs/sync/sync_cubit.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:math';
 
 import 'package:ardrive/blocs/activity/activity_cubit.dart';
@@ -9,6 +10,12 @@ import 'package:ardrive/entities/string_types.dart';
 import 'package:ardrive/main.dart';
 import 'package:ardrive/models/models.dart';
 import 'package:ardrive/services/services.dart';
+import 'package:ardrive/utils/snapshots/drive_history_composite.dart';
+import 'package:ardrive/utils/snapshots/gql_drive_history.dart';
+import 'package:ardrive/utils/snapshots/height_range.dart';
+import 'package:ardrive/utils/snapshots/range.dart';
+import 'package:ardrive/utils/snapshots/snapshot_drive_history.dart';
+import 'package:ardrive/utils/snapshots/snapshot_item.dart';
 import 'package:cryptography/cryptography.dart';
 import 'package:drift/drift.dart';
 import 'package:equatable/equatable.dart';
@@ -100,17 +107,21 @@ class SyncCubit extends Cubit<SyncState> {
   void _restartSync() {
     logSync(
         'Trying to create a sync subscription when window get focused again. This Cubit is active? ${!isClosed}');
-    final isTimerDurationReadyToSync = _lastSync != null &&
-        DateTime.now().difference(_lastSync!).inMinutes >= kSyncTimerDuration;
+    if (_lastSync != null) {
+      final minutesSinceLastSync =
+          DateTime.now().difference(_lastSync!).inMinutes;
+      final isTimerDurationReadyToSync =
+          minutesSinceLastSync >= kSyncTimerDuration;
 
-    if (!isTimerDurationReadyToSync) {
-      logSync('''
+      if (!isTimerDurationReadyToSync) {
+        logSync('''
               Can't restart sync when window is focused \n
               Is current active? ${!isClosed} \n
-              last sync was ${DateTime.now().difference(_lastSync!).inMinutes} minutes ago. \n
+              last sync was $minutesSinceLastSync minutes ago. \n
               It should be $kSyncTimerDuration
               ''');
-      return;
+        return;
+      }
     }
 
     /// This delay is for don't abruptly open the modal when the user is back
@@ -225,30 +236,31 @@ class SyncCubit extends Cubit<SyncState> {
         return;
       }
 
-      final currentBlockHeight =
-          await retry(() async => await _arweave.getCurrentBlockHeight(),
-              onRetry: (exception) {
-        logSync(
+      final currentBlockHeight = await retry(
+        () async => await _arweave.getCurrentBlockHeight(),
+        onRetry: (exception) => logSync(
           'Retrying for get the current block height on exception ${exception.toString()}',
-        );
-      });
+        ),
+      );
 
       _syncProgress = _syncProgress.copyWith(drivesCount: drives.length);
       logSync('Current block height number $currentBlockHeight');
-      final driveSyncProcesses = drives.map((drive) => _syncDrive(
-            drive.id,
-            driveDao: _driveDao,
-            arweaveService: _arweave,
-            database: _db,
-            profileState: profile,
-            addError: addError,
-            lastBlockHeight: syncDeep
-                ? 0
-                : calculateSyncLastBlockHeight(drive.lastBlockHeight!),
-            currentBlockHeight: currentBlockHeight,
-            transactionParseBatchSize:
-                200 ~/ (_syncProgress.drivesCount - _syncProgress.drivesSynced),
-          ).handleError((error, stackTrace) {
+      final driveSyncProcesses = drives.map(
+        (drive) => _syncDrive(
+          drive.id,
+          driveDao: _driveDao,
+          arweaveService: _arweave,
+          database: _db,
+          profileState: profile,
+          addError: addError,
+          lastBlockHeight: syncDeep
+              ? 0
+              : calculateSyncLastBlockHeight(drive.lastBlockHeight!),
+          currentBlockHeight: currentBlockHeight,
+          transactionParseBatchSize:
+              200 ~/ (_syncProgress.drivesCount - _syncProgress.drivesSynced),
+        ).handleError(
+          (error, stackTrace) {
             logSync('''
                     Error syncing drive with id ${drive.id}. \n
                     Skipping sync on this drive.\n
@@ -258,7 +270,9 @@ class SyncCubit extends Cubit<SyncState> {
                     ${stackTrace.toString()}
                     ''');
             addError(error!);
-          }));
+          },
+        ),
+      );
 
       double totalProgress = 0;
       await Future.wait(
@@ -266,6 +280,7 @@ class SyncCubit extends Cubit<SyncState> {
           (driveSyncProgress) async {
             double currentDriveProgress = 0;
             await for (var driveProgress in driveSyncProgress) {
+              print('Sync progress step: $driveProgress');
               currentDriveProgress =
                   (totalProgress + driveProgress) / drives.length;
               if (currentDriveProgress > _syncProgress.progress) {
@@ -273,6 +288,7 @@ class SyncCubit extends Cubit<SyncState> {
                   progress: currentDriveProgress,
                 );
               }
+              print('Updating progress: ${jsonEncode(_syncProgress)}');
               syncProgressController.add(_syncProgress);
             }
             totalProgress += 1;

--- a/lib/blocs/sync/sync_cubit.dart
+++ b/lib/blocs/sync/sync_cubit.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:math';
 
 import 'package:ardrive/blocs/activity/activity_cubit.dart';
@@ -280,7 +279,6 @@ class SyncCubit extends Cubit<SyncState> {
           (driveSyncProgress) async {
             double currentDriveProgress = 0;
             await for (var driveProgress in driveSyncProgress) {
-              print('Sync progress step: $driveProgress');
               currentDriveProgress =
                   (totalProgress + driveProgress) / drives.length;
               if (currentDriveProgress > _syncProgress.progress) {
@@ -288,7 +286,6 @@ class SyncCubit extends Cubit<SyncState> {
                   progress: currentDriveProgress,
                 );
               }
-              print('Updating progress: ${jsonEncode(_syncProgress)}');
               syncProgressController.add(_syncProgress);
             }
             totalProgress += 1;

--- a/lib/blocs/sync/utils/parse_drive_transactions.dart
+++ b/lib/blocs/sync/utils/parse_drive_transactions.dart
@@ -6,7 +6,8 @@ Stream<double> _parseDriveTransactionsIntoDatabaseEntities({
   required DriveDao driveDao,
   required Database database,
   required ArweaveService arweaveService,
-  required List<DriveEntityHistory$Query$TransactionConnection$TransactionEdge>
+  required List<
+          DriveEntityHistory$Query$TransactionConnection$TransactionEdge$Transaction>
       transactions,
   required Drive drive,
   required SecretKey? driveKey,
@@ -42,7 +43,7 @@ Stream<double> _parseDriveTransactionsIntoDatabaseEntities({
   final owner = await arweave.getOwnerForDriveEntityWithId(drive.id);
 
   yield* _batchProcess<
-          DriveEntityHistory$Query$TransactionConnection$TransactionEdge>(
+          DriveEntityHistory$Query$TransactionConnection$TransactionEdge$Transaction>(
       list: transactions,
       batchSize: batchSize,
       endOfBatchCallback: (items) async* {
@@ -50,12 +51,20 @@ Stream<double> _parseDriveTransactionsIntoDatabaseEntities({
 
         final entityHistory =
             await arweave.createDriveEntityHistoryFromTransactions(
-                items, driveKey, owner, lastBlockHeight);
+          items,
+          driveKey,
+          owner,
+          lastBlockHeight,
+        );
 
         // Create entries for all the new revisions of file and folders in this drive.
         final newEntities = entityHistory.blockHistory
-            .map((b) => b.entities)
-            .expand((entities) => entities);
+            .map(
+              (b) => b.entities,
+            )
+            .expand(
+              (entities) => entities,
+            );
 
         numberOfDriveEntitiesParsed += items.length - newEntities.length;
 

--- a/lib/blocs/sync/utils/parse_drive_transactions.dart
+++ b/lib/blocs/sync/utils/parse_drive_transactions.dart
@@ -14,6 +14,7 @@ Stream<double> _parseDriveTransactionsIntoDatabaseEntities({
   required int lastBlockHeight,
   required int currentBlockHeight,
   required int batchSize,
+  required SnapshotDriveHistory snapshotDriveHistory,
 }) async* {
   final numberOfDriveEntitiesToParse = transactions.length;
   var numberOfDriveEntitiesParsed = 0;
@@ -55,6 +56,7 @@ Stream<double> _parseDriveTransactionsIntoDatabaseEntities({
           driveKey,
           owner,
           lastBlockHeight,
+          snapshotDriveHistory: snapshotDriveHistory,
         );
 
         // Create entries for all the new revisions of file and folders in this drive.

--- a/lib/blocs/sync/utils/parse_drive_transactions.dart
+++ b/lib/blocs/sync/utils/parse_drive_transactions.dart
@@ -61,12 +61,8 @@ Stream<double> _parseDriveTransactionsIntoDatabaseEntities({
 
         // Create entries for all the new revisions of file and folders in this drive.
         final newEntities = entityHistory.blockHistory
-            .map(
-              (b) => b.entities,
-            )
-            .expand(
-              (entities) => entities,
-            );
+            .map((b) => b.entities)
+            .expand((entities) => entities);
 
         numberOfDriveEntitiesParsed += items.length - newEntities.length;
 

--- a/lib/blocs/sync/utils/sync_drive.dart
+++ b/lib/blocs/sync/utils/sync_drive.dart
@@ -177,6 +177,7 @@ Stream<double> _syncDrive(
     currentBlockHeight: currentBlockHeight,
     lastBlockHeight: lastBlockHeight,
     batchSize: transactionParseBatchSize,
+    snapshotDriveHistory: snapshotDriveHistory,
   ).map(
     (parseProgress) => parseProgress * 0.9,
   );

--- a/lib/blocs/sync/utils/sync_drive.dart
+++ b/lib/blocs/sync/utils/sync_drive.dart
@@ -41,7 +41,7 @@ Stream<double> _syncDrive(
       DriveEntityHistory$Query$TransactionConnection$TransactionEdge$Transaction>[];
 
   final snapshotsStream = arweaveService
-      .getAllSnapshotsFromDrive(
+      .getAllSnapshotsOfDrive(
         driveId,
         lastBlockHeight,
       )
@@ -153,7 +153,6 @@ Stream<double> _syncDrive(
           calculatePercentageBasedOnBlockHeights() * fetchPhaseWeight;
       yield percentage;
     }
-    print('Still looping');
   }
   print('Done fetching data - ${gqlDriveHistory.driveId}');
 

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -223,7 +223,6 @@ class ArweaveService {
       ),
     );
 
-    // release memory
     await SnapshotItemOnChain.dispose();
 
     final blockHistory = <BlockEntities>[];

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -287,7 +287,6 @@ class ArweaveService {
     }
 
     return DriveEntityHistory(
-      null,
       blockHistory.isNotEmpty ? blockHistory.last.blockHeight : lastBlockHeight,
       blockHistory,
     );
@@ -823,14 +822,12 @@ class ArweaveService {
 
 /// The entity history of a particular drive, chunked by block height.
 class DriveEntityHistory {
-  /// A cursor for continuing through this drive's history.
-  final String? cursor;
   final int? lastBlockHeight;
 
   /// A list of block entities, ordered by ascending block height.
   final List<BlockEntities> blockHistory;
 
-  DriveEntityHistory(this.cursor, this.lastBlockHeight, this.blockHistory);
+  DriveEntityHistory(this.lastBlockHeight, this.blockHistory);
 }
 
 /// The entities present in a particular block.

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -220,6 +220,9 @@ class ArweaveService {
       ),
     );
 
+    // release memory
+    await SnapshotItemOnChain.dispose();
+
     final blockHistory = <BlockEntities>[];
 
     for (var i = 0; i < entityTxs.length; i++) {

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -9,6 +9,7 @@ import 'package:ardrive/utils/extensions.dart';
 import 'package:ardrive/utils/graphql_retry.dart';
 import 'package:ardrive/utils/http_retry.dart';
 import 'package:ardrive/utils/snapshots/snapshot_drive_history.dart';
+import 'package:ardrive/utils/snapshots/snapshot_item.dart';
 import 'package:ardrive_network/ardrive_network.dart';
 import 'package:artemis/artemis.dart';
 import 'package:arweave/arweave.dart';
@@ -207,7 +208,7 @@ class ArweaveService {
       entityTxs.map(
         (entity) async {
           final txId = entity.id;
-          final cachedData = snapshotDriveHistory.getDataForTxId(txId);
+          final cachedData = SnapshotItemOnChain.getDataForTxId(txId);
           if (cachedData != null) {
             return Uint8List.fromList(utf8.encode(cachedData));
           } else {

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -208,9 +208,9 @@ class ArweaveService {
       entityTxs.map(
         (entity) async {
           final txId = entity.id;
-          final cachedData = SnapshotItemOnChain.getDataForTxId(txId);
+          final cachedData = await SnapshotItemOnChain.getDataForTxId(txId);
           if (cachedData != null) {
-            return Uint8List.fromList(utf8.encode(cachedData));
+            return cachedData;
           } else {
             return (await httpRetry
                     .processRequest(() => client.api.getSandboxedTx(txId)))

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -112,7 +112,7 @@ class ArweaveService {
   }
 
   Stream<SnapshotEntityHistory$Query$TransactionConnection$TransactionEdge>
-      getAllSnapshotsFromDrive(
+      getAllSnapshotsOfDrive(
     String driveId,
     int? lastBlockHeight,
   ) async* {

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -15,6 +15,7 @@ import 'package:artemis/artemis.dart';
 import 'package:arweave/arweave.dart';
 import 'package:cryptography/cryptography.dart';
 import 'package:drift/drift.dart';
+import 'package:http/http.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:retry/retry.dart';
 
@@ -204,17 +205,19 @@ class ArweaveService {
     int lastBlockHeight, {
     required SnapshotDriveHistory snapshotDriveHistory,
   }) async {
-    final responses = await Future.wait(
+    final List<Uint8List> responses = await Future.wait(
       entityTxs.map(
         (entity) async {
           final txId = entity.id;
-          final cachedData = await SnapshotItemOnChain.getDataForTxId(txId);
+          final Uint8List? cachedData =
+              await SnapshotItemOnChain.getDataForTxId(txId);
           if (cachedData != null) {
             return cachedData;
           } else {
-            return (await httpRetry
-                    .processRequest(() => client.api.getSandboxedTx(txId)))
-                .bodyBytes;
+            // TODO: make use of the NetworkPackage
+            final Response data = (await httpRetry
+                .processRequest(() => client.api.getSandboxedTx(txId)));
+            return data.bodyBytes;
           }
         },
       ),

--- a/lib/utils/snapshots/drive_history_composite.dart
+++ b/lib/utils/snapshots/drive_history_composite.dart
@@ -70,10 +70,7 @@ class DriveHistoryComposite implements SegmentedGQLData {
   Stream<DriveEntityHistory$Query$TransactionConnection$TransactionEdge$Transaction>
       _getNextStream() async* {
     for (SegmentedGQLData source in _subRangeToSnapshotItemMapping) {
-      await for (DriveEntityHistory$Query$TransactionConnection$TransactionEdge$Transaction node
-          in source.getNextStream()) {
-        yield node;
-      }
+      yield* source.getNextStream();
     }
   }
 }

--- a/lib/utils/snapshots/range.dart
+++ b/lib/utils/snapshots/range.dart
@@ -2,7 +2,7 @@ import 'dart:math';
 
 import 'package:equatable/equatable.dart';
 
-class Range implements Equatable {
+class Range extends Equatable {
   final int start;
   final int end;
 

--- a/lib/utils/snapshots/range.dart
+++ b/lib/utils/snapshots/range.dart
@@ -2,7 +2,7 @@ import 'dart:math';
 
 import 'package:equatable/equatable.dart';
 
-class Range {
+class Range implements Equatable {
   final int start;
   final int end;
 
@@ -86,6 +86,12 @@ class Range {
   String toString() {
     return 'Range: ($start; $end)';
   }
+
+  @override
+  List<Object?> get props => [start, end];
+
+  @override
+  bool? get stringify => true;
 }
 
 class BadRange implements Exception, Equatable {

--- a/lib/utils/snapshots/range.dart
+++ b/lib/utils/snapshots/range.dart
@@ -95,8 +95,8 @@ class Range extends Equatable {
 }
 
 class BadRange implements Exception, Equatable {
-  final int start;
-  final int end;
+  final dynamic start;
+  final dynamic end;
   BadRange({required this.start, required this.end});
 
   @override

--- a/lib/utils/snapshots/snapshot_drive_history.dart
+++ b/lib/utils/snapshots/snapshot_drive_history.dart
@@ -95,11 +95,7 @@ class SnapshotDriveHistory implements SegmentedGQLData {
     // reads the next stream of each item in the list and yields each node in order
     for (SnapshotItem item in itemsInRange) {
       final stream = item.getNextStream();
-
-      await for (DriveEntityHistory$Query$TransactionConnection$TransactionEdge$Transaction node
-          in stream) {
-        yield node;
-      }
+      yield* stream;
     }
   }
 }

--- a/lib/utils/snapshots/snapshot_drive_history.dart
+++ b/lib/utils/snapshots/snapshot_drive_history.dart
@@ -4,8 +4,6 @@ import 'package:ardrive/utils/snapshots/range.dart';
 import 'package:ardrive/utils/snapshots/segmented_gql_data.dart';
 import 'package:ardrive/utils/snapshots/snapshot_item.dart';
 
-import '../../entities/string_types.dart';
-
 class SnapshotDriveHistory implements SegmentedGQLData {
   final List<SnapshotItem> items;
   int _currentIndex = -1;
@@ -99,17 +97,5 @@ class SnapshotDriveHistory implements SegmentedGQLData {
       final stream = item.getNextStream();
       yield* stream;
     }
-  }
-
-  String? getDataForTxId(TxID txId) {
-    // FIXME: This is really slow, we should consider using a mem cache
-    for (var item in items) {
-      item as SnapshotItemOnChain;
-      final value = item.getDataForTxId(txId);
-      if (value != null) {
-        return value;
-      }
-    }
-    return null;
   }
 }

--- a/lib/utils/snapshots/snapshot_drive_history.dart
+++ b/lib/utils/snapshots/snapshot_drive_history.dart
@@ -4,6 +4,8 @@ import 'package:ardrive/utils/snapshots/range.dart';
 import 'package:ardrive/utils/snapshots/segmented_gql_data.dart';
 import 'package:ardrive/utils/snapshots/snapshot_item.dart';
 
+import '../../entities/string_types.dart';
+
 class SnapshotDriveHistory implements SegmentedGQLData {
   final List<SnapshotItem> items;
   int _currentIndex = -1;
@@ -97,5 +99,17 @@ class SnapshotDriveHistory implements SegmentedGQLData {
       final stream = item.getNextStream();
       yield* stream;
     }
+  }
+
+  String? getDataForTxId(TxID txId) {
+    // FIXME: This is really slow, we should consider using a mem cache
+    for (var item in items) {
+      item as SnapshotItemOnChain;
+      final value = item.getDataForTxId(txId);
+      if (value != null) {
+        return value;
+      }
+    }
+    return null;
   }
 }

--- a/lib/utils/snapshots/snapshot_item.dart
+++ b/lib/utils/snapshots/snapshot_item.dart
@@ -9,7 +9,6 @@ import 'package:ardrive/utils/snapshots/segmented_gql_data.dart';
 import 'package:ardrive_network/ardrive_network.dart';
 import 'package:async/async.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:stash/stash_api.dart';
 import 'package:stash_memory/stash_memory.dart';
 
@@ -185,8 +184,6 @@ class SnapshotItemOnChain implements SnapshotItem {
   String? _cachedSource;
   int _currentIndex = -1;
 
-  static const String _storeName = 'snapshot-cache';
-  // static MemoryVaultStore? _memCache;
   static Vault<Uint8List>? _jsonMetadataVault;
 
   SnapshotItemOnChain({

--- a/lib/utils/snapshots/snapshot_item.dart
+++ b/lib/utils/snapshots/snapshot_item.dart
@@ -235,8 +235,7 @@ class SnapshotItemOnChain implements SnapshotItem {
       return _cachedSource!;
     }
 
-    final dataBytes =
-        await ArdriveNetwork().getAsBytes(_dataUri.toString()).catchError(
+    final dataBytes = await ArdriveNetwork().getAsBytes(_dataUri).catchError(
       (e) {
         print('Error while fetching Snapshot Data - $e');
       },

--- a/lib/utils/snapshots/snapshot_item.dart
+++ b/lib/utils/snapshots/snapshot_item.dart
@@ -68,7 +68,6 @@ abstract class SnapshotItem implements SegmentedGQLData {
         itemsStream, {
     int? lastBlockHeight,
 
-    // FIXME: take a Map<TxID, String> instead
     @visibleForTesting String? fakeSource,
   }) async* {
     HeightRange obscuredByAccumulator = HeightRange(rangeSegments: [
@@ -89,9 +88,6 @@ abstract class SnapshotItem implements SegmentedGQLData {
         print('Ignoring snapshot transaction with wrong block range - $e');
         continue;
       }
-
-      // print(
-      //     'SnapshotItem instantiated - ${snapshotItem.subRanges.rangeSegments}');
 
       yield snapshotItem;
 
@@ -266,9 +262,6 @@ class SnapshotItemOnChain implements SnapshotItem {
   Stream<DriveEntityHistory$Query$TransactionConnection$TransactionEdge$Transaction>
       _getNextStream() async* {
     final Range range = subRanges.rangeSegments[currentIndex];
-
-    // print(
-    //     'Snapshot item ($txId) reading item #${currentIndex + 1}/${subRanges.rangeSegments.length}');
 
     final Map dataJson = jsonDecode(await _source());
     final List<Map> txSnapshots =

--- a/lib/utils/snapshots/snapshot_item.dart
+++ b/lib/utils/snapshots/snapshot_item.dart
@@ -285,7 +285,8 @@ class SnapshotItemOnChain implements SnapshotItem {
 
   static String? getDataForTxId(TxID txId) {
     // FIXME: this is really slow
-    return _txIdToDataMapping.remove(txId);
+    final maybeData = _txIdToDataMapping.remove(txId);
+    return maybeData;
   }
 
   // TODO: call this method

--- a/lib/utils/snapshots/snapshot_item.dart
+++ b/lib/utils/snapshots/snapshot_item.dart
@@ -309,9 +309,7 @@ class SnapshotItemOnChain implements SnapshotItem {
     return _jsonMetadataVault!;
   }
 
-  // TODO: call this method
-  Future<void> dispose() async {
-    _cachedSource = null;
+  static Future<void> dispose() async {
     await _jsonMetadataVault?.clear();
   }
 }

--- a/lib/utils/snapshots/snapshot_item.dart
+++ b/lib/utils/snapshots/snapshot_item.dart
@@ -181,7 +181,7 @@ class SnapshotItemOnChain implements SnapshotItem {
   final int timestamp;
   final TxID txId;
   String? _cachedSource;
-  Map<TxID, String> _txIdToDataMapping = {};
+  static Map<TxID, String> _txIdToDataMapping = {};
   int _currentIndex = -1;
 
   SnapshotItemOnChain({
@@ -283,7 +283,8 @@ class SnapshotItemOnChain implements SnapshotItem {
     return;
   }
 
-  String? getDataForTxId(TxID txId) {
+  static String? getDataForTxId(TxID txId) {
+    // FIXME: this is really slow
     return _txIdToDataMapping.remove(txId);
   }
 

--- a/lib/utils/snapshots/snapshot_item.dart
+++ b/lib/utils/snapshots/snapshot_item.dart
@@ -328,8 +328,8 @@ class SnapshotItemOnChain implements SnapshotItem {
     if (_jsonMetadataVault == null) {
       final vaultStore = await newMemoryVaultStore();
       _jsonMetadataVault = await vaultStore.vault<Uint8List>(
-          // name: 'snapshot-data',
-          );
+        name: 'snapshot-data',
+      );
     }
 
     return _jsonMetadataVault!;

--- a/lib/utils/snapshots/snapshot_item.dart
+++ b/lib/utils/snapshots/snapshot_item.dart
@@ -181,7 +181,7 @@ class SnapshotItemOnChain implements SnapshotItem {
   final int timestamp;
   final TxID txId;
   String? _cachedSource;
-  final Map<TxID, String> _txIdToDataMapping = {};
+  Map<TxID, String> _txIdToDataMapping = {};
   int _currentIndex = -1;
 
   SnapshotItemOnChain({
@@ -266,7 +266,7 @@ class SnapshotItemOnChain implements SnapshotItem {
       if (isInRange) {
         yield node;
 
-        final String? data = item['jsonData'];
+        final String? data = item['jsonMetadata'];
         if (data != null) {
           final TxID txId = node.id;
           _txIdToDataMapping[txId] = data;
@@ -276,7 +276,7 @@ class SnapshotItemOnChain implements SnapshotItem {
 
     if (currentIndex == subRanges.rangeSegments.length - 1) {
       print('Done reading snapshot item data, releasing memory');
-      // Done reading all data, wiping
+      // Done reading all data, the memory can be freed
       _cachedSource = null;
     }
 
@@ -285,5 +285,11 @@ class SnapshotItemOnChain implements SnapshotItem {
 
   String? getDataForTxId(TxID txId) {
     return _txIdToDataMapping.remove(txId);
+  }
+
+  // TODO: call this method
+  void dispose() {
+    _cachedSource = null;
+    _txIdToDataMapping = {};
   }
 }

--- a/test/services/arweave/arweave_service_test.dart
+++ b/test/services/arweave/arweave_service_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../test_utils/utils.dart';
-import '../../utils/snapshot_item_test.dart';
+import '../../utils/snapshot_test_helpers.dart';
 
 const gatewayUrl = 'https://arweave.net';
 void main() {

--- a/test/utils/drive_history_composite_test.dart
+++ b/test/utils/drive_history_composite_test.dart
@@ -10,7 +10,7 @@ import 'package:mocktail/mocktail.dart';
 
 import '../test_utils/mocks.dart';
 import 'snapshot_drive_history_test.dart';
-import 'snapshot_item_test.dart';
+import 'snapshot_test_helpers.dart';
 
 void main() {
   group('DriveHistoryComposite class', () {

--- a/test/utils/gql_drive_history_test.dart
+++ b/test/utils/gql_drive_history_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../test_utils/utils.dart';
-import 'snapshot_item_test.dart';
+import 'snapshot_test_helpers.dart';
 
 void main() {
   group('GQLDriveHistory class', () {

--- a/test/utils/range_test.dart
+++ b/test/utils/range_test.dart
@@ -28,6 +28,16 @@ void main() {
       expect(range.end, -1);
     });
 
+    test('equatability', () {
+      Range rangeA = Range(start: 0, end: 0);
+      Range rangeB = Range(start: 0, end: 0);
+      expect(rangeA == rangeB, true);
+
+      rangeA = Range(start: 50, end: 100);
+      rangeB = Range(start: 50, end: 100);
+      expect(rangeA == rangeB, true);
+    });
+
     group('difference method', () {
       test('returns an empty array if B contains A', () {
         Range A = Range(start: 25, end: 50);

--- a/test/utils/range_test.dart
+++ b/test/utils/range_test.dart
@@ -100,35 +100,35 @@ void main() {
       test('returns a sub-range of the inputs partially intersect', () {
         Range A = Range(start: 0, end: 100);
         Range B = Range(start: 50, end: 100);
-        Range? intersection = Range.intersection(A, B);
-        expect(intersection!.start, B.start);
-        expect(intersection!.end, B.end);
+        Range intersection = Range.intersection(A, B)!;
+        expect(intersection.start, B.start);
+        expect(intersection.end, B.end);
 
         A = Range(start: 0, end: 100);
         B = Range(start: 0, end: 50);
-        intersection = Range.intersection(A, B);
-        expect(intersection!.start, B.start);
-        expect(intersection!.end, B.end);
+        intersection = Range.intersection(A, B)!;
+        expect(intersection.start, B.start);
+        expect(intersection.end, B.end);
 
         A = Range(start: 0, end: 100);
         B = Range(start: 50, end: 150);
-        intersection = Range.intersection(A, B);
-        expect(intersection!.start, 50);
-        expect(intersection!.end, 100);
+        intersection = Range.intersection(A, B)!;
+        expect(intersection.start, 50);
+        expect(intersection.end, 100);
       });
 
       test('returns A if B includes A', () {
         Range A = Range(start: 25, end: 50);
         Range B = Range(start: 0, end: 100);
-        Range? intersection = Range.intersection(A, B);
-        expect(intersection!.start, A.start);
-        expect(intersection!.end, A.end);
+        Range intersection = Range.intersection(A, B)!;
+        expect(intersection.start, A.start);
+        expect(intersection.end, A.end);
 
         A = Range(start: 0, end: 100);
         B = Range(start: 0, end: 100);
-        intersection = Range.intersection(A, B);
-        expect(intersection!.start, A.start);
-        expect(intersection!.end, A.end);
+        intersection = Range.intersection(A, B)!;
+        expect(intersection.start, A.start);
+        expect(intersection.end, A.end);
       });
     });
 

--- a/test/utils/snapshot_drive_history_test.dart
+++ b/test/utils/snapshot_drive_history_test.dart
@@ -5,7 +5,7 @@ import 'package:ardrive/utils/snapshots/snapshot_drive_history.dart';
 import 'package:ardrive/utils/snapshots/snapshot_item.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'snapshot_item_test.dart';
+import 'snapshot_test_helpers.dart';
 
 void main() {
   final composableRanges = [

--- a/test/utils/snapshot_item_test.dart
+++ b/test/utils/snapshot_item_test.dart
@@ -127,9 +127,10 @@ void main() {
 
         for (int height = r.start; height <= r.end; height++) {
           // has data the first time
-          expect(item.getDataForTxId('$height'), '{"name": "$height"}');
+          expect(SnapshotItemOnChain.getDataForTxId('$height'),
+              '{"name": "$height"}');
           // further calls to the method results in a null response
-          expect(item.getDataForTxId('$height'), null);
+          expect(SnapshotItemOnChain.getDataForTxId('$height'), null);
         }
       });
 
@@ -161,7 +162,7 @@ void main() {
 
         await countStreamItems(item.getNextStream());
 
-        expect(item.getDataForTxId('not present tx id'), null);
+        expect(SnapshotItemOnChain.getDataForTxId('not present tx id'), null);
       });
     });
   });
@@ -176,7 +177,7 @@ Future<String> fakeSnapshotStream(Range range) async {
           .map(
             (event) => {
               'gqlNode': event,
-              'jsonData': '{"name": "${event.block!.height}"}',
+              'jsonMetadata': '{"name": "${event.block!.height}"}',
             },
           )
           .toList(),

--- a/test/utils/snapshot_item_test.dart
+++ b/test/utils/snapshot_item_test.dart
@@ -5,6 +5,7 @@ import 'package:ardrive/utils/snapshots/height_range.dart';
 import 'package:ardrive/utils/snapshots/range.dart';
 import 'package:ardrive/utils/snapshots/segmented_gql_data.dart';
 import 'package:ardrive/utils/snapshots/snapshot_item.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -374,10 +375,21 @@ void main() {
 
         await countStreamItems(item.getNextStream());
 
+        // There is indeed some data
+        expect(
+          await SnapshotItemOnChain.getDataForTxId('tx-0'),
+          isA<Uint8List>(),
+        );
+
+        // But data not present will return null
         expect(
           await SnapshotItemOnChain.getDataForTxId('not present tx id'),
           null,
         );
+
+        // And valid txs' data will be discarded after calling dispose
+        await SnapshotItemOnChain.dispose();
+        expect(await SnapshotItemOnChain.getDataForTxId('tx-1'), null);
       });
     });
   });

--- a/test/utils/snapshot_item_test.dart
+++ b/test/utils/snapshot_item_test.dart
@@ -8,6 +8,8 @@ import 'package:ardrive/utils/snapshots/snapshot_item.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'snapshot_test_helpers.dart';
+
 void main() {
   group('SnapshotItem class', () {
     group('fromStream factory', () {
@@ -393,49 +395,4 @@ void main() {
       });
     });
   });
-}
-
-// TODO: move these helper methods to its own source file
-
-Future<String> fakeSnapshotSource(Range range) async {
-  return jsonEncode(
-    {
-      'txSnapshots': await fakeNodesStream(range)
-          .map(
-            (event) => {
-              'gqlNode': event,
-              'jsonMetadata': '{"name": "${event.block!.height}"}',
-            },
-          )
-          .toList(),
-    },
-  );
-}
-
-Stream<DriveEntityHistory$Query$TransactionConnection$TransactionEdge$Transaction>
-    fakeNodesStream(Range range) async* {
-  for (int height = range.start; height <= range.end; height++) {
-    yield DriveEntityHistory$Query$TransactionConnection$TransactionEdge$Transaction
-        .fromJson(
-      {
-        'id': 'tx-$height',
-        'bundledIn': {'id': 'ASDASDASDASDASDASD'},
-        'owner': {'address': '1234567890'},
-        'tags': [],
-        'block': {
-          'height': height,
-          'timestamp': DateTime.now().microsecondsSinceEpoch
-        }
-      },
-    );
-  }
-}
-
-Future<int> countStreamItems(Stream stream) async {
-  int count = 0;
-  await for (DriveEntityHistory$Query$TransactionConnection$TransactionEdge$Transaction _
-      in stream) {
-    count++;
-  }
-  return count;
 }

--- a/test/utils/snapshot_item_test.dart
+++ b/test/utils/snapshot_item_test.dart
@@ -127,10 +127,14 @@ void main() {
 
         for (int height = r.start; height <= r.end; height++) {
           // has data the first time
-          expect(SnapshotItemOnChain.getDataForTxId('$height'),
-              '{"name": "$height"}');
+          expect(
+            await SnapshotItemOnChain.getDataForTxId('$height'),
+            utf8.encode(
+              '{"name": "$height"}',
+            ),
+          );
           // further calls to the method results in a null response
-          expect(SnapshotItemOnChain.getDataForTxId('$height'), null);
+          expect(await SnapshotItemOnChain.getDataForTxId('$height'), null);
         }
       });
 
@@ -162,7 +166,10 @@ void main() {
 
         await countStreamItems(item.getNextStream());
 
-        expect(SnapshotItemOnChain.getDataForTxId('not present tx id'), null);
+        expect(
+          await SnapshotItemOnChain.getDataForTxId('not present tx id'),
+          null,
+        );
       });
     });
   });

--- a/test/utils/snapshot_item_test.dart
+++ b/test/utils/snapshot_item_test.dart
@@ -101,6 +101,34 @@ void main() {
     });
 
     group('instantiateSingle static method', () {
+      test('throws if the transaction has a bad range', () async {
+        final snapshotTxWithBadRange =
+            SnapshotEntityHistory$Query$TransactionConnection$TransactionEdge$Transaction
+                .fromJson(
+          {
+            'id': 'tx-id',
+            'bundledIn': {'id': 'ASDASDASDASDASDASD'},
+            'owner': {'address': '1234567890'},
+            'tags': [
+              {'name': 'Block-Start', 'value': '-5'},
+              {'name': 'Block-End', 'value': 'invalid value'},
+              {'name': 'Drive-Id', 'value': 'DRIVE_ID'},
+            ],
+            'block': {
+              'height': 11,
+              'timestamp': DateTime.now().microsecondsSinceEpoch
+            }
+          },
+        );
+
+        expect(
+            () => SnapshotItem.instantiateSingle(
+                  snapshotTxWithBadRange,
+                  obscuredBy: HeightRange(rangeSegments: []),
+                ),
+            throwsA(isA<Exception>()));
+      });
+
       test('instantiates a single item with the correct sub-ranges', () async {
         final totalSnapshotRange = Range(start: 0, end: 10);
         final obscuredBy = HeightRange(rangeSegments: []);

--- a/test/utils/snapshot_item_test.dart
+++ b/test/utils/snapshot_item_test.dart
@@ -126,7 +126,7 @@ void main() {
                   snapshotTxWithBadRange,
                   obscuredBy: HeightRange(rangeSegments: []),
                 ),
-            throwsA(isA<Exception>()));
+            throwsA(isA<BadRange>()));
       });
 
       test('instantiates a single item with the correct sub-ranges', () async {

--- a/test/utils/snapshot_test_helpers.dart
+++ b/test/utils/snapshot_test_helpers.dart
@@ -1,0 +1,47 @@
+import 'dart:convert';
+
+import 'package:ardrive/services/arweave/graphql/graphql_api.graphql.dart';
+import 'package:ardrive/utils/snapshots/range.dart';
+
+Future<String> fakeSnapshotSource(Range range) async {
+  return jsonEncode(
+    {
+      'txSnapshots': await fakeNodesStream(range)
+          .map(
+            (event) => {
+              'gqlNode': event,
+              'jsonMetadata': '{"name": "${event.block!.height}"}',
+            },
+          )
+          .toList(),
+    },
+  );
+}
+
+Stream<DriveEntityHistory$Query$TransactionConnection$TransactionEdge$Transaction>
+    fakeNodesStream(Range range) async* {
+  for (int height = range.start; height <= range.end; height++) {
+    yield DriveEntityHistory$Query$TransactionConnection$TransactionEdge$Transaction
+        .fromJson(
+      {
+        'id': 'tx-$height',
+        'bundledIn': {'id': 'ASDASDASDASDASDASD'},
+        'owner': {'address': '1234567890'},
+        'tags': [],
+        'block': {
+          'height': height,
+          'timestamp': DateTime.now().microsecondsSinceEpoch
+        }
+      },
+    );
+  }
+}
+
+Future<int> countStreamItems(Stream stream) async {
+  int count = 0;
+  await for (DriveEntityHistory$Query$TransactionConnection$TransactionEdge$Transaction _
+      in stream) {
+    count++;
+  }
+  return count;
+}


### PR DESCRIPTION
Changes
- Instantiates the components for reading GQL Nodes from snapshots
- Replaces the source stream of GQL data with the Quick Sync one
- Consumes the data from SnapshotItem before going to the network


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/7masfamcitlj0
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/5uriaae91bps8