### PR TITLE
PE-4812: cancel button fails to stop file upload when using ARs only

### DIFF
--- a/lib/blocs/upload/upload_cubit.dart
+++ b/lib/blocs/upload/upload_cubit.dart
@@ -1034,7 +1034,7 @@ class UploadCubit extends Cubit<UploadState> {
           ),
         );
 
-        state.controller.cancel();
+        await state.controller.cancel();
 
         emit(
           UploadInProgressUsingNewUploader(

--- a/lib/blocs/upload/upload_cubit.dart
+++ b/lib/blocs/upload/upload_cubit.dart
@@ -1047,8 +1047,6 @@ class UploadCubit extends Cubit<UploadState> {
           ),
         );
 
-        logger.d('Upload canceled');
-
         emit(UploadCanceled());
       } catch (e) {
         logger.e('Error canceling upload', e);

--- a/lib/blocs/upload/upload_state.dart
+++ b/lib/blocs/upload/upload_state.dart
@@ -213,6 +213,7 @@ class UploadInProgressUsingNewUploader extends UploadState {
   final double totalProgress;
   final bool isCanceling;
   final Key? equatableBust;
+  final UploadMethod uploadMethod;
 
   UploadInProgressUsingNewUploader({
     required this.progress,
@@ -220,6 +221,7 @@ class UploadInProgressUsingNewUploader extends UploadState {
     required this.controller,
     this.equatableBust,
     this.isCanceling = false,
+    required this.uploadMethod,
   });
 
   @override
@@ -244,6 +246,10 @@ class UploadShowingWarning extends UploadState {
   @override
   List<Object> get props => [reason];
 }
+
+class UploadCanceled extends UploadState {}
+
+class CancelD2NUploadWarning extends UploadState {}
 
 enum UploadWarningReason {
   /// The user is attempting to upload a file that is too large.

--- a/lib/components/upload_form.dart
+++ b/lib/components/upload_form.dart
@@ -829,7 +829,7 @@ class _UploadFormState extends State<UploadForm> {
                         ),
                         ModalAction(
                           action: () {
-                            context.read<UploadCubit>().cancelUpload();
+                            cubit.cancelUpload();
                             Navigator.pop(context);
                           },
                           title: 'Yes',

--- a/lib/components/upload_form.dart
+++ b/lib/components/upload_form.dart
@@ -770,14 +770,15 @@ class _UploadFormState extends State<UploadForm> {
     final progress = state.progress;
     return ArDriveStandardModal(
       actions: [
-        ModalAction(
-          action: () {
-            context.read<UploadCubit>().cancelUpload();
-          },
-          title: state.isCanceling
-              ? 'Canceling...'
-              : appLocalizationsOf(context).cancelEmphasized,
-        ),
+        if (state.controller.canCancelUpload())
+          ModalAction(
+            action: () {
+              context.read<UploadCubit>().cancelUpload();
+            },
+            title: state.isCanceling
+                ? 'Canceling...'
+                : appLocalizationsOf(context).cancelEmphasized,
+          ),
       ],
       width: kLargeDialogWidth,
       title:

--- a/packages/ardrive_uploader/lib/src/d2n_streamed_upload.dart
+++ b/packages/ardrive_uploader/lib/src/d2n_streamed_upload.dart
@@ -91,8 +91,9 @@ class D2NStreamedUpload implements StreamedUpload<UploadTask, dynamic> {
   @override
   Future<void> cancel(UploadTask handle, UploadController controller) async {
     print('D2NStreamedUpload.cancel');
-    _aborter?.abort();
     _isCanceled = true;
+
+    await _aborter?.abort();
   }
 
   bool _isCanceled = false;

--- a/packages/ardrive_uploader/lib/src/d2n_streamed_upload.dart
+++ b/packages/ardrive_uploader/lib/src/d2n_streamed_upload.dart
@@ -70,6 +70,7 @@ class D2NStreamedUpload implements StreamedUpload<UploadTask, dynamic> {
     });
   }
 
+  /// Cancel D2N uploads are not supported yet.
   @override
   Future<void> cancel(UploadTask handle, UploadController controller) {
     // TODO: implement cancel

--- a/packages/ardrive_uploader/lib/src/d2n_streamed_upload.dart
+++ b/packages/ardrive_uploader/lib/src/d2n_streamed_upload.dart
@@ -15,6 +15,12 @@ class D2NStreamedUpload implements StreamedUpload<UploadTask, dynamic> {
       throw ArgumentError('handle must be of type TransactionUploadTask');
     }
 
+    /// It is possible to cancel an upload before starting the network request.
+    if (_isCanceled) {
+      print('Upload canceled on D2NStreamedUpload');
+      return;
+    }
+
     print('D2NStreamedUpload.send');
 
     handle = handle.copyWith(
@@ -86,5 +92,8 @@ class D2NStreamedUpload implements StreamedUpload<UploadTask, dynamic> {
   Future<void> cancel(UploadTask handle, UploadController controller) async {
     print('D2NStreamedUpload.cancel');
     _aborter?.abort();
+    _isCanceled = true;
   }
+
+  bool _isCanceled = false;
 }

--- a/packages/ardrive_uploader/lib/src/turbo_streamed_upload.dart
+++ b/packages/ardrive_uploader/lib/src/turbo_streamed_upload.dart
@@ -49,6 +49,15 @@ class TurboStreamedUpload implements StreamedUpload<UploadTask, dynamic> {
       size += data.length;
     }
 
+    print('Upload status after calculating the size: ${uploadTask.status}');
+
+    /// It is possible to cancel an upload before starting the network request.
+    print('Is canceled: $_isCanceled');
+    if (_isCanceled) {
+      print('Upload canceled on StreamedUpload');
+      return;
+    }
+
     /// If the file is larger than 500 MiB, we don't get progress updates.
     ///
     /// The TurboUploadServiceImpl for web uses fetch_client for the upload of files
@@ -109,8 +118,11 @@ class TurboStreamedUpload implements StreamedUpload<UploadTask, dynamic> {
     UploadTask handle,
     UploadController controller,
   ) async {
-    handle = handle.copyWith(status: UploadStatus.failed);
-    controller.updateProgress(task: handle);
+    _isCanceled = true;
     await _turbo.cancel();
+    handle = handle.copyWith(status: UploadStatus.canceled);
+    controller.updateProgress(task: handle);
   }
+
+  bool _isCanceled = false;
 }

--- a/packages/ardrive_uploader/lib/src/turbo_streamed_upload.dart
+++ b/packages/ardrive_uploader/lib/src/turbo_streamed_upload.dart
@@ -49,10 +49,7 @@ class TurboStreamedUpload implements StreamedUpload<UploadTask, dynamic> {
       size += data.length;
     }
 
-    print('Upload status after calculating the size: ${uploadTask.status}');
-
     /// It is possible to cancel an upload before starting the network request.
-    print('Is canceled: $_isCanceled');
     if (_isCanceled) {
       print('Upload canceled on StreamedUpload');
       return;

--- a/packages/ardrive_uploader/lib/src/turbo_upload_service_dart_io.dart
+++ b/packages/ardrive_uploader/lib/src/turbo_upload_service_dart_io.dart
@@ -52,7 +52,6 @@ class TurboUploadServiceImpl implements TurboUploadService<Response> {
 
       return response;
     } catch (e) {
-      print('Error on turbo upload: $e');
       if (_isCanceled) {
         _cancelToken = CancelToken();
 

--- a/packages/ardrive_uploader/lib/src/turbo_upload_service_dart_io.dart
+++ b/packages/ardrive_uploader/lib/src/turbo_upload_service_dart_io.dart
@@ -36,7 +36,6 @@ class TurboUploadServiceImpl implements TurboUploadService<Response> {
       final response = await dio.post(
         url,
         onSendProgress: (sent, total) {
-          print('Sent: $sent, total: $total');
           onSendProgress?.call(sent / total);
         },
         data: dataItem.streamGenerator(), // Creates a Stream<List<int>>.

--- a/packages/ardrive_uploader/lib/src/turbo_upload_service_web.dart
+++ b/packages/ardrive_uploader/lib/src/turbo_upload_service_web.dart
@@ -83,6 +83,7 @@ class TurboUploadServiceImpl implements TurboUploadService {
         ),
         cancelToken: _cancelToken,
       );
+      
       print('Response from turbo: ${response.statusCode}');
 
       return response;

--- a/packages/ardrive_uploader/lib/src/upload_controller.dart
+++ b/packages/ardrive_uploader/lib/src/upload_controller.dart
@@ -143,6 +143,7 @@ class FileUploadTask extends UploadTask {
     SecretKey? encryptionKey,
     StreamedUpload? streamedUpload,
   }) {
+    print('Copying new task with status: ${status ?? this.status}');
     return FileUploadTask(
       streamedUpload: streamedUpload ?? this.streamedUpload,
       encryptionKey: encryptionKey ?? this.encryptionKey,
@@ -345,10 +346,7 @@ class _UploadController implements UploadController {
       if (task.status == UploadStatus.complete) continue;
       if (task.status == UploadStatus.failed) continue;
 
-      if (task.status == UploadStatus.inProgress) {
-        print('Canceling request: ${task.id}');
-        task.streamedUpload.cancel(task, this);
-      }
+      task.streamedUpload.cancel(task, this);
 
       task = task.copyWith(status: UploadStatus.canceled);
 
@@ -742,7 +740,7 @@ class Worker {
 
       /// The upload can be canceled while the bundle is being created
       if (task.status == UploadStatus.canceled) {
-        print('Upload canceled');
+        print('Upload canceled while bundle was being created');
         return;
       }
 
@@ -769,7 +767,7 @@ class Worker {
       );
 
       if (_isCanceled) {
-        print('Upload canceled');
+        print('Upload canceled after bundle creation and before upload');
         return;
       }
 

--- a/packages/ardrive_uploader/pubspec.yaml
+++ b/packages/ardrive_uploader/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   arweave:
     git:
       url: https://github.com/ardriveapp/arweave-dart.git
-      ref: PE-3697
+      ref: PE-4812-cancel-button-fails-to-stop-file-upload-when-using-a-rs-only
   ardrive_utils:
     path: ../ardrive_utils
   ardrive_crypto:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -139,8 +139,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: PE-3697
-      resolved-ref: c2bd4e0b6475c0c62b4cbf83bb4a928e4147fc3a
+      ref: PE-4812-cancel-button-fails-to-stop-file-upload-when-using-a-rs-only
+      resolved-ref: "0fd825555310a1a5bf5d256328c3f207ce148a5e"
       url: "https://github.com/ardriveapp/arweave-dart.git"
     source: git
     version: "3.7.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -135,7 +135,7 @@ dependency_overrides:
   arweave:
     git:
       url: https://github.com/ardriveapp/arweave-dart.git
-      ref: PE-3697
+      ref: PE-4812-cancel-button-fails-to-stop-file-upload-when-using-a-rs-only
   stripe_js:
     git:
       url: https://github.com/ardriveapp/flutter_stripe/


### PR DESCRIPTION
Implements the ability to cancel a D2N upload. We are also providing a warning to the user that he can lose his money while canceling an in-progress upload.

For Turbo uploads, it doesn't change the current behavior.

https://github.com/ardriveapp/ardrive-web/assets/32248947/283b7b16-b574-43e5-b0ba-640788416fc2


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/7mmpmj5ovaar8