### PR TITLE
PE-2824: creates a table for SnapshotEntry

### DIFF
--- a/lib/models/tables/all.drift
+++ b/lib/models/tables/all.drift
@@ -6,3 +6,4 @@ import 'folder_entries.drift';
 import 'folder_revisions.drift';
 import 'profiles.drift';
 import 'network_transactions.drift';
+import 'snapshot_entries.drift';

--- a/lib/models/tables/snapshot_entries.drift
+++ b/lib/models/tables/snapshot_entries.drift
@@ -6,6 +6,8 @@ CREATE TABLE snapshot_entries (
     dataStart INTEGER NOT NULL,
     dataEnd INTEGER NOT NULL,
 
+    txId TEXT NOT NULL,
+
     dateCreated DATETIME NOT NULL DEFAULT (strftime('%s','now')),
     PRIMARY KEY (id, driveId)
 ) As SnapshotEntry;

--- a/lib/models/tables/snapshot_entries.drift
+++ b/lib/models/tables/snapshot_entries.drift
@@ -1,0 +1,11 @@
+CREATE TABLE snapshot_entries (
+    id TEXT NOT NULL,
+    driveId TEXT NOT NULL,
+    blockStart INTEGER NOT NULL,
+    blockEnd INTEGER NOT NULL,
+    dataStart INTEGER NOT NULL,
+    dataEnd INTEGER NOT NULL,
+
+    dateCreated DATETIME NOT NULL DEFAULT (strftime('%s','now')),
+    PRIMARY KEY (id, driveId)
+) As SnapshotEntry;


### PR DESCRIPTION
Changes
- Declares a new table for Snapshot Entries: It tracks:
  - The snapshot id,
  - the drive id,
  - the block range and
  - the data range, and
  - the unix time.

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/3kp3nbad076o8
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/2k58hof0rt4h0