### PR TITLE
PE-3438: Close Sync Streams as soon as we get an error

### DIFF
--- a/lib/blocs/sync/sync_cubit.dart
+++ b/lib/blocs/sync/sync_cubit.dart
@@ -252,23 +252,25 @@ class SyncCubit extends Cubit<SyncState> {
       _syncProgress = _syncProgress.copyWith(drivesCount: drives.length);
       logSync('Current block height number $currentBlockHeight');
       final driveSyncProcesses = drives.map(
-        (drive) => _syncDrive(
-          drive.id,
-          driveDao: _driveDao,
-          arweave: _arweave,
-          ghostFolders: ghostFolders,
-          database: _db,
-          profileState: profile,
-          addError: addError,
-          lastBlockHeight: syncDeep
-              ? 0
-              : calculateSyncLastBlockHeight(drive.lastBlockHeight!),
-          currentBlockHeight: currentBlockHeight,
-          transactionParseBatchSize:
-              200 ~/ (_syncProgress.drivesCount - _syncProgress.drivesSynced),
-          ownerAddress: drive.ownerAddress,
-        ).handleError(
-          (error, stackTrace) {
+        (drive) async* {
+          try {
+            yield* _syncDrive(
+              drive.id,
+              driveDao: _driveDao,
+              arweave: _arweave,
+              ghostFolders: ghostFolders,
+              database: _db,
+              profileState: profile,
+              addError: addError,
+              lastBlockHeight: syncDeep
+                  ? 0
+                  : calculateSyncLastBlockHeight(drive.lastBlockHeight!),
+              currentBlockHeight: currentBlockHeight,
+              transactionParseBatchSize: 200 ~/
+                  (_syncProgress.drivesCount - _syncProgress.drivesSynced),
+              ownerAddress: drive.ownerAddress,
+            );
+          } catch (error, stackTrace) {
             logSync('''
                     Error syncing drive with id ${drive.id}. \n
                     Skipping sync on this drive.\n
@@ -277,9 +279,9 @@ class SyncCubit extends Cubit<SyncState> {
                     StackTrace: \n
                     ${stackTrace.toString()}
                     ''');
-            addError(error!);
-          },
-        ),
+            addError(error);
+          }
+        },
       );
 
       double totalProgress = 0;

--- a/lib/blocs/sync/utils/sync_drive.dart
+++ b/lib/blocs/sync/utils/sync_drive.dart
@@ -169,22 +169,27 @@ Stream<double> _syncDrive(
     ''',
   );
 
-  yield* _parseDriveTransactionsIntoDatabaseEntities(
-    ghostFolders: ghostFolders,
-    driveDao: driveDao,
-    arweave: arweave,
-    database: database,
-    transactions: transactions,
-    drive: drive,
-    driveKey: driveKey,
-    currentBlockHeight: currentBlockHeight,
-    lastBlockHeight: lastBlockHeight,
-    batchSize: transactionParseBatchSize,
-    snapshotDriveHistory: snapshotDriveHistory,
-    ownerAddress: ownerAddress,
-  ).map(
-    (parseProgress) => parseProgress * 0.9,
-  );
+  try {
+    yield* _parseDriveTransactionsIntoDatabaseEntities(
+      ghostFolders: ghostFolders,
+      driveDao: driveDao,
+      arweave: arweave,
+      database: database,
+      transactions: transactions,
+      drive: drive,
+      driveKey: driveKey,
+      currentBlockHeight: currentBlockHeight,
+      lastBlockHeight: lastBlockHeight,
+      batchSize: transactionParseBatchSize,
+      snapshotDriveHistory: snapshotDriveHistory,
+      ownerAddress: ownerAddress,
+    ).map(
+      (parseProgress) => parseProgress * 0.9,
+    );
+  } catch (e) {
+    print('[Sync Drive] Error while parsing transactions: $e');
+    rethrow;
+  }
 
   await SnapshotItemOnChain.dispose(drive.id);
 

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -214,6 +214,14 @@ class ArweaveService {
     required SnapshotDriveHistory snapshotDriveHistory,
     required DriveID driveId,
   }) async {
+    // FIXME - PE-3440
+    /// Make use of `eagerError: true` to make it fail on first error
+    /// Also, when there's no internet connection and when we're getting
+    /// rate-limited (TODO: check the latter), many requests will be retrying.
+    /// We shall find another way to fail faster.
+
+    // MAYBE FIX: set a narrow concurrency limit
+
     final List<Uint8List> responses = await Future.wait(
       entityTxs.map(
         (entity) async {


### PR DESCRIPTION
Changes
- Wrapps the calls to the streams with a try/catch block:
  - For the `_syncDrive` method this makes the stream to be paused as soon as we get the error, and it will then emit (rethrow) the caught error, which ends the stream and can be caught by the callee.
  - The callee of `_syncDrive`: `startSync`, will now catch the **first** emitted error event and update the cubit state accordingly.
- Adds a comment for a tech_debt