### PR TITLE
PE-7256: feat(turbo upload service): Only use multipart endpoint for uploads larger or equal to 5MB

### DIFF
--- a/packages/ardrive_uploader/lib/src/exceptions.dart
+++ b/packages/ardrive_uploader/lib/src/exceptions.dart
@@ -1,4 +1,4 @@
-abstract class ArDriveUploaderExceptions {
+abstract class ArDriveUploaderExceptions implements Exception {
   abstract final String message;
   abstract final Object? error;
 }
@@ -132,6 +132,18 @@ class UnderFundException implements ArDriveUploaderExceptions {
 class ThumbnailUploadException implements UploadStrategyException {
   ThumbnailUploadException({
     required this.message,
+    this.error,
+  });
+
+  @override
+  final String message;
+  @override
+  Object? error;
+}
+
+class TurboUploadTimeoutException implements ArDriveUploaderExceptions {
+  TurboUploadTimeoutException({
+    this.message = 'Turbo upload timeout',
     this.error,
   });
 

--- a/packages/ardrive_uploader/lib/src/factories.dart
+++ b/packages/ardrive_uploader/lib/src/factories.dart
@@ -145,7 +145,7 @@ class TurboUploadServiceFactory {
     if (isMultipart) {
       return TurboUploadServiceMultipart(turboUploadUri: turboUploadUri);
     } else {
-      return TurboUploadServiceChunked(turboUploadUri: turboUploadUri);
+      return TurboUploadServiceNonChunked(turboUploadUri);
     }
   }
 }

--- a/packages/ardrive_uploader/lib/src/turbo_upload_service.dart
+++ b/packages/ardrive_uploader/lib/src/turbo_upload_service.dart
@@ -157,14 +157,12 @@ abstract class TurboUploadServiceBase implements TurboUploadService {
     }
   }
 
-  // Subclasses override this to finalize in their own way
   Future<Response> finalizeUpload({
     required String uploadId,
     required int dataItemSize,
     required TxID dataItemId,
   });
 
-  // Subclasses override this for the actual chunk upload call
   Future<Response> _uploadChunkRequest({
     required String uploadId,
     required Uint8List chunk,

--- a/packages/ardrive_uploader/lib/src/upload_strategy.dart
+++ b/packages/ardrive_uploader/lib/src/upload_strategy.dart
@@ -86,7 +86,7 @@ class UploadFileUsingDataItemFiles extends UploadFileStrategy {
       }
 
       final metadataStreamedUpload =
-          _streamedUploadFactory.fromUploadType(task.type);
+          await _streamedUploadFactory.fromUploadType(task);
 
       final uploadResult = await metadataStreamedUpload.send(
           DataItemUploadItem(
@@ -153,7 +153,7 @@ class UploadFileUsingDataItemFiles extends UploadFileStrategy {
       );
     }
 
-    final streamedUpload = _streamedUploadFactory.fromUploadType(task.type);
+    final streamedUpload = await _streamedUploadFactory.fromUploadType(task);
 
     dataItemTask = dataItemTask.copyWith(
       status: UploadStatus.inProgress,
@@ -259,7 +259,7 @@ class UploadFileUsingBundleStrategy extends UploadFileStrategy {
       throw UploadCanceledException('Upload canceled');
     }
 
-    final streamedUpload = _streamedUploadFactory.fromUploadType(task.type);
+    final streamedUpload = await _streamedUploadFactory.fromUploadType(task);
 
     task = task.copyWith(
       status: UploadStatus.inProgress,
@@ -351,7 +351,7 @@ class UploadFolderStructureAsBundleStrategy
     }
 
     final streamedUpload =
-        _streamedUploadFactory.fromUploadType(folderTask.type);
+        await _streamedUploadFactory.fromUploadType(folderTask);
 
     final result =
         await streamedUpload.send(folderTask.uploadItem!, wallet, (progress) {
@@ -407,8 +407,7 @@ class _UploadThumbnailStrategy implements UploadThumbnailStrategy {
 
     /// It will always use the Turbo for now
 
-    final streamedUpload =
-        _streamedUploadFactory.fromUploadType(UploadType.turbo);
+    final streamedUpload = await _streamedUploadFactory.fromUploadType(task);
 
     final result = await streamedUpload.send(
       task.uploadItem!,

--- a/packages/ardrive_uploader/test/factories_test.dart
+++ b/packages/ardrive_uploader/test/factories_test.dart
@@ -134,7 +134,7 @@ void main() {
         final streamedUpload = await uploadFactory.fromUploadType(task);
         expect(streamedUpload, isA<TurboStreamedUpload>());
         expect((streamedUpload as TurboStreamedUpload).service,
-            isA<TurboUploadServiceChunked>());
+            isA<TurboUploadServiceNonChunked>());
       });
 
       test('should use multipart for non-file upload tasks', () async {
@@ -144,7 +144,7 @@ void main() {
         final streamedUpload = await uploadFactory.fromUploadType(task);
         expect(streamedUpload, isA<TurboStreamedUpload>());
         expect((streamedUpload as TurboStreamedUpload).service,
-            isA<TurboUploadServiceChunked>());
+            isA<TurboUploadServiceNonChunked>());
       });
     });
   });


### PR DESCRIPTION
Only use multipart endpoint for uploads larger or equal to 5MB

- Implements the `TurboUploadServiceBase` abstracting the common logic between the chunked and multipart uploads
- use multipart endpoint for files larger or equal to 5MB
- updates unit tests

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/02g4p7rckghog