### PR TITLE
PE-3589: fix(preview button): remove preview button for private drives

### DIFF
--- a/lib/components/details_panel.dart
+++ b/lib/components/details_panel.dart
@@ -813,14 +813,15 @@ class DetailsPanelToolbar extends StatelessWidget {
                 );
               },
             ),
-            _buildActionIcon(
-              tooltip: appLocalizationsOf(context).preview,
-              icon: ArDriveIcons.externalLink(size: dropdownIconSize),
-              onTap: () {
-                final bloc = context.read<DriveDetailCubit>();
-                bloc.launchPreview((item as FileDataTableItem).dataTxId);
-              },
-            ),
+            if (drive.isPublic)
+              _buildActionIcon(
+                tooltip: appLocalizationsOf(context).preview,
+                icon: ArDriveIcons.externalLink(size: dropdownIconSize),
+                onTap: () {
+                  final bloc = context.read<DriveDetailCubit>();
+                  bloc.launchPreview((item as FileDataTableItem).dataTxId);
+                },
+              ),
           ],
           if (isDriveOwner(context.read<ArDriveAuth>(), drive.ownerAddress))
             _buildActionIcon(

--- a/lib/pages/drive_detail/components/drive_explorer_item_tile.dart
+++ b/lib/pages/drive_detail/components/drive_explorer_item_tile.dart
@@ -7,6 +7,7 @@ import 'package:ardrive/pages/drive_detail/components/hover_widget.dart';
 import 'package:ardrive/pages/drive_detail/drive_detail_page.dart';
 import 'package:ardrive/utils/app_localizations_wrapper.dart';
 import 'package:ardrive/utils/file_type_helper.dart';
+import 'package:ardrive/utils/logger/logger.dart';
 import 'package:ardrive/utils/size_constants.dart';
 import 'package:ardrive_ui/ardrive_ui.dart';
 import 'package:flutter/material.dart';
@@ -74,6 +75,9 @@ class DriveExplorerItemTileLeading extends StatelessWidget {
 
   Widget _buildFileStatus(BuildContext context) {
     late Color indicatorColor;
+
+    logger.d(
+        'item.fileStatusFromTransactions: ${item.fileStatusFromTransactions}');
 
     switch (item.fileStatusFromTransactions) {
       case TransactionStatus.pending:
@@ -303,19 +307,20 @@ class _DriveExplorerItemTileTrailingState
           ),
         ),
       ),
-      ArDriveDropdownItem(
-        onClick: () {
-          final bloc = context.read<DriveDetailCubit>();
+      if (widget.drive.isPublic)
+        ArDriveDropdownItem(
+          onClick: () {
+            final bloc = context.read<DriveDetailCubit>();
 
-          bloc.launchPreview((item as FileDataTableItem).dataTxId);
-        },
-        content: _buildItem(
-          appLocalizationsOf(context).preview,
-          ArDriveIcons.externalLink(
-            size: dropdownIconSize,
+            bloc.launchPreview((item as FileDataTableItem).dataTxId);
+          },
+          content: _buildItem(
+            appLocalizationsOf(context).preview,
+            ArDriveIcons.externalLink(
+              size: dropdownIconSize,
+            ),
           ),
         ),
-      ),
       if (isOwner) ...[
         ArDriveDropdownItem(
           onClick: () {


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/683116sttmgm0
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/2sphkldk702to