### PR TITLE
PE-3001: fix limit data item count in bundle packer for turbo

### DIFF
--- a/assets/config/dev.json
+++ b/assets/config/dev.json
@@ -2,6 +2,6 @@
   "defaultArweaveGatewayUrl": "https://arweave.net",
   "useTurbo": true,
   "defaultTurboUrl": "https://upload.ardrive.dev",
-  "allowedDataItemSizeForTurbo": 102400,
+  "allowedDataItemSizeForTurbo": 100000,
   "enableQuickSyncAuthoring": true
 }

--- a/lib/blocs/upload/models/upload_plan.dart
+++ b/lib/blocs/upload/models/upload_plan.dart
@@ -63,10 +63,10 @@ class UploadPlan {
     final int maxBundleSize = useTurbo
         ? turboService.allowedDataItemSize + approximateMetadataSize
         : (kIsWeb ? bundleSizeLimit : mobileBundleSizeLimit);
-
+    final int filesPerBundle = useTurbo ? 2 : maxFilesPerBundle;
     final bundleItems = await NextFitBundlePacker<UploadHandle>(
       maxBundleSize: maxBundleSize,
-      maxDataItemCount: maxFilesPerBundle,
+      maxDataItemCount: filesPerBundle,
     ).packItems([
       ...fileDataItemUploadHandles.values,
       ...folderDataItemUploadHandles.values


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/4t0a6368g0mag
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/5s39d5a3b2nn8