### PR TITLE
PE-7399: catch error on device info and add logs on the thumbnail creation flow

### DIFF
--- a/lib/blocs/file_download/personal_file_download_cubit.dart
+++ b/lib/blocs/file_download/personal_file_download_cubit.dart
@@ -43,12 +43,17 @@ class ProfileFileDownloadCubit extends FileDownloadCubit {
         super(FileDownloadStarting());
 
   Future<void> verifyUploadLimitationsAndDownload(SecretKey? cipherKey) async {
-    if (await AppPlatform.isSafari()) {
-      if (_file.size > publicDownloadSafariSizeLimit) {
-        emit(const FileDownloadFailure(
-            FileDownloadFailureReason.browserDoesNotSupportLargeDownloads));
-        return;
+    try {
+      if (await AppPlatform.isSafari()) {
+        if (_file.size > publicDownloadSafariSizeLimit) {
+          emit(const FileDownloadFailure(
+              FileDownloadFailureReason.browserDoesNotSupportLargeDownloads));
+          return;
+        }
       }
+    } catch (e) {
+      logger.d(
+          'Error verifying upload limitations and downloading file... proceeding with download');
     }
 
     download(cipherKey);

--- a/lib/drive_explorer/thumbnail_creation/bloc/thumbnail_creation_bloc.dart
+++ b/lib/drive_explorer/thumbnail_creation/bloc/thumbnail_creation_bloc.dart
@@ -1,5 +1,6 @@
 import 'package:ardrive/drive_explorer/thumbnail/repository/thumbnail_repository.dart';
 import 'package:ardrive/pages/drive_detail/models/data_table_item.dart';
+import 'package:ardrive/utils/logger.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -28,7 +29,8 @@ class ThumbnailCreationBloc
             fileId: event.fileDataTableItem.id);
 
         emit(ThumbnailCreationSuccess());
-      } catch (e) {
+      } catch (e, stackTrace) {
+        logger.e('Error uploading thumbnail', e, stackTrace);
         emit(ThumbnailCreationError());
       }
     });


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/3ci6drlet4458