### PR TITLE
PE-3220: chore: bump version

### DIFF
--- a/android/fastlane/metadata/android/en-US/changelogs/28.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/28.txt
@@ -1,1 +1,1 @@
-- Update "Don’t Have a Wallet? Get One Here" link
+- Update link to get a new wallet

--- a/android/fastlane/metadata/android/en-US/changelogs/28.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/28.txt
@@ -1,0 +1,1 @@
+- Update "Don’t Have a Wallet? Get One Here" link

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Secure, permanent storage
 
 publish_to: 'none'
 
-version: 1.44.1
+version: 1.44.2
 
 environment:
   sdk: '>=2.18.5 <3.0.0'


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/2gkmpr4fhj6mg
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/74f5tnp8h3muo