### PR TITLE
PE-4412: unable-to-download-manifest-file-items

### DIFF
--- a/lib/blocs/file_download/file_download_cubit.dart
+++ b/lib/blocs/file_download/file_download_cubit.dart
@@ -5,6 +5,7 @@ import 'package:ardrive/core/arfs/entities/arfs_entities.dart';
 import 'package:ardrive/core/arfs/repository/arfs_repository.dart';
 import 'package:ardrive/core/crypto/crypto.dart';
 import 'package:ardrive/core/download_service.dart';
+import 'package:ardrive/entities/constants.dart' as constants;
 import 'package:ardrive/models/models.dart';
 import 'package:ardrive/services/services.dart';
 import 'package:ardrive/utils/app_platform.dart';

--- a/lib/blocs/file_download/personal_file_download_cubit.dart
+++ b/lib/blocs/file_download/personal_file_download_cubit.dart
@@ -112,7 +112,8 @@ class ProfileFileDownloadCubit extends FileDownloadCubit {
       ),
     );
 
-    final dataBytes = await _downloadService.download(_file.txId);
+    final dataBytes = await _downloadService.download(
+        _file.txId, _file.contentType == constants.ContentType.manifest);
 
     if (drive.drivePrivacy == DrivePrivacy.private) {
       SecretKey? driveKey;

--- a/lib/core/download_service.dart
+++ b/lib/core/download_service.dart
@@ -4,7 +4,7 @@ import 'package:ardrive/services/arweave/arweave.dart';
 import 'package:ardrive_http/ardrive_http.dart';
 
 abstract class DownloadService {
-  Future<Uint8List> download(String fileId);
+  Future<Uint8List> download(String fileId, bool isManifest);
   factory DownloadService(ArweaveService arweaveService) =>
       _DownloadService(arweaveService);
 }
@@ -15,9 +15,12 @@ class _DownloadService implements DownloadService {
   final ArweaveService _arweave;
 
   @override
-  Future<Uint8List> download(String fileTxId) async {
-    final dataRes = await ArDriveHTTP()
-        .getAsBytes('${_arweave.client.api.gatewayUrl.origin}/$fileTxId');
+  Future<Uint8List> download(String fileTxId, bool isManifest) async {
+    final urlString = isManifest
+        ? '${_arweave.client.api.gatewayUrl.origin}/raw/$fileTxId'
+        : '${_arweave.client.api.gatewayUrl.origin}/$fileTxId';
+
+    final dataRes = await ArDriveHTTP().getAsBytes(urlString);
 
     if (dataRes.statusCode == 200) {
       return dataRes.data;

--- a/lib/download/download_utils.dart
+++ b/lib/download/download_utils.dart
@@ -9,10 +9,11 @@ class MultiDownloadFile extends MultiDownloadItem {
   final String fileId;
   final String fileName;
   final String txId;
+  final String? contentType;
   final int size;
 
-  MultiDownloadFile(
-      this.driveId, this.fileId, this.fileName, this.txId, this.size);
+  MultiDownloadFile(this.driveId, this.fileId, this.fileName, this.txId,
+      this.size, this.contentType);
 }
 
 class MultiDownloadFolder extends MultiDownloadItem {
@@ -37,8 +38,13 @@ Future<List<MultiDownloadItem>> convertFolderToMultidownloadFileList(
   }
 
   for (final file in folderNode.files.values) {
-    multiDownloadFileList.add(MultiDownloadFile(file.driveId, file.id,
-        '$folderPath${file.name}', file.dataTxId, file.size));
+    multiDownloadFileList.add(MultiDownloadFile(
+        file.driveId,
+        file.id,
+        '$folderPath${file.name}',
+        file.dataTxId,
+        file.size,
+        file.dataContentType));
   }
 
   return multiDownloadFileList;
@@ -67,8 +73,8 @@ Future<List<MultiDownloadItem>> convertSelectionToMultiDownloadFileList(
           driveDao, folderNode,
           path: path));
     } else if (item is FileDataTableItem) {
-      multiDownloadFileList.add(MultiDownloadFile(
-          item.driveId, item.id, item.name, item.dataTxId, item.size!));
+      multiDownloadFileList.add(MultiDownloadFile(item.driveId, item.id,
+          item.name, item.dataTxId, item.size!, item.contentType));
     }
   }
 

--- a/lib/download/multiple_download_bloc.dart
+++ b/lib/download/multiple_download_bloc.dart
@@ -5,6 +5,7 @@ import 'package:ardrive/core/arfs/repository/arfs_repository.dart';
 import 'package:ardrive/core/crypto/crypto.dart';
 import 'package:ardrive/core/download_service.dart';
 import 'package:ardrive/download/download_utils.dart';
+import 'package:ardrive/entities/constants.dart' as constants;
 import 'package:ardrive/models/models.dart';
 import 'package:ardrive/pages/drive_detail/drive_detail_page.dart';
 import 'package:ardrive/services/arweave/arweave_service.dart';
@@ -175,7 +176,8 @@ class MultipleDownloadBloc
         if (file is MultiDownloadFile) {
           // TODO: Use cancelable streaming downloading once it is available in
           // ArDriveHTTP
-          final dataBytes = await _downloadService.download(file.txId);
+          final dataBytes = await _downloadService.download(
+              file.txId, file.contentType == constants.ContentType.manifest);
 
           if (_canceled) {
             logger.d('User cancelled multi-file downloading.');

--- a/test/blocs/personal_file_download_cubit_test.dart
+++ b/test/blocs/personal_file_download_cubit_test.dart
@@ -114,7 +114,7 @@ void main() {
     setUp(() {
       when(() => mockARFSRepository.getDriveById(any()))
           .thenAnswer((_) async => mockDrivePrivate);
-      when(() => mockDownloadService.download(any()))
+      when(() => mockDownloadService.download(any(), any()))
           .thenAnswer((invocation) => Future.value(Uint8List(100)));
       when(() => mockDriveDao.getFileKey(any(), any()))
           .thenAnswer((invocation) => Future.value(SecretKey([])));
@@ -342,7 +342,7 @@ void main() {
         /// Using a public drive
         when(() => mockARFSRepository.getDriveById(any()))
             .thenAnswer((_) async => mockDrivePublic);
-        when(() => mockDownloadService.download(any()))
+        when(() => mockDownloadService.download(any(), any()))
             .thenThrow((invocation) => Exception());
       },
       act: (bloc) {
@@ -466,7 +466,7 @@ void main() {
               ],
           verify: (bloc) {
             /// public files on mobile should not call these functions
-            verifyNever(() => mockDownloadService.download(any()));
+            verifyNever(() => mockDownloadService.download(any(), any()));
             verifyNever(() => mockDriveDao.getFileKey(any(), any()));
             verifyNever(() => mockDriveDao.getDriveKey(any(), any()));
             verifyNever(
@@ -508,7 +508,7 @@ void main() {
               ],
           verify: (bloc) {
             /// public files on mobile should not call these functions
-            verifyNever(() => mockDownloadService.download(any()));
+            verifyNever(() => mockDownloadService.download(any(), any()));
             verifyNever(() => mockDriveDao.getFileKey(any(), any()));
             verifyNever(() => mockDriveDao.getDriveKey(any(), any()));
             verifyNever(
@@ -589,7 +589,7 @@ void main() {
           verifyNever(() => mockArDriveDownloader.cancelDownload());
 
           /// public files on mobile should not call these functions
-          verifyNever(() => mockDownloadService.download(any()));
+          verifyNever(() => mockDownloadService.download(any(), any()));
           verifyNever(() => mockDriveDao.getFileKey(any(), any()));
           verifyNever(() => mockDriveDao.getDriveKey(any(), any()));
           verifyNever(

--- a/test/download/multiple_download_bloc_test.dart
+++ b/test/download/multiple_download_bloc_test.dart
@@ -77,7 +77,7 @@ void main() async {
         .thenAnswer((_) async => SecretKey([]));
     when(() => mockDriveDao.getFileKey(any(), any()))
         .thenAnswer((_) async => SecretKey([]));
-    when(() => mockDownloadService.download(any()))
+    when(() => mockDownloadService.download(any(), any()))
         .thenAnswer((_) async => Uint8List(0));
     when(() => mockCrypto.decryptTransactionData(any(), any(), any()))
         .thenAnswer((_) async => Uint8List(0));
@@ -232,10 +232,10 @@ void main() async {
           'should emit Failure with fileNotFound when file is not available',
           build: () {
             final secondFileFailureService = MockDownloadService();
-            when(() => secondFileFailureService.download(any()))
+            when(() => secondFileFailureService.download(any(), any()))
                 .thenAnswer((_) async => Uint8List(0));
-            when(() => secondFileFailureService.download('fail')).thenThrow(
-                ArDriveHTTPException(
+            when(() => secondFileFailureService.download('fail', any()))
+                .thenThrow(ArDriveHTTPException(
                     exception: Exception(),
                     retryAttempts: 8,
                     statusCode: 400,
@@ -275,10 +275,10 @@ void main() async {
           'should emit Failure with networkConnectionError when status code is not 400',
           build: () {
             final secondFileFailureService = MockDownloadService();
-            when(() => secondFileFailureService.download(any()))
+            when(() => secondFileFailureService.download(any(), any()))
                 .thenAnswer((_) async => Uint8List(0));
-            when(() => secondFileFailureService.download('fail')).thenThrow(
-                ArDriveHTTPException(
+            when(() => secondFileFailureService.download('fail', any()))
+                .thenThrow(ArDriveHTTPException(
                     exception: Exception(),
                     retryAttempts: 8,
                     statusCode: 404,
@@ -319,9 +319,9 @@ void main() async {
           build: () {
             var failedOnce = false;
             final secondFileFailureService = MockDownloadService();
-            when(() => secondFileFailureService.download(any()))
+            when(() => secondFileFailureService.download(any(), any()))
                 .thenAnswer((_) async => Uint8List(0));
-            when(() => secondFileFailureService.download('fail'))
+            when(() => secondFileFailureService.download('fail', any()))
                 .thenAnswer((_) async {
               if (!failedOnce) {
                 failedOnce = true;
@@ -395,9 +395,9 @@ void main() async {
           build: () {
             var failedOnce = false;
             final secondFileFailureService = MockDownloadService();
-            when(() => secondFileFailureService.download(any()))
+            when(() => secondFileFailureService.download(any(), any()))
                 .thenAnswer((_) async => Uint8List(0));
-            when(() => secondFileFailureService.download('fail'))
+            when(() => secondFileFailureService.download('fail', any()))
                 .thenAnswer((_) async {
               if (!failedOnce) {
                 failedOnce = true;
@@ -471,13 +471,13 @@ void main() async {
           'should end Bloc after cancellation',
           build: () {
             final secondFileCancelService = MockDownloadService();
-            when(() => secondFileCancelService.download(any()))
+            when(() => secondFileCancelService.download(any(), any()))
                 .thenAnswer((_) async => Uint8List(0));
 
             final bloc = createMultipleDownloadBloc(
                 downloadService: secondFileCancelService);
 
-            when(() => secondFileCancelService.download('cancel'))
+            when(() => secondFileCancelService.download('cancel', any()))
                 .thenAnswer((_) async {
               bloc.add(const CancelDownload());
               return Uint8List(0);


### PR DESCRIPTION
adds support for downloading manifest files from raw endpoint

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/7h435u8p0sf6o