### PR TITLE
PE-2814: Snapshot to be created

### DIFF
--- a/lib/entities/constants.dart
+++ b/lib/entities/constants.dart
@@ -36,6 +36,7 @@ class EntityType {
   static const drive = 'drive';
   static const folder = 'folder';
   static const file = 'file';
+  static const snapshot = 'snapshot';
 }
 
 class Cipher {

--- a/lib/utils/snapshots/snapshot_item.dart
+++ b/lib/utils/snapshots/snapshot_item.dart
@@ -8,7 +8,6 @@ import 'package:ardrive/utils/snapshots/height_range.dart';
 import 'package:ardrive/utils/snapshots/range.dart';
 import 'package:ardrive/utils/snapshots/segmented_gql_data.dart';
 import 'package:ardrive_http/ardrive_http.dart';
-import 'package:async/async.dart';
 import 'package:flutter/foundation.dart';
 import 'package:stash/stash_api.dart';
 import 'package:stash_memory/stash_memory.dart';
@@ -47,22 +46,6 @@ abstract class SnapshotItem implements SegmentedGQLData {
       txId: txId,
       subRanges: subRanges,
       fakeSource: fakeSource,
-    );
-  }
-
-  factory SnapshotItem.fromStream({
-    required Stream<DriveHistoryTransaction> source,
-    required int blockStart,
-    required int blockEnd,
-    required DriveID driveId,
-    required HeightRange subRanges,
-  }) {
-    return SnapshotItemToBeCreated(
-      blockStart: blockStart,
-      blockEnd: blockEnd,
-      driveId: driveId,
-      subRanges: subRanges,
-      source: source,
     );
   }
 
@@ -137,72 +120,13 @@ abstract class SnapshotItem implements SegmentedGQLData {
   }
 }
 
