### PR TITLE
PE-6900: bump version and release notes

### DIFF
--- a/android/fastlane/metadata/android/en-US/changelogs/158.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/158.txt
@@ -1,0 +1,5 @@
+- New feature: auto-update for manifests after file uploads.
+- Refresh the upload UI with updated icons, dropdowns, and selectors.
+- Add loading feedback during large file fetches to prevent app unresponsiveness.
+- Improved sidebar styling.
+- Fixes an issue where the blurred seed phrase content was not displaying after resizing the page.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Secure, permanent storage
 
 publish_to: 'none'
 
-version: 2.55.1
+version: 2.56.0
 
 environment:
   sdk: '>=3.2.0 <4.0.0'


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/1v9mbt71g3r98