### PR TITLE
PE-6136: null error null check operator used on a null value overlay remove error

### DIFF
--- a/lib/components/details_panel.dart
+++ b/lib/components/details_panel.dart
@@ -1114,7 +1114,9 @@ class _CopyButtonState extends State<CopyButton> {
 
   @override
   dispose() {
-    _overlayEntry?.remove();
+    if (_overlayEntry != null && _overlayEntry!.mounted) {
+      _overlayEntry?.remove();
+    }
     super.dispose();
   }
 


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/1h1sg7sgsl328