### PR TITLE
PE-6140: don't log `EntityTransactionParseException`

### DIFF
--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -367,6 +367,7 @@ class ArweaveService {
         logger.e(
           'Failed to parse transaction '
           'with id ${parseException.transactionId}',
+          parseException,
         );
       } on GatewayError catch (fetchException) {
         logger.e(

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -364,10 +364,9 @@ class ArweaveService {
 
         // If there are errors in parsing the entity, ignore it.
       } on EntityTransactionParseException catch (parseException) {
-        logger.e(
+        logger.w(
           'Failed to parse transaction '
           'with id ${parseException.transactionId}',
-          parseException,
         );
       } on GatewayError catch (fetchException) {
         logger.e(


### PR DESCRIPTION
`EntityTransactionParseException` is an `UntrackedException`. We don't need to log as `e` since we won't log it.

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/7f5ipihmea9j8