### PR TITLE
PE-4420: implement-multiple-downloads-for-files

### DIFF
--- a/lib/blocs/file_download/file_download_state.dart
+++ b/lib/blocs/file_download/file_download_state.dart
@@ -76,4 +76,9 @@ class FileDownloadWarning extends FileDownloadState {
 
 class FileDownloadAborted extends FileDownloadState {}
 
-enum FileDownloadFailureReason { unknownError, fileAboveLimit }
+enum FileDownloadFailureReason {
+  unknownError,
+  fileAboveLimit,
+  networkConnectionError,
+  fileNotFound
+}

--- a/lib/blocs/upload/limits.dart
+++ b/lib/blocs/upload/limits.dart
@@ -6,7 +6,6 @@ final privateFileSizeLimit = const MiB(100).size;
 final mobilePrivateFileSizeLimit = const GiB(1).size;
 
 final publicFileSafeSizeLimit = const GiB(5).size;
-final publicDownloadSizeLimit = const GiB(1).size;
 
 final bundleSizeLimit = kIsWeb ? webBundleSizeLimit : mobileBundleSizeLimit;
 

--- a/lib/download/limits.dart
+++ b/lib/download/limits.dart
@@ -1,0 +1,5 @@
+import 'package:ardrive/utils/data_size.dart';
+
+// FIXME: need address size limits per browser (500 MiB for Chrome, 2 Gb for Firefox, 300 MiB for mobile)
+final publicDownloadSizeLimit = const MiB(500).size;
+final privateDownloadSizeLimit = const MiB(500).size;

--- a/lib/download/limits.dart
+++ b/lib/download/limits.dart
@@ -16,14 +16,14 @@ final privateDownloadFirefoxSizeLimit = const GiB(2).size;
 final privateDownloadMobileSizeLimit = const MiB(300).size;
 
 Future<int> calcDownloadSizeLimit(bool isPublic) async {
-  final info = await DeviceInfoPlugin().deviceInfo;
-  final isFirefox =
-      info is WebBrowserInfo && info.browserName == BrowserName.firefox;
-
   if (isPublic) {
     if (AppPlatform.isMobile) {
-      return publicDownloadWebSizeLimit;
+      return publicDownloadMobileSizeLimit;
     } else if (AppPlatform.getPlatform() == SystemPlatform.Web) {
+      final info = await DeviceInfoPlugin().deviceInfo;
+
+      final isFirefox =
+          info is WebBrowserInfo && info.browserName == BrowserName.firefox;
       return isFirefox
           ? publicDownloadFirefoxSizeLimit
           : publicDownloadWebSizeLimit;
@@ -32,8 +32,11 @@ Future<int> calcDownloadSizeLimit(bool isPublic) async {
     }
   } else {
     if (AppPlatform.isMobile) {
-      return privateDownloadWebSizeLimit;
+      return privateDownloadMobileSizeLimit;
     } else if (AppPlatform.getPlatform() == SystemPlatform.Web) {
+      final info = await DeviceInfoPlugin().deviceInfo;
+      final isFirefox =
+          info is WebBrowserInfo && info.browserName == BrowserName.firefox;
       return isFirefox
           ? privateDownloadFirefoxSizeLimit
           : privateDownloadWebSizeLimit;

--- a/lib/download/limits.dart
+++ b/lib/download/limits.dart
@@ -4,13 +4,12 @@ import 'package:device_info_plus/device_info_plus.dart';
 
 import '../utils/app_platform.dart';
 
-final publicDownloadDesktopSizeLimit = const GiB(2).size;
+final publicDownloadUnknownPlatformSizeLimit = const GiB(2).size;
 final publicDownloadWebSizeLimit = const MiB(500).size;
 final publicDownloadFirefoxSizeLimit = const GiB(2).size;
 final publicDownloadMobileSizeLimit = const MiB(300).size;
 
-// unlimited size, use 1000 GiB as a limit
-final privateDownloadDesktopSizeLimit = const GiB(2000).size;
+final privateDownloadUnknownPlatformSizeLimit = const GiB(2).size;
 final privateDownloadWebSizeLimit = const MiB(500).size;
 final privateDownloadFirefoxSizeLimit = const GiB(2).size;
 final privateDownloadMobileSizeLimit = const MiB(300).size;
@@ -18,9 +17,7 @@ final privateDownloadMobileSizeLimit = const MiB(300).size;
 Future<int> calcDownloadSizeLimit(bool isPublic,
     {DeviceInfoPlugin? deviceInfo}) async {
   if (isPublic) {
-    if (AppPlatform.isMobile) {
-      return publicDownloadMobileSizeLimit;
-    } else if (AppPlatform.getPlatform() == SystemPlatform.Web) {
+    if (AppPlatform.getPlatform() == SystemPlatform.Web) {
       final info = await (deviceInfo ?? DeviceInfoPlugin()).deviceInfo;
 
       final isFirefox =
@@ -28,21 +25,23 @@ Future<int> calcDownloadSizeLimit(bool isPublic,
       return isFirefox
           ? publicDownloadFirefoxSizeLimit
           : publicDownloadWebSizeLimit;
+    } else if (AppPlatform.isMobile) {
+      return publicDownloadMobileSizeLimit;
     } else {
-      return publicDownloadDesktopSizeLimit;
+      return publicDownloadUnknownPlatformSizeLimit;
     }
   } else {
-    if (AppPlatform.isMobile) {
-      return privateDownloadMobileSizeLimit;
-    } else if (AppPlatform.getPlatform() == SystemPlatform.Web) {
+    if (AppPlatform.getPlatform() == SystemPlatform.Web) {
       final info = await (deviceInfo ?? DeviceInfoPlugin()).deviceInfo;
       final isFirefox =
           info is WebBrowserInfo && info.browserName == BrowserName.firefox;
       return isFirefox
           ? privateDownloadFirefoxSizeLimit
           : privateDownloadWebSizeLimit;
+    } else if (AppPlatform.isMobile) {
+      return privateDownloadMobileSizeLimit;
     } else {
-      return privateDownloadDesktopSizeLimit;
+      return privateDownloadUnknownPlatformSizeLimit;
     }
   }
 }

--- a/lib/download/limits.dart
+++ b/lib/download/limits.dart
@@ -16,34 +16,38 @@ final privateDownloadMobileSizeLimit = const MiB(300).size;
 
 Future<int> calcDownloadSizeLimit(bool isPublic,
     {DeviceInfoPlugin? deviceInfo}) async {
-  if (isPublic) {
-    if (AppPlatform.getPlatform() == SystemPlatform.Web) {
-      final info = await (deviceInfo ?? DeviceInfoPlugin()).deviceInfo;
-
-      final isFirefox =
-          info is WebBrowserInfo && info.browserName == BrowserName.firefox;
-      return isFirefox
-          ? publicDownloadFirefoxSizeLimit
-          : publicDownloadWebSizeLimit;
-    } else if (AppPlatform.isMobile) {
-      return publicDownloadMobileSizeLimit;
-    } else {
-      return publicDownloadUnknownPlatformSizeLimit;
-    }
+  if (AppPlatform.getPlatform() == SystemPlatform.Web) {
+    return await _webDownloadLimit(isPublic, deviceInfo);
+  } else if (AppPlatform.isMobile) {
+    return _mobileLimit(isPublic);
   } else {
-    if (AppPlatform.getPlatform() == SystemPlatform.Web) {
-      final info = await (deviceInfo ?? DeviceInfoPlugin()).deviceInfo;
-      final isFirefox =
-          info is WebBrowserInfo && info.browserName == BrowserName.firefox;
-      return isFirefox
-          ? privateDownloadFirefoxSizeLimit
-          : privateDownloadWebSizeLimit;
-    } else if (AppPlatform.isMobile) {
-      return privateDownloadMobileSizeLimit;
-    } else {
-      return privateDownloadUnknownPlatformSizeLimit;
-    }
+    return _unknownPlatformLimit(isPublic);
   }
+}
+
+Future<int> _webDownloadLimit(
+    bool isPublic, DeviceInfoPlugin? deviceInfo) async {
+  if (isPublic) {
+    return await AppPlatform.isFireFox(deviceInfo: deviceInfo)
+        ? publicDownloadFirefoxSizeLimit
+        : publicDownloadWebSizeLimit;
+  }
+
+  return await AppPlatform.isFireFox(deviceInfo: deviceInfo)
+      ? privateDownloadFirefoxSizeLimit
+      : privateDownloadWebSizeLimit;
+}
+
+int _mobileLimit(bool isPublic) {
+  return isPublic
+      ? publicDownloadMobileSizeLimit
+      : privateDownloadMobileSizeLimit;
+}
+
+int _unknownPlatformLimit(bool isPublic) {
+  return isPublic
+      ? publicDownloadUnknownPlatformSizeLimit
+      : privateDownloadUnknownPlatformSizeLimit;
 }
 
 // TODO: extend to work drives and folders

--- a/lib/download/limits.dart
+++ b/lib/download/limits.dart
@@ -15,12 +15,13 @@ final privateDownloadWebSizeLimit = const MiB(500).size;
 final privateDownloadFirefoxSizeLimit = const GiB(2).size;
 final privateDownloadMobileSizeLimit = const MiB(300).size;
 
-Future<int> calcDownloadSizeLimit(bool isPublic) async {
+Future<int> calcDownloadSizeLimit(bool isPublic,
+    {DeviceInfoPlugin? deviceInfo}) async {
   if (isPublic) {
     if (AppPlatform.isMobile) {
       return publicDownloadMobileSizeLimit;
     } else if (AppPlatform.getPlatform() == SystemPlatform.Web) {
-      final info = await DeviceInfoPlugin().deviceInfo;
+      final info = await (deviceInfo ?? DeviceInfoPlugin()).deviceInfo;
 
       final isFirefox =
           info is WebBrowserInfo && info.browserName == BrowserName.firefox;
@@ -34,7 +35,7 @@ Future<int> calcDownloadSizeLimit(bool isPublic) async {
     if (AppPlatform.isMobile) {
       return privateDownloadMobileSizeLimit;
     } else if (AppPlatform.getPlatform() == SystemPlatform.Web) {
-      final info = await DeviceInfoPlugin().deviceInfo;
+      final info = await (deviceInfo ?? DeviceInfoPlugin()).deviceInfo;
       final isFirefox =
           info is WebBrowserInfo && info.browserName == BrowserName.firefox;
       return isFirefox
@@ -48,10 +49,12 @@ Future<int> calcDownloadSizeLimit(bool isPublic) async {
 
 // TODO: extend to work drives and folders
 Future<bool> isSizeAboveDownloadSizeLimit(
-    List<ARFSFileEntity> items, bool isPublic) async {
+    List<ARFSFileEntity> items, bool isPublic,
+    {DeviceInfoPlugin? deviceInfo}) async {
   final totalSize = items.map((e) => e.size).reduce((a, b) => a + b);
 
-  final sizeLimit = await calcDownloadSizeLimit(isPublic);
+  final sizeLimit =
+      await calcDownloadSizeLimit(isPublic, deviceInfo: deviceInfo);
 
   return totalSize > sizeLimit;
 }

--- a/lib/download/limits.dart
+++ b/lib/download/limits.dart
@@ -1,5 +1,54 @@
+import 'package:ardrive/core/arfs/entities/arfs_entities.dart';
 import 'package:ardrive/utils/data_size.dart';
+import 'package:device_info_plus/device_info_plus.dart';
 
-// FIXME: need address size limits per browser (500 MiB for Chrome, 2 Gb for Firefox, 300 MiB for mobile)
-final publicDownloadSizeLimit = const MiB(500).size;
-final privateDownloadSizeLimit = const MiB(500).size;
+import '../utils/app_platform.dart';
+
+final publicDownloadDesktopSizeLimit = const GiB(2).size;
+final publicDownloadWebSizeLimit = const MiB(500).size;
+final publicDownloadFirefoxSizeLimit = const GiB(2).size;
+final publicDownloadMobileSizeLimit = const MiB(300).size;
+
+// unlimited size, use 1000 GiB as a limit
+final privateDownloadDesktopSizeLimit = const GiB(2000).size;
+final privateDownloadWebSizeLimit = const MiB(500).size;
+final privateDownloadFirefoxSizeLimit = const GiB(2).size;
+final privateDownloadMobileSizeLimit = const MiB(300).size;
+
+Future<int> calcDownloadSizeLimit(bool isPublic) async {
+  final info = await DeviceInfoPlugin().deviceInfo;
+  final isFirefox =
+      info is WebBrowserInfo && info.browserName == BrowserName.firefox;
+
+  if (isPublic) {
+    if (AppPlatform.isMobile) {
+      return publicDownloadWebSizeLimit;
+    } else if (AppPlatform.getPlatform() == SystemPlatform.Web) {
+      return isFirefox
+          ? publicDownloadFirefoxSizeLimit
+          : publicDownloadWebSizeLimit;
+    } else {
+      return publicDownloadDesktopSizeLimit;
+    }
+  } else {
+    if (AppPlatform.isMobile) {
+      return privateDownloadWebSizeLimit;
+    } else if (AppPlatform.getPlatform() == SystemPlatform.Web) {
+      return isFirefox
+          ? privateDownloadFirefoxSizeLimit
+          : privateDownloadWebSizeLimit;
+    } else {
+      return privateDownloadDesktopSizeLimit;
+    }
+  }
+}
+
+// TODO: extend to work drives and folders
+Future<bool> isSizeAboveDownloadSizeLimit(
+    List<ARFSFileEntity> items, bool isPublic) async {
+  final totalSize = items.map((e) => e.size).reduce((a, b) => a + b);
+
+  final sizeLimit = await calcDownloadSizeLimit(isPublic);
+
+  return totalSize > sizeLimit;
+}

--- a/lib/download/multiple_download_bloc.dart
+++ b/lib/download/multiple_download_bloc.dart
@@ -9,6 +9,7 @@ import 'package:ardrive/services/arweave/arweave_service.dart';
 import 'package:ardrive/utils/logger/logger.dart';
 import 'package:ardrive_http/ardrive_http.dart';
 import 'package:cryptography/cryptography.dart';
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -26,6 +27,7 @@ class MultipleDownloadBloc
   final ARFSRepository _arfsRepository;
   final ArDriveCrypto _crypto;
   final SecretKey? _cipherKey;
+  final DeviceInfoPlugin? _deviceInfo;
 
   bool canceled = false;
   int currentFileIndex = 0;
@@ -43,6 +45,7 @@ class MultipleDownloadBloc
       required ArweaveService arweave,
       required ARFSRepository arfsRepository,
       required ArDriveCrypto crypto,
+      DeviceInfoPlugin? deviceInfo,
       SecretKey? cipherKey})
       : _downloadService = downloadService,
         _driveDao = driveDao,
@@ -50,6 +53,7 @@ class MultipleDownloadBloc
         _arfsRepository = arfsRepository,
         _crypto = crypto,
         _cipherKey = cipherKey,
+        _deviceInfo = deviceInfo,
         super(MultipleDownloadInitial()) {
     on<MultipleDownloadEvent>((event, emit) async {
       if (event is StartDownload) {
@@ -79,7 +83,8 @@ class MultipleDownloadBloc
     drive = await _arfsRepository.getDriveById(firstFile.driveId);
 
     if (await isSizeAboveDownloadSizeLimit(
-        items, drive.drivePrivacy == DrivePrivacy.public)) {
+        items, drive.drivePrivacy == DrivePrivacy.public,
+        deviceInfo: _deviceInfo)) {
       emit(
         const MultipleDownloadFailure(
           FileDownloadFailureReason.fileAboveLimit,

--- a/lib/download/multiple_download_bloc.dart
+++ b/lib/download/multiple_download_bloc.dart
@@ -31,7 +31,7 @@ class MultipleDownloadBloc
 
   bool _canceled = false;
   int _currentFileIndex = 0;
-  List<ARFSFileEntity> _skippedFiles = [];
+  final List<ARFSFileEntity> _skippedFiles = [];
   SecretKey? _driveKey;
 
   late ARFSDriveEntity _drive;

--- a/lib/download/multiple_download_bloc.dart
+++ b/lib/download/multiple_download_bloc.dart
@@ -75,15 +75,16 @@ class MultipleDownloadBloc
     items = event.items;
     skippedFiles.clear();
 
-    // check all files from same drive
+    if (items.isEmpty) {
+      emit(
+        const MultipleDownloadFailure(
+          FileDownloadFailureReason.unknownError,
+        ),
+      );
+      return;
+    }
+
     var firstFile = items[0];
-
-    // Currently assumes all files from the same drive. May need code like below
-    // to verify and emit error if not all files are from the same drive.
-    // if (!items.every((file) => file.driveId == firstFile.driveId)) {
-    //   // TODO emit error event here and exit
-    // }
-
     drive = await _arfsRepository.getDriveById(firstFile.driveId);
 
     if (await isSizeAboveDownloadSizeLimit(

--- a/lib/download/multiple_download_event.dart
+++ b/lib/download/multiple_download_event.dart
@@ -16,3 +16,7 @@ class StartDownload extends MultipleDownloadEvent {
   @override
   List<Object> get props => [items];
 }
+
+class ResumeDownload extends MultipleDownloadEvent {
+  const ResumeDownload();
+}

--- a/lib/download/multiple_download_event.dart
+++ b/lib/download/multiple_download_event.dart
@@ -21,6 +21,10 @@ class ResumeDownload extends MultipleDownloadEvent {
   const ResumeDownload();
 }
 
+class SkipFileAndResumeDownload extends MultipleDownloadEvent {
+  const SkipFileAndResumeDownload();
+}
+
 class CancelDownload extends MultipleDownloadEvent {
   const CancelDownload();
 }

--- a/lib/download/multiple_download_event.dart
+++ b/lib/download/multiple_download_event.dart
@@ -20,3 +20,7 @@ class StartDownload extends MultipleDownloadEvent {
 class ResumeDownload extends MultipleDownloadEvent {
   const ResumeDownload();
 }
+
+class CancelDownload extends MultipleDownloadEvent {
+  const CancelDownload();
+}

--- a/lib/download/multiple_download_state.dart
+++ b/lib/download/multiple_download_state.dart
@@ -10,16 +10,16 @@ abstract class MultipleDownloadState extends Equatable {
 class MultipleDownloadInitial extends MultipleDownloadState {}
 
 class MultipleDownloadInProgress extends MultipleDownloadState {
-  final String fileName;
-  final int totalByteCount;
+  final List<ARFSFileEntity> files;
+  final int currentFileIndex;
 
   const MultipleDownloadInProgress({
-    required this.fileName,
-    required this.totalByteCount,
+    required this.files,
+    required this.currentFileIndex,
   });
 
   @override
-  List<Object> get props => [fileName, totalByteCount];
+  List<Object> get props => [files, currentFileIndex];
 }
 
 class MultipleDownloadWarning extends MultipleDownloadState {}

--- a/lib/download/multiple_download_state.dart
+++ b/lib/download/multiple_download_state.dart
@@ -37,12 +37,14 @@ class MultipleDownloadFinishedWithSuccess extends MultipleDownloadState {
   const MultipleDownloadFinishedWithSuccess(
       {required this.fileName,
       required this.bytes,
-      required this.lastModified});
+      required this.lastModified,
+      required this.skippedFiles});
 
   final String fileName;
   final Uint8List bytes;
   final DateTime lastModified;
+  final List<ARFSFileEntity> skippedFiles;
 
   @override
-  List<Object> get props => [fileName, bytes, lastModified];
+  List<Object> get props => [fileName, bytes, lastModified, skippedFiles];
 }

--- a/lib/download/multiple_download_state.dart
+++ b/lib/download/multiple_download_state.dart
@@ -34,18 +34,15 @@ class MultipleDownloadFailure extends MultipleDownloadState {
 }
 
 class MultipleDownloadFinishedWithSuccess extends MultipleDownloadState {
-  final String title;
+  const MultipleDownloadFinishedWithSuccess(
+      {required this.fileName,
+      required this.bytes,
+      required this.lastModified});
 
-  const MultipleDownloadFinishedWithSuccess({required this.title});
-
-  @override
-  List<Object> get props => [title];
-}
-
-// zipping your files
-class MultipleDownloadZippingFiles extends MultipleDownloadState {
-  const MultipleDownloadZippingFiles();
+  final String fileName;
+  final Uint8List bytes;
+  final DateTime lastModified;
 
   @override
-  List<Object> get props => [];
+  List<Object> get props => [fileName, bytes, lastModified];
 }

--- a/lib/download/multiple_file_download_modal.dart
+++ b/lib/download/multiple_file_download_modal.dart
@@ -53,16 +53,23 @@ promptToDownloadMultipleFiles(
             folderName: driveDetail.folderInView.folder.name,
           ),
         ),
-      child: MultipleFilesDownload(),
+      child: const MultipleFilesDownload(),
     ),
   );
 }
 
-class MultipleFilesDownload extends StatelessWidget {
+class MultipleFilesDownload extends StatefulWidget {
+  const MultipleFilesDownload({
+    super.key,
+  });
+
+  @override
+  State<MultipleFilesDownload> createState() => _MultipleFilesDownloadState();
+}
+
+class _MultipleFilesDownloadState extends State<MultipleFilesDownload> {
   final _scrollController = ScrollController();
   CancelableOperation? autoClose;
-
-  MultipleFilesDownload({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/download/multiple_file_download_modal.dart
+++ b/lib/download/multiple_file_download_modal.dart
@@ -10,6 +10,7 @@ import 'package:ardrive/pages/pages.dart';
 import 'package:ardrive/services/arweave/arweave_service.dart';
 import 'package:ardrive/utils/app_localizations_wrapper.dart';
 import 'package:ardrive/utils/filesize.dart';
+import 'package:ardrive_io/ardrive_io.dart';
 import 'package:ardrive_ui/ardrive_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -72,9 +73,18 @@ class _MultipleFilesDownloadState extends State<MultipleFilesDownload> {
   @override
   Widget build(BuildContext context) {
     return BlocListener<MultipleDownloadBloc, MultipleDownloadState>(
-      listener: (context, state) {
+      listener: (context, state) async {
         if (state is MultipleDownloadFinishedWithSuccess) {
-          Navigator.pop(context);
+          final ArDriveIO io = ArDriveIO();
+
+          final file = await IOFile.fromData(
+            state.bytes,
+            name: state.fileName,
+            lastModifiedDate: state.lastModified,
+          );
+
+          // Close modal when save file
+          io.saveFile(file).then((value) => Navigator.pop(context));
         }
       },
       child: BlocBuilder<MultipleDownloadBloc, MultipleDownloadState>(

--- a/lib/download/multiple_file_download_modal.dart
+++ b/lib/download/multiple_file_download_modal.dart
@@ -1,7 +1,6 @@
 import 'package:ardrive/blocs/drive_detail/drive_detail_cubit.dart';
 import 'package:ardrive/blocs/file_download/file_download_cubit.dart';
 import 'package:ardrive/blocs/profile/profile_cubit.dart';
-import 'package:ardrive/components/progress_dialog.dart';
 import 'package:ardrive/core/arfs/entities/arfs_entities.dart';
 import 'package:ardrive/core/crypto/crypto.dart';
 import 'package:ardrive/core/download_service.dart';
@@ -10,7 +9,9 @@ import 'package:ardrive/models/daos/drive_dao/drive_dao.dart';
 import 'package:ardrive/pages/pages.dart';
 import 'package:ardrive/services/arweave/arweave_service.dart';
 import 'package:ardrive/utils/app_localizations_wrapper.dart';
+import 'package:ardrive/utils/filesize.dart';
 import 'package:ardrive_ui/ardrive_ui.dart';
+import 'package:async/async.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -52,21 +53,25 @@ promptToDownloadMultipleFiles(
             folderName: driveDetail.folderInView.folder.name,
           ),
         ),
-      child: const MultipleFilesDownload(),
+      child: MultipleFilesDownload(),
     ),
   );
 }
 
 class MultipleFilesDownload extends StatelessWidget {
-  const MultipleFilesDownload({super.key});
+  final _scrollController = ScrollController();
+  CancelableOperation? autoClose;
+
+  MultipleFilesDownload({super.key});
 
   @override
   Widget build(BuildContext context) {
     return BlocListener<MultipleDownloadBloc, MultipleDownloadState>(
       listener: (context, state) {
         if (state is MultipleDownloadFinishedWithSuccess) {
-          Future.delayed(const Duration(seconds: 3))
-              .then((value) => Navigator.pop(context));
+          autoClose = CancelableOperation.fromFuture(
+              Future.delayed(const Duration(seconds: 3))
+                  .then((value) => Navigator.pop(context)));
         }
       },
       child: BlocBuilder<MultipleDownloadBloc, MultipleDownloadState>(
@@ -75,14 +80,68 @@ class MultipleFilesDownload extends StatelessWidget {
           List<ModalAction> actions = [];
 
           if (state is MultipleDownloadInProgress) {
-            return ProgressDialog(
-              title: 'Downloading Multiple Files',
+            return ArDriveStandardModal(
+              width: 408,
+              // TODO: Localize text
+              title:
+                  'Downloading file(s)... ${state.currentFileIndex + 1} of ${state.files.length}',
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Align(
+                    alignment: Alignment.topCenter,
+                    child: ConstrainedBox(
+                      constraints: const BoxConstraints(maxHeight: 256),
+                      child: ArDriveScrollBar(
+                          controller: _scrollController,
+                          alwaysVisible: true,
+                          child: ListView.builder(
+                            padding: const EdgeInsets.only(top: 0),
+                            controller: _scrollController,
+                            shrinkWrap: true,
+                            itemCount: state.files.length,
+                            itemBuilder: (BuildContext context, int index) {
+                              final file = state.files[index];
+                              return Row(
+                                children: [
+                                  Flexible(
+                                    child: Text(
+                                      '${file.name} ',
+                                      style: ArDriveTypography.body.smallBold(
+                                        color: ArDriveTheme.of(context)
+                                            .themeData
+                                            .colors
+                                            .themeFgSubtle,
+                                      ),
+                                    ),
+                                  ),
+                                  Text(
+                                    filesize(file.size),
+                                    style: ArDriveTypography.body.smallRegular(
+                                      color: ArDriveTheme.of(context)
+                                          .themeData
+                                          .colors
+                                          .themeFgMuted,
+                                    ),
+                                  ),
+                                ],
+                              );
+                            },
+                          )),
+                    ),
+                  )
+                ],
+              ),
               actions: [
                 ModalAction(
                   action: () {
-                    Navigator.pop(context);
+                    context
+                        .read<MultipleDownloadBloc>()
+                        .add(const CancelDownload());
+                    Navigator.of(context).pop(false);
                   },
-                  title: appLocalizationsOf(context).cancel,
+                  title: appLocalizationsOf(context).cancelEmphasized,
                 ),
               ],
             );
@@ -95,6 +154,7 @@ class MultipleFilesDownload extends StatelessWidget {
             actions = [
               ModalAction(
                 action: () {
+                  autoClose?.cancel();
                   Navigator.pop(context);
                 },
                 title: appLocalizationsOf(context).ok,

--- a/lib/download/multiple_file_download_modal.dart
+++ b/lib/download/multiple_file_download_modal.dart
@@ -231,12 +231,14 @@ class _MultipleFilesDownloadState extends State<MultipleFilesDownload> {
               ],
             );
           } else if (state is MultipleDownloadFailure) {
+            bool showRetryAndSkip = true;
             switch (state.reason) {
               case FileDownloadFailureReason.fileAboveLimit:
                 content = Text(
                   appLocalizationsOf(context)
                       .fileFailedToDownloadFileAbovePublicLimit,
                 );
+                showRetryAndSkip = false;
                 break;
               case FileDownloadFailureReason.fileNotFound:
                 content =
@@ -261,22 +263,24 @@ class _MultipleFilesDownloadState extends State<MultipleFilesDownload> {
                 },
                 title: appLocalizationsOf(context).cancel,
               ),
-              ModalAction(
-                action: () {
-                  context
-                      .read<MultipleDownloadBloc>()
-                      .add(const ResumeDownload());
-                },
-                title: appLocalizationsOf(context).tryAgain,
-              ),
-              ModalAction(
-                action: () {
-                  context
-                      .read<MultipleDownloadBloc>()
-                      .add(const SkipFileAndResumeDownload());
-                },
-                title: appLocalizationsOf(context).skip,
-              ),
+              if (showRetryAndSkip) ...[
+                ModalAction(
+                  action: () {
+                    context
+                        .read<MultipleDownloadBloc>()
+                        .add(const ResumeDownload());
+                  },
+                  title: appLocalizationsOf(context).tryAgain,
+                ),
+                ModalAction(
+                  action: () {
+                    context
+                        .read<MultipleDownloadBloc>()
+                        .add(const SkipFileAndResumeDownload());
+                  },
+                  title: appLocalizationsOf(context).skip,
+                ),
+              ]
             ];
           } else {
             content = Text(

--- a/lib/download/multiple_file_download_modal.dart
+++ b/lib/download/multiple_file_download_modal.dart
@@ -133,15 +133,19 @@ class _MultipleFilesDownloadState extends State<MultipleFilesDownload> {
                                       ),
                                     ),
                                   ),
-                                  Text(
-                                    filesize(file.size),
-                                    style: ArDriveTypography.body.smallRegular(
-                                      color: ArDriveTheme.of(context)
-                                          .themeData
-                                          .colors
-                                          .themeFgMuted,
+                                  Padding(
+                                    padding: const EdgeInsets.only(right: 16),
+                                    child: Text(
+                                      filesize(file.size),
+                                      style:
+                                          ArDriveTypography.body.smallRegular(
+                                        color: ArDriveTheme.of(context)
+                                            .themeData
+                                            .colors
+                                            .themeFgMuted,
+                                      ),
                                     ),
-                                  ),
+                                  )
                                 ],
                               );
                             },

--- a/lib/pages/drive_detail/drive_detail_page.dart
+++ b/lib/pages/drive_detail/drive_detail_page.dart
@@ -114,9 +114,8 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
 
             final hasFiles = state.folderInView.files.isNotEmpty;
 
-            final canDownloadMultipleFiles = state.multiselect &&
-                // state.currentDrive.isPublic &&
-                !state.hasFoldersSelected;
+            final canDownloadMultipleFiles =
+                state.multiselect && !state.hasFoldersSelected;
 
             return ScreenTypeLayout.builder(
               desktop: (context) => _desktopView(

--- a/lib/pages/drive_detail/drive_detail_page.dart
+++ b/lib/pages/drive_detail/drive_detail_page.dart
@@ -215,7 +215,6 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
                                         .read<ConfigService>()
                                         .config
                                         .enableMultipleFileDownload) ...[
-                                  // TODO: check sizelimits to conditionally enable/disable the button, also for now disable if a folder is selected
                                   ArDriveIconButton(
                                     tooltip: 'Download selected files',
                                     icon: ArDriveIcons.download(),

--- a/lib/pages/drive_detail/drive_detail_page.dart
+++ b/lib/pages/drive_detail/drive_detail_page.dart
@@ -115,7 +115,7 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
             final hasFiles = state.folderInView.files.isNotEmpty;
 
             final canDownloadMultipleFiles = state.multiselect &&
-                state.currentDrive.isPublic &&
+                // state.currentDrive.isPublic &&
                 !state.hasFoldersSelected;
 
             return ScreenTypeLayout.builder(
@@ -216,6 +216,7 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
                                         .read<ConfigService>()
                                         .config
                                         .enableMultipleFileDownload) ...[
+                                  // TODO: check sizelimits to conditionally enable/disable the button, also for now disable if a folder is selected
                                   ArDriveIconButton(
                                     tooltip: 'Download selected files',
                                     icon: ArDriveIcons.download(),

--- a/lib/utils/app_platform.dart
+++ b/lib/utils/app_platform.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: depend_on_referenced_packages
 
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/foundation.dart'
     show kIsWeb, defaultTargetPlatform, TargetPlatform, visibleForTesting;
 import 'package:platform/platform.dart' as platform;
@@ -46,6 +47,11 @@ class AppPlatform {
     return kIsWeb &&
         (defaultTargetPlatform == TargetPlatform.iOS ||
             defaultTargetPlatform == TargetPlatform.android);
+  }
+
+  static Future<bool> isFireFox({DeviceInfoPlugin? deviceInfo}) async {
+    final info = await (deviceInfo ?? DeviceInfoPlugin()).deviceInfo;
+    return info is WebBrowserInfo && info.browserName == BrowserName.firefox;
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -89,7 +89,7 @@ dependencies:
   firebase_core: ^2.1.1
   bloc_concurrency: ^0.2.0
   universal_html: ^2.0.8
-  device_info_plus: ^8.0.0
+  device_info_plus: ^8.2.2
   local_auth: ^2.1.2
   flutter_secure_storage: ^8.0.0
   async: ^2.9.0

--- a/test/blocs/personal_file_download_cubit_test.dart
+++ b/test/blocs/personal_file_download_cubit_test.dart
@@ -17,39 +17,6 @@ import 'package:mocktail/mocktail.dart';
 
 import '../test_utils/mocks.dart';
 
-class MockARFSFile extends ARFSFileEntity {
-  MockARFSFile({
-    required super.appName,
-    required super.appVersion,
-    required super.arFS,
-    required super.driveId,
-    required super.entityType,
-    required super.name,
-    required super.txId,
-    required super.unixTime,
-    required super.id,
-    required super.size,
-    required super.lastModifiedDate,
-    required super.parentFolderId,
-    super.contentType,
-  });
-}
-
-class MockARFSDrive extends ARFSDriveEntity {
-  MockARFSDrive({
-    required super.appName,
-    required super.appVersion,
-    required super.arFS,
-    required super.driveId,
-    required super.entityType,
-    required super.name,
-    required super.txId,
-    required super.unixTime,
-    required super.drivePrivacy,
-    required super.rootFolderId,
-  });
-}
-
 Stream<int> mockDownloadProgress() async* {
   yield 100;
 }
@@ -57,9 +24,6 @@ Stream<int> mockDownloadProgress() async* {
 Stream<int> mockDownloadInProgress() {
   return Stream<int>.periodic(const Duration(seconds: 1), (c) => c + 1).take(5);
 }
-
-class MockTransactionCommonMixin extends Mock
-    implements TransactionCommonMixin {}
 
 // TODO(@thiagocarvalhodev): Implemente tests related to ArDriveDownloader
 void main() {
@@ -71,79 +35,18 @@ void main() {
   late DownloadService mockDownloadService;
   late ARFSRepository mockARFSRepository;
 
-  MockARFSFile testFile = MockARFSFile(
-    appName: 'appName',
-    appVersion: 'appVersion',
-    arFS: 'arFS',
-    driveId: 'driveId',
-    entityType: EntityType.file,
-    name: 'name',
-    txId: 'txId',
-    unixTime: DateTime.now(),
-    id: 'id',
-    size: const MiB(2).size,
-    lastModifiedDate: DateTime.now(),
-    parentFolderId: 'parentFolderId',
-    contentType: 'text/plain',
-  );
+  MockARFSFile testFile = createMockFile(size: const MiB(2).size);
 
-  MockARFSFile testFileAboveLimit = MockARFSFile(
-    appName: 'appName',
-    appVersion: 'appVersion',
-    arFS: 'arFS',
-    driveId: 'driveId',
-    entityType: EntityType.file,
-    name: 'name',
-    txId: 'txId',
-    unixTime: DateTime.now(),
-    id: 'id',
-    size: const MiB(301).size, // above the current limit
-    lastModifiedDate: DateTime.now(),
-    parentFolderId: 'parentFolderId',
-    contentType: 'text/plain',
-  );
+  MockARFSFile testFileAboveLimit = createMockFile(size: const MiB(301).size);
 
-  MockARFSFile testFileUnderPrivateLimitAndAboveWarningLimit = MockARFSFile(
-    appName: 'appName',
-    appVersion: 'appVersion',
-    arFS: 'arFS',
-    driveId: 'driveId',
-    entityType: EntityType.file,
-    name: 'name',
-    txId: 'txId',
-    unixTime: DateTime.now(),
-    id: 'id',
-    size: const MiB(201).size, // above the current limit
-    lastModifiedDate: DateTime.now(),
-    parentFolderId: 'parentFolderId',
-    contentType: 'text/plain',
-  );
+  MockARFSFile testFileUnderPrivateLimitAndAboveWarningLimit =
+      createMockFile(size: const MiB(201).size);
 
-  MockARFSDrive mockDrivePrivate = MockARFSDrive(
-    appName: 'appName',
-    appVersion: 'appVersion',
-    arFS: 'arFS',
-    driveId: '',
-    entityType: EntityType.drive,
-    name: 'name',
-    txId: 'txId',
-    unixTime: DateTime.now(),
-    drivePrivacy: DrivePrivacy.private,
-    rootFolderId: 'rootFolderId',
-  );
+  MockARFSDrive mockDrivePrivate =
+      createMockDrive(drivePrivacy: DrivePrivacy.private);
 
-  MockARFSDrive mockDrivePublic = MockARFSDrive(
-    appName: 'appName',
-    appVersion: 'appVersion',
-    arFS: 'arFS',
-    driveId: '',
-    entityType: EntityType.drive,
-    name: 'name',
-    txId: 'txId',
-    unixTime: DateTime.now(),
-    drivePrivacy: DrivePrivacy.public,
-    rootFolderId: 'rootFolderId',
-  );
+  MockARFSDrive mockDrivePublic =
+      createMockDrive(drivePrivacy: DrivePrivacy.public);
 
   setUpAll(() {
     registerFallbackValue(SecretKey([]));

--- a/test/download/limits_test.dart
+++ b/test/download/limits_test.dart
@@ -1,0 +1,51 @@
+import 'package:ardrive/download/limits.dart';
+import 'package:ardrive/utils/app_platform.dart';
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../test_utils/mocks.dart';
+
+void main() {
+  test('Download limits calculated correctly per-platform', () {
+    AppPlatform.setMockPlatform(platform: SystemPlatform.Web);
+    final MockDeviceInfoPlugin deviceInfo = MockDeviceInfoPlugin();
+    when(() => deviceInfo.deviceInfo).thenAnswer(
+        (invokation) async => WebBrowserInfo.fromMap({'userAgent': 'Chrome'}));
+
+    expect(calcDownloadSizeLimit(true, deviceInfo: deviceInfo),
+        completion(equals(publicDownloadWebSizeLimit)));
+
+    expect(calcDownloadSizeLimit(false, deviceInfo: deviceInfo),
+        completion(equals(privateDownloadWebSizeLimit)));
+
+    when(() => deviceInfo.deviceInfo).thenAnswer(
+        (invokation) async => WebBrowserInfo.fromMap({'userAgent': 'Firefox'}));
+
+    expect(calcDownloadSizeLimit(true, deviceInfo: deviceInfo),
+        completion(equals(publicDownloadFirefoxSizeLimit)));
+    expect(calcDownloadSizeLimit(false, deviceInfo: deviceInfo),
+        completion(equals(privateDownloadFirefoxSizeLimit)));
+
+    AppPlatform.setMockPlatform(platform: SystemPlatform.Android);
+
+    expect(calcDownloadSizeLimit(true, deviceInfo: deviceInfo),
+        completion(equals(publicDownloadMobileSizeLimit)));
+    expect(calcDownloadSizeLimit(false, deviceInfo: deviceInfo),
+        completion(equals(privateDownloadMobileSizeLimit)));
+
+    AppPlatform.setMockPlatform(platform: SystemPlatform.iOS);
+
+    expect(calcDownloadSizeLimit(true, deviceInfo: deviceInfo),
+        completion(equals(publicDownloadMobileSizeLimit)));
+    expect(calcDownloadSizeLimit(false, deviceInfo: deviceInfo),
+        completion(equals(privateDownloadMobileSizeLimit)));
+
+    AppPlatform.setMockPlatform(platform: SystemPlatform.unknown);
+
+    expect(calcDownloadSizeLimit(true, deviceInfo: deviceInfo),
+        completion(equals(publicDownloadUnknownPlatformSizeLimit)));
+    expect(calcDownloadSizeLimit(false, deviceInfo: deviceInfo),
+        completion(equals(privateDownloadUnknownPlatformSizeLimit)));
+  });
+}

--- a/test/download/multiple_download_bloc_test.dart
+++ b/test/download/multiple_download_bloc_test.dart
@@ -1,0 +1,442 @@
+import 'package:ardrive/blocs/file_download/file_download_cubit.dart';
+import 'package:ardrive/core/arfs/entities/arfs_entities.dart';
+import 'package:ardrive/core/arfs/repository/arfs_repository.dart';
+import 'package:ardrive/core/crypto/crypto.dart';
+import 'package:ardrive/core/download_service.dart';
+import 'package:ardrive/download/multiple_download_bloc.dart';
+import 'package:ardrive/models/daos/daos.dart';
+import 'package:ardrive/services/arweave/arweave.dart';
+import 'package:ardrive/utils/app_platform.dart';
+import 'package:ardrive/utils/data_size.dart';
+import 'package:ardrive_http/ardrive_http.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:cryptography/cryptography.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../test_utils/mocks.dart';
+
+void main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  DriveDao mockDriveDao = MockDriveDao();
+  ArweaveService mockArweaveService = MockArweaveService();
+  ArDriveCrypto mockCrypto = MockArDriveCrypto();
+  DownloadService mockDownloadService = MockDownloadService();
+  ARFSRepository mockARFSRepository = MockARFSRepository();
+  ARFSRepository mockARFSRepositoryPrivate = MockARFSRepository();
+
+  MockARFSFile testFile = createMockFile(size: const MiB(1).size);
+
+  MockARFSDrive mockDrivePrivate =
+      createMockDrive(drivePrivacy: DrivePrivacy.private);
+
+  MockARFSDrive mockDrivePublic =
+      createMockDrive(drivePrivacy: DrivePrivacy.public);
+
+  MockTransactionCommonMixin decryptionFailureTransaction =
+      MockTransactionCommonMixin();
+
+  MultipleDownloadBloc createMultipleDownloadBloc(
+      {downloadService, arfsRepository, arweave, crypto, driveDao, cipherKey}) {
+    return MultipleDownloadBloc(
+        downloadService: downloadService ?? mockDownloadService,
+        arfsRepository: arfsRepository ?? mockARFSRepository,
+        arweave: arweave ?? mockArweaveService,
+        crypto: crypto ?? mockCrypto,
+        driveDao: driveDao ?? mockDriveDao,
+        cipherKey: cipherKey ?? SecretKey([]));
+  }
+
+  setUpAll(() {
+    registerFallbackValue(SecretKey([]));
+    registerFallbackValue(MockTransactionCommonMixin());
+    registerFallbackValue(Uint8List(100));
+    registerFallbackValue(mockDrivePrivate);
+    registerFallbackValue(mockDrivePublic);
+    registerFallbackValue(testFile);
+  });
+
+  setUp(() {
+    /// Using a private drive
+    when(() => mockARFSRepository.getDriveById(any()))
+        .thenAnswer((_) async => mockDrivePublic);
+    when(() => mockARFSRepositoryPrivate.getDriveById(any()))
+        .thenAnswer((_) async => mockDrivePrivate);
+    when(() => mockDriveDao.getDriveKey(any(), any()))
+        .thenAnswer((_) async => SecretKey([]));
+    when(() => mockDriveDao.getFileKey(any(), any()))
+        .thenAnswer((_) async => SecretKey([]));
+    when(() => mockDownloadService.download(any()))
+        .thenAnswer((_) async => Uint8List(0));
+    when(() => mockCrypto.decryptTransactionData(any(), any(), any()))
+        .thenAnswer((_) async => Uint8List(0));
+    when(() => mockCrypto.decryptTransactionData(
+        decryptionFailureTransaction, any(), any())).thenThrow(Exception());
+    when(() => mockArweaveService.getTransactionDetails(any()))
+        .thenAnswer((invocation) async => MockTransactionCommonMixin());
+    when(() => mockArweaveService.getTransactionDetails('decryptionFailure'))
+        .thenAnswer((invocation) async => decryptionFailureTransaction);
+    when(() => mockArweaveService.getTransactionDetails(''))
+        .thenAnswer((invocation) async => null);
+  });
+
+  void performTestsForDrive(String groupLabel, ARFSRepository arfsRepository) {
+    late MultipleDownloadBloc multipleDownloadBloc;
+    group('[$groupLabel] -', () {
+      setUp(() {
+        multipleDownloadBloc = createMultipleDownloadBloc(
+          arfsRepository: arfsRepository,
+        );
+      });
+
+      group('Test file limits', () {
+        blocTest<MultipleDownloadBloc, MultipleDownloadState>(
+          'should succeed with files below limits',
+          build: () => multipleDownloadBloc,
+          setUp: () {
+            AppPlatform.setMockPlatform(platform: SystemPlatform.Android);
+          },
+          act: (bloc) => bloc.add(StartDownload([testFile])),
+          expect: () => [
+            isA<MultipleDownloadInProgress>().having(
+              (s) => s.files.length,
+              'files.length',
+              1,
+            ),
+            isA<MultipleDownloadFinishedWithSuccess>(),
+          ],
+        );
+
+        blocTest<MultipleDownloadBloc, MultipleDownloadState>(
+          'should emit failure when files above limits',
+          build: () => multipleDownloadBloc,
+          setUp: () {
+            AppPlatform.setMockPlatform(platform: SystemPlatform.Android);
+          },
+          act: (bloc) => bloc.add(StartDownload([
+            testFile,
+            createMockFile(size: const MiB(2001).size),
+          ])),
+          expect: () => [
+            isA<MultipleDownloadFailure>().having(
+              (s) => s.reason,
+              'reason',
+              FileDownloadFailureReason.fileAboveLimit,
+            ),
+          ],
+        );
+      });
+      group('Test successful download path', () {
+        blocTest<MultipleDownloadBloc, MultipleDownloadState>(
+          'should emit one MultipleDownloadInProgress event per file',
+          build: () => multipleDownloadBloc,
+          setUp: () {
+            AppPlatform.setMockPlatform(platform: SystemPlatform.Android);
+          },
+          act: (bloc) =>
+              bloc.add(StartDownload([testFile, testFile, testFile])),
+          expect: () => [
+            isA<MultipleDownloadInProgress>()
+                .having(
+                  (s) => s.files.length,
+                  'files.length',
+                  3,
+                )
+                .having((s) => s.currentFileIndex, 'currentFileIndex', 0),
+            isA<MultipleDownloadInProgress>()
+                .having(
+                  (s) => s.files.length,
+                  'files.length',
+                  3,
+                )
+                .having((s) => s.currentFileIndex, 'currentFileIndex', 1),
+            isA<MultipleDownloadInProgress>()
+                .having(
+                  (s) => s.files.length,
+                  'files.length',
+                  3,
+                )
+                .having((s) => s.currentFileIndex, 'currentFileIndex', 2),
+            isA<MultipleDownloadFinishedWithSuccess>(),
+          ],
+        );
+      });
+
+      group('Test networking', () {
+        blocTest<MultipleDownloadBloc, MultipleDownloadState>(
+          'should emit Failure with fileNotFound when file is not available',
+          build: () {
+            final secondFileFailureService = MockDownloadService();
+            when(() => secondFileFailureService.download(any()))
+                .thenAnswer((_) async => Uint8List(0));
+            when(() => secondFileFailureService.download("fail")).thenThrow(
+                ArDriveHTTPException(
+                    exception: Exception(),
+                    retryAttempts: 8,
+                    statusCode: 400,
+                    statusMessage: 'File not found'));
+            return createMultipleDownloadBloc(
+                downloadService: secondFileFailureService);
+          },
+          setUp: () {
+            AppPlatform.setMockPlatform(platform: SystemPlatform.Android);
+          },
+          act: (bloc) => bloc.add(StartDownload(
+              [testFile, createMockFile(txId: 'fail'), testFile])),
+          expect: () => [
+            isA<MultipleDownloadInProgress>()
+                .having(
+                  (s) => s.files.length,
+                  'files.length',
+                  3,
+                )
+                .having((s) => s.currentFileIndex, 'currentFileIndex', 0),
+            isA<MultipleDownloadInProgress>()
+                .having(
+                  (s) => s.files.length,
+                  'files.length',
+                  3,
+                )
+                .having((s) => s.currentFileIndex, 'currentFileIndex', 1),
+            isA<MultipleDownloadFailure>().having((s) => s.reason, 'reason',
+                FileDownloadFailureReason.fileNotFound),
+          ],
+        );
+
+        blocTest<MultipleDownloadBloc, MultipleDownloadState>(
+          'should emit Failure with networkConnectionError when status code is not 400',
+          build: () {
+            final secondFileFailureService = MockDownloadService();
+            when(() => secondFileFailureService.download(any()))
+                .thenAnswer((_) async => Uint8List(0));
+            when(() => secondFileFailureService.download("fail")).thenThrow(
+                ArDriveHTTPException(
+                    exception: Exception(),
+                    retryAttempts: 8,
+                    statusCode: 404,
+                    statusMessage: 'File not found'));
+            return createMultipleDownloadBloc(
+                downloadService: secondFileFailureService);
+          },
+          setUp: () {
+            AppPlatform.setMockPlatform(platform: SystemPlatform.Android);
+          },
+          act: (bloc) => bloc.add(StartDownload(
+              [testFile, createMockFile(txId: 'fail'), testFile])),
+          expect: () => [
+            isA<MultipleDownloadInProgress>()
+                .having(
+                  (s) => s.files.length,
+                  'files.length',
+                  3,
+                )
+                .having((s) => s.currentFileIndex, 'currentFileIndex', 0),
+            isA<MultipleDownloadInProgress>()
+                .having(
+                  (s) => s.files.length,
+                  'files.length',
+                  3,
+                )
+                .having((s) => s.currentFileIndex, 'currentFileIndex', 1),
+            isA<MultipleDownloadFailure>().having((s) => s.reason, 'reason',
+                FileDownloadFailureReason.networkConnectionError),
+          ],
+        );
+
+        blocTest<MultipleDownloadBloc, MultipleDownloadState>(
+          'should emit Failure with networkConnectionError when status code is not 400 and resumes correctly',
+          build: () {
+            var failedOnce = false;
+            final secondFileFailureService = MockDownloadService();
+            when(() => secondFileFailureService.download(any()))
+                .thenAnswer((_) async => Uint8List(0));
+            when(() => secondFileFailureService.download("fail"))
+                .thenAnswer((_) async {
+              if (!failedOnce) {
+                failedOnce = true;
+                throw ArDriveHTTPException(
+                    exception: Exception(),
+                    retryAttempts: 8,
+                    statusCode: 404,
+                    statusMessage: 'File not found');
+              }
+              return Uint8List(0);
+            });
+
+            return createMultipleDownloadBloc(
+                downloadService: secondFileFailureService);
+          },
+          setUp: () {
+            AppPlatform.setMockPlatform(platform: SystemPlatform.Android);
+          },
+          act: (bloc) async {
+            bloc.add(StartDownload(
+                [testFile, createMockFile(txId: 'fail'), testFile]));
+
+            // TODO: Replace this polling with a better solution!
+            while (bloc.state is! MultipleDownloadFailure) {
+              await Future.delayed(const Duration(milliseconds: 100));
+            }
+
+            bloc.add(const ResumeDownload());
+          },
+          expect: () => [
+            isA<MultipleDownloadInProgress>()
+                .having(
+                  (s) => s.files.length,
+                  'files.length',
+                  3,
+                )
+                .having((s) => s.currentFileIndex, 'currentFileIndex', 0),
+            isA<MultipleDownloadInProgress>()
+                .having(
+                  (s) => s.files.length,
+                  'files.length',
+                  3,
+                )
+                .having((s) => s.currentFileIndex, 'currentFileIndex', 1),
+            isA<MultipleDownloadFailure>().having((s) => s.reason, 'reason',
+                FileDownloadFailureReason.networkConnectionError),
+            isA<MultipleDownloadInProgress>()
+                .having(
+                  (s) => s.files.length,
+                  'files.length',
+                  3,
+                )
+                .having((s) => s.currentFileIndex, 'currentFileIndex', 1),
+            isA<MultipleDownloadInProgress>()
+                .having(
+                  (s) => s.files.length,
+                  'files.length',
+                  3,
+                )
+                .having((s) => s.currentFileIndex, 'currentFileIndex', 2),
+            isA<MultipleDownloadFinishedWithSuccess>(),
+          ],
+        );
+      });
+      group('Test cancelation path', () {
+        blocTest<MultipleDownloadBloc, MultipleDownloadState>(
+          'should end Bloc after cancellation',
+          build: () {
+            final secondFileCancelService = MockDownloadService();
+            when(() => secondFileCancelService.download(any()))
+                .thenAnswer((_) async => Uint8List(0));
+
+            final bloc = createMultipleDownloadBloc(
+                downloadService: secondFileCancelService);
+
+            when(() => secondFileCancelService.download('cancel'))
+                .thenAnswer((_) async {
+              bloc.add(const CancelDownload());
+              return Uint8List(0);
+            });
+
+            return bloc;
+          },
+          setUp: () {
+            AppPlatform.setMockPlatform(platform: SystemPlatform.Android);
+          },
+          act: (bloc) => bloc.add(StartDownload(
+              [testFile, createMockFile(txId: 'cancel'), testFile])),
+          expect: () => [
+            isA<MultipleDownloadInProgress>()
+                .having(
+                  (s) => s.files.length,
+                  'files.length',
+                  3,
+                )
+                .having((s) => s.currentFileIndex, 'currentFileIndex', 0),
+            isA<MultipleDownloadInProgress>()
+                .having(
+                  (s) => s.files.length,
+                  'files.length',
+                  3,
+                )
+                .having((s) => s.currentFileIndex, 'currentFileIndex', 1),
+          ],
+        );
+      });
+
+      if (arfsRepository == mockARFSRepositoryPrivate) {
+        blocTest<MultipleDownloadBloc, MultipleDownloadState>(
+          'Test missing transactionDetails should emit failure',
+          build: () => multipleDownloadBloc,
+          setUp: () {
+            AppPlatform.setMockPlatform(platform: SystemPlatform.Android);
+          },
+          act: (bloc) => bloc.add(StartDownload(
+              [testFile, testFile, createMockFile(txId: ''), testFile])),
+          expect: () => [
+            isA<MultipleDownloadInProgress>()
+                .having(
+                  (s) => s.files.length,
+                  'files.length',
+                  4,
+                )
+                .having((s) => s.currentFileIndex, 'currentFileIndex', 0),
+            isA<MultipleDownloadInProgress>()
+                .having(
+                  (s) => s.files.length,
+                  'files.length',
+                  4,
+                )
+                .having((s) => s.currentFileIndex, 'currentFileIndex', 1),
+            isA<MultipleDownloadInProgress>()
+                .having(
+                  (s) => s.files.length,
+                  'files.length',
+                  4,
+                )
+                .having((s) => s.currentFileIndex, 'currentFileIndex', 2),
+            isA<MultipleDownloadFailure>().having((s) => s.reason, 'reason',
+                FileDownloadFailureReason.unknownError),
+          ],
+        );
+        blocTest<MultipleDownloadBloc, MultipleDownloadState>(
+          'Test decryption failure should emit failure',
+          build: () => multipleDownloadBloc,
+          setUp: () {
+            AppPlatform.setMockPlatform(platform: SystemPlatform.Android);
+          },
+          act: (bloc) => bloc.add(StartDownload([
+            testFile,
+            testFile,
+            createMockFile(txId: 'decryptionFailure'),
+            testFile
+          ])),
+          expect: () => [
+            isA<MultipleDownloadInProgress>()
+                .having(
+                  (s) => s.files.length,
+                  'files.length',
+                  4,
+                )
+                .having((s) => s.currentFileIndex, 'currentFileIndex', 0),
+            isA<MultipleDownloadInProgress>()
+                .having(
+                  (s) => s.files.length,
+                  'files.length',
+                  4,
+                )
+                .having((s) => s.currentFileIndex, 'currentFileIndex', 1),
+            isA<MultipleDownloadInProgress>()
+                .having(
+                  (s) => s.files.length,
+                  'files.length',
+                  4,
+                )
+                .having((s) => s.currentFileIndex, 'currentFileIndex', 2),
+            isA<MultipleDownloadFailure>().having((s) => s.reason, 'reason',
+                FileDownloadFailureReason.unknownError),
+          ],
+        );
+      }
+    });
+  }
+
+  performTestsForDrive('Public Drive', mockARFSRepository);
+  performTestsForDrive('Private Drive', mockARFSRepositoryPrivate);
+}

--- a/test/download/multiple_download_bloc_test.dart
+++ b/test/download/multiple_download_bloc_test.dart
@@ -233,7 +233,7 @@ void main() async {
             final secondFileFailureService = MockDownloadService();
             when(() => secondFileFailureService.download(any()))
                 .thenAnswer((_) async => Uint8List(0));
-            when(() => secondFileFailureService.download("fail")).thenThrow(
+            when(() => secondFileFailureService.download('fail')).thenThrow(
                 ArDriveHTTPException(
                     exception: Exception(),
                     retryAttempts: 8,
@@ -273,7 +273,7 @@ void main() async {
             final secondFileFailureService = MockDownloadService();
             when(() => secondFileFailureService.download(any()))
                 .thenAnswer((_) async => Uint8List(0));
-            when(() => secondFileFailureService.download("fail")).thenThrow(
+            when(() => secondFileFailureService.download('fail')).thenThrow(
                 ArDriveHTTPException(
                     exception: Exception(),
                     retryAttempts: 8,
@@ -314,7 +314,7 @@ void main() async {
             final secondFileFailureService = MockDownloadService();
             when(() => secondFileFailureService.download(any()))
                 .thenAnswer((_) async => Uint8List(0));
-            when(() => secondFileFailureService.download("fail"))
+            when(() => secondFileFailureService.download('fail'))
                 .thenAnswer((_) async {
               if (!failedOnce) {
                 failedOnce = true;
@@ -387,7 +387,7 @@ void main() async {
             final secondFileFailureService = MockDownloadService();
             when(() => secondFileFailureService.download(any()))
                 .thenAnswer((_) async => Uint8List(0));
-            when(() => secondFileFailureService.download("fail"))
+            when(() => secondFileFailureService.download('fail'))
                 .thenAnswer((_) async {
               if (!failedOnce) {
                 failedOnce = true;

--- a/test/test_utils/mocks.dart
+++ b/test/test_utils/mocks.dart
@@ -1,6 +1,7 @@
 import 'package:ardrive/authentication/ardrive_auth.dart';
 import 'package:ardrive/blocs/blocs.dart';
 import 'package:ardrive/blocs/upload/upload_file_checker.dart';
+import 'package:ardrive/core/arfs/entities/arfs_entities.dart';
 import 'package:ardrive/core/arfs/repository/arfs_repository.dart';
 import 'package:ardrive/core/crypto/crypto.dart';
 import 'package:ardrive/core/download_service.dart';
@@ -81,3 +82,92 @@ class MockConfigFetcher extends Mock implements ConfigFetcher {}
 class MockConfigService extends Mock implements ConfigService {}
 
 class MockEnvFetcher extends Mock implements EnvFetcher {}
+
+class MockTransactionCommonMixin extends Mock
+    implements TransactionCommonMixin {}
+
+class MockARFSFile extends ARFSFileEntity {
+  MockARFSFile({
+    required super.appName,
+    required super.appVersion,
+    required super.arFS,
+    required super.driveId,
+    required super.entityType,
+    required super.name,
+    required super.txId,
+    required super.unixTime,
+    required super.id,
+    required super.size,
+    required super.lastModifiedDate,
+    required super.parentFolderId,
+    super.contentType,
+  });
+}
+
+class MockARFSDrive extends ARFSDriveEntity {
+  MockARFSDrive({
+    required super.appName,
+    required super.appVersion,
+    required super.arFS,
+    required super.driveId,
+    required super.entityType,
+    required super.name,
+    required super.txId,
+    required super.unixTime,
+    required super.drivePrivacy,
+    required super.rootFolderId,
+  });
+}
+
+MockARFSFile createMockFile(
+    {appName = 'appName',
+    appVersion = 'appVersion',
+    arFS = 'arFS',
+    driveId = 'driveId',
+    entityType = EntityType.file,
+    txId = 'txId',
+    unixTime,
+    id = 'id',
+    lastModifiedDate,
+    parentFolderId = 'parentFolderId',
+    size = 100,
+    name = 'name'}) {
+  return MockARFSFile(
+    appName: appName,
+    appVersion: appVersion,
+    arFS: arFS,
+    driveId: driveId,
+    entityType: entityType,
+    name: name,
+    txId: txId,
+    unixTime: unixTime ?? DateTime.now(),
+    id: id,
+    size: size,
+    lastModifiedDate: lastModifiedDate ?? DateTime.now(),
+    parentFolderId: parentFolderId,
+  );
+}
+
+MockARFSDrive createMockDrive(
+    {appName = 'appName',
+    appVersion = 'appVersion',
+    arFS = 'arFS',
+    driveId = 'driveId',
+    entityType = EntityType.drive,
+    txId = 'txId',
+    unixTime,
+    drivePrivacy = DrivePrivacy.private,
+    rootFolderId = 'rootFolderId',
+    name = 'name'}) {
+  return MockARFSDrive(
+      appName: appName,
+      appVersion: appVersion,
+      arFS: arFS,
+      driveId: driveId,
+      entityType: entityType,
+      name: name,
+      txId: txId,
+      unixTime: unixTime ?? DateTime.now(),
+      drivePrivacy: drivePrivacy,
+      rootFolderId: rootFolderId);
+}

--- a/test/test_utils/mocks.dart
+++ b/test/test_utils/mocks.dart
@@ -18,6 +18,7 @@ import 'package:ardrive/utils/upload_plan_utils.dart';
 import 'package:ardrive_io/ardrive_io.dart';
 import 'package:arweave/arweave.dart';
 import 'package:bloc_test/bloc_test.dart';
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/widgets.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -85,6 +86,8 @@ class MockEnvFetcher extends Mock implements EnvFetcher {}
 
 class MockTransactionCommonMixin extends Mock
     implements TransactionCommonMixin {}
+
+class MockDeviceInfoPlugin extends Mock implements DeviceInfoPlugin {}
 
 class MockARFSFile extends ARFSFileEntity {
   MockARFSFile({


### PR DESCRIPTION
Implements multi-file downloading for files on public and private drives with ability to skip, retry, and cancel in download error scenarios. 

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/13kdqniv14mag