### PR TITLE
PE-4499: pre-release tasks v2.8.0

### DIFF
--- a/android/fastlane/metadata/android/en-US/changelogs/54.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/54.txt
@@ -1,0 +1,8 @@
+- Implemented the pin feature for public drives
+- Re-organized the options in the NEW menu
+- Reduced the minimum Turbo top up purchase to $5
+- Implemented an option for exporting logs
+- Details Panel will now display the Metadata TX
+- Added app translations for: Spanish, Hindi, Japanese, Hong Kong Chinese and Traditional Chinese
+- Custom metadata (for JSON metadata and GQL tags) are now moved over with new entities' revisions
+- Minor UI fixes

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -79,11 +79,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: PE-4506-clicking-advanced-twice-should-close-the-sub-menu
-      resolved-ref: f69caa01e637f8781e477cf327328901b063123c
+      ref: "v1.8.0"
+      resolved-ref: "988194c87d5cfc594dc1a6365f5b4b0bc6a846d5"
       url: "https://github.com/ar-io/ardrive_ui.git"
     source: git
-    version: "1.7.0"
+    version: "1.8.0"
   args:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   ardrive_ui:
     git:
       url: https://github.com/ar-io/ardrive_ui.git
-      ref: PE-4506-clicking-advanced-twice-should-close-the-sub-menu
+      ref: v1.8.0
   artemis: ^7.0.0-beta.13
   arweave:
     git:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Secure, permanent storage
 
 publish_to: 'none'
 
-version: 2.7.0
+version: 2.8.0
 
 environment:
   sdk: '>=2.18.5 <3.0.0'


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/3gmpnak9t3egg