### PR TITLE
PE-5690: feat(ANS-105) adds new cc license types

### DIFF
--- a/lib/blocs/fs_entry_info/fs_entry_info_cubit.dart
+++ b/lib/blocs/fs_entry_info/fs_entry_info_cubit.dart
@@ -89,7 +89,6 @@ class FsEntryInfoCubit extends Cubit<FsEntryInfoState> {
                     licenseDefinitionTxId: '',
                     name: 'Pending',
                     shortName: 'Pending',
-                    version: '',
                   ),
                 );
               }

--- a/lib/blocs/fs_entry_license/fs_entry_license_bloc.dart
+++ b/lib/blocs/fs_entry_license/fs_entry_license_bloc.dart
@@ -106,7 +106,7 @@ class FsEntryLicenseBloc
   final _ccForm = FormGroup({
     'ccAttributionField': FormControl<LicenseMeta>(
       validators: [Validators.required],
-      value: ccByLicenseMetaV2,
+      value: cc0LicenseMeta,
     ),
   });
 

--- a/lib/blocs/fs_entry_license/fs_entry_license_bloc.dart
+++ b/lib/blocs/fs_entry_license/fs_entry_license_bloc.dart
@@ -349,7 +349,7 @@ class FsEntryLicenseBloc
   final ccForm = FormGroup({
     'ccAttributionField': FormControl<LicenseMeta>(
       validators: [Validators.required],
-      value: ccByLicenseMeta,
+      value: ccByLicenseMetaV2,
     ),
   });
 }

--- a/lib/blocs/fs_entry_license/fs_entry_license_bloc.dart
+++ b/lib/blocs/fs_entry_license/fs_entry_license_bloc.dart
@@ -155,10 +155,10 @@ class FsEntryLicenseBloc
 
     switch (licenseType) {
       case LicenseCategory.udl:
-        _selectedLicenseMeta = udlLicenseMeta;
+        _selectedLicenseMeta = udlLicenseMetaV2;
         break;
       case LicenseCategory.cc:
-        _selectedLicenseMeta = ccByLicenseMeta;
+        _selectedLicenseMeta = ccByLicenseMetaV2;
         break;
     }
 

--- a/lib/blocs/fs_entry_license/fs_entry_license_bloc.dart
+++ b/lib/blocs/fs_entry_license/fs_entry_license_bloc.dart
@@ -175,7 +175,7 @@ class FsEntryLicenseBloc
       _selectedLicenseMeta = ccForm.control('ccAttributionField').value;
     }
 
