### PR TITLE
PE-5605: logging(download) enhance error handling and logging for file downloads

### DIFF
--- a/lib/blocs/file_download/personal_file_download_cubit.dart
+++ b/lib/blocs/file_download/personal_file_download_cubit.dart
@@ -148,7 +148,8 @@ class ProfileFileDownloadCubit extends FileDownloadCubit {
     final dataTx = await (_arweave.getTransactionDetails(_file.txId));
 
     if (dataTx == null) {
-      throw StateError('Data transaction not found');
+      throw StateError(
+          'Failed to download: Data transaction not found for file');
     }
 
     if (drive.drivePrivacy == DrivePrivacy.private && !isPinFile) {
@@ -164,7 +165,8 @@ class ProfileFileDownloadCubit extends FileDownloadCubit {
       }
 
       if (driveKey == null) {
-        throw StateError('Drive Key not found');
+        throw StateError(
+            'Drive Key not found for file ${_file.id} in drive ${_file.driveId}');
       }
 
       fileKey = await _driveDao.getFileKey(_file.id, driveKey);
@@ -250,8 +252,13 @@ class ProfileFileDownloadCubit extends FileDownloadCubit {
         FileDownloadFailureReason.unknownError,
       ),
     );
+
     super.onError(error, stackTrace);
 
-    logger.e('Failed to download personal file', error, stackTrace);
+    logger.e(
+      'Failed to download file ${_file.id} with txId ${_file.txId} from gateway ${_arweave.client.api.gatewayUrl.origin}',
+      error,
+      stackTrace,
+    );
   }
 }

--- a/lib/blocs/file_download/shared_file_download_cubit.dart
+++ b/lib/blocs/file_download/shared_file_download_cubit.dart
@@ -35,12 +35,13 @@ class SharedFileDownloadCubit extends FileDownloadCubit {
   }
 
   Future<void> download() async {
-    try {
-      _downloadFile(revision);
-    } catch (err) {
-      logger.e('Failed to download shared file', err);
+    _downloadFile(revision).catchError((err) {
+      logger.e(
+        'Failed to download shared file ${revision.id} with name ${revision.name} (size: ${revision.size})',
+        err,
+      );
       addError(err);
-    }
+    });
   }
 
   Future<void> _downloadFile(ARFSFileEntity revision) async {
@@ -60,12 +61,13 @@ class SharedFileDownloadCubit extends FileDownloadCubit {
     final dataTx = await _arweave.getTransactionDetails(revision.dataTxId!);
 
     if (dataTx == null) {
-      throw StateError('Data transaction not found');
+      throw StateError(
+          'Data transaction not found for file ${revision.id} with txId ${revision.dataTxId} from gateway ${_arweave.client.api.gatewayUrl.origin}');
     }
 
     if (dataTxId == null) {
-      logger.e('Data transaction id is null');
-      throw StateError('Data transaction id is null');
+      throw StateError(
+          'Data transaction id is null for file ${revision.id} with name ${revision.name}');
     }
 
     if (fileKey != null && !isPinFile) {
@@ -107,8 +109,6 @@ class SharedFileDownloadCubit extends FileDownloadCubit {
         );
       },
       onError: (err) {
-        logger.e('Failed to download shared file', err);
-
         addError(err);
       },
       onDone: () {
@@ -130,6 +130,10 @@ class SharedFileDownloadCubit extends FileDownloadCubit {
     emit(const FileDownloadFailure(FileDownloadFailureReason.unknownError));
     super.onError(error, stackTrace);
 
-    logger.e('Failed to download shared file', error, stackTrace);
+    logger.e(
+      'Failed to download shared file ${revision.id} with txId ${revision.dataTxId} from gateway ${_arweave.client.api.gatewayUrl.origin}. File name: ${revision.name}, size: ${revision.size}',
+      error,
+      stackTrace,
+    );
   }
 }

--- a/lib/download/ardrive_downloader.dart
+++ b/lib/download/ardrive_downloader.dart
@@ -126,7 +126,10 @@ class _ArDriveDownloader implements ArDriveDownloader {
 
     Future.any([
       _cancelWithReason.future.then((_) => false),
-    ]).then((value) => finalize.complete(value));
+    ]).then((value) => finalize.complete(value)).catchError((e) {
+      logger.d('Download aborted');
+      finalize.complete(false);
+    });
 
     bool? saveResult;
     var bytesSaved = 0;


### PR DESCRIPTION
- Add detailed context to error messages in personal_file_download_cubit.dart including file ID, txId, and gateway URL
- Improve error messages in shared_file_download_cubit.dart with file metadata for better debugging
- Format error messages to include relevant file information directly in the message string
- Ensure consistent error logging pattern across download components
- Add missing catchError handler in ardrive_downloader.dart

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/0ngbbuoo8sevg