### PR TITLE
PE-3581: Write custom metadata while syncing

### DIFF
--- a/lib/blocs/create_manifest/create_manifest_cubit.dart
+++ b/lib/blocs/create_manifest/create_manifest_cubit.dart
@@ -213,6 +213,7 @@ class CreateManifestCubit extends Cubit<CreateManifestState> {
                   performedAction: existingManifestFileId == null
                       ? RevisionAction.create
                       : RevisionAction.uploadNewVersion,
+                  customMetaData: null,
                 ),
               );
             },

--- a/lib/blocs/drive_create/drive_create_cubit.dart
+++ b/lib/blocs/drive_create/drive_create_cubit.dart
@@ -116,8 +116,12 @@ class DriveCreateCubit extends Cubit<DriveCreateState> {
       }
 
       rootFolderEntity.txId = rootFolderDataItem.id;
-      await _driveDao.insertFolderRevision(rootFolderEntity.toRevisionCompanion(
-          performedAction: RevisionAction.create));
+      await _driveDao.insertFolderRevision(
+        rootFolderEntity.toRevisionCompanion(
+          performedAction: RevisionAction.create,
+          customJsonMetaData: null,
+        ),
+      );
 
       // Update drive with bundledIn
       // Creates a drive revision immediately after creation

--- a/lib/blocs/folder_create/folder_create_cubit.dart
+++ b/lib/blocs/folder_create/folder_create_cubit.dart
@@ -95,6 +95,7 @@ class FolderCreateCubit extends Cubit<FolderCreateState> {
 
         await _driveDao.insertFolderRevision(folderEntity.toRevisionCompanion(
           performedAction: RevisionAction.create,
+          customJsonMetaData: null,
         ));
       });
     } catch (err) {

--- a/lib/blocs/fs_entry_move/fs_entry_move_bloc.dart
+++ b/lib/blocs/fs_entry_move/fs_entry_move_bloc.dart
@@ -216,6 +216,7 @@ class FsEntryMoveBloc extends Bloc<FsEntryMoveEvent, FsEntryMoveState> {
 
         await _driveDao.insertFileRevision(fileEntity.toRevisionCompanion(
           performedAction: RevisionAction.move,
+          customMetaData: null,
         ));
       }
 
@@ -245,6 +246,7 @@ class FsEntryMoveBloc extends Bloc<FsEntryMoveEvent, FsEntryMoveState> {
 
         await _driveDao.insertFolderRevision(folderEntity.toRevisionCompanion(
           performedAction: RevisionAction.move,
+          customJsonMetaData: null,
         ));
 
         folderMap.addAll({folder.id: folder.toCompanion(false)});

--- a/lib/blocs/fs_entry_rename/fs_entry_rename_cubit.dart
+++ b/lib/blocs/fs_entry_rename/fs_entry_rename_cubit.dart
@@ -100,8 +100,12 @@ class FsEntryRenameCubit extends Cubit<FsEntryRenameState> {
 
           await _driveDao.writeToFolder(folder);
 
-          await _driveDao.insertFolderRevision(folderEntity.toRevisionCompanion(
-              performedAction: RevisionAction.rename));
+          await _driveDao.insertFolderRevision(
+            folderEntity.toRevisionCompanion(
+              performedAction: RevisionAction.rename,
+              customJsonMetaData: null,
+            ),
+          );
         });
 
         final folderMap = {folder.id: folder.toCompanion(false)};
@@ -142,8 +146,12 @@ class FsEntryRenameCubit extends Cubit<FsEntryRenameState> {
 
           await _driveDao.writeToFile(file);
 
-          await _driveDao.insertFileRevision(fileEntity.toRevisionCompanion(
-              performedAction: RevisionAction.rename));
+          await _driveDao.insertFileRevision(
+            fileEntity.toRevisionCompanion(
+              performedAction: RevisionAction.rename,
+              customMetaData: null,
+            ),
+          );
         });
 
         emit(const FileEntryRenameSuccess());

--- a/lib/blocs/ghost_fixer/ghost_fixer_cubit.dart
+++ b/lib/blocs/ghost_fixer/ghost_fixer_cubit.dart
@@ -166,8 +166,12 @@ class GhostFixerCubit extends Cubit<GhostFixerState> {
 
         await _driveDao.writeToFolder(folder);
 
-        await _driveDao.insertFolderRevision(folderEntity.toRevisionCompanion(
-            performedAction: RevisionAction.create));
+        await _driveDao.insertFolderRevision(
+          folderEntity.toRevisionCompanion(
+            performedAction: RevisionAction.create,
+            customJsonMetaData: null,
+          ),
+        );
         final folderMap = {folder.id: folder.toCompanion(false)};
         await _syncCubit.generateFsEntryPaths(folder.driveId, folderMap, {});
       });

