### PR TITLE
PE-4226: Too frequent syncs are triggered for a wallet with no drives

### DIFF
--- a/lib/blocs/sync/sync_cubit.dart
+++ b/lib/blocs/sync/sync_cubit.dart
@@ -256,8 +256,8 @@ class SyncCubit extends Cubit<SyncState> {
 
       if (drives.isEmpty) {
         _syncProgress = SyncProgress.emptySyncCompleted();
-
         syncProgressController.add(_syncProgress);
+        _lastSync = DateTime.now();
 
         emit(SyncIdle());
 


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/32qt7hjb4qr9o
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/5dfkimroigr78