-class SnapshotItemToBeCreated implements SnapshotItem {
-  final StreamQueue _streamQueue;
-  int _currentIndex = -1;
-
-  SnapshotItemToBeCreated({
-    required this.blockStart,
-    required this.blockEnd,
-    required this.driveId,
-    required this.subRanges,
-    required Stream<DriveHistoryTransaction> source,
-  }) : _streamQueue = StreamQueue(source);
-
-  @override
-  final HeightRange subRanges;
-  @override
-  final int blockStart;
-  @override
-  final int blockEnd;
-  @override
-  final DriveID driveId;
-  @override
-  int get currentIndex => _currentIndex;
-
-  @override
-  Stream<DriveHistoryTransaction> getNextStream() {
-    _currentIndex++;
-    if (currentIndex >= subRanges.rangeSegments.length) {
-      throw SubRangeIndexOverflow(index: currentIndex);
-    }
-
-    return _getNextStream();
-  }
-
-  Stream<DriveHistoryTransaction> _getNextStream() async* {
-    final Range range = subRanges.rangeSegments[currentIndex];
-
-    while (await _streamQueue.hasNext) {
-      final DriveHistoryTransaction node = (await _streamQueue.peek);
-      final height = node.block!.height;
-
-      if (range.start > height) {
-        // discard items before the sub-range
-        _streamQueue.skip(1);
-      } else if (range.isInRange(height)) {
-        // yield items in range
-        yield (await _streamQueue.next) as DriveHistoryTransaction;
-      } else {
-        // when the stream for the latest sub-range is read, close the stream
-        if (currentIndex == subRanges.rangeSegments.length - 1) {
-          _streamQueue.cancel();
-        }
-
-        // return when the next item is after the sub-range
-        return;
-      }
-    }
-  }
-}
-
 class SnapshotItemOnChain implements SnapshotItem {
   final int timestamp;
   final TxID txId;
   String? _cachedSource;
   int _currentIndex = -1;
 
-  static Map<String, Cache<Uint8List>> _jsonMetadataCaches = {};
+  static final Map<String, Cache<Uint8List>> _jsonMetadataCaches = {};
 
   SnapshotItemOnChain({
     required this.blockEnd,

--- a/lib/utils/snapshots/snapshot_item_to_be_created.dart
+++ b/lib/utils/snapshots/snapshot_item_to_be_created.dart
@@ -1,0 +1,53 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:ardrive/utils/snapshots/snapshot_types.dart';
+import 'package:ardrive/utils/snapshots/tx_snapshot_to_snapshot_data.dart';
+
+import '../../entities/string_types.dart';
+import '../../services/arweave/graphql/graphql_api.graphql.dart';
+import 'height_range.dart';
+
+typedef DriveHistoryTransaction
+    = DriveEntityHistory$Query$TransactionConnection$TransactionEdge$Transaction;
+
+class SnapshotItemToBeCreated {
+  final HeightRange subRanges;
+  final int blockStart;
+  final int blockEnd;
+  final DriveID driveId;
+  final Stream<DriveHistoryTransaction> source;
+
+  SnapshotItemToBeCreated({
+    required this.blockStart,
+    required this.blockEnd,
+    required this.driveId,
+    required this.subRanges,
+    required this.source,
+  });
+
+  Stream<Uint8List> getSnapshotData() {
+    final txSnapshotStream = source.map<TxSnapshot>(
+      (node) => TxSnapshot(
+        gqlNode: node,
+        jsonMetadata: _isSnapshotTx(node) ? '' : _jsonMetadataOfTxId(node.id),
+      ),
+    );
+
+    final snapshotDataStream =
+        txSnapshotStream.transform<Uint8List>(txSnapshotToSnapshotData);
+
+    return snapshotDataStream;
+  }
+
+  bool _isSnapshotTx(DriveHistoryTransaction node) {
+    final tags = node.tags;
+    final entityTypeTags = tags.where((tag) => tag.name == 'Entity-Type');
+
+    return entityTypeTags.any((tag) => tag.value == 'snapshot');
+  }
+
+  String _jsonMetadataOfTxId(String txId) {
+    return "TODO";
+  }
+}

--- a/lib/utils/snapshots/snapshot_item_to_be_created.dart
+++ b/lib/utils/snapshots/snapshot_item_to_be_created.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import 'package:ardrive/entities/entities.dart';
 import 'package:ardrive/utils/snapshots/snapshot_types.dart';
 import 'package:ardrive/utils/snapshots/tx_snapshot_to_snapshot_data.dart';
 
@@ -42,12 +43,14 @@ class SnapshotItemToBeCreated {
 
   bool _isSnapshotTx(DriveHistoryTransaction node) {
     final tags = node.tags;
-    final entityTypeTags = tags.where((tag) => tag.name == 'Entity-Type');
+    final entityTypeTags =
+        tags.where((tag) => tag.name == EntityTag.entityType);
 
     return entityTypeTags.any((tag) => tag.value == 'snapshot');
   }
 
   String _jsonMetadataOfTxId(String txId) {
+    // FIXME: let me read the DB, and go to the network if not present.
     return "TODO";
   }
 }

--- a/lib/utils/snapshots/snapshot_item_to_be_created.dart
+++ b/lib/utils/snapshots/snapshot_item_to_be_created.dart
@@ -2,11 +2,11 @@ import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:ardrive/entities/entities.dart';
+import 'package:ardrive/entities/string_types.dart';
+import 'package:ardrive/services/arweave/graphql/graphql_api.graphql.dart';
 import 'package:ardrive/utils/snapshots/snapshot_types.dart';
 import 'package:ardrive/utils/snapshots/tx_snapshot_to_snapshot_data.dart';
 
-import '../../entities/string_types.dart';
-import '../../services/arweave/graphql/graphql_api.graphql.dart';
 import 'height_range.dart';
 
 typedef DriveHistoryTransaction
@@ -19,26 +19,30 @@ class SnapshotItemToBeCreated {
   final DriveID driveId;
   final Stream<DriveHistoryTransaction> source;
 
+  final Future<String> Function(TxID txId) _jsonMetadataOfTxId;
+
   SnapshotItemToBeCreated({
     required this.blockStart,
     required this.blockEnd,
     required this.driveId,
     required this.subRanges,
     required this.source,
-  });
+    required Future<String> Function(TxID txId) jsonMetadataOfTxId,
+  }) : _jsonMetadataOfTxId = jsonMetadataOfTxId;
 
-  Stream<Uint8List> getSnapshotData() {
-    final txSnapshotStream = source.map<TxSnapshot>(
-      (node) => TxSnapshot(
+  Stream<Uint8List> getSnapshotData() async* {
+    final txSnapshotStream = source.asyncMap<TxSnapshot>(
+      (node) async => TxSnapshot(
         gqlNode: node,
-        jsonMetadata: _isSnapshotTx(node) ? '' : _jsonMetadataOfTxId(node.id),
+        jsonMetadata:
+            _isSnapshotTx(node) ? '' : await _jsonMetadataOfTxId(node.id),
       ),
     );
 
     final snapshotDataStream =
         txSnapshotStream.transform<Uint8List>(txSnapshotToSnapshotData);
 
-    return snapshotDataStream;
+    yield* snapshotDataStream;
   }
 
   bool _isSnapshotTx(DriveHistoryTransaction node) {
@@ -47,10 +51,5 @@ class SnapshotItemToBeCreated {
         tags.where((tag) => tag.name == EntityTag.entityType);
 
     return entityTypeTags.any((tag) => tag.value == 'snapshot');
-  }
-
-  String _jsonMetadataOfTxId(String txId) {
-    // FIXME: let me read the DB, and go to the network if not present.
-    return "TODO";
   }
 }

--- a/lib/utils/snapshots/snapshot_item_to_be_created.dart
+++ b/lib/utils/snapshots/snapshot_item_to_be_created.dart
@@ -50,6 +50,6 @@ class SnapshotItemToBeCreated {
     final entityTypeTags =
         tags.where((tag) => tag.name == EntityTag.entityType);
 
-    return entityTypeTags.any((tag) => tag.value == 'snapshot');
+    return entityTypeTags.any((tag) => tag.value == EntityType.snapshot);
   }
 }

--- a/test/utils/drive_history_composite_test.dart
+++ b/test/utils/drive_history_composite_test.dart
@@ -44,7 +44,7 @@ void main() {
       );
     });
 
-    test('constructor throws with invalid sub-ranges amount', () {
+    test('constructor throws with invalid sub-ranges amount', () async {
       GQLDriveHistory gqlDriveHistory = GQLDriveHistory(
         arweave: arweave,
         driveId: 'DRIVE_ID',
@@ -55,13 +55,13 @@ void main() {
         ]),
       );
       SnapshotDriveHistory snapshotDriveHistory = SnapshotDriveHistory(
-        items: mockSubRanges
+        items: await Future.wait(mockSubRanges
             .map(
               (r) => fakeSnapshotItemFromRange(
                 HeightRange(rangeSegments: [r]),
               ),
             )
-            .toList(),
+            .toList()),
       );
 
       expect(
@@ -96,13 +96,13 @@ void main() {
         ]),
       );
       SnapshotDriveHistory snapshotDriveHistory = SnapshotDriveHistory(
-        items: mockSubRanges
+        items: await Future.wait(mockSubRanges
             .map(
               (r) => fakeSnapshotItemFromRange(
                 HeightRange(rangeSegments: [r]),
               ),
             )
-            .toList(),
+            .toList()),
       );
       DriveHistoryComposite driveHistoryComposite = DriveHistoryComposite(
         subRanges: HeightRange(rangeSegments: [Range(start: 0, end: 100)]),

--- a/test/utils/snapshot_drive_history_test.dart
+++ b/test/utils/snapshot_drive_history_test.dart
@@ -1,3 +1,4 @@
+import 'package:ardrive/services/arweave/graphql/graphql_api.graphql.dart';
 import 'package:ardrive/utils/snapshots/height_range.dart';
 import 'package:ardrive/utils/snapshots/range.dart';
 import 'package:ardrive/utils/snapshots/segmented_gql_data.dart';
@@ -40,8 +41,8 @@ void main() {
 
   group('SnapshotDriveHistory class', () {
     test('returns a single stream if the sub-ranges are composable', () async {
-      final fakeItems =
-          composableRanges.map(fakeSnapshotItemFromRange).toList();
+      final fakeItems = await Future.wait(
+          composableRanges.map(fakeSnapshotItemFromRange).toList());
       final snapshotDriveHistory = SnapshotDriveHistory(items: fakeItems);
 
       expect(snapshotDriveHistory.subRanges.rangeSegments.length, 1);
@@ -57,8 +58,8 @@ void main() {
 
     test('returns multiple streams if the sub-ranges are not composable',
         () async {
-      final fakeItems =
-          nonComposableRanges.map(fakeSnapshotItemFromRange).toList();
+      final fakeItems = await Future.wait(
+          nonComposableRanges.map(fakeSnapshotItemFromRange).toList());
       final snapshotDriveHistory = SnapshotDriveHistory(items: fakeItems);
 
       expect(snapshotDriveHistory.subRanges.rangeSegments.length, 4);
@@ -87,13 +88,28 @@ Range heightRangeToRange(HeightRange hr) {
       end: hr.rangeSegments[hr.rangeSegments.length - 1].end);
 }
 
-SnapshotItem fakeSnapshotItemFromRange(HeightRange r) {
+Future<SnapshotItem> fakeSnapshotItemFromRange(HeightRange r) async {
   final range = heightRangeToRange(r);
-  return SnapshotItem.fromStream(
-    source: fakeNodesStream(range),
-    blockStart: range.start,
-    blockEnd: range.end,
-    driveId: 'driveId',
+  return SnapshotItem.fromGQLNode(
+    node:
+        SnapshotEntityHistory$Query$TransactionConnection$TransactionEdge$Transaction
+            .fromJson(
+      {
+        'id': 'hwgMuTV_dtFqfC9fJXfZTv00aOm17yL0wYucqh05YAQ',
+        'bundledIn': {'id': 'ASDASDASDASDASDASD'},
+        'owner': {'address': '1234567890'},
+        'tags': [
+          {'name': 'Block-Start', 'value': '${range.start}'},
+          {'name': 'Block-End', 'value': '${range.end}'},
+          {'name': 'Drive-Id', 'value': 'asdasdasdasd'},
+        ],
+        'block': {
+          'height': 100,
+          'timestamp': DateTime.now().microsecondsSinceEpoch
+        }
+      },
+    ),
+    fakeSource: await fakeSnapshotSource(range),
     subRanges: r,
   );
 }

--- a/test/utils/snapshot_item_test.dart
+++ b/test/utils/snapshot_item_test.dart
@@ -12,55 +12,6 @@ import 'snapshot_test_helpers.dart';
 
 void main() {
   group('SnapshotItem class', () {
-    group('fromStream factory', () {
-      test('getStreamForIndex returns a valid stream of nodes', () async {
-        final r = Range(start: 0, end: 10);
-
-        SnapshotItem item = SnapshotItem.fromStream(
-          blockStart: r.start,
-          blockEnd: r.end,
-          driveId: 'DRIVE_ID',
-          subRanges: HeightRange(rangeSegments: [Range(start: 0, end: 10)]),
-          source: fakeNodesStream(r),
-        );
-        expect(item.subRanges.rangeSegments.length, 1);
-        expect(item.currentIndex, -1);
-        Stream stream = item.getNextStream();
-        expect(item.currentIndex, 0);
-        expect(await countStreamItems(stream), 11);
-        expect(
-          () => item.getNextStream(),
-          throwsA(isA<SubRangeIndexOverflow>()),
-        );
-
-        item = SnapshotItem.fromStream(
-          blockStart: r.start,
-          blockEnd: r.end,
-          driveId: 'DRIVE_ID',
-          subRanges: HeightRange(
-            rangeSegments: [
-              Range(start: 0, end: 4),
-              Range(start: 6, end: 10),
-            ],
-          ),
-          source: fakeNodesStream(r),
-        );
-        expect(item.subRanges.rangeSegments.length, 2);
-        expect(item.currentIndex, -1);
-        stream = item.getNextStream();
-        expect(item.currentIndex, 0);
-        expect(await countStreamItems(stream), 5);
-        stream = item.getNextStream();
-        expect(item.currentIndex, 1);
-        expect(await countStreamItems(stream), 5);
-
-        expect(
-          () => item.getNextStream(),
-          throwsA(isA<SubRangeIndexOverflow>()),
-        );
-      });
-    });
-
     group('fromGQLNode factory', () {
       test('getStreamForIndex returns a valid stream of nodes', () async {
         final r = Range(start: 0, end: 10);

--- a/test/utils/snapshot_item_to_be_created_test.dart
+++ b/test/utils/snapshot_item_to_be_created_test.dart
@@ -18,6 +18,7 @@ void main() {
           blockEnd: 10,
           subRanges: HeightRange(rangeSegments: [Range(start: 0, end: 10)]),
           source: const Stream.empty(),
+          jsonMetadataOfTxId: (txId) async => '{"name":"$txId"}',
         );
 
         final snapshotData = (await snapshotItem
@@ -36,6 +37,7 @@ void main() {
           blockEnd: 10,
           subRanges: HeightRange(rangeSegments: [Range(start: 0, end: 10)]),
           source: fakeNodesStream(Range(start: 8, end: 8)),
+          jsonMetadataOfTxId: (txId) async => '{"name":"$txId"}',
         );
 
         final snapshotData = (await snapshotItem
@@ -46,7 +48,7 @@ void main() {
 
         expect(
           snapshotData,
-          '{"txSnapshots":[{"gqlNode":{"id":"tx-8","owner":{"address":"1234567890"},"bundledIn":{"id":"ASDASDASDASDASDASD"},"block":{"height":8,"timestamp":800},"tags":[]},"jsonMetadata":"TODO"}]}',
+          '{"txSnapshots":[{"gqlNode":{"id":"tx-8","owner":{"address":"1234567890"},"bundledIn":{"id":"ASDASDASDASDASDASD"},"block":{"height":8,"timestamp":800},"tags":[]},"jsonMetadata":"{\\"name\\":\\"tx-8\\"}"}]}',
         );
       });
 
@@ -58,23 +60,26 @@ void main() {
           blockStart: 0,
           blockEnd: 10,
           subRanges: HeightRange(rangeSegments: [Range(start: 0, end: 10)]),
-          source: Stream.fromIterable([
-            DriveEntityHistory$Query$TransactionConnection$TransactionEdge$Transaction
-                .fromJson(
-              {
-                'id': 'tx-7',
-                'bundledIn': {'id': 'ASDASDASDASDASDASD'},
-                'owner': {'address': '1234567890'},
-                'tags': [
-                  {'name': 'Entity-Type', 'value': 'snapshot'},
-                ],
-                'block': {
-                  'height': 7,
-                  'timestamp': 700,
-                }
-              },
-            ),
-          ]),
+          source: Stream.fromIterable(
+            [
+              DriveEntityHistory$Query$TransactionConnection$TransactionEdge$Transaction
+                  .fromJson(
+                {
+                  'id': 'tx-7',
+                  'bundledIn': {'id': 'ASDASDASDASDASDASD'},
+                  'owner': {'address': '1234567890'},
+                  'tags': [
+                    {'name': 'Entity-Type', 'value': 'snapshot'},
+                  ],
+                  'block': {
+                    'height': 7,
+                    'timestamp': 700,
+                  }
+                },
+              ),
+            ],
+          ),
+          jsonMetadataOfTxId: (txId) async => '{"name":"tx-$txId"}',
         );
 
         final snapshotData = (await snapshotItem

--- a/test/utils/snapshot_item_to_be_created_test.dart
+++ b/test/utils/snapshot_item_to_be_created_test.dart
@@ -53,7 +53,7 @@ void main() {
       });
 
       test(
-          'the returned data won\'t contain metadatadata of other snapshots, but only the gql node',
+          'the returned data won\'t contain the json metadata of other snapshots, but only the gql node',
           () async {
         final snapshotItem = SnapshotItemToBeCreated(
           driveId: 'DRIVE_ID',

--- a/test/utils/snapshot_item_to_be_created_test.dart
+++ b/test/utils/snapshot_item_to_be_created_test.dart
@@ -1,0 +1,93 @@
+import 'dart:convert';
+
+import 'package:ardrive/services/arweave/graphql/graphql_api.graphql.dart';
+import 'package:ardrive/utils/snapshots/height_range.dart';
+import 'package:ardrive/utils/snapshots/range.dart';
+import 'package:ardrive/utils/snapshots/snapshot_item_to_be_created.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'snapshot_test_helpers.dart';
+
+void main() {
+  group('SnapshotItemToBeCreated class', () {
+    group('getSnapshotData method', () {
+      test('returns the correct data for an empty set', () async {
+        final snapshotItem = SnapshotItemToBeCreated(
+          driveId: 'DRIVE_ID',
+          blockStart: 0,
+          blockEnd: 10,
+          subRanges: HeightRange(rangeSegments: [Range(start: 0, end: 10)]),
+          source: const Stream.empty(),
+        );
+
+        final snapshotData = (await snapshotItem
+                .getSnapshotData()
+                .map(utf8.decoder.convert)
+                .toList())
+            .join();
+
+        expect(snapshotData, '{"txSnapshots":[]}');
+      });
+
+      test('returns the correct data for a single transaction', () async {
+        final snapshotItem = SnapshotItemToBeCreated(
+          driveId: 'DRIVE_ID',
+          blockStart: 0,
+          blockEnd: 10,
+          subRanges: HeightRange(rangeSegments: [Range(start: 0, end: 10)]),
+          source: fakeNodesStream(Range(start: 8, end: 8)),
+        );
+
+        final snapshotData = (await snapshotItem
+                .getSnapshotData()
+                .map(utf8.decoder.convert)
+                .toList())
+            .join();
+
+        expect(
+          snapshotData,
+          '{"txSnapshots":[{"gqlNode":{"id":"tx-8","owner":{"address":"1234567890"},"bundledIn":{"id":"ASDASDASDASDASDASD"},"block":{"height":8,"timestamp":800},"tags":[]},"jsonMetadata":"TODO"}]}',
+        );
+      });
+
+      test(
+          'the returned data won\'t contain metadatadata of other snapshots, but only the gql node',
+          () async {
+        final snapshotItem = SnapshotItemToBeCreated(
+          driveId: 'DRIVE_ID',
+          blockStart: 0,
+          blockEnd: 10,
+          subRanges: HeightRange(rangeSegments: [Range(start: 0, end: 10)]),
+          source: Stream.fromIterable([
+            DriveEntityHistory$Query$TransactionConnection$TransactionEdge$Transaction
+                .fromJson(
+              {
+                'id': 'tx-7',
+                'bundledIn': {'id': 'ASDASDASDASDASDASD'},
+                'owner': {'address': '1234567890'},
+                'tags': [
+                  {'name': 'Entity-Type', 'value': 'snapshot'},
+                ],
+                'block': {
+                  'height': 7,
+                  'timestamp': 700,
+                }
+              },
+            ),
+          ]),
+        );
+
+        final snapshotData = (await snapshotItem
+                .getSnapshotData()
+                .map(utf8.decoder.convert)
+                .toList())
+            .join();
+
+        expect(
+          snapshotData,
+          '{"txSnapshots":[{"gqlNode":{"id":"tx-7","owner":{"address":"1234567890"},"bundledIn":{"id":"ASDASDASDASDASDASD"},"block":{"height":7,"timestamp":700},"tags":[{"name":"Entity-Type","value":"snapshot"}]},"jsonMetadata":""}]}',
+        );
+      });
+    });
+  });
+}

--- a/test/utils/snapshot_test_helpers.dart
+++ b/test/utils/snapshot_test_helpers.dart
@@ -30,7 +30,7 @@ Stream<DriveEntityHistory$Query$TransactionConnection$TransactionEdge$Transactio
         'tags': [],
         'block': {
           'height': height,
-          'timestamp': DateTime.now().microsecondsSinceEpoch
+          'timestamp': height * 100,
         }
       },
     );


### PR DESCRIPTION
Changes
- Makes SnapshotItemToBeCreated to no longer extend SnapshotItem
- SnapshotItemToBeCreated has the responsibility of knowing the data of the snapshot
- Updates the tests for SnapshotItem
- Implements the tests for SnapshotItemToBeCreated

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/2s12d12f3cj40
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/5qb0i8mp9dbp0