### PR TITLE
PE-7542: chore: bump version and release notes

### DIFF
--- a/android/fastlane/metadata/android/en-US/changelogs/174.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/174.txt
@@ -1,0 +1,2 @@
+- Set default TTL for undernames and name updates to 15 minutes.
+- Fixed issue preventing undername creation during file uploads.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Secure, permanent storage
 
 publish_to: 'none'
 
-version: 2.64.0
+version: 2.64.1
 
 environment:
   sdk: '>=3.2.0 <4.0.0'


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/1d7a5oat4ps30