### PR TITLE
PE-3352: Adds the `owners` field to the GQL queries

### DIFF
--- a/lib/blocs/create_snapshot/create_snapshot_cubit.dart
+++ b/lib/blocs/create_snapshot/create_snapshot_cubit.dart
@@ -37,7 +37,7 @@ class CreateSnapshotCubit extends Cubit<CreateSnapshotState> {
   bool returnWithoutSigningForTesting;
 
   late DriveID _driveId;
-  late String _driveOwner;
+  late String _ownerAddress;
   late Range _range;
   late int _currentHeight;
   late Transaction _preparedTx;
@@ -74,7 +74,8 @@ class CreateSnapshotCubit extends Cubit<CreateSnapshotState> {
       return;
     }
 
-    _driveOwner = await _arweave.getOwnerForDriveEntityWithId(driveId) ?? '';
+    final profileState = _profileCubit.state as ProfileLoggedIn;
+    _ownerAddress = profileState.walletAddress;
 
     _setTrustedRange(range);
 
@@ -150,7 +151,7 @@ class CreateSnapshotCubit extends Cubit<CreateSnapshotState> {
       _driveId,
       minBlockHeight: _range.start,
       maxBlockHeight: _range.end,
-      ownerAddress: _driveOwner,
+      ownerAddress: _ownerAddress,
     );
 
     // transforms the stream of arrays into a flat stream

--- a/lib/blocs/create_snapshot/create_snapshot_cubit.dart
+++ b/lib/blocs/create_snapshot/create_snapshot_cubit.dart
@@ -37,6 +37,7 @@ class CreateSnapshotCubit extends Cubit<CreateSnapshotState> {
   bool returnWithoutSigningForTesting;
 
   late DriveID _driveId;
+  late String _driveOwner;
   late Range _range;
   late int _currentHeight;
   late Transaction _preparedTx;
@@ -72,6 +73,8 @@ class CreateSnapshotCubit extends Cubit<CreateSnapshotState> {
       emit(ComputeSnapshotDataFailure(errorMessage: e.toString()));
       return;
     }
+
+    _driveOwner = await _arweave.getOwnerForDriveEntityWithId(driveId) ?? '';
 
     _setTrustedRange(range);
 
@@ -147,6 +150,7 @@ class CreateSnapshotCubit extends Cubit<CreateSnapshotState> {
       _driveId,
       minBlockHeight: _range.start,
       maxBlockHeight: _range.end,
+      ownerAddress: _driveOwner,
     );
 
     // transforms the stream of arrays into a flat stream

--- a/lib/blocs/sync/sync_cubit.dart
+++ b/lib/blocs/sync/sync_cubit.dart
@@ -266,6 +266,7 @@ class SyncCubit extends Cubit<SyncState> {
           currentBlockHeight: currentBlockHeight,
           transactionParseBatchSize:
               200 ~/ (_syncProgress.drivesCount - _syncProgress.drivesSynced),
+          ownerAddress: drive.ownerAddress,
         ).handleError(
           (error, stackTrace) {
             logSync('''

--- a/lib/blocs/sync/utils/parse_drive_transactions.dart
+++ b/lib/blocs/sync/utils/parse_drive_transactions.dart
@@ -14,6 +14,7 @@ Stream<double> _parseDriveTransactionsIntoDatabaseEntities({
   required int batchSize,
   required SnapshotDriveHistory snapshotDriveHistory,
   required Map<FolderID, GhostFolder> ghostFolders,
+  required String ownerAddress,
 }) async* {
   final numberOfDriveEntitiesToParse = transactions.length;
   var numberOfDriveEntitiesParsed = 0;
@@ -40,8 +41,6 @@ Stream<double> _parseDriveTransactionsIntoDatabaseEntities({
     'no. of entities in drive - ${drive.name} to be parsed are: $numberOfDriveEntitiesToParse\n',
   );
 
-  final owner = await arweave.getOwnerForDriveEntityWithId(drive.id);
-
   yield* _batchProcess<DriveHistoryTransaction>(
       list: transactions,
       batchSize: batchSize,
@@ -56,10 +55,10 @@ Stream<double> _parseDriveTransactionsIntoDatabaseEntities({
             await arweave.createDriveEntityHistoryFromTransactions(
           items,
           driveKey,
-          owner,
           lastBlockHeight,
           snapshotDriveHistory: snapshotDriveHistory,
           driveId: drive.id,
+          ownerAddress: ownerAddress,
         );
 
         // Create entries for all the new revisions of file and folders in this drive.

--- a/lib/blocs/sync/utils/sync_drive.dart
+++ b/lib/blocs/sync/utils/sync_drive.dart
@@ -19,6 +19,9 @@ Stream<double> _syncDrive(
   final drive = await driveDao.driveById(driveId: driveId).getSingle();
   final startSyncDT = DateTime.now();
 
+  final String owner =
+      await arweave.getOwnerForDriveEntityWithId(driveId) ?? '';
+
   logSync('Syncing drive - ${drive.name}');
 
   SecretKey? driveKey;
@@ -43,6 +46,7 @@ Stream<double> _syncDrive(
   final snapshotsStream = arweave.getAllSnapshotsOfDrive(
     driveId,
     lastBlockHeight,
+    ownerAddress: owner,
   );
   final List<SnapshotItem> snapshotItems = await SnapshotItem.instantiateAll(
     snapshotsStream,
@@ -69,6 +73,7 @@ Stream<double> _syncDrive(
     subRanges: gqlDriveHistorySubRanges,
     arweave: arweave,
     driveId: driveId,
+    ownerAddress: owner,
   );
 
   print('Total range to query for: ${totalRangeToQueryFor.rangeSegments}');

--- a/lib/blocs/sync/utils/sync_drive.dart
+++ b/lib/blocs/sync/utils/sync_drive.dart
@@ -14,13 +14,11 @@ Stream<double> _syncDrive(
   required int lastBlockHeight,
   required int transactionParseBatchSize,
   required Map<FolderID, GhostFolder> ghostFolders,
+  required String ownerAddress,
 }) async* {
   /// Variables to count the current drive's progress information
   final drive = await driveDao.driveById(driveId: driveId).getSingle();
   final startSyncDT = DateTime.now();
-
-  final String owner =
-      await arweave.getOwnerForDriveEntityWithId(driveId) ?? '';
 
   logSync('Syncing drive - ${drive.name}');
 
@@ -46,7 +44,7 @@ Stream<double> _syncDrive(
   final snapshotsStream = arweave.getAllSnapshotsOfDrive(
     driveId,
     lastBlockHeight,
-    ownerAddress: owner,
+    ownerAddress: ownerAddress,
   );
   final List<SnapshotItem> snapshotItems = await SnapshotItem.instantiateAll(
     snapshotsStream,
@@ -73,7 +71,7 @@ Stream<double> _syncDrive(
     subRanges: gqlDriveHistorySubRanges,
     arweave: arweave,
     driveId: driveId,
-    ownerAddress: owner,
+    ownerAddress: ownerAddress,
   );
 
   print('Total range to query for: ${totalRangeToQueryFor.rangeSegments}');
@@ -183,6 +181,7 @@ Stream<double> _syncDrive(
     lastBlockHeight: lastBlockHeight,
     batchSize: transactionParseBatchSize,
     snapshotDriveHistory: snapshotDriveHistory,
+    ownerAddress: ownerAddress,
   ).map(
     (parseProgress) => parseProgress * 0.9,
   );

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -209,8 +209,8 @@ class ArweaveService {
     List<DriveEntityHistory$Query$TransactionConnection$TransactionEdge$Transaction>
         entityTxs,
     SecretKey? driveKey,
-    String? owner,
     int lastBlockHeight, {
+    required String ownerAddress,
     required SnapshotDriveHistory snapshotDriveHistory,
     required DriveID driveId,
   }) async {
@@ -306,7 +306,7 @@ class ArweaveService {
       block.entities.removeWhere((e) => e == null);
       block.entities.sort((e1, e2) => e1!.createdAt.compareTo(e2!.createdAt));
       //Remove entities with spoofed owners
-      block.entities.removeWhere((e) => e!.ownerAddress != owner);
+      block.entities.removeWhere((e) => e!.ownerAddress != ownerAddress);
     }
 
     return DriveEntityHistory(

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -119,8 +119,9 @@ class ArweaveService {
 
   Stream<SnapshotEntityTransaction> getAllSnapshotsOfDrive(
     String driveId,
-    int? lastBlockHeight,
-  ) async* {
+    int? lastBlockHeight, {
+    required String ownerAddress,
+  }) async* {
     String cursor = '';
 
     while (true) {
@@ -131,6 +132,7 @@ class ArweaveService {
             driveId: driveId,
             lastBlockHeight: lastBlockHeight,
             after: cursor,
+            ownerAddress: ownerAddress,
           ),
         ),
       );
@@ -153,17 +155,20 @@ class ArweaveService {
   Stream<List<DriveEntityHistory$Query$TransactionConnection$TransactionEdge>>
       getAllTransactionsFromDrive(
     String driveId, {
+    required String ownerAddress,
     int? lastBlockHeight,
   }) {
     return getSegmentedTransactionsFromDrive(
       driveId,
       minBlockHeight: lastBlockHeight,
+      ownerAddress: ownerAddress,
     );
   }
 
   Stream<List<DriveEntityHistory$Query$TransactionConnection$TransactionEdge>>
       getSegmentedTransactionsFromDrive(
     String driveId, {
+    required String ownerAddress,
     int? minBlockHeight,
     int? maxBlockHeight,
   }) async* {
@@ -178,6 +183,7 @@ class ArweaveService {
             minBlockHeight: minBlockHeight,
             maxBlockHeight: maxBlockHeight,
             after: cursor,
+            ownerAddress: ownerAddress,
           ),
         ),
       );

--- a/lib/services/arweave/graphql/queries/DriveEntityHistory.graphql
+++ b/lib/services/arweave/graphql/queries/DriveEntityHistory.graphql
@@ -3,8 +3,10 @@ query DriveEntityHistory(
   $after: String
   $minBlockHeight: Int
   $maxBlockHeight: Int
+  $ownerAddress: String!
 ) {
   transactions(
+    owners: [$ownerAddress]
     first: 100
     sort: HEIGHT_ASC
     tags: [

--- a/lib/services/arweave/graphql/queries/SnapshotEntityHistory.graphql
+++ b/lib/services/arweave/graphql/queries/SnapshotEntityHistory.graphql
@@ -2,8 +2,10 @@ query SnapshotEntityHistory(
   $driveId: String!
   $after: String
   $lastBlockHeight: Int
+  $ownerAddress: String!
 ) {
   transactions(
+    owners: [$ownerAddress]
     first: 100
     sort: HEIGHT_DESC
     tags: [

--- a/lib/utils/snapshots/gql_drive_history.dart
+++ b/lib/utils/snapshots/gql_drive_history.dart
@@ -8,6 +8,7 @@ import '../../services/arweave/arweave_service.dart';
 
 class GQLDriveHistory implements SegmentedGQLData {
   final DriveID driveId;
+  final String ownerAddress;
 
   int _currentIndex = -1;
   final ArweaveService _arweave;
@@ -21,6 +22,7 @@ class GQLDriveHistory implements SegmentedGQLData {
     required this.subRanges,
     required ArweaveService arweave,
     required this.driveId,
+    required this.ownerAddress,
   }) : _arweave = arweave;
 
   @override
@@ -42,6 +44,7 @@ class GQLDriveHistory implements SegmentedGQLData {
       driveId,
       minBlockHeight: subRangeForIndex.start,
       maxBlockHeight: subRangeForIndex.end,
+      ownerAddress: ownerAddress,
     );
 
     await for (final multipleEdges in txsStream) {

--- a/test/blocs/create_snapshot_cubit_test.dart
+++ b/test/blocs/create_snapshot_cubit_test.dart
@@ -57,11 +57,16 @@ void main() {
             any(),
             minBlockHeight: any(named: 'minBlockHeight'),
             maxBlockHeight: any(named: 'maxBlockHeight'),
+            ownerAddress: any(named: 'ownerAddress'),
           ),
         ).thenAnswer(
           (_) async* {
             await Future.delayed(const Duration(milliseconds: 1));
           },
+        );
+
+        when(() => arweave.getOwnerForDriveEntityWithId(any())).thenAnswer(
+          (invocation) => Future.value('owner'),
         );
 
         // mocks prepareEntityTx method of ardrive

--- a/test/services/arweave/arweave_service_test.dart
+++ b/test/services/arweave/arweave_service_test.dart
@@ -25,6 +25,7 @@ void main() {
           'DRIVE_ID',
           minBlockHeight: captureAny(named: 'minBlockHeight'),
           maxBlockHeight: captureAny(named: 'maxBlockHeight'),
+          ownerAddress: any(named: 'ownerAddress'),
         ),
       ).thenAnswer(
         (invocation) => fakeNodesStream(
@@ -41,8 +42,9 @@ void main() {
             )
             .map((event) => [event]),
       );
-      // when(() => arweave.getAllTransactionsFromDrive('DRIVE_ID'));
-
+      when(() => arweave.getOwnerForDriveEntityWithId(any())).thenAnswer(
+        (invocation) => Future.value('owner'),
+      );
       when(() => arweave.getAllFileEntitiesWithId(any())).thenAnswer(
         (invocation) => Future.value(),
       );
@@ -53,9 +55,17 @@ void main() {
 
     group('getAllTransactionsFromDrive method', () {
       test('calls getAllTransactionsFromDrive once', () async {
-        arweave.getAllTransactionsFromDrive('DRIVE_ID', lastBlockHeight: 10);
-        verify(() => arweave.getSegmentedTransactionsFromDrive('DRIVE_ID'))
-            .called(1);
+        arweave.getAllTransactionsFromDrive(
+          'DRIVE_ID',
+          lastBlockHeight: 10,
+          ownerAddress: '',
+        );
+        verify(
+          () => arweave.getSegmentedTransactionsFromDrive(
+            'DRIVE_ID',
+            ownerAddress: '',
+          ),
+        ).called(1);
       },
           skip:
               'Cannot stub a single method to verify that the actual method gets called once');

--- a/test/utils/drive_history_composite_test.dart
+++ b/test/utils/drive_history_composite_test.dart
@@ -26,6 +26,7 @@ void main() {
           'DRIVE_ID',
           minBlockHeight: captureAny(named: 'minBlockHeight'),
           maxBlockHeight: captureAny(named: 'maxBlockHeight'),
+          ownerAddress: any(named: 'ownerAddress'),
         ),
       ).thenAnswer(
         (invocation) => fakeNodesStream(
@@ -42,6 +43,10 @@ void main() {
             )
             .map((event) => [event]),
       );
+
+      when(() => arweave.getOwnerForDriveEntityWithId('DRIVE_ID')).thenAnswer(
+        (invocation) => Future.value('owner'),
+      );
     });
 
     test('constructor throws with invalid sub-ranges amount', () async {
@@ -53,6 +58,7 @@ void main() {
           Range(start: 26, end: 50),
           Range(start: 99, end: 100),
         ]),
+        ownerAddress: 'owner',
       );
       SnapshotDriveHistory snapshotDriveHistory = SnapshotDriveHistory(
         items: await Future.wait(mockSubRanges
@@ -94,6 +100,7 @@ void main() {
           Range(start: 26, end: 50),
           Range(start: 99, end: 100),
         ]),
+        ownerAddress: 'owner',
       );
       SnapshotDriveHistory snapshotDriveHistory = SnapshotDriveHistory(
         items: await Future.wait(mockSubRanges

--- a/test/utils/gql_drive_history_test.dart
+++ b/test/utils/gql_drive_history_test.dart
@@ -21,6 +21,7 @@ void main() {
           'DRIVE_ID',
           minBlockHeight: captureAny(named: 'minBlockHeight'),
           maxBlockHeight: captureAny(named: 'maxBlockHeight'),
+          ownerAddress: 'owner',
         ),
       ).thenAnswer(
         (invocation) => fakeNodesStream(
@@ -37,6 +38,10 @@ void main() {
             )
             .map((event) => [event]),
       );
+
+      when(() => arweave.getOwnerForDriveEntityWithId('DRIVE_ID')).thenAnswer(
+        (invocation) => Future.value('owner'),
+      );
     });
 
     test('getStreamForIndex returns a valid stream of nodes', () async {
@@ -44,6 +49,7 @@ void main() {
         arweave: arweave,
         driveId: 'DRIVE_ID',
         subRanges: HeightRange(rangeSegments: [Range(start: 0, end: 10)]),
+        ownerAddress: 'owner',
       );
       expect(gqlDriveHistory.subRanges.rangeSegments.length, 1);
       expect(gqlDriveHistory.currentIndex, -1);
@@ -63,6 +69,7 @@ void main() {
           Range(start: 0, end: 10),
           Range(start: 20, end: 30)
         ]),
+        ownerAddress: 'owner',
       );
       expect(gqlDriveHistory.subRanges.rangeSegments.length, 2);
       expect(gqlDriveHistory.currentIndex, -1);


### PR DESCRIPTION
Changes
- Makes `DriveEntityHistory` and `SnapshotEntityHistory` queries to take the owner address.
- Refactors the callees to have the address injected into those.
  - For snapshot creation it comes from the logged in profile
  - For sync it comes from the DriveDao


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/7e9qf7is7vogo
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/555fgqh9pkid8