### PR TITLE
PE-5635: fix free uploads when payment service is down

### DIFF
--- a/lib/core/upload/uploader.dart
+++ b/lib/core/upload/uploader.dart
@@ -492,17 +492,22 @@ class UploadPaymentEvaluator {
   }
 
   Future<UploadMethod> _determineUploadMethod(
-      BigInt turboBalance,
-      int turboBundleSizes,
-      int allowedSizeForTurbo,
-      bool isTurboAvailableToUploadAllFiles) async {
+    BigInt turboBalance,
+    int turboBundleSizes,
+    int allowedSizeForTurbo,
+    bool isTurboAvailableToUploadAllFiles,
+  ) async {
+    bool isFreeUploadPossibleUsingTurbo =
+        turboBundleSizes <= allowedSizeForTurbo;
+
+    if (isFreeUploadPossibleUsingTurbo) {
+      return UploadMethod.turbo;
+    }
+
     try {
       final turboCostEstimate = await _turboUploadCostCalculator.calculateCost(
         totalSize: turboBundleSizes,
       );
-
-      bool isFreeUploadPossibleUsingTurbo =
-          turboBundleSizes <= allowedSizeForTurbo;
 
       if ((isTurboAvailableToUploadAllFiles &&
               turboBalance >= turboCostEstimate.totalCost) ||
@@ -513,6 +518,7 @@ class UploadPaymentEvaluator {
       }
     } catch (e) {
       _isTurboAvailableToUploadAllFiles = false;
+
       return UploadMethod.ar;
     }
   }


### PR DESCRIPTION
if it's free, set turbo as the default option

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/17ei90jiq9l0o