### PR TITLE
PE-5134: limit uploads for turbo on web to 500MiB

### DIFF
--- a/lib/blocs/create_snapshot/create_snapshot_cubit.dart
+++ b/lib/blocs/create_snapshot/create_snapshot_cubit.dart
@@ -469,8 +469,7 @@ class CreateSnapshotCubit extends Cubit<CreateSnapshotState> {
   }
 
   void _computeIsTurboEnabled() async {
-    bool isTurboEnabled = appConfig.useTurboUpload;
-    _isTurboUploadPossible = isTurboEnabled && _sufficentCreditsBalance;
+    _isTurboUploadPossible = _sufficentCreditsBalance;
   }
 
   void _computeIsSufficientBalance() {

--- a/lib/blocs/upload/limits.dart
+++ b/lib/blocs/upload/limits.dart
@@ -1,4 +1,5 @@
 import 'package:ardrive_utils/ardrive_utils.dart';
+import 'package:flutter/foundation.dart';
 
 final privateFileSizeLimit = const GiB(65).size;
 
@@ -9,10 +10,22 @@ final mobilePrivateFileSizeLimit = const GiB(10).size;
 final publicFileSafeSizeLimit = const GiB(5).size;
 final nonChromeBrowserUploadSafeLimitUsingTurbo = const MiB(500).size;
 
-int getBundleSizeLimit(bool isTurbo) =>
-    isTurbo ? turboBundleSizeLimit : d2nBundleSizeLimit;
+int getBundleUploadSizeLimit(bool isTurbo, {bool? mockKIsWeb}) {
+  // Use mockKIsWeb if it's provided, otherwise use the actual kIsWeb
+  bool isWeb = mockKIsWeb ?? kIsWeb;
+
+  if (isTurbo) {
+    if (isWeb) {
+      return turboWebPlatformsBundleSizeLimit;
+    }
+    return turboBundleSizeLimit;
+  }
+
+  return d2nBundleSizeLimit;
+}
 
 final d2nBundleSizeLimit = const GiB(65).size;
+final turboWebPlatformsBundleSizeLimit = const MiB(500).size;
 final turboBundleSizeLimit = const GiB(2).size;
 final mobileBundleSizeLimit = const GiB(65).size;
 const maxBundleDataItemCount = 500;

--- a/lib/blocs/upload/models/upload_plan.dart
+++ b/lib/blocs/upload/models/upload_plan.dart
@@ -60,7 +60,7 @@ class UploadPlan {
   }) async {
     logger.i(
         'Creating bundle handles from data item handles with a max number of files of $maxDataItemCount');
-    final int maxBundleSize = getBundleSizeLimit(useTurbo);
+    final int maxBundleSize = getBundleUploadSizeLimit(useTurbo);
 
     final folderItems = await NextFitBundlePacker<UploadHandle>(
       maxBundleSize: maxBundleSize,

--- a/lib/blocs/upload/upload_cubit.dart
+++ b/lib/blocs/upload/upload_cubit.dart
@@ -380,7 +380,6 @@ class UploadCubit extends Cubit<UploadState> {
         isButtonEnabled = true;
       } else if (_uploadMethod == UploadMethod.turbo &&
           paymentInfo.isUploadEligibleToTurbo &&
-          paymentInfo.isTurboAvailable &&
           sufficientBalanceToPayWithTurbo) {
         logger.d('Enabling button for Turbo payment method');
         isButtonEnabled = true;
@@ -393,8 +392,7 @@ class UploadCubit extends Cubit<UploadState> {
 
       emit(
         UploadReady(
-          isTurboUploadPossible: paymentInfo.isUploadEligibleToTurbo &&
-              paymentInfo.isTurboAvailable,
+          isTurboUploadPossible: paymentInfo.isUploadEligibleToTurbo,
           isZeroBalance: isTurboZeroBalance,
           turboCredits: literalBalance,
           uploadSize: paymentInfo.totalSize,

--- a/lib/dev_tools/app_dev_tools.dart
+++ b/lib/dev_tools/app_dev_tools.dart
@@ -116,19 +116,6 @@ class AppConfigWindowManagerState extends State<AppConfigWindowManager> {
       type: ArDriveDevToolOptionType.text,
     );
 
-    final ArDriveDevToolOption useTurboOption = ArDriveDevToolOption(
-      name: 'useTurboUpload',
-      value: config.useTurboUpload,
-      onChange: (value) {
-        setState(() {
-          configService.updateAppConfig(
-            config.copyWith(useTurboUpload: value),
-          );
-        });
-      },
-      type: ArDriveDevToolOptionType.bool,
-    );
-
     final ArDriveDevToolOption useTurboPaymentOption = ArDriveDevToolOption(
       name: 'useTurboPayment',
       value: config.useTurboPayment,
@@ -377,7 +364,6 @@ class AppConfigWindowManagerState extends State<AppConfigWindowManager> {
     );
 
     final List<ArDriveDevToolOption> options = [
-      useTurboOption,
       useTurboPaymentOption,
       defaultTurboPaymentUrlOption,
       enableSyncFromSnapshotOption,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -109,14 +109,12 @@ Future<void> _initialize() async {
     ),
     ArDriveCrypto(),
   );
-  _turboUpload = config.useTurboUpload
-      ? TurboUploadService(
-          tabVisibilitySingleton: TabVisibilitySingleton(),
-          turboUploadUri: Uri.parse(config.defaultTurboUploadUrl!),
-          allowedDataItemSize: config.allowedDataItemSizeForTurbo,
-          httpClient: ArDriveHTTP(),
-        )
-      : DontUseUploadService();
+  _turboUpload = TurboUploadService(
+    tabVisibilitySingleton: TabVisibilitySingleton(),
+    turboUploadUri: Uri.parse(config.defaultTurboUploadUrl!),
+    allowedDataItemSize: config.allowedDataItemSizeForTurbo,
+    httpClient: ArDriveHTTP(),
+  );
 
   _turboPayment = config.useTurboPayment
       ? PaymentService(

--- a/lib/services/config/app_config.dart
+++ b/lib/services/config/app_config.dart
@@ -6,7 +6,6 @@ part 'app_config.g.dart';
 @JsonSerializable()
 class AppConfig {
   final String? defaultArweaveGatewayUrl;
-  final bool useTurboUpload;
   final bool useTurboPayment;
   final String? defaultTurboUploadUrl;
   final String? defaultTurboPaymentUrl;
@@ -25,7 +24,6 @@ class AppConfig {
 
   AppConfig({
     this.defaultArweaveGatewayUrl,
-    this.useTurboUpload = false,
     this.useTurboPayment = false,
     this.defaultTurboUploadUrl,
     this.defaultTurboPaymentUrl,
@@ -71,7 +69,6 @@ class AppConfig {
     return AppConfig(
       defaultArweaveGatewayUrl:
           defaultArweaveGatewayUrl ?? this.defaultArweaveGatewayUrl,
-      useTurboUpload: useTurboUpload ?? this.useTurboUpload,
       useTurboPayment: useTurboPayment ?? this.useTurboPayment,
       defaultTurboUploadUrl:
           defaultTurboUploadUrl ?? this.defaultTurboUploadUrl,

--- a/lib/utils/upload_plan_utils.dart
+++ b/lib/utils/upload_plan_utils.dart
@@ -85,7 +85,7 @@ class UploadPlanUtils {
           ? RevisionAction.uploadNewVersion
           : RevisionAction.create;
 
-      final bundleSizeLimit = getBundleSizeLimit(useTurbo);
+      final bundleSizeLimit = getBundleUploadSizeLimit(useTurbo);
 
       if (fileSize < bundleSizeLimit) {
         fileDataItemUploadHandles[fileEntity.id!] = FileDataItemUploadHandle(

--- a/test/blocs/create_snapshot_cubit_test.dart
+++ b/test/blocs/create_snapshot_cubit_test.dart
@@ -198,7 +198,6 @@ void main() {
 
         when(() => appConfig.allowedDataItemSizeForTurbo)
             .thenAnswer((invocation) => 100);
-        when(() => appConfig.useTurboUpload).thenAnswer((invocation) => true);
         when(() => appConfig.forceNoFreeThanksToTurbo)
             .thenAnswer((invocation) => false);
         when(() => appConfig.fakeTurboCredits).thenAnswer((invocation) => null);

--- a/test/blocs/upload_cubit_test.dart
+++ b/test/blocs/upload_cubit_test.dart
@@ -228,7 +228,6 @@ void main() {
             turboCostEstimate: mockUploadCostEstimateTurbo,
             isFreeUploadPossibleUsingTurbo: false,
             totalSize: 100,
-            isTurboAvailable: true,
             turboBalance: BigInt.from(100),
           ),
         ),

--- a/test/core/upload/limits_test.dart
+++ b/test/core/upload/limits_test.dart
@@ -1,0 +1,38 @@
+import 'package:ardrive/blocs/upload/limits.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('getBundleUploadSizeLimit Tests', () {
+    test(
+        'should return turboWebPlatformsBundleSizeLimit when isTurbo is true and platform is Web',
+        () {
+      // Call the function with isTurbo = true and mockKIsWeb = true
+      final result = getBundleUploadSizeLimit(true, mockKIsWeb: true);
+
+      // Assert that the result matches the expected value
+      expect(result, equals(turboWebPlatformsBundleSizeLimit));
+    });
+
+    test(
+        'should return turboBundleSizeLimit when isTurbo is true and platform is not Web',
+        () {
+      // Call the function with isTurbo = true and mockKIsWeb = false
+      final result = getBundleUploadSizeLimit(true, mockKIsWeb: false);
+
+      // Assert that the result matches the expected value
+      expect(result, equals(turboBundleSizeLimit));
+    });
+
+    test('should return d2nBundleSizeLimit when isTurbo is false', () {
+      // Test for both Web and non-Web platforms since it should not matter in this case
+
+      // Call the function with isTurbo = false and mockKIsWeb = true
+      expect(getBundleUploadSizeLimit(false, mockKIsWeb: true),
+          equals(d2nBundleSizeLimit));
+
+      // Call the function with isTurbo = false and mockKIsWeb = false
+      expect(getBundleUploadSizeLimit(false, mockKIsWeb: false),
+          equals(d2nBundleSizeLimit));
+    });
+  });
+}

--- a/test/core/upload/uploader_test.dart
+++ b/test/core/upload/uploader_test.dart
@@ -419,7 +419,7 @@ void main() {
           expect(result.isUploadEligibleToTurbo, isTrue);
         });
 
-        test('isTurboUploadPossible returns false when not have any bundles',
+        test('isUploadEligibleToTurbo returns false when not have any bundles',
             () async {
           final mockFile = MockBundleUploadHandle();
           when(() => mockFile.size).thenReturn(501);
@@ -436,11 +436,10 @@ void main() {
 
           expect(result.isFreeUploadPossibleUsingTurbo, isFalse);
           expect(result.isUploadEligibleToTurbo, isFalse);
-          expect(result.isTurboAvailable, isTrue);
         });
 
         test(
-            'isTurboUploadPossible returns false when not have any bundles but have a v2',
+            'isUploadEligibleToTurbo returns false when not have any bundles but have a v2',
             () async {
           final mockFile = MockBundleUploadHandle();
           when(() => mockFile.size).thenReturn(501);
@@ -469,7 +468,6 @@ void main() {
 
           expect(result.isFreeUploadPossibleUsingTurbo, isFalse);
           expect(result.isUploadEligibleToTurbo, isFalse);
-          expect(result.isTurboAvailable, isTrue);
         });
 
         test(
@@ -505,41 +503,6 @@ void main() {
 
           expect(result.isFreeUploadPossibleUsingTurbo, isFalse);
           expect(result.isUploadEligibleToTurbo, isFalse);
-          expect(result.isTurboAvailable, isTrue);
-        });
-
-        test('isTurboAvailable returns false when the feature flag is false',
-            () async {
-          final turboBalanceRetriever = MockTurboBalanceRetriever();
-          final paymentEvaluatorWithFeatureFlagFalse = UploadPaymentEvaluator(
-            turboBalanceRetriever: turboBalanceRetriever,
-            uploadCostEstimateCalculatorForAR:
-                uploadCostEstimateCalculatorForAR,
-            auth: auth,
-            turboUploadCostCalculator: turboUploadCostCalculator,
-            appConfig: getFakeConfigForDisabledTurbo(),
-          );
-
-          when(() => mockFile.size).thenReturn(503);
-          when(() => mockFile2.size).thenReturn(503);
-
-          // limit of 500
-          when(() => mockBundle.computeBundleSize())
-              .thenAnswer((invocation) => Future.value(503));
-
-          when(() => uploadPlan.bundleUploadHandles).thenReturn([mockBundle]);
-
-          final result =
-              await paymentEvaluatorWithFeatureFlagFalse.getUploadPaymentInfo(
-            uploadPlanForAR: uploadPlan,
-            uploadPlanForTurbo: uploadPlan,
-          );
-
-          expect(result.isFreeUploadPossibleUsingTurbo, isFalse);
-          expect(result.isUploadEligibleToTurbo, isTrue);
-          expect(result.isTurboAvailable, isFalse);
-
-          verifyNever(() => turboBalanceRetriever.getBalance(any()));
         });
 
         test('isTurboAvailable returns false when getBalance throws', () async {
@@ -555,19 +518,16 @@ void main() {
             uploadPlanForTurbo: uploadPlan,
           );
 
-          // the important part is that we don't throw
-          expect(result.isTurboAvailable, isFalse);
-
           expect(result.isFreeUploadPossibleUsingTurbo, isFalse);
 
           // To be eligible to turbo, we just need to pass a bundle
-          expect(result.isUploadEligibleToTurbo, isTrue);
+          expect(result.isUploadEligibleToTurbo, isFalse);
 
           // the payment method must be AR
           expect(result.defaultPaymentMethod, equals(UploadMethod.ar));
         });
 
-        test('isTurboAvailable returns false when calculateCost throws',
+        test('isUploadEligibleToTurbo returns false when calculateCost throws',
             () async {
           when(() => mockFile.size).thenReturn(501);
           when(() => mockBundle.computeBundleSize())
@@ -582,9 +542,8 @@ void main() {
           );
 
           // the important part is that we don't throw
-          expect(result.isTurboAvailable, isFalse);
           expect(result.isFreeUploadPossibleUsingTurbo, isFalse);
-          expect(result.isUploadEligibleToTurbo, isTrue);
+          expect(result.isUploadEligibleToTurbo, isFalse);
 
           // the payment method must be AR
           expect(result.defaultPaymentMethod, equals(UploadMethod.ar));
@@ -892,7 +851,6 @@ void main() {
           turboCostEstimate: mockUploadCostEstimateTurbo,
           isFreeUploadPossibleUsingTurbo: true,
           totalSize: 100,
-          isTurboAvailable: true,
           turboBalance: BigInt.from(100),
         );
 
@@ -966,14 +924,12 @@ void main() {
 AppConfig getFakeConfig() => AppConfig(
       allowedDataItemSizeForTurbo: 500,
       stripePublishableKey: '',
-      useTurboUpload: true,
       useTurboPayment: true,
     );
 
 AppConfig getFakeConfigForDisabledTurbo() => AppConfig(
       allowedDataItemSizeForTurbo: 500,
       stripePublishableKey: '',
-      useTurboUpload: false,
       useTurboPayment: false,
     );
 User getFakeUser() => User(


### PR DESCRIPTION
- Updates the limit for Turbo uploads on the web to 500MiB. Mobile or any other Dart VM instance, will have the same limit.
- Removes the feature flag for enabling/disabling Turbo
- Adds unit testing for getting bundle size limits.

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/2ebqck6gas730