### PR TITLE
PE-2934: Correct the allowedFileSize Limit for Turbo

### DIFF
--- a/lib/blocs/upload/models/upload_plan.dart
+++ b/lib/blocs/upload/models/upload_plan.dart
@@ -93,12 +93,20 @@ Future<bool> canWeUseTurbo({
   required Map<String, FileV2UploadHandle> fileV2UploadHandles,
   required TurboService turboService,
 }) async {
+  // Extra fields that come into play when bundling
+  const dataItemIdOffsetByteSize = 64;
+  const noOfDataItemsByteSize = 32;
+
   if (!turboService.useTurbo) return false;
 
   final areDataItemSizesUnderThreshold = await Future.wait(
     fileDataItemUploadHandles.values.map(
-      (e) async =>
-          await e.estimateDataItemSizes() <= turboService.allowedDataItemSize,
+      (e) async {
+        final allowedDataItemSize = turboService.allowedDataItemSize +
+            dataItemIdOffsetByteSize +
+            noOfDataItemsByteSize;
+        return await e.estimateDataItemSizes() <= allowedDataItemSize;
+      },
     ),
   );
 


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/0bsueuvuu1d40
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/7m1150hio6ac0