### PR TITLE
PE-2941: re-enables quick sync authoring

### DIFF
--- a/android/fastlane/metadata/android/en-US/changelogs/21.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/21.txt
@@ -1,1 +1,2 @@
+- Introducing snapshots! This allows for a client to quickly retrieve all transactions of a specific drive when snapshots are used.
 - Fixed the issue with orphan entities. Orphan files are displayed on drive explorer again.

--- a/android/fastlane/metadata/android/en-US/changelogs/22.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/22.txt
@@ -1,2 +1,0 @@
-- Introducing snapshots! This allows for a client to quickly retrieve all transactions of a specific drive when snapshots are used.
-- Fixed the issue with orphan entities. Orphan files are displayed on drive explorer again.

--- a/android/fastlane/metadata/android/en-US/changelogs/22.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/22.txt
@@ -1,0 +1,2 @@
+- Introducing snapshots! This allows for a client to quickly retrieve all transactions of a specific drive when snapshots are used.
+- Fixed the issue with orphan entities. Orphan files are displayed on drive explorer again.

--- a/assets/config/prod.json
+++ b/assets/config/prod.json
@@ -3,5 +3,5 @@
   "useTurbo": false,
   "defaultTurboUrl": "https://upload.ardrive.io",
   "allowedDataItemSizeForTurbo": 102400,
-  "enableQuickSyncAuthoring": false
+  "enableQuickSyncAuthoring": true
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Secure, permanent storage
 
 publish_to: 'none'
 
-version: 1.41.4
+version: 1.42.0
 
 environment:
   sdk: '>=2.18.5 <3.0.0'


### PR DESCRIPTION
Changes
- Version bump 
- Re enables quick sync authoring feature flag
- Puts Android release notes

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/70b1c05g1ntsg
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/03cmbgkld51oo