### PR TITLE
PE-4359: Disable option for pin, snapshot and manifest if drive is readonly

### DIFF
--- a/lib/components/new_button/new_button.dart
+++ b/lib/components/new_button/new_button.dart
@@ -214,7 +214,9 @@ class NewButton extends StatelessWidget {
                 drive: drive!,
               );
             },
-            isDisabled: driveDetailState.driveIsEmpty || !canUpload,
+            isDisabled: !driveDetailState.hasWritePermissions ||
+                driveDetailState.driveIsEmpty ||
+                !canUpload,
             name: appLocalizations.createManifest,
             icon: ArDriveIcons.tournament(size: defaultIconSize),
           ),
@@ -228,7 +230,8 @@ class NewButton extends StatelessWidget {
                 drive!,
               );
             },
-            isDisabled: driveDetailState.driveIsEmpty ||
+            isDisabled: !driveDetailState.hasWritePermissions ||
+                driveDetailState.driveIsEmpty ||
                 !profile.hasMinimumBalanceForUpload(
                   minimumWalletBalance: minimumWalletBalance,
                 ),
@@ -243,7 +246,7 @@ class NewButton extends StatelessWidget {
             name: appLocalizationsOf(context).newFilePin,
             icon: ArDriveIcons.arconnectIcon1(size: defaultIconSize),
             onClick: () => showPinFileDialog(context: context),
-            isDisabled: drive == null,
+            isDisabled: !driveDetailState.hasWritePermissions || drive == null,
           ),
       ];
     } else {
@@ -332,7 +335,9 @@ class NewButton extends StatelessWidget {
                 drive: drive!,
               );
             },
-            isDisabled: driveDetailState.driveIsEmpty || !canUpload,
+            isDisabled: !driveDetailState.hasWritePermissions ||
+                driveDetailState.driveIsEmpty ||
+                !canUpload,
             name: appLocalizations.createManifest,
             icon: ArDriveIcons.tournament(size: defaultIconSize),
           ),
@@ -346,7 +351,8 @@ class NewButton extends StatelessWidget {
                 drive!,
               );
             },
-            isDisabled: driveDetailState.driveIsEmpty ||
+            isDisabled: !driveDetailState.hasWritePermissions ||
+                driveDetailState.driveIsEmpty ||
                 !profile.hasMinimumBalanceForUpload(
                   minimumWalletBalance: minimumWalletBalance,
                 ),
@@ -364,7 +370,7 @@ class NewButton extends StatelessWidget {
               color: ArDriveTheme.of(context).themeData.colors.themeFgMuted,
             ),
             onClick: () => showPinFileDialog(context: context),
-            isDisabled: drive == null,
+            isDisabled: !driveDetailState.hasWritePermissions || drive == null,
           ),
       ];
     } else {

--- a/lib/components/new_button/new_button.dart
+++ b/lib/components/new_button/new_button.dart
@@ -244,7 +244,7 @@ class NewButton extends StatelessWidget {
             drive?.privacy == 'public')
           ArDriveNewButtonItem(
             name: appLocalizationsOf(context).newFilePin,
-            icon: ArDriveIcons.arconnectIcon1(size: defaultIconSize),
+            icon: ArDriveIcons.pinWithCircle(size: defaultIconSize),
             onClick: () => showPinFileDialog(context: context),
             isDisabled: !driveDetailState.hasWritePermissions || drive == null,
           ),


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/6hh134cc8hrko