### PR TITLE
PE-3132 - [DO NOT MERGE]: Dev + Quickened ArConnect sync

### DIFF
--- a/lib/blocs/sync/sync_cubit.dart
+++ b/lib/blocs/sync/sync_cubit.dart
@@ -140,8 +140,10 @@ class SyncCubit extends Cubit<SyncState> {
     _profileCubit.isCurrentProfileArConnect().then((isArConnect) {
       if (isArConnect) {
         _arconnectSyncSub?.cancel();
-        _arconnectSyncSub = Stream.periodic(
-                const Duration(minutes: kArConnectSyncTimerDuration))
+        _arconnectSyncSub = Stream.periodic(const Duration(
+          // TODO: remove this change
+          seconds: 10,
+        ))
             // Do not start another sync until the previous sync has completed.
             .map((value) => Stream.fromFuture(arconnectSync()))
             .listen((_) {});


### PR DESCRIPTION
Makes ArConnect Sync happen faster (10 secs instead of 2 mins) for testing purposes.

**Note** Apart from the change, it's what we have in prod (v1.44.3).

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/013ocln6ll50o
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/6vohutteqvq0o