### PR TITLE
PE-4650: Missing 'Detach Drive' option on Android and Mobile WebView

### DIFF
--- a/lib/pages/drive_detail/drive_detail_page.dart
+++ b/lib/pages/drive_detail/drive_detail_page.dart
@@ -861,22 +861,15 @@ class MobileFolderNavigation extends StatelessWidget {
                         context.read<ProfileCubit>().state is ProfileLoggedIn)
                       ArDriveDropdownItem(
                         onClick: () {
-                          final bloc = context.read<DriveDetailCubit>();
-
-                          bloc.selectDataItem(
-                            DriveDataTableItemMapper.fromDrive(
-                              state.currentDrive,
-                              (_) => null,
-                              0,
-                              isOwner,
-                            ),
+                          showDetachDriveDialog(
+                            context: context,
+                            driveID: state.currentDrive.id,
+                            driveName: state.currentDrive.name,
                           );
                         },
                         content: _buildItem(
-                          appLocalizationsOf(context).moreInfo,
-                          ArDriveIcons.info(
-                            size: defaultIconSize,
-                          ),
+                          appLocalizationsOf(context).detachDrive,
+                          ArDriveIcons.detach(),
                         ),
                       ),
                   ],


### PR DESCRIPTION
<img width="974" alt="Screenshot 2023-09-20 at 17 56 43" src="https://github.com/ardriveapp/ardrive-web/assets/22564541/59e498d1-6e66-48e5-bf24-8370cbb39b8d">


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/5gc4p0o7dh7oo