### PR TITLE
PE-5498: duplicate public drives and uncreated folders

### DIFF
--- a/lib/sharing/folder_selector/folder_selector_bloc.dart
+++ b/lib/sharing/folder_selector/folder_selector_bloc.dart
@@ -32,13 +32,33 @@ class FolderSelectorBloc
 
         selectedDrive = event.drive;
 
-        emit(SelectingFolderState(folders: folderTree.getRecursiveFolders()));
+        emit(
+          SelectingFolderState(
+            selectedFolder: folderTree.folder,
+            isRootFolder: true,
+            folders: folderTree.subfolders.map((e) => e.folder).toList(),
+          ),
+        );
       } else if (event is SelectFolderEvent) {
-        final folders = (state as SelectingFolderState).folders;
-        emit(SelectingFolderState(
-          folders: folders,
-          selectedFolder: event.folder,
-        ));
+        final folderTree =
+            await driveDao.getFolderTree(event.folder.driveId, event.folder.id);
+        FolderEntry? parentFolder;
+        if (event.folder.parentFolderId != null) {
+          parentFolder = await driveDao
+              .folderById(
+                  driveId: event.folder.driveId,
+                  folderId: event.folder.parentFolderId!)
+              .getSingle();
+        }
+
+        emit(
+          SelectingFolderState(
+            isRootFolder: event.folder.id == selectedDrive!.rootFolderId,
+            parentFolder: parentFolder,
+            selectedFolder: event.folder,
+            folders: folderTree.subfolders.map((e) => e.folder).toList(),
+          ),
+        );
       } else if (event is ConfirmFolderEvent) {
         emit(FolderSelectedState(event.folder.id, event.folder.driveId));
       }

--- a/lib/sharing/folder_selector/folder_selector_event.dart
+++ b/lib/sharing/folder_selector/folder_selector_event.dart
@@ -39,7 +39,9 @@ final class ConfirmFolderEvent extends FolderSelectorEvent {
 final class SelectFolderEvent extends FolderSelectorEvent {
   final FolderEntry folder;
 
-  const SelectFolderEvent(this.folder);
+  const SelectFolderEvent({
+    required this.folder,
+  });
 
   @override
   List<Object> get props => [folder];

--- a/lib/sharing/folder_selector/folder_selector_state.dart
+++ b/lib/sharing/folder_selector/folder_selector_state.dart
@@ -23,9 +23,16 @@ final class SelectingDriveState extends FolderSelectorState {
 
 final class SelectingFolderState extends FolderSelectorState {
   final List<FolderEntry> folders;
+  final FolderEntry? parentFolder;
   final FolderEntry? selectedFolder;
+  final bool isRootFolder;
 
-  const SelectingFolderState({required this.folders, this.selectedFolder});
+  const SelectingFolderState({
+    required this.folders,
+    this.selectedFolder,
+    this.isRootFolder = false,
+    this.parentFolder,
+  });
 
   @override
   List<Object> get props => [folders, selectedFolder ?? ''];

--- a/lib/sharing/sharing_file_listener.dart
+++ b/lib/sharing/sharing_file_listener.dart
@@ -62,6 +62,10 @@ class _SharingFileListenerState extends State<SharingFileListener> {
                               files: state.files,
                             );
                           },
+                          dispose: () {
+                            BlocProvider.of<SharingFileBloc>(context)
+                                .add(SharingFileCleared());
+                          },
                         ),
                       ),
                     );


### PR DESCRIPTION
- enhance the folder selector widget: now you can navigate the folder tree, instead of just listing all folders
- update activity tracker properly when closing the select folder modal
- UI now gets updated when the upload finishes

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/6ihvm24sd76p8