### PR TITLE
PE-3470 - DO NOT MERGE: Updates ARB plural syntax

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -459,7 +459,7 @@
       }
     }
   },
-  "duplicateFiles": "{numberOfDuplicateFiles,plural, =1{A duplicate file found} =other{Duplicate files found}}",
+  "duplicateFiles": "{one=A duplicate file found, other=Duplicate files found}",
   "@duplicateFiles": {
     "description": "Count of conflicting items",
     "placeholders": {
@@ -470,7 +470,7 @@
       }
     }
   },
-  "duplicateFolders": "{numberOfDuplicateFolders,plural, =1{A duplicate folder found} =other{Duplicate folders found}}",
+  "duplicateFolders": "{one=A duplicate folder found, other=Duplicate folders found}",
   "@duplicateFolders": {
     "description": "Folder name conflict dialog title",
     "placeholders": {
@@ -608,7 +608,7 @@
   "@fileSize": {
     "description": "The size of a file"
   },
-  "filesTooLarge": "{numberOfFiles,plural, =1{1 file too large} =other{{numberOfFiles} files too large}}",
+  "filesTooLarge": "{one=1 file too large, other={numberOfFiles} files too large}",
   "@filesTooLarge": {
     "description": "A single or many files are too large to upload",
     "placeholders": {
@@ -635,7 +635,7 @@
   "@filesWillBePermanentlyPublicWarning": {
     "description": "Make the user aware that it is uploading permanent data publicly"
   },
-  "filesWillBeUploadedPublicly": "{numberOfFiles,plural, =1{This file will be uploaded publicly.} =other{These files will be uploaded publicly.}}",
+  "filesWillBeUploadedPublicly": "{one=This file will be uploaded publicly., other=These files will be uploaded publicly.}",
   "@filesWillBeUploadedPublicly": {
     "description": "Warning for files that will be public after uploaded",
     "placeholders": {
@@ -646,7 +646,7 @@
       }
     }
   },
-  "filesWithTheSameNameAlreadyExists": "{numberOfFiles,plural, =1{A file with the same name already exists at this location. Do you want to continue and upload this file as a new version?} =other{{numberOfFiles} files with the same name already exists at this location. Do you want to continue and upload these files as a new version?}}",
+  "filesWithTheSameNameAlreadyExists": "{one=A file with the same name already exists at this location. Do you want to continue and upload this file as a new version?, other={numberOfFiles} files with the same name already exists at this location. Do you want to continue and upload these files as a new version?}",
   "@filesWithTheSameNameAlreadyExists": {
     "description": "Asks the user what to do with the items conflicting names",
     "placeholders": {
@@ -734,7 +734,7 @@
   "@folderName": {
     "description": "The name of certain folder"
   },
-  "foldersWithTheSameNameAlreadyExists": "{numberOfFolders,plural, =1{A folder with the same name already exists at this location. Please rename it and try uploading again.}  =other{{numberOfFolders} folders with the same name already exist at this location. Please rename them and try uploading again.}}",
+  "foldersWithTheSameNameAlreadyExists": "{one=A folder with the same name already exists at this location. Please rename it and try uploading again., other={numberOfFolders} folders with the same name already exist at this location. Please rename them and try uploading again.}",
   "@foldersWithTheSameNameAlreadyExists": {
     "description": "Asks the user what to do with folder name conflicts",
     "placeholders": {
@@ -1456,7 +1456,7 @@
   "@uploadingManifestEmphasized": {
     "description": "The manifest is being uploaded"
   },
-  "uploadingNFiles": "{numberOfFiles,plural, =1{Uploading 1 file...} =other{Uploading {numberOfFiles} files...}}",
+  "uploadingNFiles": "{one=Uploading 1 file..., other=Uploading {numberOfFiles} files...}",
   "@uploadingNFiles": {
     "description": "Uploading a single or many files",
     "placeholders": {
@@ -1471,7 +1471,7 @@
   "@uploadingSnapshot": {
     "description": "Uploading Snapshot"
   },
-  "uploadNFiles": "{numberOfFiles,plural, =1{Upload 1 file} =other{Upload {numberOfFiles} files}}",
+  "uploadNFiles": "{one=Upload 1 file, other=Upload {numberOfFiles} files}",
   "@uploadNFiles": {
     "description": "Upload a single or many files",
     "placeholders": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -459,7 +459,7 @@
       }
     }
   },
-  "duplicateFiles": "{numberOfDuplicateFiles,plural, =1{Se encontró un archivo duplicado} =other{Se encontraron archivos duplicados}}",
+  "duplicateFiles": "{one=Se encontró un archivo duplicado, other=Se encontraron archivos duplicados}",
   "@duplicateFiles": {
     "description": "Count of conflicting items",
     "placeholders": {
@@ -470,7 +470,7 @@
       }
     }
   },
-  "duplicateFolders": "{numberOfDuplicateFolders,plural, =1{Se encontró una carpeta duplicada} =other{Se encontraron carpetas duplicadas}}",
+  "duplicateFolders": "{one=Se encontró una carpeta duplicada, other=Se encontraron carpetas duplicadas}",
   "@duplicateFolders": {
     "description": "Folder name conflict dialog title",
     "placeholders": {
@@ -608,7 +608,7 @@
   "@fileSize": {
     "description": "The size of a file"
   },
-  "filesTooLarge": "{numberOfFiles,plural, =1{El archivo es demasiado grande} =other{{numberOfFiles} archivos son demasiado grande}}",
+  "filesTooLarge": "{one=El archivo es demasiado grande, other={numberOfFiles} archivos son demasiado grande}",
   "@filesTooLarge": {
     "description": "A single or many files are too large to upload",
     "placeholders": {
@@ -635,7 +635,7 @@
   "@filesWillBePermanentlyPublicWarning": {
     "description": "Make the user aware that it is uploading permanent data publicly"
   },
-  "filesWillBeUploadedPublicly": "{numberOfFiles,plural, =1{Este archivo será cargado públicamente.} =other{Estos archivos serán cargados públicamente.}}",
+  "filesWillBeUploadedPublicly": "{one=Este archivo será cargado públicamente., other=Estos archivos serán cargados públicamente.}",
   "@filesWillBeUploadedPublicly": {
     "description": "Warning for files that will be public after uploaded",
     "placeholders": {
@@ -646,7 +646,7 @@
       }
     }
   },
-  "filesWithTheSameNameAlreadyExists": "{numberOfFiles,plural, =1{Ya existe un archivo con el mismo nombre en este lugar. ¿Quieres continuar y cargarlo como una nueva revisión?} =other{Hay {numberOfFiles} archivos con el mismo nombre en ese lugar. ¿Quieres continuar y cargarlo como una nueva revisión?}}",
+  "filesWithTheSameNameAlreadyExists": "{one=Ya existe un archivo con el mismo nombre en este lugar. ¿Quieres continuar y cargarlo como una nueva revisión?, other=Hay {numberOfFiles} archivos con el mismo nombre en ese lugar. ¿Quieres continuar y cargarlo como una nueva revisión?}",
   "@filesWithTheSameNameAlreadyExists": {
     "description": "Asks the user what to do with the items conflicting names",
     "placeholders": {
@@ -730,7 +730,7 @@
   "@folderName": {
     "description": "The name of certain folder"
   },
-  "foldersWithTheSameNameAlreadyExists": "{numberOfFolders,plural, =1{Ya existe una carpeta con el mismo nombre en este lugar. Por favor, renómbrala e inténtalo nuevamente.}  =other{Ya existen {numberOfFolders} carpetas con el mismo nombre en este lugar. Por favor, renómbralas e inténtalo nuevamente.}}",
+  "foldersWithTheSameNameAlreadyExists": "{one=Ya existe una carpeta con el mismo nombre en este lugar. Por favor, renómbrala e inténtalo nuevamente., other=Ya existen {numberOfFolders} carpetas con el mismo nombre en este lugar. Por favor, renómbralas e inténtalo nuevamente.}",
   "@foldersWithTheSameNameAlreadyExists": {
     "description": "Asks the user what to do with folder name conflicts",
     "placeholders": {
@@ -1444,7 +1444,7 @@
   "@uploadingManifestEmphasized": {
     "description": "The manifest is being uploaded"
   },
-  "uploadingNFiles": "{numberOfFiles,plural, =1{Cargando 1 archivo...} =other{Cargando {numberOfFiles} archivos...}}",
+  "uploadingNFiles": "{one=Cargando 1 archivo..., other=Cargando {numberOfFiles} archivos...}",
   "@uploadingNFiles": {
     "description": "Uploading a single or many files",
     "placeholders": {
@@ -1459,7 +1459,7 @@
   "@uploadingSnapshot": {
     "description": "Uploading Snapshot"
   },
-  "uploadNFiles": "{numberOfFiles,plural, =1{Cargar 1 archivo} =other{Cargar {numberOfFiles} archivos}}",
+  "uploadNFiles": "{one=Cargar 1 archivo, other=Cargar {numberOfFiles} archivos}",
   "@uploadNFiles": {
     "description": "Upload a single or many files",
     "placeholders": {

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -459,7 +459,7 @@
       }
     }
   },
-  "duplicateFiles": "{numberOfDuplicateFiles,plural, =1{एक डुप्लीकेट फ़ाइल मिली} =other{डुप्लीकेट फ़ाइलें मिली}}",
+  "duplicateFiles": "{one=एक डुप्लीकेट फ़ाइल मिली, other=डुप्लीकेट फ़ाइलें मिली}",
   "@duplicateFiles": {
     "description": "Count of conflicting items",
     "placeholders": {
@@ -470,7 +470,7 @@
       }
     }
   },
-  "duplicateFolders": "{numberOfDuplicateFolders,plural, =1{एक डुप्लीकेट फ़ोल्डर मिला} =other{डुप्लीकेट फ़ोल्डर्स मिलें}}",
+  "duplicateFolders": "{one=एक डुप्लीकेट फ़ोल्डर मिला, other=डुप्लीकेट फ़ोल्डर्स मिलें}",
   "@duplicateFolders": {
     "description": "Folder name conflict dialog title",
     "placeholders": {
@@ -608,7 +608,7 @@
   "@fileSize": {
     "description": "The size of a file"
   },
-  "filesTooLarge": "{numberOfFiles,plural, =1{1 फ़ाइल बहुत बड़ी है} =other{{numberOfFiles} फ़ाइलें बहुत बड़ी हैं}}",
+  "filesTooLarge": "{one=1 फ़ाइल बहुत बड़ी है, other={numberOfFiles} फ़ाइलें बहुत बड़ी हैं}",
   "@filesTooLarge": {
     "description": "A single or many files are too large to upload",
     "placeholders": {
@@ -635,7 +635,7 @@
   "@filesWillBePermanentlyPublicWarning": {
     "description": "Make the user aware that it is uploading permanent data publicly"
   },
-  "filesWillBeUploadedPublicly": "{numberOfFiles,plural, =1{यह फ़ाइल पब्लिक्ली अपलोड की जाएगी।} =other{ये फ़ाइलें पब्लिक्ली अपलोड की जाएंगी।}}",
+  "filesWillBeUploadedPublicly": "{one=यह फ़ाइल पब्लिक्ली अपलोड की जाएगी।, other=ये फ़ाइलें पब्लिक्ली अपलोड की जाएंगी।}",
   "@filesWillBeUploadedPublicly": {
     "description": "Warning for files that will be public after uploaded",
     "placeholders": {
@@ -646,7 +646,7 @@
       }
     }
   },
-  "filesWithTheSameNameAlreadyExists": "{numberOfFiles,plural, =1{इस लोकेशन पर इसी नाम की एक फ़ाइल पहले से मौजूद है। क्या आप जारी रखना चाहते हैं और इस फ़ाइल को एक नए वर्ज़न के तौर पर अपलोड करना चाहते हैं?} =other{इस लोकेशन पर इसी नाम की {numberOfFiles} फ़ाइलें पहले से मौजूद हैं। क्या आप जारी रखना चाहते हैं और इन फ़ाइलों को एक नए वर्ज़न के तौर पर अपलोड करना चाहते हैं?}}",
+  "filesWithTheSameNameAlreadyExists": "{one=इस लोकेशन पर इसी नाम की एक फ़ाइल पहले से मौजूद है। क्या आप जारी रखना चाहते हैं और इस फ़ाइल को एक नए वर्ज़न के तौर पर अपलोड करना चाहते हैं?, other=इस लोकेशन पर इसी नाम की {numberOfFiles} फ़ाइलें पहले से मौजूद हैं। क्या आप जारी रखना चाहते हैं और इन फ़ाइलों को एक नए वर्ज़न के तौर पर अपलोड करना चाहते हैं?}",
   "@filesWithTheSameNameAlreadyExists": {
     "description": "Asks the user what to do with the items conflicting names",
     "placeholders": {
@@ -730,7 +730,7 @@
   "@folderName": {
     "description": "The name of certain folder"
   },
-  "foldersWithTheSameNameAlreadyExists": "{numberOfFolders,plural, =1{इस लोकेशन पर इसी नाम का एक फ़ोल्डर पहले से मौजूद है। कृपया इसका नाम बदलें और दोबारा अपलोड करने की कोशिश करें।}  =other{इस लोकेशन पर इसी नाम के {numberOfFolders} फ़ोल्डर्स पहले से मौजूद हैं। कृपया उनके नाम बदलें और दोबारा अपलोड करने की कोशिश करें।}}",
+  "foldersWithTheSameNameAlreadyExists": "{one=इस लोकेशन पर इसी नाम का एक फ़ोल्डर पहले से मौजूद है। कृपया इसका नाम बदलें और दोबारा अपलोड करने की कोशिश करें।, other=इस लोकेशन पर इसी नाम के {numberOfFolders} फ़ोल्डर्स पहले से मौजूद हैं। कृपया उनके नाम बदलें और दोबारा अपलोड करने की कोशिश करें।}",
   "@foldersWithTheSameNameAlreadyExists": {
     "description": "Asks the user what to do with folder name conflicts",
     "placeholders": {
@@ -1444,7 +1444,7 @@
   "@uploadingManifestEmphasized": {
     "description": "The manifest is being uploaded"
   },
-  "uploadingNFiles": "{numberOfFiles,plural, =1{1 फ़ाइल अपलोड हो रही है...} =other{{numberOfFiles} फ़ाइलें अपलोड हो रही हैं...}}",
+  "uploadingNFiles": "{one=1 फ़ाइल अपलोड हो रही है..., other={numberOfFiles} फ़ाइलें अपलोड हो रही हैं...}",
   "@uploadingNFiles": {
     "description": "Uploading a single or many files",
     "placeholders": {
@@ -1459,7 +1459,7 @@
   "@uploadingSnapshot": {
     "description": "Uploading Snapshot"
   },
-  "uploadNFiles": "{numberOfFiles,plural, =1{1 फ़ाइल अपलोड करें} =other{{numberOfFiles} फ़ाइलें अपलोड करें}}",
+  "uploadNFiles": "{one=1 फ़ाइल अपलोड करें, other={numberOfFiles} फ़ाइलें अपलोड करें}",
   "@uploadNFiles": {
     "description": "Upload a single or many files",
     "placeholders": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -459,7 +459,7 @@
       }
     }
   },
-  "duplicateFiles": "{numberOfDuplicateFiles,plural, =1{重複する１個のファイルが見つかりました} =other{重複する複数のファイルが見つかりました}}",
+  "duplicateFiles": "{other=重複する複数のファイルが見つかりました}",
   "@duplicateFiles": {
     "description": "Count of conflicting items",
     "placeholders": {
@@ -470,7 +470,7 @@
       }
     }
   },
-  "duplicateFolders": "{numberOfDuplicateFolders,plural, =1{重複するフォルダが見つかりました。} =other{複数の重複するフォルダが見つかりました}}",
+  "duplicateFolders": "{other=複数の重複するフォルダが見つかりました}",
   "@duplicateFolders": {
     "description": "Folder name conflict dialog title",
     "placeholders": {
@@ -608,7 +608,7 @@
   "@fileSize": {
     "description": "The size of a file"
   },
-  "filesTooLarge": "{numberOfFiles,plural, =1{ファイルのサイズが大きすぎます} =other{{numberOfFiles} 複数のファイルのサイズが大きすぎます}}",
+  "filesTooLarge": "{other={numberOfFiles} 複数のファイルのサイズが大きすぎます}",
   "@filesTooLarge": {
     "description": "A single or many files are too large to upload",
     "placeholders": {
@@ -635,7 +635,7 @@
   "@filesWillBePermanentlyPublicWarning": {
     "description": "Make the user aware that it is uploading permanent data publicly"
   },
-  "filesWillBeUploadedPublicly": "{numberOfFiles,plural, =1{このファイルを公開ファイルとしてアップロードします。} =other{これらのファイルを公開ファイルとしてアップロードします。}}",
+  "filesWillBeUploadedPublicly": "{other=これらのファイルを公開ファイルとしてアップロードします。}",
   "@filesWillBeUploadedPublicly": {
     "description": "Warning for files that will be public after uploaded",
     "placeholders": {
@@ -646,7 +646,7 @@
       }
     }
   },
-  "filesWithTheSameNameAlreadyExists": "{numberOfFiles,plural, =1{ 同じ名前のファイルが既にこの場所に存在します。このファイルをこのまま新しいバージョンとしてアップロードしますか？} =other{{numberOfFiles} 個の同じ名前のファイルが既にこの場所に存在します。これらのファイルをこのまま新しいバージョンとしてアップロードしますか？}}",
+  "filesWithTheSameNameAlreadyExists": "{other={numberOfFiles} 個の同じ名前のファイルが既にこの場所に存在します。これらのファイルをこのまま新しいバージョンとしてアップロードしますか？}",
   "@filesWithTheSameNameAlreadyExists": {
     "description": "Asks the user what to do with the items conflicting names",
     "placeholders": {
@@ -730,7 +730,7 @@
   "@folderName": {
     "description": "The name of certain folder"
   },
-  "foldersWithTheSameNameAlreadyExists": "{numberOfFolders,plural, =1{ 同じ名前のフォルダが既にこの場所に存在します。名前を変更して、再度アップロードしてください。} =other{{numberOfFolders}この場所には同じ名前の複数のフォルダが既に存在しています。名前を変更して、再度アップロードしてください。}}",
+  "foldersWithTheSameNameAlreadyExists": "{other={numberOfFolders}この場所には同じ名前の複数のフォルダが既に存在しています。名前を変更して、再度アップロードしてください。}",
   "@foldersWithTheSameNameAlreadyExists": {
     "description": "Asks the user what to do with folder name conflicts",
     "placeholders": {
@@ -1444,7 +1444,7 @@
   "@uploadingManifestEmphasized": {
     "description": "The manifest is being uploaded"
   },
-  "uploadingNFiles": "{numberOfFiles,plural, =1{ 1個のファイルをアップロード中...} =other{ {numberOfFiles} 個のファイルをアップロード中...}}",
+  "uploadingNFiles": "{other= {numberOfFiles} 個のファイルをアップロード中...}",
   "@uploadingNFiles": {
     "description": "Uploading a single or many files",
     "placeholders": {
@@ -1459,7 +1459,7 @@
   "@uploadingSnapshot": {
     "description": "Uploading Snapshot"
   },
-  "uploadNFiles": "{numberOfFiles,plural, =1{1個のファイルをアップロードする} =other{{numberOfFiles} 個のファイルをアップロードする}}",
+  "uploadNFiles": "{other={numberOfFiles} 個のファイルをアップロードする}",
   "@uploadNFiles": {
     "description": "Upload a single or many files",
     "placeholders": {

--- a/lib/l10n/app_zh-HK.arb
+++ b/lib/l10n/app_zh-HK.arb
@@ -1,5 +1,5 @@
 {
-  "@@locale": "zh_HK",
+  "@@locale": "zh-HK",
   "addnewManifestEmphasized": "新增資訊清單",
   "@addnewManifestEmphasized": {
     "description": "There is a non-manifest entity with the same name"
@@ -459,7 +459,7 @@
       }
     }
   },
-  "duplicateFiles": "{numberOfDuplicateFiles,plural, =1{發現重覆的檔案} =other{發現重覆的檔案}}",
+  "duplicateFiles": "{other=發現重覆的檔案}",
   "@duplicateFiles": {
     "description": "Count of conflicting items",
     "placeholders": {
@@ -470,7 +470,7 @@
       }
     }
   },
-  "duplicateFolders": "{numberOfDuplicateFolders,plural, =1{發現重覆的資料夾} =other{發現重覆的資料夾}}",
+  "duplicateFolders": "{other=發現重覆的資料夾}",
   "@duplicateFolders": {
     "description": "Folder name conflict dialog title",
     "placeholders": {
@@ -608,7 +608,7 @@
   "@fileSize": {
     "description": "The size of a file"
   },
-  "filesTooLarge": "{numberOfFiles,plural, =1{1個檔案過大} =other{{numberOfFiles} 檔案過大}}",
+  "filesTooLarge": "{other={numberOfFiles} 檔案過大}",
   "@filesTooLarge": {
     "description": "A single or many files are too large to upload",
     "placeholders": {
@@ -635,7 +635,7 @@
   "@filesWillBePermanentlyPublicWarning": {
     "description": "Make the user aware that it is uploading permanent data publicly"
   },
-  "filesWillBeUploadedPublicly": "{numberOfFiles,plural, =1{此檔案會公開地上載.} =other{這些檔案會公開地上載。}}",
+  "filesWillBeUploadedPublicly": "{other=這些檔案會公開地上載。}",
   "@filesWillBeUploadedPublicly": {
     "description": "Warning for files that will be public after uploaded",
     "placeholders": {
@@ -646,7 +646,7 @@
       }
     }
   },
-  "filesWithTheSameNameAlreadyExists": "{numberOfFiles,plural, =1{同命檔案已於相同位置存在。你想繼續上載這檔案, 作為新的版本嗎?} =other{{numberOfFiles} 同命檔案已於相同位置存在。你想繼續上載這檔案, 作為新的版本嗎?}}",
+  "filesWithTheSameNameAlreadyExists": "{other={numberOfFiles} 同命檔案已於相同位置存在。你想繼續上載這檔案, 作為新的版本嗎?}",
   "@filesWithTheSameNameAlreadyExists": {
     "description": "Asks the user what to do with the items conflicting names",
     "placeholders": {
@@ -730,7 +730,7 @@
   "@folderName": {
     "description": "The name of certain folder"
   },
-  "foldersWithTheSameNameAlreadyExists": "{numberOfFolders,plural, =1{同命資料夾已於相同位置存在。請為其重新命名並再次上載} =other{{numberOfFolders} 請為其重新命名並再次上載。}}",
+  "foldersWithTheSameNameAlreadyExists": "{other={numberOfFolders} 請為其重新命名並再次上載。}",
   "@foldersWithTheSameNameAlreadyExists": {
     "description": "Asks the user what to do with folder name conflicts",
     "placeholders": {
@@ -1444,7 +1444,7 @@
   "@uploadingManifestEmphasized": {
     "description": "The manifest is being uploaded"
   },
-  "uploadingNFiles": "{numberOfFiles,plural, =1{正在上載 1 個檔案} =other{正在上載 {numberOfFiles} 檔案...}}",
+  "uploadingNFiles": "{other=正在上載 {numberOfFiles} 檔案...}",
   "@uploadingNFiles": {
     "description": "Uploading a single or many files",
     "placeholders": {
@@ -1459,7 +1459,7 @@
   "@uploadingSnapshot": {
     "description": "Uploading Snapshot"
   },
-  "uploadNFiles": "{numberOfFiles,plural, =1{上載 1 個檔案} =other{上載 {numberOfFiles} 檔案}}",
+  "uploadNFiles": "{other=上載 {numberOfFiles} 檔案}",
   "@uploadNFiles": {
     "description": "Upload a single or many files",
     "placeholders": {

--- a/lib/l10n/app_zh-HK.arb
+++ b/lib/l10n/app_zh-HK.arb
@@ -1,5 +1,5 @@
 {
-  "@@locale": "zh-HK",
+  "@@locale": "zh_HK",
   "addnewManifestEmphasized": "新增資訊清單",
   "@addnewManifestEmphasized": {
     "description": "There is a non-manifest entity with the same name"

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -459,7 +459,7 @@
       }
     }
   },
-  "duplicateFiles": "{numberOfDuplicateFiles,plural, =1{找到一个重复文件} =other{找到多个重复文件}}",
+  "duplicateFiles": "{other=找到多个重复文件}",
   "@duplicateFiles": {
     "description": "Count of conflicting items",
     "placeholders": {
@@ -470,7 +470,7 @@
       }
     }
   },
-  "duplicateFolders": "{numberOfDuplicateFolders,plural, =1{找到了一个重复文件夹} =other{找到多个重复文件夹}}",
+  "duplicateFolders": "{other=找到多个重复文件夹}",
   "@duplicateFolders": {
     "description": "Folder name conflict dialog title",
     "placeholders": {
@@ -608,7 +608,7 @@
   "@fileSize": {
     "description": "The size of a file"
   },
-  "filesTooLarge": "{numberOfFiles,plural, =1{文件大小过大} =other{{numberOfFiles}个文件大小过大}}",
+  "filesTooLarge": "{other={numberOfFiles}个文件大小过大}",
   "@filesTooLarge": {
     "description": "A single or many files are too large to upload",
     "placeholders": {
@@ -635,7 +635,7 @@
   "@filesWillBePermanentlyPublicWarning": {
     "description": "Make the user aware that it is uploading permanent data publicly"
   },
-  "filesWillBeUploadedPublicly": "{numberOfFiles,plural, =1{此文件将被上传并公开.} =other{这些文件将被上传并公开.}}",
+  "filesWillBeUploadedPublicly": "{other=这些文件将被上传并公开.}",
   "@filesWillBeUploadedPublicly": {
     "description": "Warning for files that will be public after uploaded",
     "placeholders": {
@@ -646,7 +646,7 @@
       }
     }
   },
-  "filesWithTheSameNameAlreadyExists": "{numberOfFiles,plural, =1{本路径已有相同名称的文件. 你是否想要继续并更新文件版本?} =other{本路径已有{numberOfFiles}个相同名称的文件. 你是否想要继续并更新这些文件的版本??}}",
+  "filesWithTheSameNameAlreadyExists": "{other=本路径已有{numberOfFiles}个相同名称的文件. 你是否想要继续并更新这些文件的版本??}",
   "@filesWithTheSameNameAlreadyExists": {
     "description": "Asks the user what to do with the items conflicting names",
     "placeholders": {
@@ -730,7 +730,7 @@
   "@folderName": {
     "description": "The name of certain folder"
   },
-  "foldersWithTheSameNameAlreadyExists": "{numberOfFolders,plural, =1{本路径已有相同名称的文件夹. 请修改名称并重新上传.}  =other{本路径已有{numberOfFolders}个相同名称的文件夹. 请修改名称并重新上传.}}",
+  "foldersWithTheSameNameAlreadyExists": "{other=本路径已有{numberOfFolders}个相同名称的文件夹. 请修改名称并重新上传.}",
   "@foldersWithTheSameNameAlreadyExists": {
     "description": "Asks the user what to do with folder name conflicts",
     "placeholders": {
@@ -1444,7 +1444,7 @@
   "@uploadingManifestEmphasized": {
     "description": "The manifest is being uploaded"
   },
-  "uploadingNFiles": "{numberOfFiles,plural, =1{上传1个文件中...} =other{上传{numberOfFiles}个文件中...}}",
+  "uploadingNFiles": "{other=上传{numberOfFiles}个文件中...}",
   "@uploadingNFiles": {
     "description": "Uploading a single or many files",
     "placeholders": {
@@ -1459,7 +1459,7 @@
   "@uploadingSnapshot": {
     "description": "Uploading Snapshot"
   },
-  "uploadNFiles": "{numberOfFiles,plural, =1{上传1个文件} =other{上传{numberOfFiles}个文件}}",
+  "uploadNFiles": "{other=上传{numberOfFiles}个文件}",
   "@uploadNFiles": {
     "description": "Upload a single or many files",
     "placeholders": {


### PR DESCRIPTION
This is the Localizely ARB export for a failed attempt to overwrite the syntax of the export. 

Steps to reproduce:

1. Have the ARB file firstly uploaded with the following plurals syntax: `{count, plural, =1{One thing} =other{Many things: {count}}}`
2. Re-upload the file changing the plurals syntax: `{count, plural, =1{One thing} other{Many things: {count}}}` removing the `=` to "other"



--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/2v2im3i2bm67o
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/6tus6q9f2k0mo