### PR TITLE
PE-5662: reduce turbo free file size limit check to match service

### DIFF
--- a/assets/config/dev.json
+++ b/assets/config/dev.json
@@ -4,7 +4,7 @@
   "useTurboPayment": true,
   "defaultTurboUploadUrl": "https://upload.ardrive.dev",
   "defaultTurboPaymentUrl": "https://payment.ardrive.dev",
-  "allowedDataItemSizeForTurbo": 500000,
+  "allowedDataItemSizeForTurbo": 100000,
   "enableQuickSyncAuthoring": true,
   "enableMultipleFileDownload": true,
   "enableVideoPreview": true,

--- a/assets/config/prod.json
+++ b/assets/config/prod.json
@@ -4,7 +4,7 @@
   "useTurboPayment": true,
   "defaultTurboUploadUrl": "https://upload.ardrive.io",
   "defaultTurboPaymentUrl": "https://payment.ardrive.io",
-  "allowedDataItemSizeForTurbo": 500000,
+  "allowedDataItemSizeForTurbo": 100000,
   "enableQuickSyncAuthoring": true,
   "enableMultipleFileDownload": true,
   "enableVideoPreview": true,

--- a/assets/config/staging.json
+++ b/assets/config/staging.json
@@ -4,7 +4,7 @@
   "useTurboPayment": true,
   "defaultTurboUploadUrl": "https://upload.ardrive.io",
   "defaultTurboPaymentUrl": "https://payment.ardrive.io",
-  "allowedDataItemSizeForTurbo": 500000,
+  "allowedDataItemSizeForTurbo": 100000,
   "enableQuickSyncAuthoring": true,
   "enableMultipleFileDownload": true,
   "enableVideoPreview": true,

--- a/lib/core/upload/uploader.dart
+++ b/lib/core/upload/uploader.dart
@@ -451,12 +451,19 @@ class UploadPaymentEvaluator {
       );
     }
 
-    uploadMethod = await _determineUploadMethod(
-      turboBalance,
-      turboBundleSizes,
-      _appConfig.allowedDataItemSizeForTurbo,
-      _isTurboAvailableToUploadAllFiles,
-    );
+    // Checking isFreeUploadPossibleUsingTurbo uses the 100KB file size check
+    // against the date, but using _determineUploadMethod() additionally uses the
+    // Turbo bundle headers as part of the size check. A 100KB file might be
+    // larger than _appConfig.allowedDataItemSizeForTurbo due to the headers,
+    // so we need to catch that here.
+    uploadMethod = isFreeUploadPossibleUsingTurbo
+        ? UploadMethod.turbo
+        : await _determineUploadMethod(
+            turboBalance,
+            turboBundleSizes,
+            _appConfig.allowedDataItemSizeForTurbo,
+            _isTurboAvailableToUploadAllFiles,
+          );
 
     return UploadPaymentInfo(
       isTurboAvailable: _isTurboAvailableToUploadAllFiles,


### PR DESCRIPTION
* modifies config values that control turbo free size limit check to match new values from turbo service

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/4tfsedf452sm0