### PR TITLE
PE-5087: download modal stays open in android for private files

### DIFF
--- a/lib/download/ardrive_downloader.dart
+++ b/lib/download/ardrive_downloader.dart
@@ -69,7 +69,7 @@ class _ArDriveDownloader implements ArDriveDownloader {
       final isPrivateFile =
           fileKey != null && cipher != null && cipherIvString != null;
 
-      if (isPrivateFile && cipherIvString == Cipher.aes256gcm) {
+      if (isPrivateFile && cipher == Cipher.aes256gcm) {
         return _getDartVMGCMDecryptStream(
           cipher,
           cipherIvString,

--- a/lib/download/ardrive_downloader.dart
+++ b/lib/download/ardrive_downloader.dart
@@ -65,6 +65,28 @@ class _ArDriveDownloader implements ArDriveDownloader {
     String? cipher,
     String? cipherIvString,
   }) async {
+    if (AppPlatform.isMobile) {
+      final isPrivateFile =
+          fileKey != null && cipher != null && cipherIvString != null;
+
+      if (isPrivateFile && cipherIvString == Cipher.aes256gcm) {
+        return _getDartVMGCMDecryptStream(
+          cipher,
+          cipherIvString,
+          (await arweave.download(
+            txId: dataTx.id,
+            onProgress: (progress, speed) => logger.d(progress.toString()),
+          ))
+              .$1,
+          fileSize,
+          fileName,
+          lastModifiedDate,
+          contentType,
+          fileKey,
+        );
+      }
+    }
+
     Stream<Uint8List> saveStream;
 
     if (isManifest) {
@@ -215,5 +237,39 @@ class _ArDriveDownloader implements ArDriveDownloader {
 
     logger.d('No cipher found. Saving file as is...');
     return streamDownload.transform(listIntToUint8ListTransformer);
+  }
+
+  Stream<double> _getDartVMGCMDecryptStream(
+    String cipher,
+    String cipherIvString,
+    Stream<List<int>> streamDownload,
+    int fileSize,
+    String fileName,
+    DateTime lastModifiedDate,
+    String contentType,
+    SecretKey fileKey,
+  ) async* {
+    List<int> bytes = [];
+
+    await for (var chunk in streamDownload) {
+      bytes.addAll(chunk);
+      yield bytes.length / fileSize * 100;
+    }
+
+    final encryptedData = await decryptTransactionData(
+      cipher,
+      cipherIvString,
+      Uint8List.fromList(bytes),
+      fileKey,
+    );
+
+    _ardriveIo.saveFile(
+      await IOFile.fromData(encryptedData,
+          name: fileName,
+          lastModifiedDate: lastModifiedDate,
+          contentType: contentType),
+    );
+
+    return;
   }
 }


### PR DESCRIPTION
- use the `decryptTransactionData` instead of `decryptTransactionDataStream` method to decrypt the file on Dart VM (Mobile).

Using the `decryptTransactionDataStream` we get the following exception: 
```
Error saving file: 'package:webcrypto/src/impl_ffi/impl_ffi.aesctr.dart': Failed assertion: line 155 pos 16: 'i == M': is not true.
```

Note that it seems to use the aes ctr even passing the right cipher: **GCM**.

For now, we are using the old method (current in prod) to decrypt the file using GCM.

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/5c7rp53c6c740