### PR TITLE
PE-2969: fixes edge case where failure event wasn't emitted 

### DIFF
--- a/lib/blocs/create_snapshot/create_snapshot_cubit.dart
+++ b/lib/blocs/create_snapshot/create_snapshot_cubit.dart
@@ -56,7 +56,12 @@ class CreateSnapshotCubit extends Cubit<CreateSnapshotState> {
     DriveID driveId, {
     Range? range,
   }) async {
-    await _reset(driveId);
+    try {
+      await _reset(driveId);
+    } catch (e) {
+      emit(ComputeSnapshotDataFailure(errorMessage: e.toString()));
+      return;
+    }
 
     _setTrustedRange(range);
 
@@ -98,8 +103,7 @@ class CreateSnapshotCubit extends Cubit<CreateSnapshotState> {
   }
 
   Future<void> _reset(DriveID driveId) async {
-    final currentHeight = await _arweave.getCurrentBlockHeight();
-    _currentHeight = currentHeight;
+    _currentHeight = await _arweave.getCurrentBlockHeight();
     _driveId = driveId;
     _itemToBeCreated = null;
     _snapshotEntity = null;


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/703mhl64q0flo
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/1jklhai1m1ldo