### PR TITLE
PE-4051: fix(turbo + arconnect): use getOwner instead of publicKey with RSA

### DIFF
--- a/lib/services/turbo/payment_service.dart
+++ b/lib/services/turbo/payment_service.dart
@@ -60,7 +60,7 @@ class PaymentService {
     required Wallet wallet,
   }) async {
     final nonce = const Uuid().v4();
-    final publicKey = await wallet.getPublicKey();
+    final publicKey = await wallet.getOwner();
     final signature = await signNonceAndData(
       nonce: nonce,
       wallet: wallet,
@@ -70,7 +70,7 @@ class PaymentService {
       headers: {
         'x-nonce': nonce,
         'x-signature': signature,
-        'x-public-key': publicKeyToHeader(publicKey),
+        'x-public-key': publicKey,
       },
     ).onError((ArDriveHTTPException error, stackTrace) {
       logger.e('Error getting balance', error, stackTrace);


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/1v05ontk8nns8
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/39elmhvui4vig