### PR TITLE
PE-4173: inject tab visibility

### DIFF
--- a/lib/blocs/profile/profile_cubit.dart
+++ b/lib/blocs/profile/profile_cubit.dart
@@ -4,14 +4,13 @@ import 'package:ardrive/entities/profile_types.dart';
 import 'package:ardrive/models/models.dart';
 import 'package:ardrive/services/arconnect/arconnect_wallet.dart';
 import 'package:ardrive/services/services.dart';
+import 'package:ardrive/utils/html/html_util.dart';
 import 'package:ardrive/utils/logger/logger.dart';
 import 'package:arweave/arweave.dart';
 import 'package:cryptography/cryptography.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-
-import '../../utils/html/implementations/html_web.dart';
 
 part 'profile_state.dart';
 
@@ -22,16 +21,19 @@ class ProfileCubit extends Cubit<ProfileState> {
   final TurboUploadService _turboUploadService;
   final ProfileDao _profileDao;
   final Database _db;
+  final TabVisibilitySingleton _tabVisibilitySingleton;
 
   ProfileCubit({
     required ArweaveService arweave,
     required TurboUploadService turboUploadService,
     required ProfileDao profileDao,
     required Database db,
+    required TabVisibilitySingleton tabVisibilitySingleton,
   })  : _arweave = arweave,
         _turboUploadService = turboUploadService,
         _profileDao = profileDao,
         _db = db,
+        _tabVisibilitySingleton = tabVisibilitySingleton,
         super(ProfileCheckingAvailability()) {
     promptToAuthenticate();
   }
@@ -103,15 +105,15 @@ class ProfileCubit extends Cubit<ProfileState> {
           return true;
         }
       } catch (e) {
-        if (isTabFocused()) {
+        if (_tabVisibilitySingleton.isTabFocused()) {
           return false;
         }
 
         logger.e('Error checking ArConnect permissions: $e');
-        
+
         bool isWalletMismatch = false;
 
-        await onTabGetsFocusedFuture(() async {
+        await _tabVisibilitySingleton.onTabGetsFocusedFuture(() async {
           isWalletMismatch = await checkIfWalletMismatch();
         });
 

--- a/lib/blocs/upload/upload_cubit.dart
+++ b/lib/blocs/upload/upload_cubit.dart
@@ -549,6 +549,7 @@ class UploadCubit extends Cubit<UploadState> {
             'Preparing bundle.. using turbo: ${_uploadMethod == UploadMethod.turbo}');
 
         await handle.prepareAndSignBundleTransaction(
+          tabVisibilitySingleton: TabVisibilitySingleton(),
           arweaveService: _arweave,
           turboUploadService: _turbo,
           pstService: _pst,

--- a/lib/blocs/upload/upload_handles/bundle_upload_handle.dart
+++ b/lib/blocs/upload/upload_handles/bundle_upload_handle.dart
@@ -6,6 +6,7 @@ import 'package:ardrive/core/upload/bundle_signer.dart';
 import 'package:ardrive/entities/entities.dart';
 import 'package:ardrive/models/daos/daos.dart';
 import 'package:ardrive/services/services.dart';
+import 'package:ardrive/utils/html/html_util.dart';
 import 'package:ardrive/utils/logger/logger.dart';
 import 'package:arweave/arweave.dart';
 import 'package:flutter/foundation.dart';
@@ -23,7 +24,7 @@ class BundleUploadHandle implements UploadHandle {
     this.folderDataItemUploadHandles = const [],
     this.size = 0,
     this.hasError = false,
-}) {
+  }) {
     fileEntities = fileDataItemUploadHandles.map((item) => item.entity);
   }
 
@@ -57,6 +58,7 @@ class BundleUploadHandle implements UploadHandle {
     required TurboUploadService turboUploadService,
     required PstService pstService,
     required Wallet wallet,
+    required TabVisibilitySingleton tabVisibilitySingleton,
     bool isArConnect = false,
     bool useTurbo = false,
   }) async {
@@ -64,14 +66,16 @@ class BundleUploadHandle implements UploadHandle {
 
     late DataBundle bundle;
     try {
-      bundle =
-          await safeArConnectAction<DataBundle>((_) => DataBundle.fromHandles(
-                parallelize: !isArConnect,
-                handles: List.castFrom<FileDataItemUploadHandle,
-                        DataItemHandle>(fileDataItemUploadHandles) +
-                    List.castFrom<FolderDataItemUploadHandle, DataItemHandle>(
-                        folderDataItemUploadHandles),
-              ));
+      bundle = await safeArConnectAction<DataBundle>(
+        tabVisibilitySingleton,
+        (_) => DataBundle.fromHandles(
+          parallelize: !isArConnect,
+          handles: List.castFrom<FileDataItemUploadHandle, DataItemHandle>(
+                  fileDataItemUploadHandles) +
+              List.castFrom<FolderDataItemUploadHandle, DataItemHandle>(
+                  folderDataItemUploadHandles),
+        ),
+      );
     } catch (e) {
       logger.e('Error while preparing bundle: $e');
       hasError = true;

--- a/lib/core/arconnect/safe_arconnect_action.dart
+++ b/lib/core/arconnect/safe_arconnect_action.dart
@@ -1,8 +1,11 @@
-import 'package:ardrive/utils/html/implementations/html_web.dart';
+import 'package:ardrive/utils/html/html_util.dart';
 import 'package:ardrive/utils/logger/logger.dart';
 
-Future<R> safeArConnectAction<R>(Future<R> Function(dynamic) action,
-    [dynamic args]) async {
+Future<R> safeArConnectAction<R>(
+  TabVisibilitySingleton tabVisibility,
+  Future<R> Function(dynamic) action, [
+  dynamic args,
+]) async {
   try {
     logger.d('Calling action');
     R result = await action(args);
@@ -15,16 +18,16 @@ Future<R> safeArConnectAction<R>(Future<R> Function(dynamic) action,
 
     late R result;
 
-    if (!isTabFocused()) {
+    if (!tabVisibility.isTabFocused()) {
       logger.i(
         'Preparing snapshot transaction while user is not focusing the tab. Waiting...',
       );
       logger.e('Error preparing bundle', e);
 
-      await onTabGetsFocusedFuture(() async {
+      await tabVisibility.onTabGetsFocusedFuture(() async {
         logger.i('Preparing bundle after get the focus...');
 
-        result = await safeArConnectAction(action, args);
+        result = await safeArConnectAction(tabVisibility, action, args);
       });
 
       logger.i('Preparing bundle after get the focus... Done');

--- a/lib/core/upload/bundle_signer.dart
+++ b/lib/core/upload/bundle_signer.dart
@@ -75,17 +75,21 @@ class ArweaveBundleTransactionSigner implements BundleTransactionSigner {
 }
 
 class SafeArConnectSigner<T> extends BundleSigner<T> {
-  final TabVisibilitySingleton tabVisibilitySingleton =
-      TabVisibilitySingleton();
+  final TabVisibilitySingleton _tabVisibilitySingleton;
 
   final BundleSigner bundleSigner;
 
-  SafeArConnectSigner(this.bundleSigner);
+  SafeArConnectSigner(this.bundleSigner,
+      {TabVisibilitySingleton? tabVisibility})
+      : _tabVisibilitySingleton = tabVisibility ?? TabVisibilitySingleton();
 
   @override
   Future<T> signBundle({required DataBundle unSignedBundle}) async {
-    final T signedItem = await safeArConnectAction<T>((_) async =>
-        await bundleSigner.signBundle(unSignedBundle: unSignedBundle));
+    final T signedItem = await safeArConnectAction<T>(
+      _tabVisibilitySingleton,
+      (_) async =>
+          await bundleSigner.signBundle(unSignedBundle: unSignedBundle),
+    );
 
     return signedItem;
   }

--- a/lib/core/upload/transaction_signer.dart
+++ b/lib/core/upload/transaction_signer.dart
@@ -107,6 +107,7 @@ class SafeArConnectTransactionSigner extends ArweaveTransactionSigner {
     required FileEntity entity,
   }) async {
     final signedItem = await safeArConnectAction(
+      tabVisibilitySingleton,
       (_) => super.signTransaction(
         isPrivate: isPrivate,
         file: file,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -265,6 +265,7 @@ class AppState extends State<App> {
                   turboUploadService: context.read<TurboUploadService>(),
                   profileDao: context.read<ProfileDao>(),
                   db: context.read<Database>(),
+                  tabVisibilitySingleton: TabVisibilitySingleton(),
                 ),
               ),
               BlocProvider(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -107,6 +107,7 @@ Future<void> _initialize() async {
   );
   _turboUpload = config.useTurboUpload
       ? TurboUploadService(
+          tabVisibilitySingleton: TabVisibilitySingleton(),
           turboUploadUri: Uri.parse(config.defaultTurboUploadUrl!),
           allowedDataItemSize: config.allowedDataItemSizeForTurbo!,
           httpClient: ArDriveHTTP(),

--- a/lib/services/turbo/upload_service.dart
+++ b/lib/services/turbo/upload_service.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:ardrive/core/arconnect/safe_arconnect_action.dart';
 import 'package:ardrive/utils/data_item_utils.dart';
+import 'package:ardrive/utils/html/html_util.dart';
 import 'package:ardrive/utils/logger/logger.dart';
 import 'package:ardrive/utils/turbo_utils.dart';
 import 'package:ardrive_http/ardrive_http.dart';
@@ -13,12 +14,14 @@ class TurboUploadService {
   final Uri turboUploadUri;
   final int allowedDataItemSize;
   ArDriveHTTP httpClient;
+  final TabVisibilitySingleton _tabVisibility;
 
   TurboUploadService({
     required this.turboUploadUri,
     required this.allowedDataItemSize,
     required this.httpClient,
-  });
+    required TabVisibilitySingleton tabVisibilitySingleton,
+  }) : _tabVisibility = tabVisibilitySingleton;
 
   Stream<double> postDataItemWithProgress({
     required DataItem dataItem,
@@ -57,9 +60,11 @@ class TurboUploadService {
 
     final nonce = const Uuid().v4();
     final publicKey = await safeArConnectAction<String>(
+      _tabVisibility,
       (_) => wallet.getOwner(),
     );
     final signature = await safeArConnectAction<String>(
+      _tabVisibility,
       (_) => signNonceAndData(
         nonce: nonce,
         wallet: wallet,
@@ -120,4 +125,7 @@ class DontUseUploadService implements TurboUploadService {
     // TODO: implement postDataItemWithProgress
     throw UnimplementedError();
   }
+
+  @override
+  TabVisibilitySingleton get _tabVisibility => throw UnimplementedError();
 }


### PR DESCRIPTION
TODO - we have to cleanup html_utils.dart in order to avoid this kind of confusion: we cannot use the JS implementations directly in the code because they will throw in non-JS platforms.

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/6dq855tgj7v1g
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/086ubcdd5qfbg