### PR TITLE
PE-5431: show appropriate icon on upload page for file with extension written in uppercase

### DIFF
--- a/lib/pages/drive_detail/components/drive_explorer_item_tile.dart
+++ b/lib/pages/drive_detail/components/drive_explorer_item_tile.dart
@@ -113,6 +113,8 @@ class DriveExplorerItemTileLeading extends StatelessWidget {
 }
 
 ArDriveIcon getIconForContentType(String contentType, {double size = 18}) {
+  contentType = contentType.toLowerCase();
+
   if (contentType == 'folder') {
     return ArDriveIcons.folderOutline(
       size: size,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -84,11 +84,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "v1.4.4"
-      resolved-ref: "6ff48b9cea11774ad3e47664d20e6dd08a55467f"
+      ref: PE-5431-show-appropriate-icon-on-upload-page-for-file-with-extensions-written-in-uppercase
+      resolved-ref: "606f87c904a7a4b47b67570210af958f72b1037a"
       url: "https://github.com/ar-io/ardrive_io.git"
     source: git
-    version: "1.4.4"
+    version: "1.4.5"
   ardrive_logger:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -160,7 +160,7 @@ dependency_overrides:
   ardrive_io:
     git:
       url: https://github.com/ar-io/ardrive_io.git
-      ref: v1.4.4
+      ref: PE-5431-show-appropriate-icon-on-upload-page-for-file-with-extensions-written-in-uppercase
 
 dev_dependencies:
   integration_test:


### PR DESCRIPTION
- set content type to lower case for getting the right icon

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/59otoa42nu1g8