### PR TITLE
More fixes

### DIFF
--- a/lib/components/details_panel.dart
+++ b/lib/components/details_panel.dart
@@ -761,6 +761,8 @@ class _DetailsPanelState extends State<DetailsPanel> {
                   ? LicenseDetailsPopoverButton(
                       licenseState: state.licenseState!,
                       fileItem: item,
+                      updateButton:
+                          !widget.isSharePage && pinnedDataOwnerAddress == null,
                       anchor: const Aligned(
                         follower: Alignment.bottomRight,
                         target: Alignment.topRight,

--- a/lib/components/details_panel.dart
+++ b/lib/components/details_panel.dart
@@ -751,48 +751,15 @@ class _DetailsPanelState extends State<DetailsPanel> {
       sizedBoxHeight16px,
       if (state is FsEntryFileInfoSuccess)
         DetailsPanelItem(
-          itemTitle: 'License',
           // TODO: Localize
           // itemTitle: appLocalizationsOf(context).license,
+          itemTitle: 'License',
           leading: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              (!widget.isSharePage &&
-                      state.licenseState == null &&
-                      pinnedDataOwnerAddress == null)
-                  ? ArDriveButton(
-                      text: 'Add',
-                      icon: ArDriveIcons.license(
-                        size: 16,
-                        color:
-                            ArDriveTheme.of(context).themeData.backgroundColor,
-                      ),
-                      fontStyle: ArDriveTypography.body.buttonNormalBold(
-                        color:
-                            ArDriveTheme.of(context).themeData.backgroundColor,
-                      ),
-                      backgroundColor: ArDriveTheme.of(context)
-                          .themeData
-                          .colors
-                          .themeFgDefault,
-                      maxHeight: 32,
-                      onPressed: () => promptToLicense(
-                        context,
-                        driveId: item.driveId,
-                        selectedItems: [item],
-                      ),
-                    )
-                  : LicenseDetailsPopoverButton(
-                      licenseState: state.licenseState ??
-                          const LicenseState(
-                            meta: LicenseMeta(
-                              licenseType: LicenseType.unknown,
-                              licenseDefinitionTxId: '',
-                              name: 'Unknown',
-                              shortName: 'Unknown',
-                              version: '0',
-                            ),
-                          ),
+              state.licenseState != null
+                  ? LicenseDetailsPopoverButton(
+                      licenseState: state.licenseState!,
                       fileItem: item,
                       anchor: const Aligned(
                         follower: Alignment.bottomRight,
@@ -805,6 +772,38 @@ class _DetailsPanelState extends State<DetailsPanel> {
                         ),
                       ),
                     )
+                  : (!widget.isSharePage && pinnedDataOwnerAddress == null)
+                      ? ArDriveButton(
+                          text: 'Add',
+                          icon: ArDriveIcons.license(
+                            size: 16,
+                            color: ArDriveTheme.of(context)
+                                .themeData
+                                .backgroundColor,
+                          ),
+                          fontStyle: ArDriveTypography.body.buttonNormalBold(
+                            color: ArDriveTheme.of(context)
+                                .themeData
+                                .backgroundColor,
+                          ),
+                          backgroundColor: ArDriveTheme.of(context)
+                              .themeData
+                              .colors
+                              .themeFgDefault,
+                          maxHeight: 32,
+                          onPressed: () => promptToLicense(
+                            context,
+                            driveId: item.driveId,
+                            selectedItems: [item],
+                          ),
+                        )
+                      : Text(
+                          // TODO: Localize
+                          // appLocalizationsOf(context).noLicense,
+                          'None',
+                          textAlign: TextAlign.right,
+                          style: ArDriveTypography.body.buttonNormalRegular(),
+                        ),
             ],
           ),
         ),

--- a/lib/components/license_details_popover.dart
+++ b/lib/components/license_details_popover.dart
@@ -9,12 +9,14 @@ import 'package:flutter/widgets.dart';
 class LicenseDetailsPopoverButton extends StatefulWidget {
   final LicenseState licenseState;
   final FileDataTableItem fileItem;
+  final bool updateButton;
   final Aligned anchor;
 
   const LicenseDetailsPopoverButton({
     super.key,
     required this.licenseState,
     required this.fileItem,
+    required this.updateButton,
     required this.anchor,
   });
 
@@ -42,6 +44,7 @@ class _LicenseDetailsPopoverButtonState
       content: LicenseDetailsPopover(
         licenseState: widget.licenseState,
         fileItem: widget.fileItem,
+        updateButton: widget.updateButton,
         closePopover: () {
           setState(() {
             _showLicenseDetailsCard = false;
@@ -71,12 +74,14 @@ class _LicenseDetailsPopoverButtonState
 class LicenseDetailsPopover extends StatelessWidget {
   final LicenseState licenseState;
   final FileDataTableItem fileItem;
+  final bool updateButton;
   final VoidCallback closePopover;
 
   const LicenseDetailsPopover({
     super.key,
     required this.licenseState,
     required this.fileItem,
+    required this.updateButton,
     required this.closePopover,
   });
 
@@ -90,30 +95,31 @@ class LicenseDetailsPopover extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           LicenseSummary(licenseState: licenseState),
-          ArDriveButton(
-            text:
-                // TODO: Localize
-                // appLocalizationsOf(context).licenseUpdate
-                'Update',
-            icon: ArDriveIcons.license(
-              size: 16,
-              color: ArDriveTheme.of(context).themeData.backgroundColor,
+          if (updateButton)
+            ArDriveButton(
+              text:
+                  // TODO: Localize
+                  // appLocalizationsOf(context).licenseUpdate
+                  'Update',
+              icon: ArDriveIcons.license(
+                size: 16,
+                color: ArDriveTheme.of(context).themeData.backgroundColor,
+              ),
+              fontStyle: ArDriveTypography.body.buttonNormalBold(
+                color: ArDriveTheme.of(context).themeData.backgroundColor,
+              ),
+              backgroundColor:
+                  ArDriveTheme.of(context).themeData.colors.themeFgDefault,
+              maxHeight: 32,
+              onPressed: () {
+                closePopover();
+                promptToLicense(
+                  context,
+                  driveId: fileItem.driveId,
+                  selectedItems: [fileItem],
+                );
+              },
             ),
-            fontStyle: ArDriveTypography.body.buttonNormalBold(
-              color: ArDriveTheme.of(context).themeData.backgroundColor,
-            ),
-            backgroundColor:
-                ArDriveTheme.of(context).themeData.colors.themeFgDefault,
-            maxHeight: 32,
-            onPressed: () {
-              closePopover();
-              promptToLicense(
-                context,
-                driveId: fileItem.driveId,
-                selectedItems: [fileItem],
-              );
-            },
-          ),
           const SizedBox(height: 8),
         ],
       ),

--- a/lib/components/license_summary.dart
+++ b/lib/components/license_summary.dart
@@ -59,7 +59,7 @@ class LicenseSummary extends StatelessWidget {
                 recognizer: TapGestureRecognizer()
                   ..onTap = () async {
                     final url =
-                        'https://viewblock.io/arweave/tx/${licenseState.meta.licenseDefinitionTxId}';
+                        'https://arweave.net/${licenseState.meta.licenseDefinitionTxId}';
                     await openUrl(url: url);
                   },
               ),


### PR DESCRIPTION
- License Summary: Link directly to license instead of viewblock page
- Details License View: "None" for license when it shouldn't be added (i.e. on Share page or if a pinned file)
<img width="339" alt="Screenshot 2024-01-16 at 7 25 07 AM" src="https://github.com/ardriveapp/ardrive-web/assets/7699058/29eef562-1a36-457b-a8b9-f893acbf21cf">

- Disable update button on popover when it shouldn't be modified

<img width="324" alt="Screenshot 2024-01-16 at 7 31 54 AM" src="https://github.com/ardriveapp/ardrive-web/assets/7699058/568f4a2f-2778-40d5-8ab0-040d7ed14e5c">
<img width="324" alt="Screenshot 2024-01-16 at 7 25 52 AM" src="https://github.com/ardriveapp/ardrive-web/assets/7699058/a71d3f4a-f869-45df-8681-17598bc1341b">
