### PR TITLE
PE-5544: update sharing_file_bloc.dart

### DIFF
--- a/lib/sharing/blocs/sharing_file_bloc.dart
+++ b/lib/sharing/blocs/sharing_file_bloc.dart
@@ -1,6 +1,7 @@
 import 'package:ardrive/core/activity_tracker.dart';
 import 'package:ardrive/utils/logger.dart';
 import 'package:ardrive_io/ardrive_io.dart';
+import 'package:ardrive_utils/ardrive_utils.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_sharing_intent/flutter_sharing_intent.dart';
@@ -17,6 +18,10 @@ class SharingFileBloc extends Bloc<SharingFileEvent, SharingFileState> {
   SharingFileBloc(
     this.activityTracker,
   ) : super(SharingFileInitial()) {
+    if (!AppPlatform.isMobile) {
+      return;
+    }
+
     FlutterSharingIntent.instance
         .getInitialSharing()
         .then((List<SharedFile> value) {


### PR DESCRIPTION
only initialize the sharing intent if running on mobile

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/5bllmrhlbb6c0