### PR TITLE
PE-4228: change equal symbol to estimate symbol

### DIFF
--- a/lib/components/top_up_dialog.dart
+++ b/lib/components/top_up_dialog.dart
@@ -689,9 +689,24 @@ class PriceEstimateView extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             const Divider(height: 32),
-            Text(
-              '$fiatCurrency $fiatAmount = ${convertCreditsToLiteralString(estimatedCredits)} ${appLocalizationsOf(context).credits} = $estimatedStorage $storageUnit',
-              style: ArDriveTypography.body.buttonNormalBold(),
+            Row(
+              children: [
+                Text(
+                  '$fiatCurrency $fiatAmount = ${convertCreditsToLiteralString(estimatedCredits)} ${appLocalizationsOf(context).credits}',
+                  style: ArDriveTypography.body.buttonNormalBold(),
+                ),
+                Transform.translate(
+                  offset: const Offset(0, 4),
+                  child: Text(
+                    ' ~ ',
+                    style: ArDriveTypography.body.buttonNormalBold(),
+                  ),
+                ),
+                Text(
+                  '$estimatedStorage $storageUnit',
+                  style: ArDriveTypography.body.buttonNormalBold(),
+                ),
+              ],
             ),
             const SizedBox(height: 4),
             ArDriveClickArea(


### PR DESCRIPTION
<img width="265" alt="image" src="https://github.com/ardriveapp/ardrive-web/assets/9200155/cee087e6-6e62-46f2-ba48-733ed2f5e0c9">


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/17u6jn0cd85r8
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/4jq38kq3v1e2g