### PR TITLE
PE-6633: fix(attach drives): remove Drive-Privacy filter

### DIFF
--- a/android/fastlane/metadata/android/en-US/changelogs/146.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/146.txt
@@ -1,0 +1,1 @@
+- Fixes an issue attaching drives due to timeout

--- a/lib/services/arweave/graphql/queries/FirstDriveEntityWithIdOwner.graphql
+++ b/lib/services/arweave/graphql/queries/FirstDriveEntityWithIdOwner.graphql
@@ -6,7 +6,6 @@ query FirstDriveEntityWithIdOwner($driveId: String!, $after: String) {
     tags: [
       { name: "Drive-Id", values: [$driveId] }
       { name: "Entity-Type", values: ["drive"] }
-      { name: "Drive-Privacy", values: ["public", "private"]}
     ]
   ) {
     edges {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Secure, permanent storage
 
 publish_to: 'none'
 
-version: 2.51.0
+version: 2.51.1
 
 environment:
   sdk: '>=3.2.0 <4.0.0'


### PR DESCRIPTION
~hotfix: remove drive-privacy tag that causes a timeout on attach drive query~

That's not a hotfix, but the Drive-Privacy filter makes the query slower.