### PR TITLE
PE-4243: Replicate checkbox line functionality on review page

### DIFF
--- a/lib/turbo/topup/views/topup_review_view.dart
+++ b/lib/turbo/topup/views/topup_review_view.dart
@@ -488,60 +488,55 @@ class _TurboReviewViewState extends State<TurboReviewView> {
                             _emailChecked &&
                             _emailController.text.isNotEmpty,
                       ),
-                      Row(
-                        children: [
-                          ArDriveCheckBox(
-                            title: '',
-                            checked: _isTermsChecked,
-                            onChange: ((value) {
-                              setState(() => _isTermsChecked = value);
-                            }),
-                          ),
-                          Flexible(
-                            child: Text.rich(
-                              TextSpan(
-                                children: splitTranslationsWithMultipleStyles<
-                                    InlineSpan>(
-                                  originalText: appLocalizationsOf(context)
-                                      .aggreeToTerms_body,
-                                  defaultMapper: (text) => TextSpan(
-                                    text: text,
-                                    style:
-                                        ArDriveTypography.body.buttonNormalBold(
-                                      color: ArDriveTheme.of(context)
-                                          .themeData
-                                          .colors
-                                          .themeFgDefault,
-                                    ),
+                      ArDriveCheckBox(
+                        titleWidget: Flexible(
+                          child: Text.rich(
+                            TextSpan(
+                              children: splitTranslationsWithMultipleStyles<
+                                  InlineSpan>(
+                                originalText: appLocalizationsOf(context)
+                                    .aggreeToTerms_body,
+                                defaultMapper: (text) => TextSpan(
+                                  text: text,
+                                  style:
+                                      ArDriveTypography.body.buttonNormalBold(
+                                    color: ArDriveTheme.of(context)
+                                        .themeData
+                                        .colors
+                                        .themeFgDefault,
                                   ),
-                                  parts: {
-                                    appLocalizationsOf(context).aggreeToTerms_link:
-                                        (text) => TextSpan(
-                                              text: text,
-                                              style: ArDriveTypography.body
-                                                  .buttonNormalBold(
-                                                    color:
-                                                        ArDriveTheme.of(context)
-                                                            .themeData
-                                                            .colors
-                                                            .themeFgDefault,
-                                                  )
-                                                  .copyWith(
-                                                    decoration: TextDecoration
-                                                        .underline,
-                                                  ),
-                                              recognizer: TapGestureRecognizer()
-                                                ..onTap = () => openUrl(
-                                                      url: Resources
-                                                          .agreementLink,
-                                                    ),
-                                            ),
-                                  },
                                 ),
+                                parts: {
+                                  appLocalizationsOf(context).aggreeToTerms_link:
+                                      (text) => TextSpan(
+                                            text: text,
+                                            style: ArDriveTypography.body
+                                                .buttonNormalBold(
+                                                  color:
+                                                      ArDriveTheme.of(context)
+                                                          .themeData
+                                                          .colors
+                                                          .themeFgDefault,
+                                                )
+                                                .copyWith(
+                                                  decoration:
+                                                      TextDecoration.underline,
+                                                ),
+                                            recognizer: TapGestureRecognizer()
+                                              ..onTap = () => openUrl(
+                                                    url:
+                                                        Resources.agreementLink,
+                                                  ),
+                                          ),
+                                },
                               ),
                             ),
                           ),
-                        ],
+                        ),
+                        checked: _isTermsChecked,
+                        onChange: ((value) {
+                          setState(() => _isTermsChecked = value);
+                        }),
                       ),
                       const Divider(
                         height: 80,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -87,11 +87,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: PE-4295-update-label-color-of-ar-drive-text-field
-      resolved-ref: "8bbb34d41f60b990018c933ae1eea8e5189724a7"
+      ref: PE-4243-replicate-checkbox-line-functionality
+      resolved-ref: b32da9c1397de7f5b58563df58165c416cee9058
       url: "https://github.com/ar-io/ardrive_ui.git"
     source: git
-    version: "1.5.1"
+    version: "1.5.0"
   args:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   ardrive_ui:
     git:
       url: https://github.com/ar-io/ardrive_ui.git
-      ref: PE-4295-update-label-color-of-ar-drive-text-field
+      ref: PE-4243-replicate-checkbox-line-functionality
   artemis: ^7.0.0-beta.13
   arweave:
     git:


### PR DESCRIPTION
- use `titleWidget` on checkbox at the review page
- use fixed version of ardrive_ui


https://github.com/ardriveapp/ardrive-web/assets/32248947/f726a31d-6991-4b45-8ab8-5ddabae0491a



--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/64m3kltsufs8g