### PR TITLE
feat(topup dialog): remove leading zeroes from the custom amount

### DIFF
--- a/lib/components/top_up_dialog.dart
+++ b/lib/components/top_up_dialog.dart
@@ -441,9 +441,13 @@ class _PresetAmountSelectorState extends State<PresetAmountSelector> {
                     keyboardType: TextInputType.number,
                     inputFormatters: [
                       TextInputFormatter.withFunction((oldValue, newValue) {
-                        // Remove any non-digit character
-                        String newValueText =
-                            newValue.text.replaceAll(RegExp(r'\D'), '');
+                        String newValueText = newValue.text
+                            // Remove any non-digit character
+                            .replaceAll(RegExp(r'\D'), '')
+                            // Replace multiple zeroes with a single one
+                            .replaceAll(RegExp(r'^0+$'), '0')
+                            // Remove any leading zeroes
+                            .replaceAll(RegExp(r'^0+(?=[^0])'), '');
 
                         if (newValueText.isNotEmpty) {
                           int valueAsInt = int.parse(newValueText);


### PR DESCRIPTION
Suggestion to avoid typing as many zeros as they want in the Custom Amount field.

### Before
https://github.com/ardriveapp/ardrive-web/assets/22564541/f39b67fa-45eb-4d0b-8d0a-2ddc6cc8f490

### After

https://github.com/ardriveapp/ardrive-web/assets/22564541/d1400301-f99c-4d86-a11d-389c6bfa4266


