### PR TITLE
PE-4842: wrap text on details panel when values are huge

### DIFF
--- a/lib/components/details_panel.dart
+++ b/lib/components/details_panel.dart
@@ -651,6 +651,7 @@ class _DetailsPanelState extends State<DetailsPanel> {
       DetailsPanelItem(
         leading: Text(
           widget.item.contentType,
+          textAlign: TextAlign.right,
           style: ArDriveTypography.body.buttonNormalRegular(),
         ),
         itemTitle: appLocalizationsOf(context).fileType,
@@ -906,7 +907,7 @@ class DetailsPanelItem extends StatelessWidget {
                   ],
                 ),
               ),
-              if (leading != null) leading!,
+              if (leading != null) Flexible(child: leading!),
             ],
           ),
         ),


### PR DESCRIPTION
<img width="391" alt="image" src="https://github.com/ardriveapp/ardrive-web/assets/9200155/0447abec-39af-4cb0-8bcb-be748d2a2787">
<img width="311" alt="image" src="https://github.com/ardriveapp/ardrive-web/assets/9200155/aaa4959b-220a-4158-9657-67f37e4bf0a1">


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/0o6d959ghr0kg