### PR TITLE
PE-2929: feat(sync drive) ignore unknown entities

### DIFF
--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -282,9 +282,10 @@ class ArweaveService {
 
     // Sort the entities in each block by ascending commit time.
     for (final block in blockHistory) {
+      block.entities.removeWhere((e) => e == null);
       block.entities.sort((e1, e2) => e1!.createdAt.compareTo(e2!.createdAt));
       //Remove entities with spoofed owners
-      block.entities.removeWhere((e) => e == null || e.ownerAddress != owner);
+      block.entities.removeWhere((e) => e!.ownerAddress != owner);
     }
 
     return DriveEntityHistory(


### PR DESCRIPTION
Since a new Entity-Type was added, the sync process wasn't ready to handle these. Now, the sync process will ignore "unknown" (or "yet unimplemented") entities.

**Changes**
- Ignore unknown ArFS entities 

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/7hvussu7ths8g
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/2q28gqhpss74g