### PR TITLE
PE-6777: feat(upload): display original file sizes on the upload modal

### DIFF
--- a/lib/blocs/upload/upload_cubit.dart
+++ b/lib/blocs/upload/upload_cubit.dart
@@ -120,6 +120,7 @@ class UploadCubit extends Cubit<UploadState> {
             showArnsCheckbox: showArnsCheckbox,
             showArnsNameSelection: false,
             loadingArNSNames: true,
+            totalSize: await _getTotalSize(),
           ),
         );
 
@@ -156,6 +157,7 @@ class UploadCubit extends Cubit<UploadState> {
             isArConnect: (state as UploadReadyToPrepare).isArConnect,
             showArnsCheckbox: showArnsCheckbox,
             showArnsNameSelection: false,
+            totalSize: await _getTotalSize(),
           ),
         );
       }
@@ -174,6 +176,16 @@ class UploadCubit extends Cubit<UploadState> {
         );
       }
     }
+  }
+
+  Future<int> _getTotalSize() async {
+    int size = 0;
+
+    for (final file in files) {
+      size += await file.ioFile.length;
+    }
+
+    return size;
   }
 
   void initialScreenNext({required LicenseCategory licenseCategory}) {

--- a/lib/blocs/upload/upload_state.dart
+++ b/lib/blocs/upload/upload_state.dart
@@ -97,6 +97,7 @@ class UploadReady extends UploadState {
   final bool showArnsNameSelection;
   final bool loadingArNSNames;
   final bool loadingArNSNamesError;
+  final int totalSize;
 
   final bool isArConnect;
 
@@ -112,6 +113,7 @@ class UploadReady extends UploadState {
     required this.showArnsNameSelection,
     this.loadingArNSNames = false,
     this.loadingArNSNamesError = false,
+    required this.totalSize,
   });
 
   // copyWith
@@ -129,6 +131,7 @@ class UploadReady extends UploadState {
     bool? showArnsNameSelection,
     bool? loadingArNSNames,
     bool? loadingArNSNamesError,
+    int? totalSize,
   }) {
     return UploadReady(
       loadingArNSNames: loadingArNSNames ?? this.loadingArNSNames,
@@ -144,6 +147,7 @@ class UploadReady extends UploadState {
           showArnsNameSelection ?? this.showArnsNameSelection,
       loadingArNSNamesError:
           loadingArNSNamesError ?? this.loadingArNSNamesError,
+      totalSize: totalSize ?? this.totalSize,
     );
   }
 
@@ -155,7 +159,6 @@ class UploadReady extends UploadState {
         loadingArNSNamesError,
         loadingArNSNames,
         showArnsCheckbox,
-        
       ];
 
   @override

--- a/lib/components/upload_form.dart
+++ b/lib/components/upload_form.dart
@@ -1568,7 +1568,7 @@ class _StatsScreenState extends State<StatsScreen> {
               ),
               TextSpan(
                 text: filesize(
-                  widget.readyState.paymentInfo.totalSize,
+                  widget.readyState.totalSize,
                 ),
                 style: typography.paragraphNormal(
                   fontWeight: ArFontWeight.bold,


### PR DESCRIPTION
- use size of the files instead of the data items being uploaded

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/5j8grleft46vg