### PR TITLE
PE-4230: capitalize credits word

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -364,7 +364,7 @@
   "@creditCard": {},
   "credits": "Credits",
   "@credits": {},
-  "creditsTurbo": "credits",
+  "creditsTurbo": "Credits",
   "@creditsTurbo": {
     "description": "suffix for turbo balance"
   },
@@ -1650,7 +1650,7 @@
   "@tryOnAnotherDevice": {
     "description": "Screen not supported page"
   },
-  "turboAddCreditsBlurb": "Add credits using your card for faster uploads.",
+  "turboAddCreditsBlurb": "Add Credits using your card for faster uploads.",
   "@turboAddCreditsBlurb": {
     "description": "text placeholder for turbo balance when no user"
   },
@@ -1896,7 +1896,7 @@
   "@yourChoice": {
     "description": "User can choose whether or not to make the content public"
   },
-  "yourCreditsWillBeAddedToYourAccount": "Your credits will be added to your account soon. You can close this window.",
+  "yourCreditsWillBeAddedToYourAccount": "Your Credits will be added to your account soon. You can close this window.",
   "@yourCreditsWillBeAddedToYourAccount": {},
   "yourPrivateSecureAndPermanentDrive": "Your private, secure, and permanent hard drive.",
   "@yourPrivateSecureAndPermanentDrive": {


### PR DESCRIPTION
<img width="504" alt="image" src="https://github.com/ardriveapp/ardrive-web/assets/9200155/85410273-072e-487f-9221-181758459aa7">
<img width="269" alt="image" src="https://github.com/ardriveapp/ardrive-web/assets/9200155/061b49e5-e7a9-4add-b620-df3b19da27a6">

Translations also updated in Localizely

--- Releases ---
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/54c37bn81sotg
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/5nd7ma2enkdj8