### PR TITLE
PE-5897: meta-mask-authentication-error-due-to-graph-ql-transaction-retrieval-issue

### DIFF
--- a/lib/services/arweave/graphql/queries/FirstTxForWallet.graphql
+++ b/lib/services/arweave/graphql/queries/FirstTxForWallet.graphql
@@ -1,5 +1,5 @@
 query FirstTxForWallet($owner: String!) {
-  transactions(owners: [$owner], first: 1) {
+  transactions(owners: [$owner], first: 1, sort: HEIGHT_ASC) {
     edges {
       node {
         id


### PR DESCRIPTION
fixes gql query to sort before grabbing first tx

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/2quaf5b8r9tng