### PR TITLE
PE-4157: update texts on top up and upload form

### DIFF
--- a/lib/components/top_up_dialog.dart
+++ b/lib/components/top_up_dialog.dart
@@ -379,7 +379,7 @@ class _PresetAmountSelectorState extends State<PresetAmountSelector> {
           const SizedBox(height: 8),
           Text(
             appLocalizationsOf(context)
-                .arDriveCreditsWillBeAutomaticallyAddedToYourTurboBalance,
+                .creditsWillBeAutomaticallyAddedToYourTurboBalance,
             style: ArDriveTypography.body.buttonNormalBold(
               color: ArDriveTheme.of(context).themeData.colors.themeFgSubtle,
             ),

--- a/lib/components/upload_form.dart
+++ b/lib/components/upload_form.dart
@@ -519,6 +519,7 @@ class _UploadFormState extends State<UploadForm> {
                       options: [
                         RadioButtonOptions(
                           value: state.uploadMethod == UploadMethod.ar,
+                          // TODO: Localization
                           text:
                               'Cost: ${winstonToAr(state.costEstimateAr.totalCost)} AR',
                           textStyle: ArDriveTypography.body.buttonLargeBold(),
@@ -527,9 +528,10 @@ class _UploadFormState extends State<UploadForm> {
                             state.isTurboUploadPossible)
                           RadioButtonOptions(
                             value: state.uploadMethod == UploadMethod.turbo,
+                            // TODO: Localization
                             text: state.isZeroBalance
                                 ? ''
-                                : 'Cost ${winstonToAr(state.costEstimateTurbo!.totalCost)} Credits',
+                                : 'Cost: ${winstonToAr(state.costEstimateTurbo!.totalCost)} Credits',
                             textStyle: ArDriveTypography.body.buttonLargeBold(),
                             content: state.isZeroBalance
                                 ? GestureDetector(

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -76,8 +76,8 @@
   "@arConnectWalletDoestNotMatchArDriveWallet": {
     "description": "Your ArConnect wallet does not match your ArDrive wallet. Please try again."
   },
-  "arDriveCreditsWillBeAutomaticallyAddedToYourTurboBalance": "ArDrive Credits will be automatically added to your Turbo balance, and you can start using them right away.",
-  "@arDriveCreditsWillBeAutomaticallyAddedToYourTurboBalance": {},
+  "creditsWillBeAutomaticallyAddedToYourTurboBalance": "Credits will be automatically added to your Turbo balance, and you can start using them right away.",
+  "@creditsWillBeAutomaticallyAddedToYourTurboBalance": {},
   "ardriveIsntJustAnotherCloudSyncApp": "ArDrive isn’t just another cloud sync app. It’s the beginning of a permanent hard drive.",
   "@ardriveIsntJustAnotherCloudSyncApp": {
     "description": "Description about the permanence and uniqueness of ArDrive"
@@ -1058,7 +1058,7 @@
   "@learnMore": {
     "description": "Link to a document explaining manifests in detail"
   },
-  "leaveAnEmailToReceiveAReceipt": "Please leave an email if you want a receipt.",
+  "leaveAnEmailToReceiveAReceipt": "To receive a receipt, please provide an email.",
   "@leaveAnEmailToReceiveAReceipt": {},
   "leaveFeedback": "Leave Feedback",
   "@leaveFeedback": {
@@ -1776,7 +1776,7 @@
   "@validationPasswordIncorrect": {
     "description": "Input validation error: the given password is wrong"
   },
-  "validationRequired": "This field is required.",
+  "validationRequired": "Field required.",
   "@validationRequired": {
     "description": "Input validation error: the field is empty, but it's required"
   },


### PR DESCRIPTION
Update receipt text to, “To receive a receipt, please provide an email.”
![image](https://github.com/ardriveapp/ardrive-web/assets/9200155/cee5b62c-e16a-4fa5-a933-7681c697db98)

Update empty field error to, “Field required”
![image](https://github.com/ardriveapp/ardrive-web/assets/9200155/d360b7c5-dd76-4d9f-886a-17a993f49551)

Change “ArDrive Credits” to “Credits” on turbo top up
![image](https://github.com/ardriveapp/ardrive-web/assets/9200155/c7980a34-cd8f-43cb-a3df-6428b5e1faa4)

Missing colon. Both should say “Cost:” but the “:” is missing from the Credit option
![image](https://github.com/ardriveapp/ardrive-web/assets/9200155/993f20ac-e5f4-481a-ad29-8dd4c8f35b61)


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/5bf0m5vs1ee7g
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/6d99446vm4hro