### PR TITLE
PE-6456: chore: bump version and release notes

### DIFF
--- a/android/fastlane/metadata/android/en-US/changelogs/140.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/140.txt
@@ -1,0 +1,1 @@
+- Improves handling of a few common errors

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Secure, permanent storage
 
 publish_to: 'none'
 
-version: 2.49.3
+version: 2.49.4
 
 environment:
   sdk: '>=3.2.0 <4.0.0'


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/0u3veu5u4hkng