### PR TITLE
PE-5598: viewport is cutoff by bottom navigation bar

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -183,12 +183,14 @@ class AppState extends State<App> {
                 }
               },
               builder: (context, state) {
-                return ArDriveApp(
-                  onThemeChanged: (theme) {
-                    context.read<ThemeSwitcherBloc>().add(ChangeTheme());
-                  },
-                  key: arDriveAppKey,
-                  builder: _appBuilder,
+                return SafeArea(
+                  child: ArDriveApp(
+                    onThemeChanged: (theme) {
+                      context.read<ThemeSwitcherBloc>().add(ChangeTheme());
+                    },
+                    key: arDriveAppKey,
+                    builder: _appBuilder,
+                  ),
                 );
               },
             ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -183,14 +183,12 @@ class AppState extends State<App> {
                 }
               },
               builder: (context, state) {
-                return SafeArea(
-                  child: ArDriveApp(
-                    onThemeChanged: (theme) {
-                      context.read<ThemeSwitcherBloc>().add(ChangeTheme());
-                    },
-                    key: arDriveAppKey,
-                    builder: _appBuilder,
-                  ),
+                return ArDriveApp(
+                  onThemeChanged: (theme) {
+                    context.read<ThemeSwitcherBloc>().add(ChangeTheme());
+                  },
+                  key: arDriveAppKey,
+                  builder: _appBuilder,
                 );
               },
             ),

--- a/lib/pages/drive_detail/drive_detail_page.dart
+++ b/lib/pages/drive_detail/drive_detail_page.dart
@@ -211,27 +211,30 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
                     hasFiles: hasFiles,
                     canDownloadMultipleFiles: canDownloadMultipleFiles,
                   ),
-                  mobile: (context) => Scaffold(
-                    drawerScrimColor: Colors.transparent,
-                    drawer: const AppSideBar(),
-                    appBar: (driveDetailState.showSelectedItemDetails &&
-                            context.read<DriveDetailCubit>().selectedItem !=
-                                null)
-                        ? MobileAppBar(
-                            leading: ArDriveIconButton(
-                              icon: ArDriveIcons.arrowLeft(),
-                              onPressed: () {
-                                context
-                                    .read<DriveDetailCubit>()
-                                    .toggleSelectedItemDetails();
-                              },
-                            ),
-                          )
-                        : null,
-                    body: _mobileView(
-                      driveDetailState,
-                      hasSubfolders,
-                      hasFiles,
+                  mobile: (context) => SafeArea(
+                    child: Scaffold(
+                      resizeToAvoidBottomInset: false,
+                      drawerScrimColor: Colors.transparent,
+                      drawer: const AppSideBar(),
+                      appBar: (driveDetailState.showSelectedItemDetails &&
+                              context.read<DriveDetailCubit>().selectedItem !=
+                                  null)
+                          ? MobileAppBar(
+                              leading: ArDriveIconButton(
+                                icon: ArDriveIcons.arrowLeft(),
+                                onPressed: () {
+                                  context
+                                      .read<DriveDetailCubit>()
+                                      .toggleSelectedItemDetails();
+                                },
+                              ),
+                            )
+                          : null,
+                      body: _mobileView(
+                        driveDetailState,
+                        hasSubfolders,
+                        hasFiles,
+                      ),
                     ),
                   ),
                 );

--- a/lib/pages/drive_detail/drive_detail_page.dart
+++ b/lib/pages/drive_detail/drive_detail_page.dart
@@ -211,30 +211,28 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
                     hasFiles: hasFiles,
                     canDownloadMultipleFiles: canDownloadMultipleFiles,
                   ),
-                  mobile: (context) => SafeArea(
-                    child: Scaffold(
-                      resizeToAvoidBottomInset: false,
-                      drawerScrimColor: Colors.transparent,
-                      drawer: const AppSideBar(),
-                      appBar: (driveDetailState.showSelectedItemDetails &&
-                              context.read<DriveDetailCubit>().selectedItem !=
-                                  null)
-                          ? MobileAppBar(
-                              leading: ArDriveIconButton(
-                                icon: ArDriveIcons.arrowLeft(),
-                                onPressed: () {
-                                  context
-                                      .read<DriveDetailCubit>()
-                                      .toggleSelectedItemDetails();
-                                },
-                              ),
-                            )
-                          : null,
-                      body: _mobileView(
-                        driveDetailState,
-                        hasSubfolders,
-                        hasFiles,
-                      ),
+                  mobile: (context) => Scaffold(
+                    resizeToAvoidBottomInset: false,
+                    drawerScrimColor: Colors.transparent,
+                    drawer: const AppSideBar(),
+                    appBar: (driveDetailState.showSelectedItemDetails &&
+                            context.read<DriveDetailCubit>().selectedItem !=
+                                null)
+                        ? MobileAppBar(
+                            leading: ArDriveIconButton(
+                              icon: ArDriveIcons.arrowLeft(),
+                              onPressed: () {
+                                context
+                                    .read<DriveDetailCubit>()
+                                    .toggleSelectedItemDetails();
+                              },
+                            ),
+                          )
+                        : null,
+                    body: _mobileView(
+                      driveDetailState,
+                      hasSubfolders,
+                      hasFiles,
                     ),
                   ),
                 );


### PR DESCRIPTION
- Adds the SafeArea widget on top of the drive detail page
- Now the bottom bar won't be displayed when the keyboard is appearing, for example, when renaming a file. That's the change with the `resizeToAvoidBottomInsets` to `false`

------ 

### Before:

https://github.com/ardriveapp/ardrive-web/assets/32248947/bfd32a10-beb3-4ba2-ad04-ef586c7b8f46

### Now:
https://github.com/ardriveapp/ardrive-web/assets/32248947/7e2805ce-92fe-41c5-8717-7a38e1fd3204




--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/62b57dnipqihg