### PR TITLE
PE-2875: removes the import of snapshot entries

### DIFF
--- a/android/fastlane/metadata/android/en-US/changelogs/18.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/18.txt
@@ -1,0 +1,1 @@
+- fixes uncaught error

--- a/lib/models/tables/all.drift
+++ b/lib/models/tables/all.drift
@@ -6,4 +6,4 @@ import 'folder_entries.drift';
 import 'folder_revisions.drift';
 import 'profiles.drift';
 import 'network_transactions.drift';
-import 'snapshot_entries.drift';
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Secure, permanent storage
 
 publish_to: 'none'
 
-version: 1.41.2
+version: 1.41.3
 
 environment:
   sdk: '>=2.18.5 <3.0.0'


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/3e7caao7oljeo
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/4qj9mmm3i5sl0