### PR TITLE
PE-4928: Corrects the duplicate time indicators for video preview in drive explorer

### DIFF
--- a/lib/pages/drive_detail/components/fs_entry_preview_widget.dart
+++ b/lib/pages/drive_detail/components/fs_entry_preview_widget.dart
@@ -273,13 +273,14 @@ class _VideoPlayerWidgetState extends State<VideoPlayerWidget>
                 const SizedBox(height: 8),
                 Row(
                   children: [
-                    ScreenTypeLayout.builder(
-                      desktop: (context) => Row(children: [
-                        Text(currentTime),
-                        const SizedBox(width: 8),
-                      ]),
-                      mobile: (context) => const SizedBox.shrink(),
-                    ),
+                    if (widget.isSharePage)
+                      ScreenTypeLayout.builder(
+                        desktop: (context) => Row(children: [
+                          Text(currentTime),
+                          const SizedBox(width: 8),
+                        ]),
+                        mobile: (context) => const SizedBox.shrink(),
+                      ),
                     Expanded(
                       child: SliderTheme(
                         data: SliderThemeData(
@@ -351,13 +352,14 @@ class _VideoPlayerWidgetState extends State<VideoPlayerWidget>
                         ),
                       ),
                     ),
-                    ScreenTypeLayout.builder(
-                      desktop: (context) => Row(children: [
-                        const SizedBox(width: 8),
-                        Text(duration),
-                      ]),
-                      mobile: (context) => const SizedBox.shrink(),
-                    ),
+                    if (widget.isSharePage)
+                      ScreenTypeLayout.builder(
+                        desktop: (context) => Row(children: [
+                          const SizedBox(width: 8),
+                          Text(duration),
+                        ]),
+                        mobile: (context) => const SizedBox.shrink(),
+                      ),
                   ],
                 ),
                 const SizedBox(height: 4),


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/5b4r0usi4sbfo