### PR TITLE
PE-2903: Update ArDrive Icon in ArConnect

### DIFF
--- a/web/js/arconnect.js
+++ b/web/js/arconnect.js
@@ -6,12 +6,16 @@ const permissions = [
   'ACCESS_ALL_ADDRESSES',
 ];
 
+const appInfo = {
+  logo: 'https://app.ardrive.io/favicon.png',
+}
+
 function isExtensionPresent() {
   return window.arweaveWallet != null && window.arweaveWallet != 'undefined';
 }
 
 async function connect() {
-  return await window.arweaveWallet.connect(permissions);
+  return await window.arweaveWallet.connect(permissions, appInfo);
 }
 
 async function checkPermissions() {

--- a/web/js/arconnect.js
+++ b/web/js/arconnect.js
@@ -8,6 +8,7 @@ const permissions = [
 
 const appInfo = {
   logo: 'https://app.ardrive.io/favicon.png',
+  name: 'ArDrive',
 }
 
 function isExtensionPresent() {


### PR DESCRIPTION
Changes
- Passes the favicon URL to ArConnect as the app `logo` through the `appInfo` parameter of the `connect` method.



--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/7dt0luggs7jjo
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/4ughg5igova10