### PR TITLE
PE-5843: (Firefox) fix snapshot creation on huge drives by fetching entities using a batching strategy

### DIFF
--- a/lib/utils/snapshots/snapshot_item_to_be_created.dart
+++ b/lib/utils/snapshots/snapshot_item_to_be_created.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:ardrive/services/arweave/graphql/graphql_api.graphql.dart';
 import 'package:ardrive/sync/domain/models/drive_entity_history.dart';
+import 'package:ardrive/sync/utils/batch_processor.dart';
 import 'package:ardrive/utils/snapshots/snapshot_types.dart';
 import 'package:ardrive/utils/snapshots/tx_snapshot_to_snapshot_data.dart';
 import 'package:ardrive_utils/ardrive_utils.dart';
@@ -49,13 +50,24 @@ class SnapshotItemToBeCreated {
     // Convert the source Stream into a List to get all elements at once
     final nodes = await source.toList();
 
-    // Process each node concurrently
-    for (var node in nodes) {
-      tasks.add(_processNode(node.transactionCommonMixin));
-    }
+    final processor = BatchProcessor();
+    List<TxSnapshot> results = [];
+    final stream = processor.batchProcess<DriveEntityHistoryTransactionModel>(
+      list: nodes,
+      endOfBatchCallback: (items) async* {
+        // Process each node concurrently
+        for (var node in items) {
+          tasks.add(_processNode(node.transactionCommonMixin));
+        }
 
-    // Wait for all tasks to finish in their original order
-    List<TxSnapshot> results = await Future.wait(tasks);
+        results.addAll(await Future.wait(tasks));
+
+        yield 1;
+      },
+      batchSize: 100,
+    );
+
+    await for (var _ in stream) {}
 
     // Create a stream that emits each TxSnapshot in their original order
     Stream<TxSnapshot> snapshotStream = Stream.fromIterable(results);


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/10m1hgpvc1jf0