### PR TITLE
PE-3762: Add Keyfile Login "Learn More" Link

### DIFF
--- a/lib/authentication/login/views/login_page.dart
+++ b/lib/authentication/login/views/login_page.dart
@@ -362,9 +362,36 @@ class _PromptWalletViewState extends State<PromptWalletView> {
                       TextSpan(
                         children: [
                           TextSpan(
-                              text: appLocalizationsOf(context)
-                                  .securityWalletOverlay,
-                              style: ArDriveTypography.body.smallBold()),
+                            text: appLocalizationsOf(context)
+                                .securityWalletOverlay,
+                            style: ArDriveTypography.body.smallBold(),
+                          ),
+                          TextSpan(
+                            text: ' ',
+                            style: ArDriveTypography.body.buttonNormalRegular(
+                              color: ArDriveTheme.of(context)
+                                  .themeData
+                                  .colors
+                                  .themeFgOnAccent,
+                            ),
+                          ),
+                          TextSpan(
+                            text: appLocalizationsOf(context).learnMore,
+                            style: ArDriveTypography.body
+                                .buttonNormalRegular(
+                                  color: ArDriveTheme.of(context)
+                                      .themeData
+                                      .colors
+                                      .themeFgOnAccent,
+                                )
+                                .copyWith(
+                                  decoration: TextDecoration.underline,
+                                ),
+                            recognizer: TapGestureRecognizer()
+                              ..onTap = () => openUrl(
+                                    url: Resources.howDoesKeyFileLoginWork,
+                                  ),
+                          ),
                         ],
                       ),
                     ),

--- a/lib/components/create_manifest_form.dart
+++ b/lib/components/create_manifest_form.dart
@@ -234,8 +234,9 @@ class _CreateManifestFormState extends State<CreateManifestForm> {
                                   .aManifestIsASpecialKindOfFile, // trimmed spaces
                               style: textStyle,
                             ),
+                            const TextSpan(text: ' '),
                             TextSpan(
-                              text: ' ${appLocalizationsOf(context).learnMore}',
+                              text: appLocalizationsOf(context).learnMore,
                               style: textStyle.copyWith(
                                 decoration: TextDecoration.underline,
                               ),

--- a/lib/misc/resources.dart
+++ b/lib/misc/resources.dart
@@ -9,6 +9,9 @@ class Resources {
   static const helpLink = 'https://ar-io.zendesk.com/hc/en-us';
   static const agreementLink = 'https://ardrive.io/tos-and-privacy/';
   static const getWalletLink = 'https://www.arconnect.io/';
+
+  static const howDoesKeyFileLoginWork =
+      'https://ar-io.zendesk.com/hc/en-us/articles/15412384724251-How-Does-Keyfile-Login-Work-';
 }
 
 class Images {


### PR DESCRIPTION
Changes
- Adds the link to the resources file
- Puts the "Learn More" link in the tooltip

Free win:
- Fixes the missing space for the Manifest Explanation

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/2uoa5lq56tkl0
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/1lm7ulgtisks0