### PR TITLE
License on upload

### DIFF
--- a/lib/components/upload_form.dart
+++ b/lib/components/upload_form.dart
@@ -1321,8 +1321,6 @@ class _StatsScreenState extends State<StatsScreen> {
         .readyState.paymentInfo.uploadPlanForAR?.bundleUploadHandles
         .toList();
 
-    ;
-
     if (v2Files != null) {
       files = [];
 

--- a/lib/components/upload_form.dart
+++ b/lib/components/upload_form.dart
@@ -512,9 +512,9 @@ class _UploadFormState extends State<UploadForm> {
                                 return DropdownMenuItem(
                                   value: value,
                                   child: Text(
-                                    licenseCategoryNames[value] ?? 'Select',
+                                    licenseCategoryNames[value] ?? 'None',
                                     // TODO: Localize
-                                    // appLocalizationsOf(context).selectLicense,
+                                    // appLocalizationsOf(context).none,
                                   ),
                                 );
                               },

--- a/lib/components/upload_form.dart
+++ b/lib/components/upload_form.dart
@@ -1560,9 +1560,6 @@ class UploadReadyModalBase extends StatelessWidget {
         child: ArDriveStandardModal(
           title: appLocalizationsOf(context)
               .uploadNFiles(readyState.numberOfFiles),
-          // TODO: Create "subtitle"
-          // TODO: Localize
-          description: 'Files will be uploaded publicly.',
           width: width,
           hasCloseButton: hasCloseButton,
           content: ConstrainedBox(

--- a/lib/components/upload_form.dart
+++ b/lib/components/upload_form.dart
@@ -512,7 +512,9 @@ class _UploadFormState extends State<UploadForm> {
                                 return DropdownMenuItem(
                                   value: value,
                                   child: Text(
-                                    licenseCategoryNames[value] ?? '---',
+                                    licenseCategoryNames[value] ?? 'Select',
+                                    // TODO: Localize
+                                    // appLocalizationsOf(context).selectLicense,
                                   ),
                                 );
                               },

--- a/lib/components/upload_form.dart
+++ b/lib/components/upload_form.dart
@@ -1111,24 +1111,13 @@ class _UploadFormState extends State<UploadForm> {
                                                 ),
                                               ),
                                             ),
-                                          const SizedBox(
-                                            width: 8,
-                                          ),
                                         ],
                                       ),
                                     ),
                                   ],
                                 ),
                               ),
-                          Divider(
-                            color: ArDriveTheme.of(context)
-                                .themeData
-                                .colors
-                                .themeFgSubtle
-                                .withOpacity(0.5),
-                            thickness: 0.5,
-                            height: 8,
-                          )
+                          const Divider(height: 20)
                         ],
                       );
                     },
@@ -1432,9 +1421,7 @@ class _StatsScreenState extends State<StatsScreen> {
                       )),
                 ),
               ),
-        const Divider(
-          height: 20,
-        ),
+        const Divider(height: 20),
         RichText(
           text: TextSpan(
             children: [
@@ -1475,9 +1462,8 @@ class _StatsScreenState extends State<StatsScreen> {
             style: ArDriveTypography.body.buttonNormalRegular(),
           ),
         ),
-        const Divider(
-          height: 20,
-        ),
+        const SizedBox(height: 10),
+        const Divider(height: 10),
         ...widget.children,
       ],
     );

--- a/lib/models/forms/cc.dart
+++ b/lib/models/forms/cc.dart
@@ -12,7 +12,7 @@ const ccLicensesEnabled = [
   ccBySAMeta,
 ];
 
-const ccLicenseDefault = ccByLicenseMetaV2;
+const ccLicenseDefault = cc0LicenseMeta;
 
 FormGroup createCcTypeForm() => FormGroup({
       'ccTypeField': FormControl<LicenseMeta>(


### PR DESCRIPTION
Changes
- Factor out shared form / logic / UI between FsEntryLicence & to share with Upload
- FsEntryLicence
  - Be more explicit about using `LicenseCategory`
  - Fix inconsistent behaviour of back button in FsEntryLicence review screen - now it returns to the previous screen for all CC licenses
  - Fix sometimes using v0.1 of UDL license instead of v0.2
- Upload UI
  - Added dropdown to select `LicenseCategory`
  - Added screen to configure selected `LicenseCategory`
  - Added Review screen (only for when license is configured)
  - modified `_uploadUsing*Uploader` functions to accept the configured License
- Misc naming fixes
- Misc DRY