### PR TITLE
Fix: EthArEum login

### DIFF
--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -1108,17 +1108,52 @@ class ArweaveService {
   }
 
   Future<String?> getFirstTxForWallet(String owner) async {
-    final firstTxQuery = await graphQLRetry.execute(
+    final firstTxForWalletQuery = await graphQLRetry.execute(
       FirstTxForWalletQuery(
         variables: FirstTxForWalletArguments(owner: owner),
       ),
     );
 
-    if (firstTxQuery.data!.transactions.edges.isEmpty) {
+    if (firstTxForWalletQuery.data!.transactions.edges.isEmpty) {
       return null;
     }
 
-    return firstTxQuery.data!.transactions.edges.first.node.id;
+    return firstTxForWalletQuery.data!.transactions.edges.first.node.id;
+  }
+
+  Future<List<(String, int)>?> getTransactionsAtHeight(
+      String owner, int height) async {
+    final transactionsAtHeightQuery = await graphQLRetry.execute(
+      TransactionsAtHeightQuery(
+        variables: TransactionsAtHeightArguments(
+          owner: owner,
+          height: height,
+        ),
+      ),
+    );
+
+    if (transactionsAtHeightQuery.data!.transactions.edges.isEmpty) {
+      return null;
+    }
+
+    return transactionsAtHeightQuery.data!.transactions.edges
+        .map((e) => (e.node.id, int.parse(e.node.data.size)))
+        .toList();
+  }
+
+  Future<int?> getFirstTxBlockHeightForWallet(String owner) async {
+    final firstTxBlockHeightForWalletQuery = await graphQLRetry.execute(
+      FirstTxBlockHeightForWalletQuery(
+        variables: FirstTxBlockHeightForWalletArguments(owner: owner),
+      ),
+    );
+
+    if (firstTxBlockHeightForWalletQuery.data!.transactions.edges.isEmpty) {
+      return null;
+    }
+
+    return firstTxBlockHeightForWalletQuery
+        .data!.transactions.edges.first.node.block?.height;
   }
 
   /// Creates and signs a [Transaction] representing the provided entity.

--- a/lib/services/arweave/graphql/queries/FirstTxBlockHeightForWallet.graphql
+++ b/lib/services/arweave/graphql/queries/FirstTxBlockHeightForWallet.graphql
@@ -1,0 +1,11 @@
+query FirstTxBlockHeightForWallet($owner: String!) {
+  transactions(owners: [$owner], first: 1, sort: HEIGHT_ASC) {
+    edges {
+      node {
+        block {
+          height
+        }
+      }
+    }
+  }
+}

--- a/lib/services/arweave/graphql/queries/TransactionsAtHeight.graphql
+++ b/lib/services/arweave/graphql/queries/TransactionsAtHeight.graphql
@@ -1,0 +1,17 @@
+query TransactionsAtHeight($owner: String!, $height: Int!) {
+  transactions(owners: [$owner],
+    block: {
+      min: $height,
+      max: $height
+    }
+  ) {
+    edges {
+      node {
+        id
+        data {
+          size
+        }
+      }
+    }
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -676,34 +676,34 @@ packages:
     dependency: transitive
     description:
       name: file_selector_android
-      sha256: "1cd66575f063b689e041aec836905ba7be18d76c9f0634d0d75daec825f67095"
+      sha256: "8bcc3af859e9d47fab9c7dc315537406511a894ab578e198bd8f9ed745ea5a01"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0+7"
+    version: "0.5.1+2"
   file_selector_ios:
     dependency: transitive
     description:
       name: file_selector_ios
-      sha256: "0a1196a9c5795858aa315332da2fb5c4bcfdcb312d8a4e27651f765b87904431"
+      sha256: "94b98ad950b8d40d96fee8fa88640c2e4bd8afcdd4817993bd04e20310f45420"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1+9"
+    version: "0.5.3+1"
   file_selector_linux:
     dependency: transitive
     description:
       name: file_selector_linux
-      sha256: "045d372bf19b02aeb69cacf8b4009555fb5f6f0b7ad8016e5f46dd1387ddd492"
+      sha256: "54cbbd957e1156d29548c7d9b9ec0c0ebb6de0a90452198683a7d23aed617a33"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.2+1"
+    version: "0.9.3+2"
   file_selector_macos:
     dependency: transitive
     description:
       name: file_selector_macos
-      sha256: b15c3da8bd4908b9918111fa486903f5808e388b8d1c559949f584725a6594d6
+      sha256: "271ab9986df0c135d45c3cdb6bd0faa5db6f4976d3e4b437cf7d0f258d941bfc"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.3+3"
+    version: "0.9.4+2"
   file_selector_platform_interface:
     dependency: transitive
     description:
@@ -716,18 +716,18 @@ packages:
     dependency: transitive
     description:
       name: file_selector_web
-      sha256: "619e431b224711a3869e30dbd7d516f5f5a4f04b265013a50912f39e1abc88c8"
+      sha256: c4c0ea4224d97a60a7067eca0c8fd419e708ff830e0c83b11a48faf566cec3e7
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.4+1"
+    version: "0.9.4+2"
   file_selector_windows:
     dependency: transitive
     description:
       name: file_selector_windows
-      sha256: d3547240c20cabf205c7c7f01a50ecdbc413755814d6677f3cb366f04abcead0
+      sha256: "8f5d2f6590d51ecd9179ba39c64f722edc15226cc93dcc8698466ad36a4a85a4"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.3+1"
+    version: "0.9.3+3"
   file_system_access_api:
     dependency: transitive
     description:
@@ -809,10 +809,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_downloader
-      sha256: "188d921f78471cb28ec2346bcf4045a27a516e384e2bfc9b4be12ae12d3ff8c8"
+      sha256: b6da5495b6258aa7c243d0f0a5281e3430b385bccac11cc508f981e653b25aa6
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.7"
+    version: "1.11.8"
   flutter_driver:
     dependency: "direct dev"
     description: flutter
@@ -1240,34 +1240,34 @@ packages:
     dependency: transitive
     description:
       name: image_picker
-      sha256: "1f498d086203360cca099d20ffea2963f48c39ce91bdd8a3b6d4a045786b02c8"
+      sha256: "021834d9c0c3de46bf0fe40341fa07168407f694d9b2bb18d532dc1261867f7a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.8"
+    version: "1.1.2"
   image_picker_android:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: "844c6da4e4f2829dffdab97816bca09d0e0977e8dcef7450864aba4e07967a58"
+      sha256: "0f57fee1e8bfadf8cc41818bbcd7f72e53bb768a54d9496355d5e8a5681a19f1"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.9+6"
+    version: "0.8.12+1"
   image_picker_for_web:
     dependency: transitive
     description:
       name: image_picker_for_web
-      sha256: "5d6eb13048cd47b60dbf1a5495424dea226c5faf3950e20bf8120a58efb5b5f3"
+      sha256: "65d94623e15372c5c51bebbcb820848d7bcb323836e12dfdba60b5d3a8b39e50"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.4"
+    version: "3.0.5"
   image_picker_ios:
     dependency: transitive
     description:
       name: image_picker_ios
-      sha256: "917a5cadd67d052554cfb258595e54217de53fac5b52939426e26319a02e6297"
+      sha256: "4f0568120c6fcc0aaa04511cb9f9f4d29fc3d0139884b1d06be88dcec7641d6b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.9+2"
+    version: "0.8.12+1"
   image_picker_linux:
     dependency: transitive
     description:
@@ -1725,34 +1725,34 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_android
-      sha256: "1acac6bae58144b442f11e66621c062aead9c99841093c38f5bcdcc24c1c3474"
+      sha256: "71bbecfee799e65aff7c744761a57e817e73b738fedf62ab7afd5593da21f9f1"
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.5"
+    version: "12.0.13"
   permission_handler_apple:
     dependency: transitive
     description:
       name: permission_handler_apple
-      sha256: e9ad66020b89ff1b63908f247c2c6f931c6e62699b756ef8b3c4569350cd8662
+      sha256: e6f6d73b12438ef13e648c4ae56bd106ec60d17e90a59c4545db6781229082a0
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.4"
+    version: "9.4.5"
   permission_handler_html:
     dependency: transitive
     description:
       name: permission_handler_html
-      sha256: "54bf176b90f6eddd4ece307e2c06cf977fb3973719c35a93b85cc7093eb6070d"
+      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.1"
+    version: "0.1.3+5"
   permission_handler_platform_interface:
     dependency: transitive
     description:
       name: permission_handler_platform_interface
-      sha256: "48d4fcf201a1dad93ee869ab0d4101d084f49136ec82a8a06ed9cfeacab9fd20"
+      sha256: e9c8eadee926c4532d0305dff94b85bf961f16759c3af791486613152af4b4f9
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.1"
+    version: "4.2.3"
   permission_handler_windows:
     dependency: transitive
     description:


### PR DESCRIPTION
* handle situation where multiple txs are made by wallet and settled in same block as initial signature recording tx

Verification system assumes first tx by wallet made is recording of verification signature. In some cases when a user made further tx's (e.g., added a folder, uploaded data), and those tx's were settled in the same block as the first tx, the GQL query would return a different tx than expected for verification. 

The change here does the following:

1. Get the blockheight of the first tx reported for the wallet
2. Query for all txs at that blockheight for the wallet
3. Filter txs by size == verification signature size
4. Download data for those txs and check against verification signature to check for a match
