### PR TITLE
PE-4005: retains previous amount instead of displaying newly selected amount

### DIFF
--- a/lib/components/top_up_dialog.dart
+++ b/lib/components/top_up_dialog.dart
@@ -40,6 +40,7 @@ class _TopUpEstimationViewState extends State<TopUpEstimationView> {
 
     return BlocBuilder<TurboTopUpEstimationBloc, TopupEstimationState>(
       bloc: paymentBloc,
+      buildWhen: (_, current) => current is! EstimationLoading,
       builder: (context, state) {
         if (state is EstimationLoading) {
           return const SizedBox(
@@ -148,20 +149,26 @@ class _TopUpEstimationViewState extends State<TopUpEstimationView> {
                           ],
                         ),
                       ),
-                      ArDriveButton(
-                        isDisabled: paymentBloc.currentAmount == 0,
-                        maxWidth: 143,
-                        maxHeight: 40,
-                        fontStyle: ArDriveTypography.body
-                            .buttonLargeBold()
-                            .copyWith(fontWeight: FontWeight.w700),
-                        text: appLocalizationsOf(context).next,
-                        onPressed: () {
-                          // Go to the paumentFormView.
-                          // Will be implemented in the next PR.
-                          context
-                              .read<TurboTopupFlowBloc>()
-                              .add(const TurboTopUpShowPaymentFormView());
+                      BlocBuilder<TurboTopUpEstimationBloc,
+                          TopupEstimationState>(
+                        builder: (context, state) {
+                          return ArDriveButton(
+                            isDisabled: paymentBloc.currentAmount == 0 ||
+                                state is EstimationLoading,
+                            maxWidth: 143,
+                            maxHeight: 40,
+                            fontStyle: ArDriveTypography.body
+                                .buttonLargeBold()
+                                .copyWith(fontWeight: FontWeight.w700),
+                            text: appLocalizationsOf(context).next,
+                            onPressed: () {
+                              // Go to the paumentFormView.
+                              // Will be implemented in the next PR.
+                              context
+                                  .read<TurboTopupFlowBloc>()
+                                  .add(const TurboTopUpShowPaymentFormView());
+                            },
+                          );
                         },
                       ),
                     ],

--- a/lib/components/top_up_dialog.dart
+++ b/lib/components/top_up_dialog.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:ardrive/blocs/profile/profile_cubit.dart';
 import 'package:ardrive/misc/resources.dart';
 import 'package:ardrive/turbo/topup/blocs/topup_estimation_bloc.dart';
@@ -236,15 +234,8 @@ class _PresetAmountSelectorState extends State<PresetAmountSelector> {
 
   DateTime lastChanged = DateTime.now();
 
-  Timer? _timer;
-
   void _onAmountChanged(String amount) {
-    if (_timer != null && _timer!.isActive) {
-      _timer?.cancel();
-    }
-    _timer = Timer(const Duration(milliseconds: 500), () {
-      widget.onAmountSelected(int.parse(amount));
-    });
+    widget.onAmountSelected(int.parse(amount));
   }
 
   void _onPresetAmountSelected(int amount) {

--- a/lib/turbo/topup/blocs/topup_estimation_bloc.dart
+++ b/lib/turbo/topup/blocs/topup_estimation_bloc.dart
@@ -112,6 +112,8 @@ class TurboTopUpEstimationBloc
     required String currentCurrency,
     required FileSizeUnit currentDataUnit,
   }) async {
+    emit(EstimationLoading());
+    
     final priceEstimate = await turbo.computePriceEstimate(
       currentAmount: currentAmount,
       currentCurrency: currentCurrency,

--- a/lib/turbo/topup/blocs/topup_estimation_bloc.dart
+++ b/lib/turbo/topup/blocs/topup_estimation_bloc.dart
@@ -113,7 +113,7 @@ class TurboTopUpEstimationBloc
     required FileSizeUnit currentDataUnit,
   }) async {
     emit(EstimationLoading());
-    
+
     final priceEstimate = await turbo.computePriceEstimate(
       currentAmount: currentAmount,
       currentCurrency: currentCurrency,

--- a/lib/turbo/topup/blocs/topup_estimation_state.dart
+++ b/lib/turbo/topup/blocs/topup_estimation_state.dart
@@ -54,3 +54,8 @@ class EstimationError extends TopupEstimationState {
   @override
   List<Object?> get props => [];
 }
+
+class EstimationLoadError extends TopupEstimationState {
+  @override
+  List<Object?> get props => [];
+}

--- a/test/turbo/blocs/topup_estimation_bloc_test.dart
+++ b/test/turbo/blocs/topup_estimation_bloc_test.dart
@@ -48,6 +48,7 @@ void main() {
           bloc.add(LoadInitialData());
         },
         expect: () => [
+          EstimationLoading(),
           EstimationLoaded(
             balance: BigInt.from(10),
             estimatedStorageForBalance: '1.00',
@@ -72,6 +73,7 @@ void main() {
             bloc.add(LoadInitialData());
           },
           expect: () => [
+                EstimationLoading(),
                 EstimationError(),
               ]);
       blocTest(
@@ -94,6 +96,7 @@ void main() {
                 .thenThrow(Exception());
           },
           expect: () => [
+                EstimationLoading(),
                 EstimationError(),
               ]);
       blocTest(
@@ -125,6 +128,7 @@ void main() {
                 )).thenThrow(Exception());
           },
           expect: () => [
+                EstimationLoading(),
                 EstimationError(),
               ]);
     });
@@ -162,6 +166,8 @@ void main() {
             )).thenAnswer((_) async => 1);
       },
       expect: () => [
+        EstimationLoading(),
+
         // first loads with usd
         EstimationLoaded(
           balance: BigInt.from(10),
@@ -172,6 +178,7 @@ void main() {
           currencyUnit: 'usd',
           dataUnit: FileSizeUnit.gigabytes,
         ),
+
         // then emit eur
         EstimationLoaded(
           balance: BigInt.from(10),
@@ -226,6 +233,8 @@ void main() {
             )).thenAnswer((_) async => 1);
       },
       expect: () => [
+        EstimationLoading(),
+
         // first loads with usd
         EstimationLoaded(
           balance: BigInt.from(10),
@@ -259,8 +268,6 @@ void main() {
         bloc.add(const FiatAmountSelected(100));
       },
       setUp: () {
-        when(() => mockTurbo.onPriceEstimateChanged)
-            .thenAnswer((_) => Stream.empty());
         final mockPriceEstimate = PriceEstimate(
             credits: BigInt.from(10), priceInCurrency: 0, estimatedStorage: 1);
         final mockPriceEstimate100 = PriceEstimate(
@@ -292,6 +299,8 @@ void main() {
             )).thenAnswer((_) async => 1);
       },
       expect: () => [
+        EstimationLoading(),
+
         // start with 0
         EstimationLoaded(
           balance: BigInt.from(10),
@@ -302,6 +311,7 @@ void main() {
           currencyUnit: 'usd',
           dataUnit: FileSizeUnit.gigabytes,
         ),
+
         // 100
         EstimationLoaded(
           balance: BigInt.from(10),


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/1gr8f6acuo998
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/7gsjr95og93r0