### PR TITLE
PE-5474: fix missing cipher and cipherIv tags for Turbo uploads

### DIFF
--- a/packages/ardrive_uploader/lib/src/upload_controller.dart
+++ b/packages/ardrive_uploader/lib/src/upload_controller.dart
@@ -876,6 +876,7 @@ class UploadDispatcher {
           file: task.file,
           metadata: task.metadata,
           wallet: wallet,
+          driveKey: task.encryptionKey,
           onStartBundleCreation: () {
             controller.updateProgress(
               task: task.copyWith(


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/3c6j9g6ntkh7g