### PR TITLE
PE-5017: Fix Preview Panel showing for private files larger than previewMaxFileSize

### DIFF
--- a/lib/blocs/fs_entry_preview/fs_entry_preview_cubit.dart
+++ b/lib/blocs/fs_entry_preview/fs_entry_preview_cubit.dart
@@ -114,6 +114,10 @@ class FsEntryPreviewCubit extends Cubit<FsEntryPreviewState> {
 
   Future<void> _preview() async {
     final selectedItem = maybeSelectedItem;
+
+    // initially set to no preview available to help reduce tab flickering
+    emit(FsEntryPreviewUnavailable());
+
     if (selectedItem != null) {
       if (selectedItem.runtimeType == FileDataTableItem) {
         _entrySubscription = _driveDao
@@ -160,6 +164,8 @@ class FsEntryPreviewCubit extends Cubit<FsEntryPreviewState> {
               default:
                 emit(FsEntryPreviewUnavailable());
             }
+          } else {
+            emit(FsEntryPreviewUnavailable());
           }
         });
       } else {


### PR DESCRIPTION
* Added missing emit of FsEntryPreviewUnavailable() for condition when file.size > previewMaxFileSize
* Added additional initial emitting of FsEntryPreviewUnavailable() as a starting state, since the determination of preview type is done async. This reduces the flickering of tabs when going to items that do not have preview (would show a tab then quickly remove it). 

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/4ib7rc0rgc8lg