### PR TITLE
PE-6375: add create snapshot to drive options on desktop and mobile

### DIFF
--- a/lib/pages/drive_detail/drive_detail_page.dart
+++ b/lib/pages/drive_detail/drive_detail_page.dart
@@ -11,6 +11,7 @@ import 'package:ardrive/blocs/prompt_to_snapshot/prompt_to_snapshot_state.dart';
 import 'package:ardrive/components/app_bottom_bar.dart';
 import 'package:ardrive/components/app_top_bar.dart';
 import 'package:ardrive/components/components.dart';
+import 'package:ardrive/components/create_snapshot_dialog.dart';
 import 'package:ardrive/components/csv_export_dialog.dart';
 import 'package:ardrive/components/details_panel.dart';
 import 'package:ardrive/components/drive_detach_dialog.dart';
@@ -411,7 +412,7 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
                                             ),
                                           ),
                                         ),
-                                        if (isDriveOwner)
+                                        if (isDriveOwner) ...[
                                           ArDriveDropdownItem(
                                             onClick: () {
                                               promptToRenameDrive(
@@ -430,6 +431,38 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
                                               ),
                                             ),
                                           ),
+                                          ArDriveDropdownItem(
+                                            onClick: () {
+                                              promptToRenameDrive(
+                                                context,
+                                                driveId: driveDetailState
+                                                    .currentDrive.id,
+                                                driveName: driveDetailState
+                                                    .currentDrive.name,
+                                              );
+                                            },
+                                            content: _buildItem(
+                                              appLocalizationsOf(context)
+                                                  .renameDrive,
+                                              ArDriveIcons.edit(
+                                                size: defaultIconSize,
+                                              ),
+                                            ),
+                                          ),
+                                        ],
+                                        ArDriveDropdownItem(
+                                          onClick: () {
+                                            promptToCreateSnapshot(context,
+                                                driveDetailState.currentDrive);
+                                          },
+                                          content: _buildItem(
+                                            appLocalizationsOf(context)
+                                                .createSnapshot,
+                                            ArDriveIcons.iconCreateSnapshot(
+                                              size: defaultIconSize,
+                                            ),
+                                          ),
+                                        ),
                                         ArDriveDropdownItem(
                                           onClick: () {
                                             promptToShareDrive(
@@ -991,7 +1024,7 @@ class MobileFolderNavigation extends StatelessWidget {
                             size: defaultIconSize,
                           ),
                         )),
-                    if (isOwner)
+                    if (isOwner) ...[
                       ArDriveDropdownItem(
                         onClick: () {
                           promptToRenameDrive(
@@ -1007,6 +1040,18 @@ class MobileFolderNavigation extends StatelessWidget {
                           ),
                         ),
                       ),
+                      ArDriveDropdownItem(
+                        onClick: () {
+                          promptToCreateSnapshot(context, state.currentDrive);
+                        },
+                        content: _buildItem(
+                          appLocalizationsOf(context).createSnapshot,
+                          ArDriveIcons.iconCreateSnapshot(
+                            size: defaultIconSize,
+                          ),
+                        ),
+                      ),
+                    ],
                     ArDriveDropdownItem(
                       onClick: () {
                         promptToShareDrive(

--- a/lib/pages/drive_detail/drive_detail_page.dart
+++ b/lib/pages/drive_detail/drive_detail_page.dart
@@ -423,24 +423,6 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
                                                     .currentDrive.name,
                                               );
                                             },
-                                            content: ArDriveDropdownItemTile(
-                                              name: appLocalizationsOf(context)
-                                                  .renameDrive,
-                                              icon: ArDriveIcons.edit(
-                                                size: defaultIconSize,
-                                              ),
-                                            ),
-                                          ),
-                                          ArDriveDropdownItem(
-                                            onClick: () {
-                                              promptToRenameDrive(
-                                                context,
-                                                driveId: driveDetailState
-                                                    .currentDrive.id,
-                                                driveName: driveDetailState
-                                                    .currentDrive.name,
-                                              );
-                                            },
                                             content: _buildItem(
                                               appLocalizationsOf(context)
                                                   .renameDrive,


### PR DESCRIPTION
add create snapshot to drive options on desktop and mobile

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/0seq0a0o61fr8