### PR TITLE
PE-6470: better handling on the get pending tx fees method for null error null check operator used on a null value

### DIFF
--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 
 import 'package:ardrive/core/crypto/crypto.dart';
 import 'package:ardrive/entities/entities.dart';
+import 'package:ardrive/services/arweave/arweave_service_exception.dart';
 import 'package:ardrive/services/arweave/error/gateway_error.dart';
 import 'package:ardrive/services/arweave/get_segmented_transaction_from_drive_strategy.dart';
 import 'package:ardrive/services/services.dart';
@@ -117,8 +118,18 @@ class ArweaveService {
 
   /// Returns the pending transaction fees of the specified address that is not reflected by `getWalletBalance()`.
   Future<BigInt> getPendingTxFees(String address) async {
-    final query = await graphQLRetry.execute(PendingTxFeesQuery(
-        variables: PendingTxFeesArguments(walletAddress: address)));
+    final query = await graphQLRetry.execute(
+      PendingTxFeesQuery(
+        variables: PendingTxFeesArguments(
+          walletAddress: address,
+        ),
+      ),
+    );
+
+    if (query.data == null) {
+      throw ArweaveServiceException(
+          'Error fetching pending transaction fees. The query `PendingTxFeesQuery` returned null');
+    }
 
     return query.data!.transactions.edges
         .map((edge) => edge.node)

--- a/lib/services/arweave/arweave_service_exception.dart
+++ b/lib/services/arweave/arweave_service_exception.dart
@@ -1,0 +1,10 @@
+class ArweaveServiceException implements Exception {
+  final String message;
+
+  ArweaveServiceException(this.message);
+
+  @override
+  String toString() {
+    return 'ArweaveServiceException: $message';
+  }
+}


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/1807onkvbh2c0