### PR TITLE
PE-5461: renaming folder still doesnt update instantly

### DIFF
--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -398,7 +398,7 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
     _refreshSelectedItem = true;
 
     if (state is DriveDetailLoadSuccess) {
-      await Future.delayed(const Duration(milliseconds: 50));
+      await Future.delayed(const Duration(milliseconds: 100));
       emit((state as DriveDetailLoadSuccess)
           .copyWith(forceRebuildKey: UniqueKey()));
     }

--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -394,10 +394,11 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
     );
   }
 
-  void refreshDriveDataTable() {
+  void refreshDriveDataTable() async {
     _refreshSelectedItem = true;
 
     if (state is DriveDetailLoadSuccess) {
+      await Future.delayed(const Duration(milliseconds: 50));
       emit((state as DriveDetailLoadSuccess)
           .copyWith(forceRebuildKey: UniqueKey()));
     }


### PR DESCRIPTION
For large folders, we perform huge computational tasks renaming and generating the fs entry paths. This triggers the DriveDetailCubit to rebuild lots of times, it is not tooooo expensive, because it won't rebuilt the datatable those hundreds of times. But, it leads an issue where the state is emitted before the UI gets updated. The UI won't have the new state and then won't update the drive explorer.

This delay fixes it. Some refs: 
https://stackoverflow.com/questions/64370986/blocbuilder-not-updating-after-cubit-emit, https://github.com/felangel/bloc/issues/2094

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/3ogaotkkbce70