### PR TITLE
PE-5899: Dont log `TurboUserNotFound` on Sentry

### DIFF
--- a/lib/turbo/services/payment_service.dart
+++ b/lib/turbo/services/payment_service.dart
@@ -4,6 +4,7 @@ import 'package:ardrive/turbo/topup/models/payment_model.dart';
 import 'package:ardrive/utils/logger.dart';
 import 'package:ardrive/utils/turbo_utils.dart';
 import 'package:ardrive_http/ardrive_http.dart';
+import 'package:ardrive_logger/ardrive_logger.dart';
 import 'package:arweave/arweave.dart';
 import 'package:dio/dio.dart';
 import 'package:equatable/equatable.dart';
@@ -252,7 +253,7 @@ String _urlParamsForGetPriceForFiat({
   return urlParams;
 }
 
-class TurboUserNotFound implements Exception {
+class TurboUserNotFound implements UntrackedException {
   TurboUserNotFound();
 }
 


### PR DESCRIPTION
- TurboUserNotFound exception implements now the UntrackedException