### PR TITLE
PE-3396: replaces in the implementation document.onFocus with window.onFocus

### DIFF
--- a/lib/utils/html/implementations/html_web.dart
+++ b/lib/utils/html/implementations/html_web.dart
@@ -44,9 +44,11 @@ Future<void> onTabGetsFocusedFuture(FutureOr<Function> onFocus) async {
 }
 
 StreamSubscription<Event> onTabGetsFocused(Function onFocus) {
-  final subscription = document.onFocus.listen((event) {
-    onFocus();
-  });
+  final subscription = window.onFocus.listen(
+    (event) {
+      onFocus();
+    },
+  );
   return subscription;
 }
 


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/0lrqfkc2en3pg
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/1m6j5lg2qn440