### PR TITLE
PE-4778: missing-normal-playback-option-video-preview

### DIFF
--- a/lib/pages/drive_detail/components/fs_entry_preview_widget.dart
+++ b/lib/pages/drive_detail/components/fs_entry_preview_widget.dart
@@ -439,7 +439,10 @@ class _VideoPlayerWidgetState extends State<VideoPlayerWidget>
                                               });
                                             },
                                             title: Text(
-                                              '$v',
+                                              v == 1.0
+                                                  ? appLocalizationsOf(context)
+                                                      .normal
+                                                  : '$v',
                                               style: ArDriveTypography.body
                                                   .buttonNormalBold(
                                                       color: colors
@@ -956,7 +959,11 @@ class _FullScreenVideoPlayerWidgetState
                                                           });
                                                         },
                                                         title: Text(
-                                                          '$v',
+                                                          v == 1.0
+                                                              ? appLocalizationsOf(
+                                                                      context)
+                                                                  .normal
+                                                              : '$v',
                                                           style: ArDriveTypography
                                                               .body
                                                               .buttonNormalBold(


### PR DESCRIPTION
Changes video player popup to show 'Normal' in the same way as implemented as Audio Player. 

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/7bn0281d665h0