### PR TITLE
PE-4274: bump version and android release notes

### DIFF
--- a/android/fastlane/metadata/android/en-US/changelogs/52.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/52.txt
@@ -1,0 +1,2 @@
+- After adding Turbo balance, the upload modal automatically updates to reflect the new balance and enables Turbo selection.
+- Fixes an issue on Create Manifest using Light Mode

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Secure, permanent storage
 
 publish_to: 'none'
 
-version: 2.6.0
+version: 2.6.1
 
 environment:
   sdk: '>=2.18.5 <3.0.0'


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/3cnta7vo77428
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/21307k47r7l8o