### PR TITLE
PE-7394: fallback tx id not displayed after updating manifest

### DIFF
--- a/lib/blocs/create_manifest/create_manifest_cubit.dart
+++ b/lib/blocs/create_manifest/create_manifest_cubit.dart
@@ -307,6 +307,7 @@ class CreateManifestCubit extends Cubit<CreateManifestState> {
                 createManifestUploadReview.existingManifestFileId,
             uploadType: uploadType,
             wallet: _auth.currentUser.wallet,
+            fallbackTxId: _getFallbackTxId(),
           ),
           processId: _selectedAntRecord?.processId,
           undername: getSelectedUndername(),
@@ -373,15 +374,17 @@ class CreateManifestCubit extends Cubit<CreateManifestState> {
 
   TxID? _fallbackTxId;
 
-  void setFallbackTxId(TxID txId) {
+  void setFallbackTxId(TxID txId, {bool emitState = true}) {
     _fallbackTxId = txId;
 
-    emit(
-      (state as CreateManifestFolderLoadSuccess).copyWith(
-        fallbackTxId: _getFallbackTxId(),
-        enableManifestCreationButton: _getEnableManifestCreationButton(),
-      ),
-    );
+    if (emitState) {
+      emit(
+        (state as CreateManifestFolderLoadSuccess).copyWith(
+          fallbackTxId: _getFallbackTxId(),
+          enableManifestCreationButton: _getEnableManifestCreationButton(),
+        ),
+      );
+    }
   }
 
   TxID? _getFallbackTxId() {

--- a/lib/blocs/upload/upload_cubit.dart
+++ b/lib/blocs/upload/upload_cubit.dart
@@ -161,6 +161,7 @@ class UploadCubit extends Cubit<UploadState> {
           )
           .getSingle();
 
+      /// If the manifest has a fallback tx id, we need to reuse it
       await _createManifestCubit.prepareManifestTx(
         manifestName: manifestFileEntry.name,
         folderId: manifestFileEntry.parentFolderId,
@@ -223,6 +224,13 @@ class UploadCubit extends Cubit<UploadState> {
           )
           .getSingle();
 
+      if (manifestFileEntry.fallbackTxId != null) {
+        _createManifestCubit.setFallbackTxId(
+          manifestFileEntry.fallbackTxId!,
+          emitState: false,
+        );
+      }
+
       await _createManifestCubit.prepareManifestTx(
         manifestName: manifestFileEntry.name,
         folderId: manifestFileEntry.parentFolderId,
@@ -230,13 +238,11 @@ class UploadCubit extends Cubit<UploadState> {
       );
 
       emit(UploadingManifests(
-      manifestFiles: manifestModels,
+        manifestFiles: manifestModels,
         completedCount: completedCount,
       ));
 
-      await _createManifestCubit.uploadManifest(
-        method: _manifestUploadMethod,
-      );
+      await _createManifestCubit.uploadManifest(method: _manifestUploadMethod);
 
       final manifestFile = await _driveDao
           .fileById(

--- a/lib/components/details_panel.dart
+++ b/lib/components/details_panel.dart
@@ -776,6 +776,21 @@ class _DetailsPanelState extends State<DetailsPanel> {
         itemTitle: appLocalizationsOf(context).dataTxID,
       ),
       sizedBoxHeight16px,
+      if (item.fallbackTxId != null)
+        DetailsPanelItem(
+          leading: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _TxIdTextLink(txId: item.fallbackTxId!),
+              const SizedBox(width: 12),
+              CopyButton(
+                text: item.fallbackTxId!,
+              ),
+            ],
+          ),
+          itemTitle: 'Manifest Fallback TxID',
+        ),
+      sizedBoxHeight16px,
       if (state is FsEntryFileInfoSuccess)
         DetailsPanelItem(
           // TODO: Localize

--- a/lib/entities/file_entity.dart
+++ b/lib/entities/file_entity.dart
@@ -45,6 +45,9 @@ class FileEntity extends EntityWithCustomMetadata {
   @JsonKey(includeFromJson: true, includeToJson: true)
   Thumbnail? thumbnail;
 
+  @JsonKey(includeIfNull: false, name: 'fallbackTxId')
+  String? fallbackTxId;
+
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
   List<String> reservedGqlTags = [
@@ -79,6 +82,7 @@ class FileEntity extends EntityWithCustomMetadata {
     this.isHidden,
     this.thumbnail,
     this.assignedNames,
+    this.fallbackTxId,
   }) : super(ArDriveCrypto());
 
   FileEntity.withUserProvidedDetails({

--- a/lib/manifest/domain/manifest_repository.dart
+++ b/lib/manifest/domain/manifest_repository.dart
@@ -91,6 +91,7 @@ class ManifestRepositoryImpl implements ManifestRepository {
         dataContentType: ContentType.manifest,
         assignedNames:
             manifest.assignedName != null ? [manifest.assignedName!] : null,
+        fallbackTxId: manifest.fallbackTxId,
       );
 
       manifestFileEntity.txId = manifest.metadataTxId!;
@@ -133,6 +134,7 @@ class ManifestRepositoryImpl implements ManifestRepository {
           privacy: DrivePrivacyTag.public,
           assignedName:
               undername != null ? getLiteralARNSRecordName(undername) : null,
+          fallbackTxId: params.fallbackTxId,
         ),
         wallet: params.wallet,
         type: params.uploadType,
@@ -307,6 +309,7 @@ class ManifestUploadParams {
   final String? existingManifestFileId;
   final UploadType uploadType;
   final Wallet wallet;
+  final String? fallbackTxId;
 
   ManifestUploadParams({
     required this.manifestFile,
@@ -315,5 +318,6 @@ class ManifestUploadParams {
     required this.uploadType,
     this.existingManifestFileId,
     required this.wallet,
+    this.fallbackTxId,
   });
 }

--- a/lib/models/daos/drive_dao/drive_dao.dart
+++ b/lib/models/daos/drive_dao/drive_dao.dart
@@ -661,6 +661,7 @@ class DriveDao extends DatabaseAccessor<Database> with _$DriveDaoMixin {
           ? Value(jsonEncode(entity.thumbnail!.toJson()))
           : const Value(null),
       assignedNames: Value(_encodeAssignedNames(entity.assignedNames)),
+      fallbackTxId: Value(entity.fallbackTxId),
     );
 
     return into(fileEntries).insert(

--- a/lib/models/database/database.dart
+++ b/lib/models/database/database.dart
@@ -30,7 +30,7 @@ class Database extends _$Database {
   Database([QueryExecutor? e]) : super(e ?? openConnection());
 
   @override
-  int get schemaVersion => 23;
+  int get schemaVersion => 24;
   @override
   MigrationStrategy get migration => MigrationStrategy(
         onCreate: (Migrator m) {
@@ -147,6 +147,12 @@ class Database extends _$Database {
 
               await m.addColumn(drives, drives.isHidden);
               await m.addColumn(driveRevisions, driveRevisions.isHidden);
+            }
+            if (from < 24) {
+              logger.d('Migrating schema from v23 to v24');
+
+              await m.addColumn(fileEntries, fileEntries.fallbackTxId);
+              await m.addColumn(fileRevisions, fileRevisions.fallbackTxId);
             }
           } catch (e, stacktrace) {
             logger.e(

--- a/lib/models/file_entry.dart
+++ b/lib/models/file_entry.dart
@@ -27,6 +27,7 @@ extension FileEntryExtensions on FileEntry {
               .map((e) => e.toString())
               .toList()
           : null,
+      fallbackTxId: fallbackTxId,
     );
 
     file.customJsonMetadata = parseCustomJsonMetadata(customJsonMetadata);

--- a/lib/models/file_revision.dart
+++ b/lib/models/file_revision.dart
@@ -30,6 +30,7 @@ extension FileRevisionsCompanionExtensions on FileRevisionsCompanion {
         path: '',
         thumbnail: Value(thumbnail.value),
         assignedNames: Value(assignedNames.value),
+        fallbackTxId: fallbackTxId,
       );
 
   /// Returns a list of [NetworkTransactionsCompanion] representing the metadata and data transactions
@@ -81,6 +82,7 @@ extension FileEntityExtensions on FileEntity {
       isHidden: Value(isHidden ?? false),
       thumbnail: Value(thumbnailData),
       assignedNames: Value(assignedNamesData),
+      fallbackTxId: Value(fallbackTxId),
     );
   }
 
@@ -127,6 +129,9 @@ extension FileEntityExtensions on FileEntity {
       [FileRevisionsCompanion? previousRevision]) {
     if (previousRevision == null) {
       return RevisionAction.create;
+    } else if (fallbackTxId != null &&
+        fallbackTxId != previousRevision.fallbackTxId.value) {
+      return RevisionAction.uploadNewVersion;
     } else if (name != previousRevision.name.value) {
       return RevisionAction.rename;
     } else if (parentFolderId != previousRevision.parentFolderId.value) {

--- a/lib/models/tables/file_entries.drift
+++ b/lib/models/tables/file_entries.drift
@@ -30,5 +30,7 @@ CREATE TABLE file_entries (
 
     assignedNames TEXT,
 
+    fallbackTxId TEXT,
+
     PRIMARY KEY (id, driveId)
 ) AS FileEntry;

--- a/lib/models/tables/file_revisions.drift
+++ b/lib/models/tables/file_revisions.drift
@@ -32,6 +32,8 @@ CREATE TABLE file_revisions (
 
     assignedNames TEXT,
 
+    fallbackTxId TEXT,
+
     PRIMARY KEY (fileId, driveId, dateCreated),
     FOREIGN KEY (licenseTxId) REFERENCES network_transactions(id),
     FOREIGN KEY (metadataTxId) REFERENCES network_transactions(id),

--- a/lib/pages/drive_detail/models/data_table_item.dart
+++ b/lib/pages/drive_detail/models/data_table_item.dart
@@ -89,7 +89,7 @@ class FileDataTableItem extends ArDriveDataTableItem {
   final String? pinnedDataOwnerAddress;
   final Thumbnail? thumbnail;
   final List<String>? assignedNames;
-
+  final String? fallbackTxId;
   FileDataTableItem(
       {required super.driveId,
       required super.lastUpdated,
@@ -108,6 +108,7 @@ class FileDataTableItem extends ArDriveDataTableItem {
       required this.metadataTx,
       required this.dataTx,
       required this.pinnedDataOwnerAddress,
+      this.fallbackTxId,
       this.assignedNames,
       this.thumbnail,
       super.licenseType,
@@ -158,6 +159,7 @@ class DriveDataTableItemMapper {
       thumbnail: file.thumbnail != null && file.thumbnail != 'null'
           ? Thumbnail.fromJson(jsonDecode(file.thumbnail!))
           : null,
+      fallbackTxId: file.fallbackTxId,
     );
   }
 
@@ -188,10 +190,11 @@ class DriveDataTableItemMapper {
       thumbnail: fileEntry.thumbnail != null && fileEntry.thumbnail != 'null'
           ? Thumbnail.fromJson(jsonDecode(fileEntry.thumbnail!))
           : null,
+      fallbackTxId: fileEntry.fallbackTxId,
     );
   }
 
-static FolderDataTableItem fromFolderEntry(
+  static FolderDataTableItem fromFolderEntry(
     FolderEntry folderEntry,
     int index,
     bool isOwner,
@@ -256,6 +259,7 @@ static FolderDataTableItem fromFolderEntry(
       thumbnail: revision.thumbnail != null && revision.thumbnail != 'null'
           ? Thumbnail.fromJson(jsonDecode(revision.thumbnail!))
           : null,
+      fallbackTxId: revision.fallbackTxId,
     );
   }
 }

--- a/packages/ardrive_uploader/lib/src/arfs_upload_metadata.dart
+++ b/packages/ardrive_uploader/lib/src/arfs_upload_metadata.dart
@@ -170,6 +170,7 @@ class ARFSFileUploadMetadata extends ARFSUploadMetadata with ARFSUploadData {
     required super.id,
     required super.isPrivate,
     this.assignedName,
+    this.fallbackTxId,
   });
 
   /// The size of the file in bytes.
@@ -207,6 +208,8 @@ class ARFSFileUploadMetadata extends ARFSUploadMetadata with ARFSUploadData {
 
   String? assignedName;
 
+  final String? fallbackTxId;
+
   // Public method to set licenseTxId with validation or additional logic
   void updateLicenseTxId(String licenseTxId) {
     _licenseTxId = licenseTxId;
@@ -236,6 +239,7 @@ class ARFSFileUploadMetadata extends ARFSUploadMetadata with ARFSUploadData {
         },
       if (licenseTxId != null) 'licenseTxId': licenseTxId,
       if (assignedName != null) 'assignedNames': [assignedName!],
+      if (fallbackTxId != null) 'fallbackTxId': fallbackTxId,
     };
   }
 }

--- a/packages/ardrive_uploader/lib/src/metadata_generator.dart
+++ b/packages/ardrive_uploader/lib/src/metadata_generator.dart
@@ -98,6 +98,7 @@ class ARFSUploadMetadataGenerator
         licenseDefinitionTxId: arguments.licenseDefinitionTxId,
         licenseAdditionalTags: arguments.licenseAdditionalTags,
         assignedName: arguments.assignedName,
+        fallbackTxId: arguments.fallbackTxId,
       )
         ..setDataTags(tags['data-item']!)
         ..setEntityMetadataTags(tags['entity']!);
@@ -174,6 +175,7 @@ class ARFSUploadMetadataArgs extends Equatable {
   final String? licenseDefinitionTxId;
   final Map<String, String>? licenseAdditionalTags;
   final String? assignedName;
+  final String? fallbackTxId;
 
   factory ARFSUploadMetadataArgs.file({
     required String driveId,
@@ -183,6 +185,7 @@ class ARFSUploadMetadataArgs extends Equatable {
     String? entityId,
     Map<String, String>? customBundleTags,
     String? assignedName,
+    String? fallbackTxId,
   }) {
     return ARFSUploadMetadataArgs(
       driveId: driveId,
@@ -191,6 +194,7 @@ class ARFSUploadMetadataArgs extends Equatable {
       entityId: entityId,
       type: type,
       assignedName: assignedName,
+      fallbackTxId: fallbackTxId,
     );
   }
 
@@ -231,6 +235,7 @@ class ARFSUploadMetadataArgs extends Equatable {
     this.licenseDefinitionTxId,
     this.licenseAdditionalTags,
     this.assignedName,
+    this.fallbackTxId,
   });
 
   @override


### PR DESCRIPTION
- add fallbackTxId to manifest's metadata
- reuse the fallbackTxId when auto-updating a manifest if the previous has one
- add fallbackTxId property on the FileEntry and FileRevision objects
- migrate the database

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/4n1gd3ra46tv0