### PR TITLE
PE-3390: Removes ArFS tag filter from the query; filters out the results on client-side

### DIFF
--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -188,7 +188,20 @@ class ArweaveService {
         ),
       );
 
-      yield driveEntityHistoryQuery.data!.transactions.edges;
+      final List<DriveEntityHistory$Query$TransactionConnection$TransactionEdge>
+          transactions = driveEntityHistoryQuery.data!.transactions.edges;
+
+      // NOTE: this filter is being made in order to remove from the query
+      /// the ArFS tag filter, in order to make the query faster
+      // TODO: factor out this into its own testable method . [PUT JIRA TICKET NUMBER HERE]
+      yield transactions.where((tx) {
+        final tags = tx.node.tags;
+        final arFsTags = tags.where((tag) => tag.name == 'ArFS');
+        final arFsCorrectVersion = arFsTags.any(
+          (tag) => ['0.10', '0.11', '0.12'].contains(tag.value),
+        );
+        return arFsCorrectVersion;
+      }).toList();
 
       cursor = driveEntityHistoryQuery.data!.transactions.edges.isNotEmpty
           ? driveEntityHistoryQuery.data!.transactions.edges.last.cursor

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -193,7 +193,7 @@ class ArweaveService {
 
       // NOTE: this filter is being made in order to remove from the query
       /// the ArFS tag filter, in order to make the query faster
-      // TODO: factor out this into its own testable method . [PUT JIRA TICKET NUMBER HERE]
+      // TODO: factor out this into its own testable method. [PE-3398]
       yield transactions.where((tx) {
         final tags = tx.node.tags;
         final arFsTags = tags.where((tag) => tag.name == 'ArFS');

--- a/lib/services/arweave/graphql/queries/DriveEntityHistory.graphql
+++ b/lib/services/arweave/graphql/queries/DriveEntityHistory.graphql
@@ -9,10 +9,7 @@ query DriveEntityHistory(
     owners: [$ownerAddress]
     first: 100
     sort: HEIGHT_ASC
-    tags: [
-      { name: "ArFS", values: ["0.10", "0.11", "0.12"] }
-      { name: "Drive-Id", values: [$driveId] }
-    ]
+    tags: [{ name: "Drive-Id", values: [$driveId] }]
     after: $after
     block: { min: $minBlockHeight, max: $maxBlockHeight }
   ) {

--- a/lib/utils/arfs_transactions_filter.dart
+++ b/lib/utils/arfs_transactions_filter.dart
@@ -1,0 +1,17 @@
+import 'package:ardrive/services/arweave/graphql/graphql_api.graphql.dart';
+
+const validArFsVersions = ['0.10', '0.11', '0.12'];
+
+// NOTE: this filter is being made in order to remove from the query
+/// the ArFS tag filter, in order to make the query faster
+// TODO: [PE-3398]
+bool arFsTransactionsFilter(
+  DriveEntityHistory$Query$TransactionConnection$TransactionEdge tx,
+) {
+  final tags = tx.node.tags;
+  final arFsTags = tags.where((tag) => tag.name == 'ArFS');
+  final arFsCorrectVersion = arFsTags.any(
+    (tag) => validArFsVersions.contains(tag.value),
+  );
+  return arFsCorrectVersion;
+}

--- a/test/utils/arfs_transactions_filter_test.dart
+++ b/test/utils/arfs_transactions_filter_test.dart
@@ -1,0 +1,69 @@
+import 'package:ardrive/services/arweave/arweave.dart';
+import 'package:ardrive/utils/arfs_transactions_filter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+DriveEntityHistory$Query$TransactionConnection$TransactionEdge stubTransaction({
+  required String? arFsVersion,
+}) {
+  return DriveEntityHistory$Query$TransactionConnection$TransactionEdge
+      .fromJson({
+    'node': {
+      'id': 'txId',
+      'bundledIn': {'id': 'ASDASDASDASDASDASD'},
+      'owner': {'address': '1234567890'},
+      'tags': [
+        if (arFsVersion != null)
+          {
+            'name': 'ArFS',
+            'value': arFsVersion,
+          },
+      ],
+      'block': {
+        'height': 1,
+        'timestamp': 100,
+      }
+    },
+    'cursor': 'cursor',
+  });
+}
+
+void main() {
+  group('arFsTransactionsFilter', () {
+    test('filters out transactions with no ArFS tags on it', () {
+      final transactionsWithNoArFsTag = [
+        stubTransaction(arFsVersion: null),
+      ];
+
+      final filteredTransactions =
+          transactionsWithNoArFsTag.where(arFsTransactionsFilter).toList();
+
+      expect(filteredTransactions, isEmpty);
+    });
+
+    test('preserves transactions with valid values', () {
+      final transactionsWithValidArFsTag = [
+        stubTransaction(arFsVersion: '0.10'),
+        stubTransaction(arFsVersion: '0.11'),
+        stubTransaction(arFsVersion: '0.12'),
+      ];
+
+      final filteredTransactions =
+          transactionsWithValidArFsTag.where(arFsTransactionsFilter).toList();
+
+      expect(filteredTransactions, transactionsWithValidArFsTag);
+    });
+
+    test('filters out transactions with invalid values', () {
+      final transactionsWithInvalidArFsTag = [
+        stubTransaction(arFsVersion: '0.13'),
+        stubTransaction(arFsVersion: '0.14'),
+        stubTransaction(arFsVersion: '0.15'),
+      ];
+
+      final filteredTransactions =
+          transactionsWithInvalidArFsTag.where(arFsTransactionsFilter).toList();
+
+      expect(filteredTransactions, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Changelog
- Removes the tag filter: `ArFS` from the `DriveEntityHistory` query.
- Runs the filter on the client side


--- Releases ---
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/6lo013ea9sbn0
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/7o17g580ar45g