### PR TITLE
Request credentials before switching chain.

### DIFF
--- a/lib/services/ethereum/provider/implementations/ethereum_provider_web.dart
+++ b/lib/services/ethereum/provider/implementations/ethereum_provider_web.dart
@@ -26,20 +26,19 @@ class JSrawRequestParams {
 Future<EthereumProviderWallet?> connect() async {
   final eth = _getProvider();
 
-  // Ensure the user is on Ethereum chain before requesting account
+  final credentials = await eth.requestAccount();
+  if (!eth.isConnected()) {
+    return null;
+  }
+  final address = credentials.address;
+
+  // Ensure the user is on Ethereum chain
   await eth.rawRequest(
     'wallet_switchEthereumChain',
     params: [
       JSrawRequestParams(chainId: '0x1'),
     ],
   );
-
-  final credentials = await eth.requestAccount();
-  if (!eth.isConnected()) {
-    return null;
-  }
-
-  final address = credentials.address;
 
   return EthereumProviderWallet(credentials, address.hex);
 }


### PR DESCRIPTION
This improves compatibility with some other wallets (e.g. Phantom)