### PR TITLE
PE-4275: fixes the issue when the unlock page is displayed when the user has only public drives

### DIFF
--- a/lib/authentication/ardrive_auth.dart
+++ b/lib/authentication/ardrive_auth.dart
@@ -20,6 +20,7 @@ import '../core/crypto/crypto.dart';
 abstract class ArDriveAuth {
   Future<bool> isUserLoggedIn();
   Future<bool> isExistingUser(Wallet wallet);
+  Future<bool> userHasPassword(Wallet wallet);
   Future<User> login(Wallet wallet, String password, ProfileType profileType);
   Future<User> unlockWithBiometrics({required String localizedReason});
   Future<User> unlockUser({required String password});
@@ -304,6 +305,17 @@ class _ArDriveAuth implements ArDriveAuth {
   @override
   Future<bool> isBiometricsEnabled() {
     return _biometricAuthentication.isEnabled();
+  }
+
+  /// To have at least a single private drive means the user has set a password.
+  @override
+  Future<bool> userHasPassword(Wallet wallet) async {
+    final firstDrivePrivateDriveTxId = await _arweave.getFirstPrivateDriveTxId(
+      wallet,
+      maxRetries: profileQueryMaxRetries,
+    );
+
+    return firstDrivePrivateDriveTxId != null;
   }
 }
 

--- a/lib/authentication/login/blocs/login_bloc.dart
+++ b/lib/authentication/login/blocs/login_bloc.dart
@@ -116,7 +116,7 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
       final wallet =
           Wallet.fromJwk(json.decode(await event.walletFile.readAsString()));
 
-      if (await _arDriveAuth.isExistingUser(wallet)) {
+      if (await _arDriveAuth.userHasPassword(wallet)) {
         emit(PromptPassword(walletFile: wallet));
       } else {
         emit(LoginOnBoarding(wallet));
@@ -228,7 +228,7 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
 
       lastKnownWalletAddress = await wallet.getAddress();
 
-      if (await _arDriveAuth.isExistingUser(wallet)) {
+      if (await _arDriveAuth.userHasPassword(wallet)) {
         emit(PromptPassword(walletFile: wallet));
       } else {
         emit(LoginOnBoarding(wallet));
@@ -376,7 +376,7 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
     profileType = ProfileType.json;
 
     try {
-      if (await _arDriveAuth.isExistingUser(wallet)) {
+      if (await _arDriveAuth.userHasPassword(wallet)) {
         emit(PromptPassword(walletFile: wallet));
       } else {
         emit(LoginOnBoarding(wallet));

--- a/test/authentication/ardrive_auth_test.dart
+++ b/test/authentication/ardrive_auth_test.dart
@@ -16,7 +16,7 @@ class TransactionCommonMixinFake extends Fake
     implements TransactionCommonMixin {}
 
 void main() {
-  late ArDriveAuth arDriveAuth;
+  late ArDriveAuthImpl arDriveAuth;
   late MockArweaveService mockArweaveService;
   late MockUserRepository mockUserRepository;
   late MockArDriveCrypto mockArDriveCrypto;
@@ -40,7 +40,7 @@ void main() {
       await newMemoryCacheStore(),
     );
 
-    arDriveAuth = ArDriveAuth(
+    arDriveAuth = ArDriveAuthImpl(
       arweave: mockArweaveService,
       userRepository: mockUserRepository,
       crypto: mockArDriveCrypto,
@@ -130,6 +130,85 @@ void main() {
 
       // assert
       expect(hasPassword, false);
+    });
+  });
+
+  group('testing if getFirstPrivateDriveTxId is called only once', () {
+    final loggedUser = User(
+      password: 'password',
+      wallet: wallet,
+      walletAddress: 'walletAddress',
+      walletBalance: BigInt.one,
+      cipherKey: SecretKey([]),
+      profileType: ProfileType.json,
+    );
+
+    /// For this test we'll call the same method twice to validate if the
+    /// getFirstPrivateDriveTxId is called only once
+
+    test(
+        'should call getFirstPrivateDriveTxId only once when has private drives and login with sucess. ',
+        () async {
+      // arrange
+      when(() => mockArweaveService.getFirstPrivateDriveTxId(wallet,
+              maxRetries: any(named: 'maxRetries')))
+          .thenAnswer((_) async => 'some_id');
+
+      // biometrics is not enabled
+      when(() => mockBiometricAuthentication.isEnabled())
+          .thenAnswer((_) async => false);
+
+      // mock cripto derive drive key
+      when(
+        () => mockArDriveCrypto.deriveDriveKey(
+          wallet,
+          any(),
+          any(),
+        ),
+      ).thenAnswer((invocation) => Future.value(SecretKey([])));
+
+      when(() => mockUserRepository.hasUser())
+          .thenAnswer((invocation) => Future.value(true));
+
+      when(() => mockArweaveService.getLatestDriveEntityWithId(
+              any(), any(), any()))
+          .thenAnswer((invocation) => Future.value(DriveEntity(
+                id: 'some_id',
+                rootFolderId: 'some_id',
+              )));
+
+      when(() => mockUserRepository.deleteUser())
+          .thenAnswer((invocation) async {});
+
+      when(() =>
+              mockUserRepository.saveUser('password', ProfileType.json, wallet))
+          .thenAnswer((invocation) => Future.value(null));
+
+      when(() => mockUserRepository.getUser('password'))
+          .thenAnswer((invocation) async => loggedUser);
+
+      // act
+      await arDriveAuth.login(wallet, 'password', ProfileType.json);
+      await arDriveAuth.login(wallet, 'password', ProfileType.json);
+
+      // assert
+      verify(() => mockArweaveService.getFirstPrivateDriveTxId(wallet,
+          maxRetries: any(named: 'maxRetries'))).called(1);
+    });
+
+    test(
+        'should call getFirstPrivateDriveTxId only once when has private drives and login with sucess. ',
+        () async {
+      when(() => mockArweaveService.getFirstPrivateDriveTxId(wallet,
+              maxRetries: any(named: 'maxRetries')))
+          .thenAnswer((_) async => 'some_id');
+      // act
+      await arDriveAuth.userHasPassword(wallet);
+      await arDriveAuth.userHasPassword(wallet);
+
+      // assert
+      verify(() => mockArweaveService.getFirstPrivateDriveTxId(wallet,
+          maxRetries: any(named: 'maxRetries'))).called(1);
     });
   });
 
@@ -408,6 +487,8 @@ void main() {
     });
   });
 
+  group('testing if getFirstPrivateDriveTxId is called only once', () {});
+
   group('testing ArDriveAuth logout method', () {
     final unlockedUser = User(
       password: 'password',
@@ -442,12 +523,13 @@ void main() {
       await arDriveAuth.logout();
 
       // assert
+      expect(() => arDriveAuth.currentUser,
+          throwsA(isA<AuthenticationUserIsNotLoggedInException>()));
+      expect(arDriveAuth.firstPrivateDriveTxId, isNull);
       verify(() => mockSecureKeyValueStore.remove('password')).called(1);
       verify(() => mockSecureKeyValueStore.remove('biometricEnabled'))
           .called(1);
       verify(() => mockDatabaseHelpers.deleteAllTables()).called(1);
-      expect(() => arDriveAuth.currentUser,
-          throwsA(isA<AuthenticationUserIsNotLoggedInException>()));
     });
 
     /// This is for the case when has user is true but the user is not logged in
@@ -470,6 +552,78 @@ void main() {
       verify(() => mockDatabaseHelpers.deleteAllTables()).called(1);
       expect(() => arDriveAuth.currentUser,
           throwsA(isA<AuthenticationUserIsNotLoggedInException>()));
+    });
+
+    test('testing login + logout', () async {
+      final loggedUser = User(
+        password: 'password',
+        wallet: wallet,
+        walletAddress: 'walletAddress',
+        walletBalance: BigInt.one,
+        cipherKey: SecretKey([]),
+        profileType: ProfileType.json,
+      );
+      // arrange login
+      when(() => mockArweaveService.getFirstPrivateDriveTxId(wallet,
+              maxRetries: any(named: 'maxRetries')))
+          .thenAnswer((_) async => 'some_id');
+
+      // biometrics is not enabled
+      when(() => mockBiometricAuthentication.isEnabled())
+          .thenAnswer((_) async => false);
+
+      // mock cripto derive drive key
+      when(
+        () => mockArDriveCrypto.deriveDriveKey(
+          wallet,
+          any(),
+          any(),
+        ),
+      ).thenAnswer((invocation) => Future.value(SecretKey([])));
+
+      when(() => mockUserRepository.hasUser())
+          .thenAnswer((invocation) => Future.value(true));
+
+      when(() => mockArweaveService.getLatestDriveEntityWithId(
+              any(), any(), any()))
+          .thenAnswer((invocation) => Future.value(DriveEntity(
+                id: 'some_id',
+                rootFolderId: 'some_id',
+              )));
+
+      when(() => mockUserRepository.deleteUser())
+          .thenAnswer((invocation) async {});
+
+      when(() =>
+              mockUserRepository.saveUser('password', ProfileType.json, wallet))
+          .thenAnswer((invocation) => Future.value(null));
+
+      when(() => mockUserRepository.getUser('password'))
+          .thenAnswer((invocation) async => loggedUser);
+
+      /// arrange logout
+      when(() => mockUserRepository.deleteUser())
+          .thenAnswer((invocation) async {});
+      when(() => mockSecureKeyValueStore.remove('password'))
+          .thenAnswer((invocation) => Future.value(true));
+      when(() => mockSecureKeyValueStore.remove('biometricEnabled'))
+          .thenAnswer((invocation) => Future.value(true));
+      when(() => mockDatabaseHelpers.deleteAllTables())
+          .thenAnswer((invocation) async {});
+
+      await arDriveAuth.login(wallet, 'password', ProfileType.json);
+
+      await arDriveAuth.logout();
+
+      /// verifies that we cleaned up the user
+      expect(arDriveAuth.firstPrivateDriveTxId, isNull);
+      expect(() => arDriveAuth.currentUser,
+          throwsA(isA<AuthenticationUserIsNotLoggedInException>()));
+      verify(() => mockSecureKeyValueStore.remove('password')).called(1);
+      verify(() => mockSecureKeyValueStore.remove('biometricEnabled'))
+          .called(1);
+      verify(() => mockDatabaseHelpers.deleteAllTables()).called(1);
+      verify(() => mockUserRepository.deleteUser()).called(1);
     });
   });
 

--- a/test/authentication/ardrive_auth_test.dart
+++ b/test/authentication/ardrive_auth_test.dart
@@ -105,6 +105,33 @@ void main() {
       expect(isExisting, false);
     });
   });
+  group('ArDriveAuth testing userHasPassword method', () {
+    // test
+    test('Should return true when user has a private drive', () async {
+      // arrange
+      when(() => mockArweaveService.getFirstPrivateDriveTxId(wallet,
+              maxRetries: any(named: 'maxRetries')))
+          .thenAnswer((_) async => 'some_id');
+      // act
+      final hasPassword = await arDriveAuth.userHasPassword(wallet);
+
+      // assert
+      expect(hasPassword, true);
+    });
+
+    test(
+        'Should return false when user does not created a password yet when they dont have any ',
+        () async {
+      // arrange
+      when(() => mockArweaveService.getFirstPrivateDriveTxId(wallet,
+          maxRetries: any(named: 'maxRetries'))).thenAnswer((_) async => null);
+      // act
+      final hasPassword = await arDriveAuth.userHasPassword(wallet);
+
+      // assert
+      expect(hasPassword, false);
+    });
+  });
 
   group('ArDriveAuth testing login method without biometrics', () {
     final loggedUser = User(

--- a/test/authentication/login/blocs/login_bloc_test.dart
+++ b/test/authentication/login/blocs/login_bloc_test.dart
@@ -41,7 +41,7 @@ void main() {
         );
       },
       setUp: () {
-        when(() => mockArDriveAuth.isExistingUser(any()))
+        when(() => mockArDriveAuth.userHasPassword(any()))
             .thenAnswer((_) async => true);
       },
       act: (bloc) async {
@@ -66,7 +66,7 @@ void main() {
       },
       setUp: () {
         // user doesn't exist
-        when(() => mockArDriveAuth.isExistingUser(any()))
+        when(() => mockArDriveAuth.userHasPassword(any()))
             .thenAnswer((_) async => false);
       },
       act: (bloc) async {
@@ -566,7 +566,7 @@ void main() {
             .thenAnswer((invocation) => Future.value(true));
         when(() => mockArConnectService.getWalletAddress())
             .thenAnswer((invocation) => Future.value('walletAddress'));
-        when(() => mockArDriveAuth.isExistingUser(any()))
+        when(() => mockArDriveAuth.userHasPassword(any()))
             .thenAnswer((invocation) => Future.value(true));
       },
       act: (bloc) async {
@@ -591,7 +591,7 @@ void main() {
         when(() => mockArConnectService.getWalletAddress())
             .thenAnswer((invocation) => Future.value('walletAddress'));
         // new user
-        when(() => mockArDriveAuth.isExistingUser(any()))
+        when(() => mockArDriveAuth.userHasPassword(any()))
             .thenAnswer((invocation) => Future.value(false));
       },
       act: (bloc) async {


### PR DESCRIPTION
- implements `userHasPassword` method to verify if the user has created at least a single private drive.
- Shows the onboarding if the user has drives or not but no private drives

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/190rpfkooohdg
iOS release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:ios:06ea33a95a2e0d42ffce07/releases/0b70saavbvnfg