### PR TITLE
PE-2981: Makes the AppDialog title to wrap on overflow 

### DIFF
--- a/lib/components/app_dialog.dart
+++ b/lib/components/app_dialog.dart
@@ -53,12 +53,14 @@ class AppDialog extends StatelessWidget {
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
-                    Text(
-                      title,
-                      style: Theme.of(context)
-                          .textTheme
-                          .headline6!
-                          .copyWith(color: kOnDarkSurfaceHighEmphasis),
+                    Expanded(
+                      child: Text(
+                        title,
+                        style: Theme.of(context)
+                            .textTheme
+                            .headline6!
+                            .copyWith(color: kOnDarkSurfaceHighEmphasis),
+                      ),
                     ),
                   ],
                 ),


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/0m0oqo7jkimt8
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/593qcop9q4ocg