### PR TITLE
PE-4030: fix: use metadata tx id on details panel

### DIFF
--- a/lib/components/details_panel.dart
+++ b/lib/components/details_panel.dart
@@ -338,6 +338,12 @@ class _DetailsPanelState extends State<DetailsPanel> {
   }
 
   List<Widget> _fileDetails() {
+    String? metadataTxId;
+
+    if (widget.item is FileDataTableItem) {
+      metadataTxId = (widget.item as FileDataTableItem).metadataTx?.id;
+    }
+
     return [
       DetailsPanelItem(
         leading: CopyButton(text: widget.item.id),
@@ -375,13 +381,15 @@ class _DetailsPanelState extends State<DetailsPanel> {
         ),
         itemTitle: 'File type',
       ),
-      sizedBoxHeight16px,
-      DetailsPanelItem(
-        leading: CopyButton(
-          text: widget.item.driveId,
+      if (metadataTxId != null) ...[
+        sizedBoxHeight16px,
+        DetailsPanelItem(
+          leading: CopyButton(
+            text: metadataTxId,
+          ),
+          itemTitle: appLocalizationsOf(context).metadataTxID,
         ),
-        itemTitle: appLocalizationsOf(context).metadataTxID,
-      ),
+      ],
       sizedBoxHeight16px,
       DetailsPanelItem(
         leading: Row(


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/7051kman9fh2o
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/5ipjj47s7j0d8