### PR TITLE
PE-7153: fix license sync

### DIFF
--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -262,6 +262,7 @@ class ArweaveService {
 
       yield licenseComposedQuery.data!.transactions.edges
           .map((e) => e.node)
+          .where(e)
           .toList();
     }
   }

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -262,7 +262,7 @@ class ArweaveService {
 
       yield licenseComposedQuery.data!.transactions.edges
           .map((e) => e.node)
-          .where(e)
+          .where((e) => e.tags.any((t) => t.name == 'License'))
           .toList();
     }
   }

--- a/lib/services/arweave/graphql/queries/LicenseDataBundled.graphql
+++ b/lib/services/arweave/graphql/queries/LicenseDataBundled.graphql
@@ -1,7 +1,6 @@
 query LicenseComposed($transactionIds: [ID!]) {
   transactions(
     ids: $transactionIds
-    tags: [{ name: "License", values: [""], op: NEQ }]
   ) {
     edges {
       node {


### PR DESCRIPTION
- remove NEQ operator and filter the licenses in the client

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/365f5pn687obo