### PR TITLE
PE-3977: Before-release preparations

### DIFF
--- a/android/fastlane/metadata/android/en-US/changelogs/45.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/45.txt
@@ -1,0 +1,1 @@
+- Removes the “Insufficient Funds“ warning underneath the New button

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Secure, permanent storage
 
 publish_to: 'none'
 
-version: 2.0.2
+version: 2.2.0
 
 environment:
   sdk: '>=2.18.5 <3.0.0'


### PR DESCRIPTION
Changes
- Android release notes (next prod deploy number is 45)
- App version bump

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/1fue73b2crtdo
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/14oalufdvedho