### PR TITLE
PE-4225: Change wording for the "session expired" message of turbo top-up

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -485,6 +485,8 @@
   "@dragAndDropDescription": {
     "description": "text of description drag and drop"
   },
+  "driveDoingInitialSetupMessage": "Your drive is doing it's initial setup. This may take a few minutes. Please wait before taking any action.",
+  "@driveDoingInitialSetupMessage": {},
   "driveID": "Drive ID",
   "@driveID": {
     "description": "The Drive-ID tag"
@@ -1662,7 +1664,7 @@
   "@turboErrorMessageNetwork": {},
   "turboErrorMessageServer": "The payment was not successful. Please check your card information and try again.",
   "@turboErrorMessageServer": {},
-  "turboErrorMessageSessionExpired": "Your session has expired. Please try again.",
+  "turboErrorMessageSessionExpired": "Your Turbo session has expired. Please try again.",
   "@turboErrorMessageSessionExpired": {},
   "turboErrorMessageUnknown": "The payment was not successful. Please check your card information and try again.",
   "@turboErrorMessageUnknown": {},

--- a/lib/l10n/app_zh-HK.arb
+++ b/lib/l10n/app_zh-HK.arb
@@ -1,5 +1,5 @@
 {
-  "@@locale": "zh_HK",
+  "@@locale": "zh-HK",
   "addnewManifestEmphasized": "新增資訊清單",
   "@addnewManifestEmphasized": {
     "description": "There is a non-manifest entity with the same name"

--- a/lib/l10n/app_zh-HK.arb
+++ b/lib/l10n/app_zh-HK.arb
@@ -1,5 +1,5 @@
 {
-  "@@locale": "zh-HK",
+  "@@locale": "zh_HK",
   "addnewManifestEmphasized": "新增資訊清單",
   "@addnewManifestEmphasized": {
     "description": "There is a non-manifest entity with the same name"


### PR DESCRIPTION
Exported the most recent translations from Localizely

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/2le7flvq1ulco
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/0h3qfoe4cnieg