### PR TITLE
PE-5697: chore(bump version and android build)

### DIFF
--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -102,6 +102,8 @@ jobs:
         run: bundle exec fastlane deploy type:staging
 
   build-android:
+    # Skipped until fix the upload to turbo
+    if: false
     needs: pre-build
     runs-on: ubuntu-latest
     steps:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Secure, permanent storage
 
 publish_to: 'none'
 
-version: 2.34.3
+version: 2.35.0
 
 environment:
   sdk: '>=3.0.2 <4.0.0'


### PR DESCRIPTION
- disables production android build
- bump version

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/4uje6i4q58i0g