### PR TITLE
PE-4907: add Version to Share Page

### DIFF
--- a/lib/components/details_panel.dart
+++ b/lib/components/details_panel.dart
@@ -354,7 +354,7 @@ class _DetailsPanelState extends State<DetailsPanel> {
                             ArDriveButton(
                               style: ArDriveButtonStyle.tertiary,
                               onPressed: () =>
-                                  openUrl(url: 'https://ardrive.io/'),
+                                  openUrl(url: Resources.ardrivePublicSiteLink),
                               text: appLocalizationsOf(context).whatIsArDrive,
                             ),
                             if (widget.isSharePage) ...[
@@ -447,7 +447,7 @@ class _DetailsPanelState extends State<DetailsPanel> {
               const SizedBox(height: 16),
               ArDriveButton(
                 style: ArDriveButtonStyle.tertiary,
-                onPressed: () => openUrl(url: 'https://ardrive.io/'),
+                onPressed: () => openUrl(url: Resources.ardrivePublicSiteLink),
                 text: appLocalizationsOf(context).whatIsArDrive,
               ),
               if (widget.isSharePage) ...[

--- a/lib/components/details_panel.dart
+++ b/lib/components/details_panel.dart
@@ -1,5 +1,6 @@
 import 'package:ardrive/authentication/ardrive_auth.dart';
 import 'package:ardrive/blocs/fs_entry_preview/fs_entry_preview_cubit.dart';
+import 'package:ardrive/components/app_version_widget.dart';
 import 'package:ardrive/components/components.dart';
 import 'package:ardrive/components/dotted_line.dart';
 import 'package:ardrive/components/drive_rename_form.dart';
@@ -356,6 +357,14 @@ class _DetailsPanelState extends State<DetailsPanel> {
                                   openUrl(url: 'https://ardrive.io/'),
                               text: appLocalizationsOf(context).whatIsArDrive,
                             ),
+                            if (widget.isSharePage) ...[
+                              AppVersionWidget(
+                                color: ArDriveTheme.of(context)
+                                    .themeData
+                                    .colors
+                                    .themeFgDefault,
+                              ),
+                            ]
                           ],
                         ),
                       ),
@@ -441,6 +450,12 @@ class _DetailsPanelState extends State<DetailsPanel> {
                 onPressed: () => openUrl(url: 'https://ardrive.io/'),
                 text: appLocalizationsOf(context).whatIsArDrive,
               ),
+              if (widget.isSharePage) ...[
+                AppVersionWidget(
+                  color:
+                      ArDriveTheme.of(context).themeData.colors.themeFgDefault,
+                ),
+              ]
             ],
           ),
         ),

--- a/lib/misc/resources.dart
+++ b/lib/misc/resources.dart
@@ -8,6 +8,7 @@ class Resources {
       'https://pds-inc.typeform.com/UserSurvey';
 
   static const helpLink = 'https://ardrive.zendesk.com/hc/en-us';
+  static const ardrivePublicSiteLink = 'https://ardrive.io/';
   static const agreementLink = 'https://ardrive.io/tos-and-privacy/';
   static const getWalletLink = 'https://www.arconnect.io/';
 

--- a/lib/pages/shared_file/shared_file_page.dart
+++ b/lib/pages/shared_file/shared_file_page.dart
@@ -229,7 +229,7 @@ class SharedFilePage extends StatelessWidget {
   Widget _buildReturnToAppLink(BuildContext context) {
     return ArDriveButton(
       style: ArDriveButtonStyle.tertiary,
-      onPressed: () => openUrl(url: 'https://ardrive.io/'),
+      onPressed: () => openUrl(url: Resources.ardrivePublicSiteLink),
       text: appLocalizationsOf(context).whatIsArDrive,
     );
   }


### PR DESCRIPTION
Adds the app version to the details panel (only on the share page)

---

### Desktop
![Screenshot 2023-11-29 at 16 20 37](https://github.com/ardriveapp/ardrive-web/assets/32248947/9dafa511-9eff-4888-86d4-2dcc9b9853c9)

### Mobile
![Screenshot 2023-11-29 at 16 20 46](https://github.com/ardriveapp/ardrive-web/assets/32248947/60c7a393-f505-4251-87c0-7be84ad42427)


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/7q0pf7a1tmiao