-    if (_selectedLicenseMeta.licenseType == LicenseType.udl) {
+    if (_selectedLicenseMeta.licenseType == LicenseType.udlV2) {
       licenseParams = await _udlFormToLicenseParams(udlForm);
     } else {
       addError(

--- a/lib/components/details_panel.dart
+++ b/lib/components/details_panel.dart
@@ -1039,10 +1039,10 @@ class DetailsPanelItem extends StatelessWidget {
       children: [
         Flexible(
           child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            mainAxisAlignment: MainAxisAlignment.start,
             mainAxisSize: MainAxisSize.max,
             children: [
-              Flexible(
+              Expanded(
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   crossAxisAlignment: CrossAxisAlignment.start,
@@ -1051,7 +1051,7 @@ class DetailsPanelItem extends StatelessWidget {
                       child: Text(
                         itemTitle,
                         style: ArDriveTypography.body.buttonNormalRegular(),
-                        maxLines: 2,
+                        maxLines: 4,
                       ),
                     ),
                     if (itemSubtitle != null)
@@ -1062,7 +1062,11 @@ class DetailsPanelItem extends StatelessWidget {
                   ],
                 ),
               ),
-              if (leading != null) Flexible(child: leading!),
+              if (leading != null)
+                Padding(
+                  padding: const EdgeInsets.only(left: 8.0),
+                  child: leading!,
+                ),
             ],
           ),
         ),

--- a/lib/components/fs_entry_license_form.dart
+++ b/lib/components/fs_entry_license_form.dart
@@ -309,7 +309,7 @@ class _FsEntryLicenseFormState extends State<FsEntryLicenseForm> {
             return ArDriveScrollBar(
               child: SingleChildScrollView(
                 child: ArDriveStandardModal(
-                  title: 'Configure ${licenseMeta.name}',
+                  title: 'Configure Creative Commons License',
                   width: kLargeDialogWidth,
                   content: Column(
                     mainAxisSize: MainAxisSize.min,

--- a/lib/components/fs_entry_license_form.dart
+++ b/lib/components/fs_entry_license_form.dart
@@ -330,7 +330,7 @@ class _FsEntryLicenseFormState extends State<FsEntryLicenseForm> {
                               formGroup:
                                   context.watch<FsEntryLicenseBloc>().udlForm,
                             )
-                          : licenseType == LicenseType.ccBy
+                          : licenseType == LicenseType.ccByV2
                               ? CcParamsForm(
                                   formGroup: context
                                       .watch<FsEntryLicenseBloc>()

--- a/lib/components/fs_entry_license_form.dart
+++ b/lib/components/fs_entry_license_form.dart
@@ -2,11 +2,13 @@ import 'package:ardrive/blocs/blocs.dart';
 import 'package:ardrive/components/license_summary.dart';
 import 'package:ardrive/core/crypto/crypto.dart';
 import 'package:ardrive/l11n/validation_messages.dart';
+import 'package:ardrive/misc/resources.dart';
 import 'package:ardrive/models/models.dart';
 import 'package:ardrive/services/services.dart';
 import 'package:ardrive/theme/theme.dart';
 import 'package:ardrive/turbo/services/upload_service.dart';
 import 'package:ardrive/utils/app_localizations_wrapper.dart';
+import 'package:ardrive/utils/open_url.dart';
 import 'package:ardrive/utils/show_general_dialog.dart';
 import 'package:ardrive_ui/ardrive_ui.dart';
 import 'package:flutter/material.dart';
@@ -89,7 +91,7 @@ class _FsEntryLicenseFormState extends State<FsEntryLicenseForm> {
       builder: (context, state) {
         return Builder(builder: (context) {
           final licenseMeta =
-              context.read<FsEntryLicenseBloc>().selectFormLicenseMeta;
+              context.read<FsEntryLicenseBloc>().selectedLicenseMeta;
           if (state is FsEntryLicenseNoFiles) {
             return ArDriveCard(
               height: 350,
@@ -196,20 +198,23 @@ class _FsEntryLicenseFormState extends State<FsEntryLicenseForm> {
               width: kMediumDialogWidth,
               // TODO: Localize
               // title: appLocalizationsOf(context).renameFolderEmphasized,
-              content: SizedBox(
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisAlignment: MainAxisAlignment.start,
-                  children: [
-                    LicenseFileList(fileList: filesToLicense),
-                    const SizedBox(height: 16),
-                    const Divider(height: 24),
-                    ReactiveForm(
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.start,
+                children: [
+                  LicenseFileList(fileList: filesToLicense),
+                  const SizedBox(height: 16),
+                  const Divider(height: 24),
+                  SizedBox(
+                    child: ReactiveForm(
                       formGroup: context.watch<FsEntryLicenseBloc>().selectForm,
                       child: ReactiveDropdownField(
+                        alignment: AlignmentDirectional.centerStart,
+                        isExpanded: true,
                         formControlName: 'licenseType',
                         decoration: InputDecoration(
+                          border: InputBorder.none,
                           label: Text(
                             'License',
                             // TODO: Localize
@@ -232,40 +237,56 @@ class _FsEntryLicenseFormState extends State<FsEntryLicenseForm> {
                             control.dirty && control.invalid,
                         validationMessages:
                             kValidationMessages(appLocalizationsOf(context)),
-                        items: licenseMetaMap.values
-                            .map(
-                              (value) => DropdownMenuItem(
-                                value: value,
-                                child:
-                                    Text('${value.name} (${value.shortName})'),
+                        items: LicenseCategory.values.map(
+                          (value) {
+                            return DropdownMenuItem(
+                              value: value,
+                              child: Text(
+                                '${licenseCategoryNames[value]}',
                               ),
-                            )
-                            .toList(),
+                            );
+                          },
+                        ).toList(),
                       ),
                     ),
-                    const Divider(height: 32),
-                    Text(
-                      // TODO: Localize
-                      'Cost: 0 AR',
-                      style: ArDriveTypography.body.buttonLargeRegular(
-                        color: ArDriveTheme.of(context)
-                            .themeData
-                            .colors
-                            .themeFgDefault,
+                  ),
+                  ArDriveClickArea(
+                    child: GestureDetector(
+                      onTap: () {
+                        openUrl(
+                          url: Resources.howDoesKeyFileLoginWork,
+                        );
+                      },
+                      child: Text(
+                        'Learn More about Licensing',
+                        style: ArDriveTypography.body
+                            .buttonNormalRegular()
+                            .copyWith(decoration: TextDecoration.underline),
                       ),
                     ),
-                    Text(
-                      // TODO: Localize
-                      'Free for now, maybe paid later.',
-                      style: ArDriveTypography.body.captionRegular(
-                        color: ArDriveTheme.of(context)
-                            .themeData
-                            .colors
-                            .themeFgSubtle,
-                      ),
+                  ),
+                  const Divider(height: 32),
+                  Text(
+                    // TODO: Localize
+                    'Cost: 0 AR',
+                    style: ArDriveTypography.body.buttonLargeRegular(
+                      color: ArDriveTheme.of(context)
+                          .themeData
+                          .colors
+                          .themeFgDefault,
                     ),
-                  ],
-                ),
+                  ),
+                  Text(
+                    // TODO: Localize
+                    'Free for now, maybe paid later.',
+                    style: ArDriveTypography.body.captionRegular(
+                      color: ArDriveTheme.of(context)
+                          .themeData
+                          .colors
+                          .themeFgSubtle,
+                    ),
+                  ),
+                ],
               ),
               actions: [
                 ModalAction(
@@ -281,12 +302,15 @@ class _FsEntryLicenseFormState extends State<FsEntryLicenseForm> {
               ],
             );
           } else if (state is FsEntryLicenseConfiguring) {
+            final licenseType = context
+                .read<FsEntryLicenseBloc>()
+                .selectedLicenseMeta
+                .licenseType;
             return ArDriveScrollBar(
               child: SingleChildScrollView(
                 child: ArDriveStandardModal(
-                  title:
-                      'Configure ${licenseMeta.name} (${licenseMeta.shortName})',
-                  width: kMediumDialogWidth,
+                  title: 'Configure ${licenseMeta.name}',
+                  width: kLargeDialogWidth,
                   content: Column(
                     mainAxisSize: MainAxisSize.min,
                     crossAxisAlignment: CrossAxisAlignment.start,
@@ -298,11 +322,7 @@ class _FsEntryLicenseFormState extends State<FsEntryLicenseForm> {
                               .filesToLicense!),
                       const SizedBox(height: 16),
                       const Divider(height: 24),
-                      context
-                                  .read<FsEntryLicenseBloc>()
-                                  .selectFormLicenseMeta
-                                  .licenseType ==
-                              LicenseType.udl
+                      licenseType == LicenseType.udl
                           ? UdlParamsForm(
                               onChangeLicenseFee: () {
                                 setState(() {});
@@ -310,7 +330,13 @@ class _FsEntryLicenseFormState extends State<FsEntryLicenseForm> {
                               formGroup:
                                   context.watch<FsEntryLicenseBloc>().udlForm,
                             )
-                          : const Text('Unsupported license type'),
+                          : licenseType == LicenseType.ccBy
+                              ? CcParamsForm(
+                                  formGroup: context
+                                      .watch<FsEntryLicenseBloc>()
+                                      .ccForm,
+                                )
+                              : const Text('Unsupported license type'),
                     ],
                   ),
                   actions: [
@@ -826,5 +852,95 @@ class _UdlParamsFormState extends State<UdlParamsForm> {
               )
               .toList(),
         ));
+  }
+}
+
+class CcParamsForm extends StatefulWidget {
+  const CcParamsForm({super.key, required this.formGroup});
+
+  final FormGroup formGroup;
+
+  @override
+  State<CcParamsForm> createState() => _CcParamsFormState();
+}
+
+class _CcParamsFormState extends State<CcParamsForm> {
+  LicenseMeta get licenseMeta =>
+      context.read<FsEntryLicenseBloc>().selectedLicenseMeta;
+
+  @override
+  Widget build(BuildContext context) {
+    final inputBorder = OutlineInputBorder(
+      borderSide: BorderSide(
+        color: ArDriveTheme.of(context)
+            .themeData
+            .colors
+            .themeFgDisabled
+            .withOpacity(0.3),
+        width: 2,
+      ),
+      borderRadius: BorderRadius.circular(4),
+    );
+
+    return ReactiveForm(
+      formGroup: widget.formGroup,
+      child: Column(
+          mainAxisSize: MainAxisSize.min,
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisSize: MainAxisSize.max,
+              mainAxisAlignment: MainAxisAlignment.start,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Flexible(
+                  child: LabeledInput(
+                    labelText: 'Type',
+                    child: ReactiveDropdownField(
+                      formControlName: 'ccAttributionField',
+                      decoration: InputDecoration(
+                        enabledBorder: inputBorder,
+                        focusedBorder: inputBorder,
+                      ),
+                      onChanged: (e) {
+                        setState(() {});
+                      },
+                      showErrors: (control) => control.dirty && control.invalid,
+                      validationMessages:
+                          kValidationMessages(appLocalizationsOf(context)),
+                      items: ccLicenses
+                          .map(
+                            (e) => DropdownMenuItem(
+                              value: e,
+                              child: Text(e.name),
+                            ),
+                          )
+                          .toList(),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            Builder(
+              builder: (context) {
+                final selectedLicenseMeta = context
+                    .watch<FsEntryLicenseBloc>()
+                    .ccForm
+                    .value['ccAttributionField'] as LicenseMeta;
+
+                return Text(
+                  selectedLicenseMeta.shortName,
+                  style: ArDriveTypography.body.buttonNormalBold(
+                    color: ArDriveTheme.of(context)
+                        .themeData
+                        .colors
+                        .themeFgDisabled,
+                  ),
+                );
+              },
+            ),
+          ]),
+    );
   }
 }

--- a/lib/components/fs_entry_license_form.dart
+++ b/lib/components/fs_entry_license_form.dart
@@ -306,10 +306,15 @@ class _FsEntryLicenseFormState extends State<FsEntryLicenseForm> {
                 .read<FsEntryLicenseBloc>()
                 .selectedLicenseMeta
                 .licenseType;
+            final modalTitle = licenseType == LicenseType.udlV2
+                ? 'Configure Universal Data License'
+                : licenseType == LicenseType.ccByV2
+                    ? 'Configure Creative Commons License'
+                    : 'Unsupported license type';
             return ArDriveScrollBar(
               child: SingleChildScrollView(
                 child: ArDriveStandardModal(
-                  title: 'Configure Creative Commons License',
+                  title: modalTitle,
                   width: kLargeDialogWidth,
                   content: Column(
                     mainAxisSize: MainAxisSize.min,

--- a/lib/components/fs_entry_license_form.dart
+++ b/lib/components/fs_entry_license_form.dart
@@ -322,7 +322,7 @@ class _FsEntryLicenseFormState extends State<FsEntryLicenseForm> {
                               .filesToLicense!),
                       const SizedBox(height: 16),
                       const Divider(height: 24),
-                      licenseType == LicenseType.udl
+                      licenseType == LicenseType.udlV2
                           ? UdlParamsForm(
                               onChangeLicenseFee: () {
                                 setState(() {});

--- a/lib/entities/license_assertion.dart
+++ b/lib/entities/license_assertion.dart
@@ -55,7 +55,10 @@ class LicenseAssertionEntity with TransactionPropertiesMixin {
       }
       return licenseAssertionEntity;
     } catch (e, stacktrace) {
-      logger.e('Failed to parse license assertion transaction', e, stacktrace);
+      logger.e(
+          'Failed to parse license assertion transaction. licenseDefinitionTxId: ${transaction.tags.firstWhere((tag) => tag.name == LicenseTag.licenseDefinitionTxId).value}',
+          e,
+          stacktrace);
       throw LicenseAssertionTransactionParseException(
         transactionId: transaction.id,
       );

--- a/lib/entities/license_assertion.dart
+++ b/lib/entities/license_assertion.dart
@@ -1,3 +1,4 @@
+import 'package:ardrive/utils/logger.dart';
 import 'package:ardrive_utils/ardrive_utils.dart';
 import 'package:arweave/arweave.dart';
 import 'package:drift/drift.dart';
@@ -53,7 +54,8 @@ class LicenseAssertionEntity with TransactionPropertiesMixin {
             DateTime.fromMillisecondsSinceEpoch(transaction.block!.timestamp);
       }
       return licenseAssertionEntity;
-    } catch (_) {
+    } catch (e, stacktrace) {
+      logger.e('Failed to parse license assertion transaction', e, stacktrace);
       throw LicenseAssertionTransactionParseException(
         transactionId: transaction.id,
       );

--- a/lib/services/license/license_service.dart
+++ b/lib/services/license/license_service.dart
@@ -31,6 +31,7 @@ class LicenseService {
   }) {
     switch (licenseType) {
       case LicenseType.udl:
+      case LicenseType.udlV2:
         return UdlLicenseParams.fromAdditionalTags(additionalTags ?? {});
       case LicenseType.ccBy:
       case LicenseType.ccByV2:

--- a/lib/services/license/license_service.dart
+++ b/lib/services/license/license_service.dart
@@ -33,6 +33,7 @@ class LicenseService {
       case LicenseType.udl:
       case LicenseType.udlV2:
         return UdlLicenseParams.fromAdditionalTags(additionalTags ?? {});
+      case LicenseType.cc0:
       case LicenseType.ccBy:
       case LicenseType.ccByV2:
       case LicenseType.ccByNC:

--- a/lib/services/license/license_service.dart
+++ b/lib/services/license/license_service.dart
@@ -33,6 +33,7 @@ class LicenseService {
       case LicenseType.udl:
         return UdlLicenseParams.fromAdditionalTags(additionalTags ?? {});
       case LicenseType.ccBy:
+      case LicenseType.ccByV2:
       case LicenseType.ccByNC:
       case LicenseType.ccByNCND:
       case LicenseType.ccByNCSA:

--- a/lib/services/license/license_service.dart
+++ b/lib/services/license/license_service.dart
@@ -33,6 +33,11 @@ class LicenseService {
       case LicenseType.udl:
         return UdlLicenseParams.fromAdditionalTags(additionalTags ?? {});
       case LicenseType.ccBy:
+      case LicenseType.ccByNC:
+      case LicenseType.ccByNCND:
+      case LicenseType.ccByNCSA:
+      case LicenseType.ccByND:
+      case LicenseType.ccBySA:
         return EmptyParams();
       default:
         throw ArgumentError('Unknown license type: $licenseType');

--- a/lib/services/license/license_state.dart
+++ b/lib/services/license/license_state.dart
@@ -59,9 +59,9 @@ final licenseMetaMap = {
   LicenseType.ccBy: ccByLicenseMeta,
   LicenseType.ccByNC: ccByNCLicenseMeta,
   LicenseType.ccByNCND: ccByNCNDLicenseMeta,
-  LicenseType.ccByNCSA: ccByNCSA,
+  LicenseType.ccByNCSA: ccByNCSAMeta,
   LicenseType.ccByND: ccByNDLicenseMeta,
-  LicenseType.ccBySA: ccBySA,
+  LicenseType.ccBySA: ccBySAMeta,
 };
 
 final licenseCategoryNames = {

--- a/lib/services/license/license_state.dart
+++ b/lib/services/license/license_state.dart
@@ -8,6 +8,7 @@ import 'package:equatable/equatable.dart';
 enum LicenseType {
   udl,
   udlV2,
+  cc0,
   ccBy,
   ccByV2,
   ccByNC,
@@ -26,6 +27,7 @@ enum LicenseCategory {
 final licenseMetaMap = {
   LicenseType.udl: udlLicenseMeta,
   LicenseType.udlV2: udlLicenseMetaV2,
+  LicenseType.cc0: cc0LicenseMeta,
   LicenseType.ccBy: ccByLicenseMeta,
   LicenseType.ccByV2: ccByLicenseMetaV2,
   LicenseType.ccByNC: ccByNCLicenseMeta,

--- a/lib/services/license/license_state.dart
+++ b/lib/services/license/license_state.dart
@@ -4,7 +4,17 @@ import 'package:equatable/equatable.dart';
 enum LicenseType {
   udl,
   ccBy,
+  ccByNC,
+  ccByNCND,
+  ccByNCSA,
+  ccByND,
+  ccBySA,
   unknown,
+}
+
+enum LicenseCategory {
+  cc,
+  udl,
 }
 
 class LicenseMeta extends Equatable {
@@ -47,6 +57,16 @@ class EmptyParams extends LicenseParams {}
 final licenseMetaMap = {
   LicenseType.udl: udlLicenseMeta,
   LicenseType.ccBy: ccByLicenseMeta,
+  LicenseType.ccByNC: ccByNCLicenseMeta,
+  LicenseType.ccByNCND: ccByNCNDLicenseMeta,
+  LicenseType.ccByNCSA: ccByNCSA,
+  LicenseType.ccByND: ccByNDLicenseMeta,
+  LicenseType.ccBySA: ccBySA,
+};
+
+final licenseCategoryNames = {
+  LicenseCategory.udl: 'Universal Data License - UDL',
+  LicenseCategory.cc: 'Creative Commons - CC',
 };
 
 class LicenseState extends Equatable {

--- a/lib/services/license/license_state.dart
+++ b/lib/services/license/license_state.dart
@@ -3,7 +3,9 @@ import 'package:equatable/equatable.dart';
 
 enum LicenseType {
   udl,
+  udlV2,
   ccBy,
+  ccByV2,
   ccByNC,
   ccByNCND,
   ccByNCSA,
@@ -22,7 +24,6 @@ class LicenseMeta extends Equatable {
   final String licenseDefinitionTxId;
   final String name;
   final String shortName;
-  final String version;
   final bool hasParams;
 
   const LicenseMeta({
@@ -30,7 +31,6 @@ class LicenseMeta extends Equatable {
     required this.licenseDefinitionTxId,
     required this.name,
     required this.shortName,
-    required this.version,
     this.hasParams = false,
   });
 
@@ -40,7 +40,6 @@ class LicenseMeta extends Equatable {
         licenseDefinitionTxId,
         name,
         shortName,
-        version,
         hasParams,
       ];
 }
@@ -56,7 +55,9 @@ class EmptyParams extends LicenseParams {}
 
 final licenseMetaMap = {
   LicenseType.udl: udlLicenseMeta,
+  LicenseType.udlV2: udlLicenseMetaV2,
   LicenseType.ccBy: ccByLicenseMeta,
+  LicenseType.ccByV2: ccByLicenseMetaV2,
   LicenseType.ccByNC: ccByNCLicenseMeta,
   LicenseType.ccByNCND: ccByNCNDLicenseMeta,
   LicenseType.ccByNCSA: ccByNCSAMeta,

--- a/lib/services/license/license_state.dart
+++ b/lib/services/license/license_state.dart
@@ -1,6 +1,10 @@
-import 'package:ardrive/services/license/licenses/licenses.dart';
+import 'package:ardrive/services/license/license.dart';
 import 'package:equatable/equatable.dart';
 
+/// Updating a license type version will require to update the corresponding [licenseMetaMap].
+/// The [licenseMetaMap] is used to map the license type to the corresponding [LicenseMeta].
+///
+/// Please ensure to update the [licenseMetaMap] when adding a new license type.
 enum LicenseType {
   udl,
   udlV2,
@@ -18,6 +22,18 @@ enum LicenseCategory {
   cc,
   udl,
 }
+
+final licenseMetaMap = {
+  LicenseType.udl: udlLicenseMeta,
+  LicenseType.udlV2: udlLicenseMetaV2,
+  LicenseType.ccBy: ccByLicenseMeta,
+  LicenseType.ccByV2: ccByLicenseMetaV2,
+  LicenseType.ccByNC: ccByNCLicenseMeta,
+  LicenseType.ccByNCND: ccByNCNDLicenseMeta,
+  LicenseType.ccByNCSA: ccByNCSAMeta,
+  LicenseType.ccByND: ccByNDLicenseMeta,
+  LicenseType.ccBySA: ccBySAMeta,
+};
 
 class LicenseMeta extends Equatable {
   final LicenseType licenseType;
@@ -52,18 +68,6 @@ abstract class LicenseParams extends Equatable {
 }
 
 class EmptyParams extends LicenseParams {}
-
-final licenseMetaMap = {
-  LicenseType.udl: udlLicenseMeta,
-  LicenseType.udlV2: udlLicenseMetaV2,
-  LicenseType.ccBy: ccByLicenseMeta,
-  LicenseType.ccByV2: ccByLicenseMetaV2,
-  LicenseType.ccByNC: ccByNCLicenseMeta,
-  LicenseType.ccByNCND: ccByNCNDLicenseMeta,
-  LicenseType.ccByNCSA: ccByNCSAMeta,
-  LicenseType.ccByND: ccByNDLicenseMeta,
-  LicenseType.ccBySA: ccBySAMeta,
-};
 
 final licenseCategoryNames = {
   LicenseCategory.udl: 'Universal Data License - UDL',

--- a/lib/services/license/licenses/cc_by.dart
+++ b/lib/services/license/licenses/cc_by.dart
@@ -9,51 +9,59 @@ List<LicenseMeta> ccLicenses = [
   ccBySAMeta,
 ];
 
+// Version 4.0
 const ccByLicenseMeta = LicenseMeta(
+  licenseType: LicenseType.ccBy,
+  licenseDefinitionTxId: 'rz2DNzn9pnYOU6049Wm6V7kr0BhyfWE6ZD_mqrXMv5A',
+  name: 'Attribution',
+  shortName: 'CC-BY',
+  hasParams: true,
+);
+
+const ccByLicenseMetaV2 = LicenseMeta(
   licenseType: LicenseType.ccBy,
   licenseDefinitionTxId: 'mSOFUrl5mUQvG7VBP36DD39kzJASv9FDe3GxHpcCvRA',
   name: 'Attribution',
   shortName: 'CC-BY',
-  version: '4.0',
   hasParams: true,
 );
 
+// Version 4.0
 const ccByNCLicenseMeta = LicenseMeta(
   licenseType: LicenseType.ccByNC,
   licenseDefinitionTxId: '9jG6a1fWgQ_wE4R6OGA2Xg9vGRAwpkrQIMC83nC3kvI',
   name: 'Attribution Non-Commercial',
   shortName: 'CC-BY-NC',
-  version: '4.0',
 );
 
+// Version 4.0
 const ccByNCNDLicenseMeta = LicenseMeta(
   licenseType: LicenseType.ccByNCND,
   licenseDefinitionTxId: 'OlTlW1xEw75UC0cdmNqvxc3j6iAmFXrS4usWIBfu_3E',
   name: 'Attribution Non-Commercial No-Derivatives',
   shortName: 'CC-BY-NC-ND',
-  version: '4.0',
 );
 
+// Version 4.0
 const ccByNCSAMeta = LicenseMeta(
   licenseType: LicenseType.ccByNCSA,
-  licenseDefinitionTxId: '2PO2MDRNZLJjgA_0hNGUAD7yXg9nneq-3fxTTLP-uo8',
+  licenseDefinitionTxId: 'c1TDjOvM0PiwLKOGMYNUOCfe2iO_yPiN1LTit78DZUM',
   name: 'Attribution Non-Commercial Share-A-Like',
   shortName: 'CC-BY-NC-SA',
-  version: '4.0',
 );
 
+// Version 4.0
 const ccByNDLicenseMeta = LicenseMeta(
   licenseType: LicenseType.ccByND,
   licenseDefinitionTxId: 'XaIMRBMNqTUlHa_hzypkopfRFyAKqit-AWo-OxwIxoo',
   name: 'Attribution No-Derivatives',
   shortName: 'CC-BY-ND',
-  version: '4.0',
 );
 
+// Version 4.0
 const ccBySAMeta = LicenseMeta(
   licenseType: LicenseType.ccBySA,
   licenseDefinitionTxId: 'sKz-PZ96ApDoy5RTBspxhs1GP-cHommw4_9hEiZ6K3c',
   name: 'Attribution Share-A-Like',
   shortName: 'CC-BY-SA',
-  version: '4.0',
 );

--- a/lib/services/license/licenses/cc_by.dart
+++ b/lib/services/license/licenses/cc_by.dart
@@ -1,9 +1,59 @@
 import '../license_state.dart';
 
+List<LicenseMeta> ccLicenses = [
+  ccByLicenseMeta,
+  ccByNCLicenseMeta,
+  ccByNCNDLicenseMeta,
+  ccByNCSA,
+  ccByNDLicenseMeta,
+  ccBySA,
+];
+
 const ccByLicenseMeta = LicenseMeta(
   licenseType: LicenseType.ccBy,
   licenseDefinitionTxId: 'rz2DNzn9pnYOU6049Wm6V7kr0BhyfWE6ZD_mqrXMv5A',
-  name: 'Creative Commons Attribution',
+  name: 'Attribution',
   shortName: 'CC-BY',
+  version: '4.0',
+  hasParams: true,
+);
+
+const ccByNCLicenseMeta = LicenseMeta(
+  licenseType: LicenseType.ccByNC,
+  licenseDefinitionTxId: '9jG6a1fWgQ_wE4R6OGA2Xg9vGRAwpkrQIMC83nC3kvI',
+  name: 'Attribution Non-Commercial',
+  shortName: 'CC-BY-NC',
+  version: '4.0',
+);
+
+const ccByNCNDLicenseMeta = LicenseMeta(
+  licenseType: LicenseType.ccByNCND,
+  licenseDefinitionTxId: 'OlTlW1xEw75UC0cdmNqvxc3j6iAmFXrS4usWIBfu_3E',
+  name: 'Attribution Non-Commercial No-Derivatives',
+  shortName: 'CC-BY-NC-ND',
+  version: '4.0',
+);
+
+const ccByNCSA = LicenseMeta(
+  licenseType: LicenseType.ccByNCSA,
+  licenseDefinitionTxId: '2PO2MDRNZLJjgA_0hNGUAD7yXg9nneq-3fxTTLP-uo8',
+  name: 'Attribution Non-Commercial Share-A-Like',
+  shortName: 'CC-BY-NC-SA',
+  version: '4.0',
+);
+
+const ccByNDLicenseMeta = LicenseMeta(
+  licenseType: LicenseType.ccByND,
+  licenseDefinitionTxId: 'XaIMRBMNqTUlHa_hzypkopfRFyAKqit-AWo-OxwIxoo',
+  name: 'Attribution No-Derivatives',
+  shortName: 'CC-BY-ND',
+  version: '4.0',
+);
+
+const ccBySA = LicenseMeta(
+  licenseType: LicenseType.ccBySA,
+  licenseDefinitionTxId: 'sKz-PZ96ApDoy5RTBspxhs1GP-cHommw4_9hEiZ6K3c',
+  name: 'Attribution Share-A-Like',
+  shortName: 'CC-BY-SA',
   version: '4.0',
 );

--- a/lib/services/license/licenses/cc_by.dart
+++ b/lib/services/license/licenses/cc_by.dart
@@ -4,9 +4,9 @@ List<LicenseMeta> ccLicenses = [
   ccByLicenseMeta,
   ccByNCLicenseMeta,
   ccByNCNDLicenseMeta,
-  ccByNCSA,
+  ccByNCSAMeta,
   ccByNDLicenseMeta,
-  ccBySA,
+  ccBySAMeta,
 ];
 
 const ccByLicenseMeta = LicenseMeta(
@@ -34,7 +34,7 @@ const ccByNCNDLicenseMeta = LicenseMeta(
   version: '4.0',
 );
 
-const ccByNCSA = LicenseMeta(
+const ccByNCSAMeta = LicenseMeta(
   licenseType: LicenseType.ccByNCSA,
   licenseDefinitionTxId: '2PO2MDRNZLJjgA_0hNGUAD7yXg9nneq-3fxTTLP-uo8',
   name: 'Attribution Non-Commercial Share-A-Like',
@@ -50,7 +50,7 @@ const ccByNDLicenseMeta = LicenseMeta(
   version: '4.0',
 );
 
-const ccBySA = LicenseMeta(
+const ccBySAMeta = LicenseMeta(
   licenseType: LicenseType.ccBySA,
   licenseDefinitionTxId: 'sKz-PZ96ApDoy5RTBspxhs1GP-cHommw4_9hEiZ6K3c',
   name: 'Attribution Share-A-Like',

--- a/lib/services/license/licenses/cc_by.dart
+++ b/lib/services/license/licenses/cc_by.dart
@@ -11,7 +11,7 @@ List<LicenseMeta> ccLicenses = [
 
 const ccByLicenseMeta = LicenseMeta(
   licenseType: LicenseType.ccBy,
-  licenseDefinitionTxId: 'rz2DNzn9pnYOU6049Wm6V7kr0BhyfWE6ZD_mqrXMv5A',
+  licenseDefinitionTxId: 'mSOFUrl5mUQvG7VBP36DD39kzJASv9FDe3GxHpcCvRA',
   name: 'Attribution',
   shortName: 'CC-BY',
   version: '4.0',

--- a/lib/services/license/licenses/cc_by.dart
+++ b/lib/services/license/licenses/cc_by.dart
@@ -23,7 +23,6 @@ const ccByLicenseMeta = LicenseMeta(
   licenseDefinitionTxId: 'rz2DNzn9pnYOU6049Wm6V7kr0BhyfWE6ZD_mqrXMv5A',
   name: 'Attribution',
   shortName: 'CC-BY',
-  hasParams: true,
 );
 
 const ccByLicenseMetaV2 = LicenseMeta(

--- a/lib/services/license/licenses/cc_by.dart
+++ b/lib/services/license/licenses/cc_by.dart
@@ -1,13 +1,21 @@
 import '../license_state.dart';
 
 List<LicenseMeta> ccLicenses = [
-  ccByLicenseMeta,
+  cc0LicenseMeta,
+  ccByLicenseMetaV2,
   ccByNCLicenseMeta,
   ccByNCNDLicenseMeta,
   ccByNCSAMeta,
   ccByNDLicenseMeta,
   ccBySAMeta,
 ];
+
+const cc0LicenseMeta = LicenseMeta(
+  licenseType: LicenseType.cc0,
+  licenseDefinitionTxId: 'nF6Mjy_Yy_Gv-DYLq7QPxz5PdXUQ4rtOpbJZdcaFEKw',
+  name: 'Public Domain',
+  shortName: 'CC0',
+);
 
 // Version 4.0
 const ccByLicenseMeta = LicenseMeta(
@@ -19,7 +27,7 @@ const ccByLicenseMeta = LicenseMeta(
 );
 
 const ccByLicenseMetaV2 = LicenseMeta(
-  licenseType: LicenseType.ccBy,
+  licenseType: LicenseType.ccByV2,
   licenseDefinitionTxId: 'mSOFUrl5mUQvG7VBP36DD39kzJASv9FDe3GxHpcCvRA',
   name: 'Attribution',
   shortName: 'CC-BY',
@@ -45,7 +53,7 @@ const ccByNCNDLicenseMeta = LicenseMeta(
 // Version 4.0
 const ccByNCSAMeta = LicenseMeta(
   licenseType: LicenseType.ccByNCSA,
-  licenseDefinitionTxId: 'c1TDjOvM0PiwLKOGMYNUOCfe2iO_yPiN1LTit78DZUM',
+  licenseDefinitionTxId: '2PO2MDRNZLJjgA_0hNGUAD7yXg9nneq-3fxTTLP-uo8',
   name: 'Attribution Non-Commercial Share-A-Like',
   shortName: 'CC-BY-NC-SA',
 );

--- a/lib/services/license/licenses/udl.dart
+++ b/lib/services/license/licenses/udl.dart
@@ -1,11 +1,20 @@
 import '../license_state.dart';
 
+// Version 0.2
+const udlLicenseMetaV2 = LicenseMeta(
+  licenseType: LicenseType.udl,
+  licenseDefinitionTxId: 'yRj4a5KMctX_uOmKWCFJIjmY8DeJcusVk6-HzLiM_t8',
+  name: 'Universal Data License',
+  shortName: 'UDL',
+  hasParams: true,
+);
+
+// Version 0.1
 const udlLicenseMeta = LicenseMeta(
   licenseType: LicenseType.udl,
   licenseDefinitionTxId: 'IVjAM1C3x3GFdc3t9EqMnbtGnpgTuJbaiYZa1lk09_8',
   name: 'Universal Data License',
   shortName: 'UDL',
-  version: '2.0',
   hasParams: true,
 );
 

--- a/lib/services/license/licenses/udl.dart
+++ b/lib/services/license/licenses/udl.dart
@@ -1,7 +1,7 @@
 import '../license_state.dart';
 
-// Version 0.2
-const udlLicenseMetaV2 = LicenseMeta(
+// Version 0.1
+const udlLicenseMeta = LicenseMeta(
   licenseType: LicenseType.udl,
   licenseDefinitionTxId: 'yRj4a5KMctX_uOmKWCFJIjmY8DeJcusVk6-HzLiM_t8',
   name: 'Universal Data License',
@@ -9,9 +9,9 @@ const udlLicenseMetaV2 = LicenseMeta(
   hasParams: true,
 );
 
-// Version 0.1
-const udlLicenseMeta = LicenseMeta(
-  licenseType: LicenseType.udl,
+// Version 0.2
+const udlLicenseMetaV2 = LicenseMeta(
+  licenseType: LicenseType.udlV2,
   licenseDefinitionTxId: 'IVjAM1C3x3GFdc3t9EqMnbtGnpgTuJbaiYZa1lk09_8',
   name: 'Universal Data License',
   shortName: 'UDL',

--- a/lib/services/license/licenses/udl.dart
+++ b/lib/services/license/licenses/udl.dart
@@ -2,10 +2,10 @@ import '../license_state.dart';
 
 const udlLicenseMeta = LicenseMeta(
   licenseType: LicenseType.udl,
-  licenseDefinitionTxId: 'yRj4a5KMctX_uOmKWCFJIjmY8DeJcusVk6-HzLiM_t8',
+  licenseDefinitionTxId: 'IVjAM1C3x3GFdc3t9EqMnbtGnpgTuJbaiYZa1lk09_8',
   name: 'Universal Data License',
   shortName: 'UDL',
-  version: '1.0',
+  version: '2.0',
   hasParams: true,
 );
 

--- a/test/services/license/license_state_test.dart
+++ b/test/services/license/license_state_test.dart
@@ -19,4 +19,60 @@ void main() {
           reason: 'Map should not contain meta for unknown license type');
     });
   });
+
+  group(
+      'Ensure we wont change a licenseDefinitionTxId of existing licenses meta',
+      () {
+    test(
+        'cc0',
+        () => expect(licenseMetaMap[LicenseType.cc0]!.licenseDefinitionTxId,
+            'nF6Mjy_Yy_Gv-DYLq7QPxz5PdXUQ4rtOpbJZdcaFEKw'));
+
+    test(
+        'ccBy v1',
+        () => expect(licenseMetaMap[LicenseType.ccBy]!.licenseDefinitionTxId,
+            'rz2DNzn9pnYOU6049Wm6V7kr0BhyfWE6ZD_mqrXMv5A'));
+
+    test(
+        'ccBy v2',
+        () => expect(licenseMetaMap[LicenseType.ccByV2]!.licenseDefinitionTxId,
+            'mSOFUrl5mUQvG7VBP36DD39kzJASv9FDe3GxHpcCvRA'));
+
+    test(
+        'ccByNC',
+        () => expect(licenseMetaMap[LicenseType.ccByNC]!.licenseDefinitionTxId,
+            '9jG6a1fWgQ_wE4R6OGA2Xg9vGRAwpkrQIMC83nC3kvI'));
+
+    test(
+        'ccByNCND',
+        () => expect(
+            licenseMetaMap[LicenseType.ccByNCND]!.licenseDefinitionTxId,
+            'OlTlW1xEw75UC0cdmNqvxc3j6iAmFXrS4usWIBfu_3E'));
+
+    test(
+        'ccByNCSA',
+        () => expect(
+            licenseMetaMap[LicenseType.ccByNCSA]!.licenseDefinitionTxId,
+            '2PO2MDRNZLJjgA_0hNGUAD7yXg9nneq-3fxTTLP-uo8'));
+
+    test(
+        'ccByND',
+        () => expect(licenseMetaMap[LicenseType.ccByND]!.licenseDefinitionTxId,
+            'XaIMRBMNqTUlHa_hzypkopfRFyAKqit-AWo-OxwIxoo'));
+
+    test(
+        'ccBySA',
+        () => expect(licenseMetaMap[LicenseType.ccBySA]!.licenseDefinitionTxId,
+            'sKz-PZ96ApDoy5RTBspxhs1GP-cHommw4_9hEiZ6K3c'));
+
+    test(
+        'udl',
+        () => expect(licenseMetaMap[LicenseType.udl]!.licenseDefinitionTxId,
+            'yRj4a5KMctX_uOmKWCFJIjmY8DeJcusVk6-HzLiM_t8'));
+
+    test(
+        'udlV2',
+        () => expect(licenseMetaMap[LicenseType.udlV2]!.licenseDefinitionTxId,
+            'IVjAM1C3x3GFdc3t9EqMnbtGnpgTuJbaiYZa1lk09_8'));
+  });
 }

--- a/test/services/license/license_state_test.dart
+++ b/test/services/license/license_state_test.dart
@@ -1,0 +1,22 @@
+import 'package:ardrive/services/license/license_state.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('License Meta Map', () {
+    test('should contain all LicenseType enum values', () {
+      // Iterate over all LicenseType values
+      for (var type in LicenseType.values) {
+        if (type == LicenseType.unknown) continue;
+        // Check if the licenseMetaMap contains the current enum value
+        expect(licenseMetaMap.containsKey(type), isTrue,
+            reason: 'Missing meta for $type');
+      }
+    });
+
+    test('should not contain unknown LicenseType in map', () {
+      // Verify the 'unknown' LicenseType is not in the map
+      expect(licenseMetaMap.containsKey(LicenseType.unknown), isFalse,
+          reason: 'Map should not contain meta for unknown license type');
+    });
+  });
+}


### PR DESCRIPTION
#### Expanded Creative Commons License Types: 
We've added a variety of CC licenses to offer a broader range of sharing permissions. The new licenses include:
- CC0 (Public Domain Dedication)
- CC-BY (Attribution)
- CC-BY-NC (Attribution-NonCommercial)
- CC-BY-NC-ND (Attribution-NonCommercial-NoDerivs)
- CC-BY-NC-SA (Attribution-NonCommercial-ShareAlike)
- CC-BY-ND (Attribution-NoDerivs)
- CC-BY-SA (Attribution-ShareAlike)

#### License Metadata Updates
- Removed Unused Property: The version property of `LicenseMeta` 
- Introduced LicenseCategory Enum

#### License Version Updates:
- We have updated the versioning for both UDL and CC-BY licenses. The UDL license is now at version 0.2, reflecting recent enhancements.
- additionally, we've incorporated a new transaction for the CC-BY 4.0 license

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/5r3tide3hval0