### PR TITLE
PE-3421: no button to close details activity panel

### DIFF
--- a/lib/components/file_download_dialog.dart
+++ b/lib/components/file_download_dialog.dart
@@ -97,9 +97,9 @@ Future<void> promptToDownloadSharedFile({
     fileKey: fileKey,
     arweave: context.read<ArweaveService>(),
   );
-  return showDialog(
-    context: context,
-    builder: (_) => BlocProvider<FileDownloadCubit>.value(
+  return showAnimatedDialog(
+    context,
+    content: BlocProvider<FileDownloadCubit>.value(
       value: cubit,
       child: const FileDownloadDialog(),
     ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -72,8 +72,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: PE-3309-new-drive-explorer-mobile
-      resolved-ref: af335ce60e19481f02e76f67b23729162da89c4e
+      ref: PE-3421-no-button-to-close-details-activity-panel
+      resolved-ref: c5ebdb387ca847096db7d5652a16148a202074c3
       url: "https://github.com/ar-io/ardrive_ui.git"
     source: git
     version: "1.0.0"
@@ -1000,7 +1000,7 @@ packages:
       name: lottie
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   ardrive_ui:
     git:
       url: https://github.com/ar-io/ardrive_ui.git
-      ref: PE-3309-new-drive-explorer-mobile
+      ref: PE-3421-no-button-to-close-details-activity-panel
   artemis: ^7.0.0-beta.13
   arweave:
     git:


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/16aoapp217vf8
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/64eujjda66sa0