### PR TITLE
PE-5457: modal doesnt reappear after closing with x

### DIFF
--- a/lib/blocs/prompt_to_snapshot/prompt_to_snapshot_bloc.dart
+++ b/lib/blocs/prompt_to_snapshot/prompt_to_snapshot_bloc.dart
@@ -57,6 +57,8 @@ class PromptToSnapshotBloc
     on<SyncRunning>(_onSyncRunning);
     on<DriveSnapshotted>(_onDriveSnapshotted);
     on<DismissDontAskAgain>(_onDismissDontAskAgain);
+    on<ClosePromptToSnapshot>(
+        (event, emit) => emit(const PromptToSnapshotIdle()));
 
     _maybeStore ??= store;
     _durationBeforePrompting = durationBeforePrompting;

--- a/lib/blocs/prompt_to_snapshot/prompt_to_snapshot_event.dart
+++ b/lib/blocs/prompt_to_snapshot/prompt_to_snapshot_event.dart
@@ -70,3 +70,7 @@ class DismissDontAskAgain extends PromptToSnapshotEvent {
     required this.dontAskAgain,
   }) : super(driveId: null);
 }
+
+class ClosePromptToSnapshot extends PromptToSnapshotEvent {
+  const ClosePromptToSnapshot() : super(driveId: null);
+}

--- a/lib/components/prompt_to_snapshot_dialog.dart
+++ b/lib/components/prompt_to_snapshot_dialog.dart
@@ -19,7 +19,7 @@ Future<void> promptToSnapshot(
       promptToSnapshotBloc: promptToSnapshotBloc,
       drive: drive,
     ),
-  );
+  ).then((value) => promptToSnapshotBloc.add(const ClosePromptToSnapshot()));
 }
 
 class PromptToSnapshotDialog extends StatefulWidget {


### PR DESCRIPTION
- add event for when the modal is closed

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/6s0ek01uv25lo