### PR TITLE
PE-3109: fix - add size check before using turbo for manifests

### DIFF
--- a/lib/blocs/create_manifest/create_manifest_cubit.dart
+++ b/lib/blocs/create_manifest/create_manifest_cubit.dart
@@ -231,8 +231,9 @@ class CreateManifestCubit extends Cubit<CreateManifestState> {
               );
             },
           );
-
-      if (_turboService.useTurbo) {
+      final canUseTUrbo = _turboService.useTurbo &&
+          arweaveManifest.size < _turboService.allowedDataItemSize;
+      if (canUseTUrbo) {
         emit(
           CreateManifestTurboUploadConfirmation(
             manifestSize: arweaveManifest.size,

--- a/lib/blocs/create_manifest/create_manifest_cubit.dart
+++ b/lib/blocs/create_manifest/create_manifest_cubit.dart
@@ -231,9 +231,9 @@ class CreateManifestCubit extends Cubit<CreateManifestState> {
               );
             },
           );
-      final canUseTUrbo = _turboService.useTurbo &&
+      final canUseTurbo = _turboService.useTurbo &&
           arweaveManifest.size < _turboService.allowedDataItemSize;
-      if (canUseTUrbo) {
+      if (canUseTurbo) {
         emit(
           CreateManifestTurboUploadConfirmation(
             manifestSize: arweaveManifest.size,


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/2pg4pj2mgneo8
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/087p1b2ehegm0