### PR TITLE
PE-4498: 'Next' button currently inactive despite $5 minimum purchase

### DIFF
--- a/lib/components/top_up_dialog.dart
+++ b/lib/components/top_up_dialog.dart
@@ -287,7 +287,7 @@ class _PresetAmountSelectorState extends State<PresetAmountSelector> {
   }
 
   void _onCustomAmountSelected(String amount) {
-    int amountInt = int.parse(amount);
+    int amountInt = int.tryParse(amount) ?? 0;
 
     // Selects zero to disable the button
     if (amount.isEmpty || amountInt < minAmount) {
@@ -512,6 +512,7 @@ class _PresetAmountSelectorState extends State<PresetAmountSelector> {
             setState(() {
               if (s == null || s.isEmpty) {
                 _customAmountValidationMessage = null;
+                _onCustomAmountSelected('');
                 return;
               }
 

--- a/lib/components/top_up_dialog.dart
+++ b/lib/components/top_up_dialog.dart
@@ -290,7 +290,7 @@ class _PresetAmountSelectorState extends State<PresetAmountSelector> {
     int amountInt = int.parse(amount);
 
     // Selects zero to disable the button
-    if (amount.isEmpty || amountInt < 10) {
+    if (amount.isEmpty || amountInt < minAmount) {
       amountInt = 0;
     }
 
@@ -391,6 +391,7 @@ class _PresetAmountSelectorState extends State<PresetAmountSelector> {
         ),
       ),
     );
+
     return ArDriveForm(
       key: _formKey,
       child: Column(


### PR DESCRIPTION
Changes:
- Makes the button be enabled when the minimum is set.
- Makes it be disabled when the text field is empty.