### PR TITLE
Fixes for Shared File Page

### DIFF
--- a/lib/components/license_summary.dart
+++ b/lib/components/license_summary.dart
@@ -43,26 +43,28 @@ class LicenseSummary extends StatelessWidget {
                       ArDriveTheme.of(context).themeData.colors.themeFgDefault,
                 ),
               ),
-              const TextSpan(text: '   '),
-              TextSpan(
-                text: 'View',
-                style: ArDriveTypography.body
-                    .buttonLargeRegular(
-                      color: ArDriveTheme.of(context)
-                          .themeData
-                          .colors
-                          .themeFgSubtle,
-                    )
-                    .copyWith(
-                      decoration: TextDecoration.underline,
-                    ),
-                recognizer: TapGestureRecognizer()
-                  ..onTap = () async {
-                    final url =
-                        'https://arweave.net/${licenseState.meta.licenseDefinitionTxId}';
-                    await openUrl(url: url);
-                  },
-              ),
+              if (licenseState.meta.licenseType != LicenseType.unknown) ...[
+                const TextSpan(text: '   '),
+                TextSpan(
+                  text: 'View',
+                  style: ArDriveTypography.body
+                      .buttonLargeRegular(
+                        color: ArDriveTheme.of(context)
+                            .themeData
+                            .colors
+                            .themeFgSubtle,
+                      )
+                      .copyWith(
+                        decoration: TextDecoration.underline,
+                      ),
+                  recognizer: TapGestureRecognizer()
+                    ..onTap = () async {
+                      final url =
+                          'https://arweave.net/${licenseState.meta.licenseDefinitionTxId}';
+                      await openUrl(url: url);
+                    },
+                ),
+              ]
             ],
           ),
         ),


### PR DESCRIPTION
- Details: Prefer `FileRevision`/`LicenseState` from App DB, even for Shared Files
- Details: Fall back to "Pending" License when licenseTxId is present in Latest Revision, but not mined or in DB
- LicensePopover will not show the "View" link for "unknown" type Licenses