### PR TITLE
PE-2583: feat(snapshot entity): fixes broken test after integrating dev

### DIFF
--- a/lib/entities/snapshot_entity.dart
+++ b/lib/entities/snapshot_entity.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'package:ardrive/core/crypto/crypto.dart';
 import 'package:ardrive/entities/string_types.dart';
 import 'package:ardrive/services/services.dart';
 import 'package:arweave/arweave.dart';
@@ -37,7 +38,7 @@ class SnapshotEntity extends Entity {
     this.dataStart,
     this.dataEnd,
     this.data,
-  });
+  }) : super(ArDriveCrypto());
 
   static Future<SnapshotEntity> fromTransaction(
     TransactionCommonMixin transaction,


### PR DESCRIPTION
Fixes broken test on #850 - This change doesn't affect the way SnapshotEntities deals with encryption (it doesn't use encryption since the data for private drives will be already encrypted).

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/1ilt8udj3d9p8
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/1ar55s6il9hug