### PR TITLE
PE-3082: chore - version bump 1.43.0

### DIFF
--- a/android/fastlane/metadata/android/en-US/changelogs/23.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/23.txt
@@ -1,0 +1,1 @@
+- All transactions under 100KB are now free

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Secure, permanent storage
 
 publish_to: 'none'
 
-version: 1.42.1
+version: 1.43.0
 
 environment:
   sdk: '>=2.18.5 <3.0.0'


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/63macs8qgp1t8
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/2tcv525jio2sg