### PR TITLE
PE-3566: Sign and prepare phase of snapshot creation throws an error when back on focus

### DIFF
--- a/lib/blocs/create_snapshot/create_snapshot_cubit.dart
+++ b/lib/blocs/create_snapshot/create_snapshot_cubit.dart
@@ -259,7 +259,9 @@ class CreateSnapshotCubit extends Cubit<CreateSnapshotState> {
           'Signing snapshot transaction while user is not focusing the tab. Waiting...',
         );
         await _tabVisibility.onTabGetsFocusedFuture(
-          () => signTx(isArConnectProfile),
+          () async {
+            await signTx(isArConnectProfile);
+          },
         );
       } else {
         // ignore: avoid_print

--- a/lib/utils/html/html_util.dart
+++ b/lib/utils/html/html_util.dart
@@ -17,13 +17,10 @@ class TabVisibilitySingleton {
 
   bool isTabVisible() => implementation.isTabVisible();
 
-  Future<void> onTabGetsVisibleFuture(FutureOr<Function> onFocus) async =>
-      implementation.onTabGetsVisibleFuture(onFocus);
-
   void onTabGetsVisible(Function onFocus) =>
       implementation.onTabGetsVisible(onFocus);
 
-  Future<void> onTabGetsFocusedFuture(FutureOr<Function> onFocus) async =>
+  Future<void> onTabGetsFocusedFuture(Future Function() onFocus) =>
       implementation.onTabGetsFocusedFuture(onFocus);
 
   StreamSubscription onTabGetsFocused(Function onFocus) =>

--- a/lib/utils/html/implementations/html_web.dart
+++ b/lib/utils/html/implementations/html_web.dart
@@ -33,10 +33,10 @@ void onTabGetsVisible(Function onFocus) {
   });
 }
 
-Future<void> onTabGetsFocusedFuture(FutureOr<Function> onFocus) async {
+Future<void> onTabGetsFocusedFuture(Future Function() onFocus) async {
   final completer = Completer<void>();
   final subscription = onTabGetsFocused(() async {
-    await onFocus;
+    await onFocus();
     completer.complete();
   });
   await completer.future; // wait for the completer to be resolved

--- a/test/blocs/create_snapshot_cubit_test.dart
+++ b/test/blocs/create_snapshot_cubit_test.dart
@@ -339,7 +339,7 @@ void main() {
             );
           });
 
-          when(() => tabVisibility.onTabGetsVisibleFuture(any())).thenAnswer(
+          when(() => tabVisibility.onTabGetsFocusedFuture(any())).thenAnswer(
             (invocation) async {
               await Future.delayed(const Duration(milliseconds: 10));
               await invocation.positionalArguments.first();


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/687dl69g9tib8
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/4pve58qndokjo