### PR TITLE
PE-3132: ArConnect logout MVP

### DIFF
--- a/lib/blocs/create_snapshot/create_snapshot_cubit.dart
+++ b/lib/blocs/create_snapshot/create_snapshot_cubit.dart
@@ -209,7 +209,7 @@ class CreateSnapshotCubit extends Cubit<CreateSnapshotState> {
         skipSignature: true,
       );
     } catch (e) {
-      if (isArConnectProfile && !_tabVisibility.isTabFocused()) {
+      if (isArConnectProfile && !_tabVisibility.isTabVisible()) {
         // ignore: avoid_print
         print(
           'Preparing snapshot transaction while user is not focusing the tab. Waiting...',
@@ -220,7 +220,7 @@ class CreateSnapshotCubit extends Cubit<CreateSnapshotState> {
       } else {
         // ignore: avoid_print
         print(
-            'Error preparing snapshot transaction - $e isArConnectProfile: $isArConnectProfile, isTabFocused: ${_tabVisibility.isTabFocused()}');
+            'Error preparing snapshot transaction - $e isArConnectProfile: $isArConnectProfile, isTabFocused: ${_tabVisibility.isTabVisible()}');
         rethrow;
       }
     }
@@ -245,7 +245,7 @@ class CreateSnapshotCubit extends Cubit<CreateSnapshotState> {
 
       await _preparedTx.sign(wallet);
     } catch (e) {
-      if (isArConnectProfile && !_tabVisibility.isTabFocused()) {
+      if (isArConnectProfile && !_tabVisibility.isTabVisible()) {
         // ignore: avoid_print
         print(
           'Signing snapshot transaction while user is not focusing the tab. Waiting...',
@@ -256,7 +256,7 @@ class CreateSnapshotCubit extends Cubit<CreateSnapshotState> {
       } else {
         // ignore: avoid_print
         print(
-            'Error signing snapshot transaction - $e isArConnectProfile: $isArConnectProfile, isTabFocused: ${_tabVisibility.isTabFocused()}');
+            'Error signing snapshot transaction - $e isArConnectProfile: $isArConnectProfile, isTabFocused: ${_tabVisibility.isTabVisible()}');
         rethrow;
       }
     }

--- a/lib/blocs/create_snapshot/create_snapshot_cubit.dart
+++ b/lib/blocs/create_snapshot/create_snapshot_cubit.dart
@@ -209,7 +209,7 @@ class CreateSnapshotCubit extends Cubit<CreateSnapshotState> {
         skipSignature: true,
       );
     } catch (e) {
-      if (isArConnectProfile && !_tabVisibility.isTabVisible()) {
+      if (isArConnectProfile && !_tabVisibility.isTabFocused()) {
         // ignore: avoid_print
         print(
           'Preparing snapshot transaction while user is not focusing the tab. Waiting...',
@@ -220,7 +220,7 @@ class CreateSnapshotCubit extends Cubit<CreateSnapshotState> {
       } else {
         // ignore: avoid_print
         print(
-            'Error preparing snapshot transaction - $e isArConnectProfile: $isArConnectProfile, isTabFocused: ${_tabVisibility.isTabVisible()}');
+            'Error preparing snapshot transaction - $e isArConnectProfile: $isArConnectProfile, isTabFocused: ${_tabVisibility.isTabFocused()}');
         rethrow;
       }
     }
@@ -245,7 +245,7 @@ class CreateSnapshotCubit extends Cubit<CreateSnapshotState> {
 
       await _preparedTx.sign(wallet);
     } catch (e) {
-      if (isArConnectProfile && !_tabVisibility.isTabVisible()) {
+      if (isArConnectProfile && !_tabVisibility.isTabFocused()) {
         // ignore: avoid_print
         print(
           'Signing snapshot transaction while user is not focusing the tab. Waiting...',
@@ -256,7 +256,7 @@ class CreateSnapshotCubit extends Cubit<CreateSnapshotState> {
       } else {
         // ignore: avoid_print
         print(
-            'Error signing snapshot transaction - $e isArConnectProfile: $isArConnectProfile, isTabFocused: ${_tabVisibility.isTabVisible()}');
+            'Error signing snapshot transaction - $e isArConnectProfile: $isArConnectProfile, isTabFocused: ${_tabVisibility.isTabFocused()}');
         rethrow;
       }
     }

--- a/lib/blocs/sync/sync_cubit.dart
+++ b/lib/blocs/sync/sync_cubit.dart
@@ -205,7 +205,7 @@ class SyncCubit extends Cubit<SyncState> {
 
         logSync('User is ar connect? $isArConnect');
 
-        if (isArConnect && !_tabVisibility.isTabVisible()) {
+        if (isArConnect && !_tabVisibility.isTabFocused()) {
           logSync('Tab hidden, skipping sync...');
           emit(SyncIdle());
           return;

--- a/lib/blocs/sync/sync_cubit.dart
+++ b/lib/blocs/sync/sync_cubit.dart
@@ -205,7 +205,7 @@ class SyncCubit extends Cubit<SyncState> {
 
         logSync('User is ar connect? $isArConnect');
 
-        if (isArConnect && !_tabVisibility.isTabFocused()) {
+        if (isArConnect && !_tabVisibility.isTabVisible()) {
           logSync('Tab hidden, skipping sync...');
           emit(SyncIdle());
           return;

--- a/lib/blocs/sync/sync_cubit.dart
+++ b/lib/blocs/sync/sync_cubit.dart
@@ -151,7 +151,7 @@ class SyncCubit extends Cubit<SyncState> {
   }
 
   Future<void> arconnectSync() async {
-    if (_tabVisibility.isTabFocused() &&
+    if (_tabVisibility.isTabVisible() &&
         await _profileCubit.logoutIfWalletMismatch()) {
       emit(SyncWalletMismatch());
       return;
@@ -204,7 +204,7 @@ class SyncCubit extends Cubit<SyncState> {
 
         logSync('User is ar connect? $isArConnect');
 
-        if (isArConnect && !_tabVisibility.isTabFocused()) {
+        if (isArConnect && !_tabVisibility.isTabVisible()) {
           logSync('Tab hidden, skipping sync...');
           emit(SyncIdle());
           return;

--- a/lib/blocs/sync/sync_cubit.dart
+++ b/lib/blocs/sync/sync_cubit.dart
@@ -151,8 +151,9 @@ class SyncCubit extends Cubit<SyncState> {
   }
 
   Future<void> arconnectSync() async {
-    if (_tabVisibility.isTabVisible() &&
-        await _profileCubit.logoutIfWalletMismatch()) {
+    final isTabFocused = _tabVisibility.isTabFocused();
+    print('[ArConnect SYNC] isTabFocused: $isTabFocused');
+    if (isTabFocused && await _profileCubit.logoutIfWalletMismatch()) {
       emit(SyncWalletMismatch());
       return;
     }

--- a/lib/services/arconnect/is_document_focused.dart
+++ b/lib/services/arconnect/is_document_focused.dart
@@ -1,0 +1,4 @@
+import 'package:js/js.dart';
+
+@JS('isDocumentFocused')
+external bool isDocumentFocused();

--- a/lib/utils/html/html_util.dart
+++ b/lib/utils/html/html_util.dart
@@ -15,7 +15,7 @@ class TabVisibilitySingleton {
 
   bool isTabFocused() => implementation.isTabFocused();
 
-  bool isTabFocused() => implementation.isTabFocused();
+  bool isTabVisible() => implementation.isTabVisible();
 
   Future<void> onTabGetsFocusedFuture(FutureOr<Function> onFocus) async =>
       implementation.onTabGetsFocusedFuture(onFocus);

--- a/lib/utils/html/html_util.dart
+++ b/lib/utils/html/html_util.dart
@@ -15,6 +15,8 @@ class TabVisibilitySingleton {
 
   bool isTabFocused() => implementation.isTabFocused();
 
+  bool isTabFocused() => implementation.isTabFocused();
+
   Future<void> onTabGetsFocusedFuture(FutureOr<Function> onFocus) async =>
       implementation.onTabGetsFocusedFuture(onFocus);
 

--- a/lib/utils/html/implementations/html_stub.dart
+++ b/lib/utils/html/implementations/html_stub.dart
@@ -1,5 +1,9 @@
 import 'dart:async';
 
+bool isTabVisible() {
+  return true;
+}
+
 bool isTabFocused() {
   return true;
 }

--- a/lib/utils/html/implementations/html_web.dart
+++ b/lib/utils/html/implementations/html_web.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:universal_html/html.dart';
 
-bool isTabFocused() {
+bool isTabVisible() {
   return window.document.visibilityState == 'visible';
 }
 

--- a/lib/utils/html/implementations/html_web.dart
+++ b/lib/utils/html/implementations/html_web.dart
@@ -1,6 +1,11 @@
 import 'dart:async';
 
+import 'package:ardrive/services/arconnect/is_document_focused.dart';
 import 'package:universal_html/html.dart';
+
+bool isTabFocused() {
+  return isDocumentFocused();
+}
 
 bool isTabVisible() {
   return window.document.visibilityState == 'visible';
@@ -11,7 +16,7 @@ late StreamSubscription _onVisibilityChangeStream;
 Future<void> onTabGetsFocusedFuture(FutureOr<Function> onFocus) async {
   final completer = Completer<void>();
   _onVisibilityChangeStream = document.onVisibilityChange.listen((event) async {
-    if (isTabFocused()) {
+    if (isTabVisible()) {
       await onFocus;
       await closeVisibilityChangeStream();
       completer.complete(); // resolve the completer when onFocus completes
@@ -22,7 +27,7 @@ Future<void> onTabGetsFocusedFuture(FutureOr<Function> onFocus) async {
 
 void onTabGetsFocused(Function onFocus) {
   _onVisibilityChangeStream = document.onVisibilityChange.listen((event) {
-    if (isTabFocused()) {
+    if (isTabVisible()) {
       onFocus();
     }
   });

--- a/lib/utils/html/implementations/html_web.dart
+++ b/lib/utils/html/implementations/html_web.dart
@@ -16,7 +16,7 @@ late StreamSubscription _onVisibilityChangeStream;
 Future<void> onTabGetsFocusedFuture(FutureOr<Function> onFocus) async {
   final completer = Completer<void>();
   _onVisibilityChangeStream = document.onVisibilityChange.listen((event) async {
-    if (isTabFocused()) {
+    if (isTabVisible()) {
       await onFocus;
       await closeVisibilityChangeStream();
       completer.complete(); // resolve the completer when onFocus completes
@@ -27,7 +27,7 @@ Future<void> onTabGetsFocusedFuture(FutureOr<Function> onFocus) async {
 
 void onTabGetsFocused(Function onFocus) {
   _onVisibilityChangeStream = document.onVisibilityChange.listen((event) {
-    if (isTabFocused()) {
+    if (isTabVisible()) {
       onFocus();
     }
   });

--- a/lib/utils/html/implementations/html_web.dart
+++ b/lib/utils/html/implementations/html_web.dart
@@ -16,7 +16,7 @@ late StreamSubscription _onVisibilityChangeStream;
 Future<void> onTabGetsFocusedFuture(FutureOr<Function> onFocus) async {
   final completer = Completer<void>();
   _onVisibilityChangeStream = document.onVisibilityChange.listen((event) async {
-    if (isTabVisible()) {
+    if (isTabFocused()) {
       await onFocus;
       await closeVisibilityChangeStream();
       completer.complete(); // resolve the completer when onFocus completes
@@ -27,7 +27,7 @@ Future<void> onTabGetsFocusedFuture(FutureOr<Function> onFocus) async {
 
 void onTabGetsFocused(Function onFocus) {
   _onVisibilityChangeStream = document.onVisibilityChange.listen((event) {
-    if (isTabVisible()) {
+    if (isTabFocused()) {
       onFocus();
     }
   });

--- a/test/blocs/create_snapshot_cubit_test.dart
+++ b/test/blocs/create_snapshot_cubit_test.dart
@@ -317,7 +317,7 @@ void main() {
 
           // mocks the TabVisibilitySingleton class
           final responses = [false, false, true];
-          when(() => tabVisibility.isTabFocused()).thenAnswer(
+          when(() => tabVisibility.isTabVisible()).thenAnswer(
             (_) => responses.removeAt(0),
           );
 

--- a/test/blocs/create_snapshot_cubit_test.dart
+++ b/test/blocs/create_snapshot_cubit_test.dart
@@ -317,7 +317,7 @@ void main() {
 
           // mocks the TabVisibilitySingleton class
           final responses = [false, false, true];
-          when(() => tabVisibility.isTabVisible()).thenAnswer(
+          when(() => tabVisibility.isTabFocused()).thenAnswer(
             (_) => responses.removeAt(0),
           );
 

--- a/web/index.html
+++ b/web/index.html
@@ -18,6 +18,7 @@
     <title>ArDrive</title>
     <link rel="manifest" href="manifest.json" />
     <script defer src="js/arconnect.js"></script>
+    <script defer src="js/is_document_focused.js"></script>
 
     <!-- Plausible Web Analytics -->
     <script defer data-domain="app.ardrive.io" src="https://plausible.io/js/plausible.js"></script>

--- a/web/js/is_document_focused.js
+++ b/web/js/is_document_focused.js
@@ -1,0 +1,3 @@
+function isDocumentFocused() {
+  return document.hasFocus();
+}


### PR DESCRIPTION
Changes:

1. Renames `isTabFocused` into `isTabVisible`
2. Implements `isTabFocused` for web only, based on the `document.hasFocus` method in JavaScript.
3. Refactors the call to `arconnectSync` to call the new `isTabFocused` instead of the old one (now called `isTabVisible`)

**Note** See "Quickened arconnect sync" for testing/QA: #973

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/6pjp7e9i70vh0
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/6fd6p4m1h3kvo