### PR TITLE
PE-5521: missing modal for txt files

### DIFF
--- a/lib/blocs/sync/sync_cubit.dart
+++ b/lib/blocs/sync/sync_cubit.dart
@@ -191,9 +191,15 @@ class SyncCubit extends Cubit<SyncState> {
   var ghostFolders = <FolderID, GhostFolder>{};
 
   Future<void> startSync({bool syncDeep = false}) async {
-    if (_activityTracker.isSharingFilesFromExternalApp) {
-      logger.d('An activity is in progress, skipping sync.');
-      return;
+    if (AppPlatform.isMobile) {
+      if (_activityTracker.isSharingFilesFromExternalApp) {
+        logger.d('An activity is in progress, skipping sync.');
+
+        return;
+      } else if (_activityTracker.isVerifyingSharingFilesFromExternalApp) {
+        Future.delayed(const Duration(seconds: 2)).then((value) => startSync());
+        return;
+      }
     }
 
     logger.i('Starting Sync');

--- a/lib/core/activity_tracker.dart
+++ b/lib/core/activity_tracker.dart
@@ -5,6 +5,7 @@ class ActivityTracker extends ChangeNotifier {
   bool _isShowingAnyDialog = false;
   bool _isUploading = false;
   bool _isSharingFilesFromExternalApp = false;
+  bool _isVerifyingSharingFilesFromExternalApp = true;
 
   // getters
   bool get isToppingUp => _isToppingUp;
@@ -20,6 +21,9 @@ class ActivityTracker extends ChangeNotifier {
   bool get isUploading => _isUploading;
 
   bool get isSharingFilesFromExternalApp => _isSharingFilesFromExternalApp;
+
+  bool get isVerifyingSharingFilesFromExternalApp =>
+      _isVerifyingSharingFilesFromExternalApp;
 
   // setters
   void setUploading(bool value) {
@@ -38,6 +42,11 @@ class ActivityTracker extends ChangeNotifier {
 
   void setSharingFilesFromExternalApp(bool value) {
     _isSharingFilesFromExternalApp = value;
+    notifyListeners();
+  }
+
+  void setVerifyingSharingFilesFromExternalApp(bool value) {
+    _isVerifyingSharingFilesFromExternalApp = value;
     notifyListeners();
   }
 }

--- a/lib/sharing/blocs/sharing_file_bloc.dart
+++ b/lib/sharing/blocs/sharing_file_bloc.dart
@@ -35,11 +35,6 @@ class SharingFileBloc extends Bloc<SharingFileEvent, SharingFileState> {
       }
     });
 
-    // For sharing images coming from outside the app while the app is in the memory
-    FlutterSharingIntent.instance.getMediaStream().listen((event) {
-      add(SharingFileReceived(event));
-    });
-
     on<SharingFileEvent>((event, emit) async {
       if (event is SharingFileReceived) {
         activityTracker.setSharingFilesFromExternalApp(true);

--- a/lib/sharing/blocs/sharing_file_bloc.dart
+++ b/lib/sharing/blocs/sharing_file_bloc.dart
@@ -25,6 +25,8 @@ class SharingFileBloc extends Bloc<SharingFileEvent, SharingFileState> {
       if (value.isNotEmpty) {
         add(SharingFileReceived(value));
       }
+
+      activityTracker.setVerifyingSharingFilesFromExternalApp(false);
     });
 
     FlutterSharingIntent.instance.getMediaStream().listen((value) {

--- a/lib/sharing/folder_selector/folder_selector.dart
+++ b/lib/sharing/folder_selector/folder_selector.dart
@@ -179,6 +179,7 @@ class _FolderSelectorState extends State<FolderSelector> {
           content = SizedBox(
             height: 400,
             child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 if (state.selectedFolder != null) ...[
                   SizedBox(

--- a/lib/sharing/sharing_file_listener.dart
+++ b/lib/sharing/sharing_file_listener.dart
@@ -63,7 +63,6 @@ class _SharingFileListenerState extends State<SharingFileListener> {
                             );
                           },
                           dispose: () {
-                            Navigator.of(context).pop();
                             sharingFileBloc.add(SharingFileCleared());
                           },
                         ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -928,10 +928,11 @@ packages:
   flutter_sharing_intent:
     dependency: "direct main"
     description:
-      name: flutter_sharing_intent
-      sha256: "6eb896e6523b735e8230eeb206fd3b9f220f11ce879c2400a90b443147036ff9"
-      url: "https://pub.dev"
-    source: hosted
+      path: "."
+      ref: "5f4f2e66c02580105ba89b3fec5a7be907d5466f"
+      resolved-ref: "5f4f2e66c02580105ba89b3fec5a7be907d5466f"
+      url: "https://github.com/bhagat-techind/flutter_sharing_intent"
+    source: git
     version: "1.1.0"
   flutter_stripe:
     dependency: "direct main"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -132,7 +132,10 @@ dependencies:
   loading_animation_widget: ^1.2.0+4
   synchronized: ^3.1.0
   confetti: ^0.7.0
-  flutter_sharing_intent: ^1.1.0
+  flutter_sharing_intent: 
+    git:
+      url: https://github.com/bhagat-techind/flutter_sharing_intent
+      ref: 5f4f2e66c02580105ba89b3fec5a7be907d5466f
   sentry_flutter: ^7.14.0
 
 dependency_overrides:


### PR DESCRIPTION
- use a fixed version of the sharing intent plugin.

https://github.com/bhagat-techind/flutter_sharing_intent/pull/51

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/2nl9m5ui9qu4g