--- a/lib/blocs/sync/utils/add_drive_entity_revisions.dart
+++ b/lib/blocs/sync/utils/add_drive_entity_revisions.dart
@@ -23,8 +23,7 @@ Future<DriveRevisionsCompanion?> _addNewDriveEntityRevisions({
     }
     final revision = entity.toRevisionCompanion(
       performedAction: revisionPerformedAction,
-      customJsonMetaData:
-          latestRevision?.customJsonMetaData ?? const Value.absent(),
+      customJsonMetaData: Value<String?>(entity.customMetadata),
     );
 
     if (revision.action.value.isEmpty) {

--- a/lib/blocs/sync/utils/add_file_entity_revisions.dart
+++ b/lib/blocs/sync/utils/add_file_entity_revisions.dart
@@ -31,8 +31,10 @@ Future<List<FileRevisionsCompanion>> _addNewFileEntityRevisions({
     // If Parent-Folder-Id is missing for a file, put it in the root folder
 
     entity.parentFolderId = entity.parentFolderId ?? rootPath;
-    final revision =
-        entity.toRevisionCompanion(performedAction: revisionPerformedAction);
+    final revision = entity.toRevisionCompanion(
+      performedAction: revisionPerformedAction,
+      customMetaData: entity.customJsonMetaData,
+    );
 
     if (revision.action.value.isEmpty) {
       continue;

--- a/lib/blocs/sync/utils/add_folder_entity_revisions.dart
+++ b/lib/blocs/sync/utils/add_folder_entity_revisions.dart
@@ -28,8 +28,10 @@ Future<List<FolderRevisionsCompanion>> _addNewFolderEntityRevisions({
     if (revisionPerformedAction == null) {
       continue;
     }
-    final revision =
-        entity.toRevisionCompanion(performedAction: revisionPerformedAction);
+    final revision = entity.toRevisionCompanion(
+      performedAction: revisionPerformedAction,
+      customJsonMetaData: entity.customJsonMetaData,
+    );
 
     if (revision.action.value.isEmpty) {
       continue;

--- a/lib/blocs/sync/utils/parse_drive_transactions.dart
+++ b/lib/blocs/sync/utils/parse_drive_transactions.dart
@@ -51,39 +51,6 @@ Stream<double> _parseDriveTransactionsIntoDatabaseEntities({
           logSync('Getting metadata from drive ${drive.name}');
         }
 
-        // FIXME - PE-3440
-        /// Make use of `eagerError: true` to make it fail on first error
-        /// Also, when there's no internet connection and when we're getting
-        /// rate-limited (TODO: check the latter), many requests will be retrying.
-        /// We shall find another way to fail faster.
-
-        // MAYBE FIX: set a narrow concurrency limit
-
-        final List<Uint8List> entitiesData = await Future.wait(
-          items.map(
-            (entity) async {
-              final tags = entity.tags;
-              final isSnapshot = tags.any(
-                (tag) =>
-                    tag.name == EntityTag.entityType &&
-                    tag.value == EntityType.snapshot.toString(),
-              );
-
-              // don't fetch data for snapshots
-              if (isSnapshot) {
-                print('skipping unnecessary request for snapshot data');
-                return Uint8List(0);
-              }
-
-              return arweave.getEntityData(
-                entityId: entity.id,
-                driveId: ownerAddress,
-                isPrivate: driveKey != null,
-              );
-            },
-          ),
-        );
-
         final entityHistory =
             await arweave.createDriveEntityHistoryFromTransactions(
           items,
@@ -92,7 +59,6 @@ Stream<double> _parseDriveTransactionsIntoDatabaseEntities({
           snapshotDriveHistory: snapshotDriveHistory,
           driveId: drive.id,
           ownerAddress: ownerAddress,
-          entitiesData: entitiesData,
         );
 
         // Create entries for all the new revisions of file and folders in this drive.

--- a/lib/blocs/upload/upload_handles/file_data_item_upload_handle.dart
+++ b/lib/blocs/upload/upload_handles/file_data_item_upload_handle.dart
@@ -65,7 +65,10 @@ class FileDataItemUploadHandle implements UploadHandle, DataItemHandle {
     await driveDao.transaction(() async {
       await driveDao.writeFileEntity(entity, path);
       await driveDao.insertFileRevision(
-        entity.toRevisionCompanion(performedAction: revisionAction),
+        entity.toRevisionCompanion(
+          performedAction: revisionAction,
+          customMetaData: null,
+        ),
       );
     });
   }

--- a/lib/blocs/upload/upload_handles/file_v2_upload_handle.dart
+++ b/lib/blocs/upload/upload_handles/file_v2_upload_handle.dart
@@ -52,7 +52,10 @@ class FileV2UploadHandle implements UploadHandle {
     await driveDao.transaction(() async {
       await driveDao.writeFileEntity(entity, path);
       await driveDao.insertFileRevision(
-        entity.toRevisionCompanion(performedAction: revisionAction),
+        entity.toRevisionCompanion(
+          performedAction: revisionAction,
+          customMetaData: null,
+        ),
       );
     });
   }

--- a/lib/blocs/upload/upload_handles/folder_data_item_upload_handle.dart
+++ b/lib/blocs/upload/upload_handles/folder_data_item_upload_handle.dart
@@ -85,6 +85,7 @@ class FolderDataItemUploadHandle implements UploadHandle, DataItemHandle {
       await driveDao.insertFolderRevision(
         folderEntity.toRevisionCompanion(
           performedAction: RevisionAction.create,
+          customJsonMetaData: null,
         ),
       );
     });

--- a/lib/entities/custom_metadata.dart
+++ b/lib/entities/custom_metadata.dart
@@ -1,11 +1,16 @@
 import 'dart:convert';
 
+import 'package:ardrive/utils/logger/logger.dart';
+
 String Function() customMetadataFactory(
   Map<String, dynamic> metadata,
-  List<String> reservedFields,
-) {
+  List<String> reservedFields, {
+  String entityType = 'entity',
+}) {
   return () {
     metadata.removeWhere((key, value) => reservedFields.contains(key));
-    return json.encode(metadata);
+    final customMetadataAsString = json.encode(metadata);
+    logger.d('Custom metadata for $entityType: $customMetadataAsString');
+    return customMetadataAsString;
   };
 }

--- a/lib/entities/custom_metadata.dart
+++ b/lib/entities/custom_metadata.dart
@@ -2,11 +2,23 @@ import 'dart:convert';
 
 import 'package:ardrive/utils/logger/logger.dart';
 
+const Map<String, List<String>> reservedFieldsPerEntityType = {
+  'drive': ['name', 'rootFolderId'],
+  'folder': ['name'],
+  'file': ['name', 'size', 'lastModifiedDate', 'dataTxId', 'dataContentType'],
+  'test': ['reserved'],
+};
+
 String Function() customMetadataFactory(
-  Map<String, dynamic> metadata,
-  List<String> reservedFields, {
-  String entityType = 'entity',
+  Map<String, dynamic> metadata, {
+  required String entityType,
 }) {
+  if (!reservedFieldsPerEntityType.containsKey(entityType)) {
+    throw Exception('Bad entity type: $entityType');
+  }
+
+  final reservedFields = reservedFieldsPerEntityType[entityType]!;
+
   return () {
     metadata.removeWhere((key, value) => reservedFields.contains(key));
     final customMetadataAsString = json.encode(metadata);

--- a/lib/entities/custom_metadata.dart
+++ b/lib/entities/custom_metadata.dart
@@ -1,0 +1,11 @@
+import 'dart:convert';
+
+String Function() customMetadataFactory(
+  Map<String, dynamic> metadata,
+  List<String> reservedFields,
+) {
+  return () {
+    metadata.removeWhere((key, value) => reservedFields.contains(key));
+    return json.encode(metadata);
+  };
+}

--- a/lib/entities/custom_metadata.dart
+++ b/lib/entities/custom_metadata.dart
@@ -9,7 +9,7 @@ const Map<String, List<String>> reservedFieldsPerEntityType = {
   'test': ['reserved'],
 };
 
-String Function() customMetadataFactory(
+String extractCustomMetadataForEntityType(
   Map<String, dynamic> metadata, {
   required String entityType,
 }) {
@@ -19,10 +19,8 @@ String Function() customMetadataFactory(
 
   final reservedFields = reservedFieldsPerEntityType[entityType]!;
 
-  return () {
-    metadata.removeWhere((key, value) => reservedFields.contains(key));
-    final customMetadataAsString = json.encode(metadata);
-    logger.d('Custom metadata for $entityType: $customMetadataAsString');
-    return customMetadataAsString;
-  };
+  metadata.removeWhere((key, value) => reservedFields.contains(key));
+  final customMetadataAsString = json.encode(metadata);
+  logger.d('Custom metadata for $entityType: $customMetadataAsString');
+  return customMetadataAsString;
 }

--- a/lib/entities/drive_entity.dart
+++ b/lib/entities/drive_entity.dart
@@ -61,7 +61,10 @@ class DriveEntity extends Entity {
         ..txId = transaction.id
         ..ownerAddress = transaction.owner.address
         ..bundledIn = transaction.bundledIn?.id
-        ..customMetadata = customMetaDataFromData(entityJson)
+        ..customMetadata = extractCustomMetadataForEntityType(
+          entityJson,
+          entityType: EntityType.drive,
+        )
         ..createdAt = transaction.getCommitTime();
     } catch (_) {
       throw EntityTransactionParseException(transactionId: transaction.id);
@@ -82,12 +85,6 @@ class DriveEntity extends Entity {
       tx.addTag(EntityTag.driveAuthMode, authMode!);
     }
   }
-
-  static String customMetaDataFromData(Map<String, dynamic> metadata) =>
-      customMetadataFactory(
-        metadata,
-        entityType: EntityType.drive,
-      )();
 
   factory DriveEntity.fromJson(Map<String, dynamic> json) =>
       _$DriveEntityFromJson(json);

--- a/lib/entities/drive_entity.dart
+++ b/lib/entities/drive_entity.dart
@@ -2,8 +2,8 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:ardrive/core/crypto/crypto.dart';
+import 'package:ardrive/entities/custom_metadata.dart';
 import 'package:ardrive/services/services.dart';
-import 'package:ardrive/utils/logger/logger.dart';
 import 'package:arweave/arweave.dart';
 import 'package:cryptography/cryptography.dart';
 import 'package:json_annotation/json_annotation.dart';
@@ -83,13 +83,11 @@ class DriveEntity extends Entity {
     }
   }
 
-  static String customMetaDataFromData(Map<String, dynamic> metadata) {
-    metadata.remove('name');
-    metadata.remove('rootFolderId');
-    final customMetadataAsString = json.encode(metadata);
-    logger.d('Custom metadata for drive: $customMetadataAsString');
-    return customMetadataAsString;
-  }
+  static String customMetaDataFromData(Map<String, dynamic> metadata) =>
+      customMetadataFactory(metadata, [
+        'name',
+        'rootFolderId',
+      ])();
 
   factory DriveEntity.fromJson(Map<String, dynamic> json) =>
       _$DriveEntityFromJson(json);

--- a/lib/entities/drive_entity.dart
+++ b/lib/entities/drive_entity.dart
@@ -84,10 +84,14 @@ class DriveEntity extends Entity {
   }
 
   static String customMetaDataFromData(Map<String, dynamic> metadata) =>
-      customMetadataFactory(metadata, [
-        'name',
-        'rootFolderId',
-      ])();
+      customMetadataFactory(
+        metadata,
+        [
+          'name',
+          'rootFolderId',
+        ],
+        entityType: 'drive',
+      )();
 
   factory DriveEntity.fromJson(Map<String, dynamic> json) =>
       _$DriveEntityFromJson(json);

--- a/lib/entities/drive_entity.dart
+++ b/lib/entities/drive_entity.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:ardrive/core/crypto/crypto.dart';
 import 'package:ardrive/services/services.dart';
+import 'package:ardrive/utils/logger/logger.dart';
 import 'package:arweave/arweave.dart';
 import 'package:cryptography/cryptography.dart';
 import 'package:json_annotation/json_annotation.dart';
@@ -86,7 +87,7 @@ class DriveEntity extends Entity {
     metadata.remove('name');
     metadata.remove('rootFolderId');
     final customMetadataAsString = json.encode(metadata);
-    print('Custom metadata for drive: $customMetadataAsString');
+    logger.d('Custom metadata for drive: $customMetadataAsString');
     return customMetadataAsString;
   }
 

--- a/lib/entities/drive_entity.dart
+++ b/lib/entities/drive_entity.dart
@@ -23,10 +23,14 @@ class DriveEntity extends Entity {
   String? name;
   String? rootFolderId;
 
+  @JsonKey(ignore: true)
+  String? customMetadata;
+
   DriveEntity({
     this.id,
     this.name,
     this.rootFolderId,
+    this.customMetadata,
     this.privacy,
     this.authMode,
   }) : super(ArDriveCrypto());
@@ -56,6 +60,7 @@ class DriveEntity extends Entity {
         ..txId = transaction.id
         ..ownerAddress = transaction.owner.address
         ..bundledIn = transaction.bundledIn?.id
+        ..customMetadata = customMetaDataFromData(entityJson)
         ..createdAt = transaction.getCommitTime();
     } catch (_) {
       throw EntityTransactionParseException(transactionId: transaction.id);
@@ -75,6 +80,14 @@ class DriveEntity extends Entity {
     if (privacy == DrivePrivacy.private) {
       tx.addTag(EntityTag.driveAuthMode, authMode!);
     }
+  }
+
+  static String customMetaDataFromData(Map<String, dynamic> metadata) {
+    metadata.remove('name');
+    metadata.remove('rootFolderId');
+    final customMetadataAsString = json.encode(metadata);
+    print('Custom metadata for drive: $customMetadataAsString');
+    return customMetadataAsString;
   }
 
   factory DriveEntity.fromJson(Map<String, dynamic> json) =>

--- a/lib/entities/drive_entity.dart
+++ b/lib/entities/drive_entity.dart
@@ -86,11 +86,7 @@ class DriveEntity extends Entity {
   static String customMetaDataFromData(Map<String, dynamic> metadata) =>
       customMetadataFactory(
         metadata,
-        [
-          'name',
-          'rootFolderId',
-        ],
-        entityType: 'drive',
+        entityType: EntityType.drive,
       )();
 
   factory DriveEntity.fromJson(Map<String, dynamic> json) =>

--- a/lib/entities/file_entity.dart
+++ b/lib/entities/file_entity.dart
@@ -96,14 +96,7 @@ class FileEntity extends Entity {
   static String customMetaDataFromData(Map<String, dynamic> metadata) =>
       customMetadataFactory(
         metadata,
-        [
-          'name',
-          'size',
-          'lastModifiedDate',
-          'dataTxId',
-          'dataContentType',
-        ],
-        entityType: 'file',
+        entityType: EntityType.file,
       )();
 
   @override

--- a/lib/entities/file_entity.dart
+++ b/lib/entities/file_entity.dart
@@ -32,6 +32,9 @@ class FileEntity extends Entity {
   String? dataTxId;
   String? dataContentType;
 
+  @JsonKey(ignore: true)
+  String? customJsonMetaData;
+
   FileEntity({
     this.id,
     this.driveId,
@@ -41,6 +44,7 @@ class FileEntity extends Entity {
     this.lastModifiedDate,
     this.dataTxId,
     this.dataContentType,
+    this.customJsonMetaData,
   }) : super(ArDriveCrypto());
 
   FileEntity.withUserProvidedDetails({
@@ -81,10 +85,22 @@ class FileEntity extends Entity {
         ..txId = transaction.id
         ..ownerAddress = transaction.owner.address
         ..bundledIn = transaction.bundledIn?.id
+        ..customJsonMetaData = customMetaDataFromData(entityJson)
         ..createdAt = commitTime;
     } catch (_) {
       throw EntityTransactionParseException(transactionId: transaction.id);
     }
+  }
+
+  static String customMetaDataFromData(Map<String, dynamic> metadata) {
+    metadata.remove('name');
+    metadata.remove('size');
+    metadata.remove('lastModifiedDate');
+    metadata.remove('dataTxId');
+    metadata.remove('dataContentType');
+    final customMetadataAsString = json.encode(metadata);
+    print('Custom metadata for file: $customMetadataAsString');
+    return customMetadataAsString;
   }
 
   @override

--- a/lib/entities/file_entity.dart
+++ b/lib/entities/file_entity.dart
@@ -94,13 +94,17 @@ class FileEntity extends Entity {
   }
 
   static String customMetaDataFromData(Map<String, dynamic> metadata) =>
-      customMetadataFactory(metadata, [
-        'name',
-        'size',
-        'lastModifiedDate',
-        'dataTxId',
-        'dataContentType',
-      ])();
+      customMetadataFactory(
+        metadata,
+        [
+          'name',
+          'size',
+          'lastModifiedDate',
+          'dataTxId',
+          'dataContentType',
+        ],
+        entityType: 'file',
+      )();
 
   @override
   void addEntityTagsToTransaction<T extends TransactionBase>(T tx) {

--- a/lib/entities/file_entity.dart
+++ b/lib/entities/file_entity.dart
@@ -86,18 +86,15 @@ class FileEntity extends Entity {
         ..txId = transaction.id
         ..ownerAddress = transaction.owner.address
         ..bundledIn = transaction.bundledIn?.id
-        ..customJsonMetaData = customMetaDataFromData(entityJson)
+        ..customJsonMetaData = extractCustomMetadataForEntityType(
+          entityJson,
+          entityType: EntityType.file,
+        )
         ..createdAt = commitTime;
     } catch (_) {
       throw EntityTransactionParseException(transactionId: transaction.id);
     }
   }
-
-  static String customMetaDataFromData(Map<String, dynamic> metadata) =>
-      customMetadataFactory(
-        metadata,
-        entityType: EntityType.file,
-      )();
 
   @override
   void addEntityTagsToTransaction<T extends TransactionBase>(T tx) {

--- a/lib/entities/file_entity.dart
+++ b/lib/entities/file_entity.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:ardrive/core/crypto/crypto.dart';
 import 'package:ardrive/services/services.dart';
+import 'package:ardrive/utils/logger/logger.dart';
 import 'package:arweave/arweave.dart';
 import 'package:cryptography/cryptography.dart';
 import 'package:json_annotation/json_annotation.dart';
@@ -99,7 +100,7 @@ class FileEntity extends Entity {
     metadata.remove('dataTxId');
     metadata.remove('dataContentType');
     final customMetadataAsString = json.encode(metadata);
-    print('Custom metadata for file: $customMetadataAsString');
+    logger.d('Custom metadata for file: $customMetadataAsString');
     return customMetadataAsString;
   }
 

--- a/lib/entities/file_entity.dart
+++ b/lib/entities/file_entity.dart
@@ -2,8 +2,8 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:ardrive/core/crypto/crypto.dart';
+import 'package:ardrive/entities/custom_metadata.dart';
 import 'package:ardrive/services/services.dart';
-import 'package:ardrive/utils/logger/logger.dart';
 import 'package:arweave/arweave.dart';
 import 'package:cryptography/cryptography.dart';
 import 'package:json_annotation/json_annotation.dart';
@@ -93,16 +93,14 @@ class FileEntity extends Entity {
     }
   }
 
-  static String customMetaDataFromData(Map<String, dynamic> metadata) {
-    metadata.remove('name');
-    metadata.remove('size');
-    metadata.remove('lastModifiedDate');
-    metadata.remove('dataTxId');
-    metadata.remove('dataContentType');
-    final customMetadataAsString = json.encode(metadata);
-    logger.d('Custom metadata for file: $customMetadataAsString');
-    return customMetadataAsString;
-  }
+  static String customMetaDataFromData(Map<String, dynamic> metadata) =>
+      customMetadataFactory(metadata, [
+        'name',
+        'size',
+        'lastModifiedDate',
+        'dataTxId',
+        'dataContentType',
+      ])();
 
   @override
   void addEntityTagsToTransaction<T extends TransactionBase>(T tx) {

--- a/lib/entities/folder_entity.dart
+++ b/lib/entities/folder_entity.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:ardrive/core/crypto/crypto.dart';
 import 'package:ardrive/services/services.dart';
+import 'package:ardrive/utils/logger/logger.dart';
 import 'package:arweave/arweave.dart';
 import 'package:cryptography/cryptography.dart';
 import 'package:json_annotation/json_annotation.dart';
@@ -67,7 +68,7 @@ class FolderEntity extends Entity {
   static String customMetaDataFromData(Map<String, dynamic> metadata) {
     metadata.remove('name');
     final customMetadataAsString = json.encode(metadata);
-    print('Custom metadata for folder: $customMetadataAsString');
+    logger.d('Custom metadata for folder: $customMetadataAsString');
     return customMetadataAsString;
   }
 

--- a/lib/entities/folder_entity.dart
+++ b/lib/entities/folder_entity.dart
@@ -66,7 +66,7 @@ class FolderEntity extends Entity {
   }
 
   static String customMetaDataFromData(Map<String, dynamic> metadata) =>
-      customMetadataFactory(metadata, ['name'])();
+      customMetadataFactory(metadata, ['name'], entityType: 'folder')();
 
   @override
   void addEntityTagsToTransaction<T extends TransactionBase>(T tx) {

--- a/lib/entities/folder_entity.dart
+++ b/lib/entities/folder_entity.dart
@@ -66,7 +66,10 @@ class FolderEntity extends Entity {
   }
 
   static String customMetaDataFromData(Map<String, dynamic> metadata) =>
-      customMetadataFactory(metadata, ['name'], entityType: 'folder')();
+      customMetadataFactory(
+        metadata,
+        entityType: EntityType.folder,
+      )();
 
   @override
   void addEntityTagsToTransaction<T extends TransactionBase>(T tx) {

--- a/lib/entities/folder_entity.dart
+++ b/lib/entities/folder_entity.dart
@@ -2,8 +2,8 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:ardrive/core/crypto/crypto.dart';
+import 'package:ardrive/entities/custom_metadata.dart';
 import 'package:ardrive/services/services.dart';
-import 'package:ardrive/utils/logger/logger.dart';
 import 'package:arweave/arweave.dart';
 import 'package:cryptography/cryptography.dart';
 import 'package:json_annotation/json_annotation.dart';
@@ -65,12 +65,8 @@ class FolderEntity extends Entity {
     }
   }
 
-  static String customMetaDataFromData(Map<String, dynamic> metadata) {
-    metadata.remove('name');
-    final customMetadataAsString = json.encode(metadata);
-    logger.d('Custom metadata for folder: $customMetadataAsString');
-    return customMetadataAsString;
-  }
+  static String customMetaDataFromData(Map<String, dynamic> metadata) =>
+      customMetadataFactory(metadata, ['name'])();
 
   @override
   void addEntityTagsToTransaction<T extends TransactionBase>(T tx) {

--- a/lib/entities/folder_entity.dart
+++ b/lib/entities/folder_entity.dart
@@ -58,18 +58,15 @@ class FolderEntity extends Entity {
         ..parentFolderId = transaction.getTag(EntityTag.parentFolderId)
         ..txId = transaction.id
         ..ownerAddress = transaction.owner.address
-        ..customJsonMetaData = customMetaDataFromData(entityJson)
+        ..customJsonMetaData = extractCustomMetadataForEntityType(
+          entityJson,
+          entityType: EntityType.folder,
+        )
         ..createdAt = transaction.getCommitTime();
     } catch (_) {
       throw EntityTransactionParseException(transactionId: transaction.id);
     }
   }
-
-  static String customMetaDataFromData(Map<String, dynamic> metadata) =>
-      customMetadataFactory(
-        metadata,
-        entityType: EntityType.folder,
-      )();
 
   @override
   void addEntityTagsToTransaction<T extends TransactionBase>(T tx) {

--- a/lib/entities/folder_entity.dart
+++ b/lib/entities/folder_entity.dart
@@ -22,11 +22,15 @@ class FolderEntity extends Entity {
 
   String? name;
 
+  @JsonKey(ignore: true)
+  String? customJsonMetaData;
+
   FolderEntity({
     this.id,
     this.driveId,
     this.parentFolderId,
     this.name,
+    this.customJsonMetaData,
   }) : super(ArDriveCrypto());
 
   static Future<FolderEntity> fromTransaction(
@@ -53,10 +57,18 @@ class FolderEntity extends Entity {
         ..parentFolderId = transaction.getTag(EntityTag.parentFolderId)
         ..txId = transaction.id
         ..ownerAddress = transaction.owner.address
+        ..customJsonMetaData = customMetaDataFromData(entityJson)
         ..createdAt = transaction.getCommitTime();
     } catch (_) {
       throw EntityTransactionParseException(transactionId: transaction.id);
     }
+  }
+
+  static String customMetaDataFromData(Map<String, dynamic> metadata) {
+    metadata.remove('name');
+    final customMetadataAsString = json.encode(metadata);
+    print('Custom metadata for folder: $customMetadataAsString');
+    return customMetadataAsString;
   }
 
   @override

--- a/lib/models/file_revision.dart
+++ b/lib/models/file_revision.dart
@@ -37,6 +37,7 @@ extension FileEntityExtensions on FileEntity {
   /// This requires a `performedAction` to be specified.
   FileRevisionsCompanion toRevisionCompanion({
     required String performedAction,
+    required String? customMetaData,
   }) =>
       FileRevisionsCompanion.insert(
         fileId: id!,
@@ -51,6 +52,7 @@ extension FileEntityExtensions on FileEntity {
         dataContentType: Value(dataContentType),
         action: performedAction,
         bundledIn: Value(bundledIn),
+        customJsonMetaData: Value<String?>(customMetaData),
       );
 
   FileRevision toRevision({

--- a/lib/models/folder_revision.dart
+++ b/lib/models/folder_revision.dart
@@ -32,8 +32,10 @@ extension FolderEntityExtensions on FolderEntity {
   /// Converts the entity to an instance of [FolderRevisionsCompanion].
   ///
   /// This requires a `performedAction` to be specified.
-  FolderRevisionsCompanion toRevisionCompanion(
-          {required String performedAction}) =>
+  FolderRevisionsCompanion toRevisionCompanion({
+    required String performedAction,
+    required String? customJsonMetaData,
+  }) =>
       FolderRevisionsCompanion.insert(
         folderId: id!,
         driveId: driveId!,
@@ -42,6 +44,7 @@ extension FolderEntityExtensions on FolderEntity {
         metadataTxId: txId,
         dateCreated: Value(createdAt),
         action: performedAction,
+        customJsonMetaData: Value<String?>(customJsonMetaData),
       );
 
   /// Returns the action performed on the folder that lead to the new revision.

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -250,7 +250,7 @@ class ArweaveService {
 
           return _getEntityData(
             entityId: entity.id,
-            driveId: ownerAddress,
+            driveId: driveId,
             isPrivate: driveKey != null,
           );
         },

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -221,40 +221,8 @@ class ArweaveService {
     required String ownerAddress,
     required SnapshotDriveHistory snapshotDriveHistory,
     required DriveID driveId,
+    required List<Uint8List> entitiesData,
   }) async {
-    // FIXME - PE-3440
-    /// Make use of `eagerError: true` to make it fail on first error
-    /// Also, when there's no internet connection and when we're getting
-    /// rate-limited (TODO: check the latter), many requests will be retrying.
-    /// We shall find another way to fail faster.
-
-    // MAYBE FIX: set a narrow concurrency limit
-
-    final List<Uint8List> responses = await Future.wait(
-      entityTxs.map(
-        (entity) async {
-          final tags = entity.tags;
-          final isSnapshot = tags.any(
-            (tag) =>
-                tag.name == EntityTag.entityType &&
-                tag.value == EntityType.snapshot.toString(),
-          );
-
-          // don't fetch data for snapshots
-          if (isSnapshot) {
-            print('skipping unnecessary request for snapshot data');
-            return Uint8List(0);
-          }
-
-          return _getEntityData(
-            entityId: entity.id,
-            driveId: driveId,
-            isPrivate: driveKey != null,
-          );
-        },
-      ),
-    );
-
     final blockHistory = <BlockEntities>[];
 
     for (var i = 0; i < entityTxs.length; i++) {
@@ -273,7 +241,7 @@ class ArweaveService {
 
       try {
         final entityType = transaction.getTag(EntityTag.entityType);
-        final entityResponse = responses[i];
+        final entityResponse = entitiesData[i];
         final rawEntityData = entityResponse;
 
         Entity? entity;
@@ -347,7 +315,7 @@ class ArweaveService {
     return privateDriveTxs.isNotEmpty;
   }
 
-  Future<Uint8List> _getEntityData({
+  Future<Uint8List> getEntityData({
     required String entityId,
     required String driveId,
     required bool isPrivate,

--- a/test/entities/custom_metadata.dart
+++ b/test/entities/custom_metadata.dart
@@ -1,0 +1,75 @@
+import 'package:ardrive/entities/custom_metadata.dart';
+import 'package:ardrive/entities/entities.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Custom metadata', () {
+    test('customMetadataFactory method removes reserved keys', () {
+      final metadata = {
+        'name': 'test',
+        'reserved': 'reserved',
+      };
+      final customMetadata = customMetadataFactory(metadata, ['reserved'])();
+      expect(customMetadata, '{"name":"test"}');
+    });
+
+    test('of drive entity removes expected fields', () {
+      final metadata = {
+        'name': 'reserved',
+        'rootFolderId': 'reserved',
+        'Foo': 'Bar',
+        'Mati rocks': 'Of course',
+        'Dont let': [
+          'me down',
+          'your dreams be dreams',
+          'anyone tell you otherwise'
+        ],
+      };
+      final customMetadata = DriveEntity.customMetaDataFromData(metadata);
+      expect(
+        customMetadata,
+        '{"Foo":"Bar","Mati rocks":"Of course","Dont let":["me down","your dreams be dreams","anyone tell you otherwise"]}',
+      );
+    });
+
+    test('of folder entity removes expected fields', () {
+      final metadata = {
+        'name': 'reserved',
+        'Foo': 'Bar',
+        'Mati rocks': 'Of course',
+        'Dont let': [
+          'me down',
+          'your dreams be dreams',
+          'anyone tell you otherwise'
+        ],
+      };
+      final customMetadata = FolderEntity.customMetaDataFromData(metadata);
+      expect(
+        customMetadata,
+        '{"Foo":"Bar","Mati rocks":"Of course","Dont let":["me down","your dreams be dreams","anyone tell you otherwise"]}',
+      );
+    });
+
+    test('of file entity removes expected fields', () {
+      final metadata = {
+        'name': 'reserved',
+        'size': 'reserved',
+        'lastModifiedDate': 'reserved',
+        'dataTxId': 'reserved',
+        'dataContentType': 'reserved',
+        'Foo': 'Bar',
+        'Mati rocks': 'Of course',
+        'Dont let': [
+          'me down',
+          'your dreams be dreams',
+          'anyone tell you otherwise'
+        ],
+      };
+      final customMetadata = FileEntity.customMetaDataFromData(metadata);
+      expect(
+        customMetadata,
+        '{"Foo":"Bar","Mati rocks":"Of course","Dont let":["me down","your dreams be dreams","anyone tell you otherwise"]}',
+      );
+    });
+  });
+}

--- a/test/entities/custom_metadata_test.dart
+++ b/test/entities/custom_metadata_test.dart
@@ -4,12 +4,21 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('Custom metadata', () {
+    test('customMetadataFactory throws for unknown entityType', () {
+      const unknownEntityType = 'La magia de la amistad';
+      expect(
+        () => customMetadataFactory({}, entityType: unknownEntityType),
+        throwsException,
+      );
+    });
+
     test('customMetadataFactory method removes reserved keys', () {
       final metadata = {
         'name': 'test',
         'reserved': 'reserved',
       };
-      final customMetadata = customMetadataFactory(metadata, ['reserved'])();
+      final customMetadata =
+          customMetadataFactory(metadata, entityType: 'test')();
       expect(customMetadata, '{"name":"test"}');
     });
 

--- a/test/entities/custom_metadata_test.dart
+++ b/test/entities/custom_metadata_test.dart
@@ -7,7 +7,8 @@ void main() {
     test('customMetadataFactory throws for unknown entityType', () {
       const unknownEntityType = 'La magia de la amistad';
       expect(
-        () => customMetadataFactory({}, entityType: unknownEntityType),
+        () => extractCustomMetadataForEntityType({},
+            entityType: unknownEntityType),
         throwsException,
       );
     });
@@ -18,7 +19,7 @@ void main() {
         'reserved': 'reserved',
       };
       final customMetadata =
-          customMetadataFactory(metadata, entityType: 'test')();
+          extractCustomMetadataForEntityType(metadata, entityType: 'test');
       expect(customMetadata, '{"name":"test"}');
     });
 
@@ -34,7 +35,10 @@ void main() {
           'anyone tell you otherwise'
         ],
       };
-      final customMetadata = DriveEntity.customMetaDataFromData(metadata);
+      final customMetadata = extractCustomMetadataForEntityType(
+        metadata,
+        entityType: EntityType.drive,
+      );
       expect(
         customMetadata,
         '{"Foo":"Bar","Mati rocks":"Of course","Dont let":["me down","your dreams be dreams","anyone tell you otherwise"]}',
@@ -52,7 +56,10 @@ void main() {
           'anyone tell you otherwise'
         ],
       };
-      final customMetadata = FolderEntity.customMetaDataFromData(metadata);
+      final customMetadata = extractCustomMetadataForEntityType(
+        metadata,
+        entityType: EntityType.folder,
+      );
       expect(
         customMetadata,
         '{"Foo":"Bar","Mati rocks":"Of course","Dont let":["me down","your dreams be dreams","anyone tell you otherwise"]}',
@@ -74,7 +81,10 @@ void main() {
           'anyone tell you otherwise'
         ],
       };
-      final customMetadata = FileEntity.customMetaDataFromData(metadata);
+      final customMetadata = extractCustomMetadataForEntityType(
+        metadata,
+        entityType: EntityType.file,
+      );
       expect(
         customMetadata,
         '{"Foo":"Bar","Mati rocks":"Of course","Dont let":["me down","your dreams be dreams","anyone tell you otherwise"]}',


### PR DESCRIPTION
Changes
- Adds to drive, folder, and file entities the customJsonMetaData field
- Sets the value ONLY at sync time - For creation/rename/move and any other operation, it's not being set


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/5v4k4e780i600
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/5osi9ig195g98