### PR TITLE
PE-5914: fix(login): download wallet

### DIFF
--- a/lib/authentication/login/views/wallet_created_view.dart
+++ b/lib/authentication/login/views/wallet_created_view.dart
@@ -8,7 +8,9 @@ import 'package:ardrive/authentication/login/blocs/login_bloc.dart';
 import 'package:ardrive/misc/resources.dart';
 import 'package:ardrive/utils/io_utils.dart';
 import 'package:ardrive/utils/plausible_event_tracker/plausible_event_tracker.dart';
+import 'package:ardrive/utils/show_general_dialog.dart';
 import 'package:ardrive_ui/ardrive_ui.dart';
+import 'package:ardrive_utils/ardrive_utils.dart';
 import 'package:arweave/arweave.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -248,6 +250,26 @@ class _WalletCreatedViewState extends State<WalletCreatedView> {
 
               await ioUtils.downloadWalletAsJsonFile(
                 wallet: widget.wallet,
+                onDownloadComplete: (success) {
+                  if (success && AppPlatform.isAndroid) {
+                    showArDriveDialog(
+                      context,
+                      content: ArDriveStandardModalNew(
+                        title: 'Download Successful',
+                        description:
+                            'Your wallet keyfile has been downloaded successfully. You can find it in your Downloads folder.',
+                        actions: [
+                          ModalAction(
+                            title: 'OK',
+                            action: () {
+                              Navigator.of(context).pop();
+                            },
+                          ),
+                        ],
+                      ),
+                    );
+                  }
+                },
               );
             },
             rightIcon: IgnorePointer(

--- a/lib/user/download_wallet/bloc/download_wallet_bloc.dart
+++ b/lib/user/download_wallet/bloc/download_wallet_bloc.dart
@@ -32,9 +32,14 @@ class DownloadWalletBloc
 
             await _ardriveIOUtils.downloadWalletAsJsonFile(
               wallet: wallet,
+              onDownloadComplete: (success) {
+                if (!success) {
+                  emit(DownloadWalletFailure());
+                } else {
+                  emit(const DownloadWalletSuccess());
+                }
+              },
             );
-
-            emit(const DownloadWalletSuccess());
           } catch (e) {
             emit(DownloadWalletFailure());
           }

--- a/lib/utils/io_utils.dart
+++ b/lib/utils/io_utils.dart
@@ -17,8 +17,14 @@ class ArDriveIOUtils {
 
   /// Download the wallet as a json file
   /// Throws an exception if the wallet is an ArConnect wallet
+  ///
+  /// Returns a Future that completes when the download is finished
+  ///
+  /// If provided, the [onDownloadComplete] callback will be called with a boolean
+  /// indicating whether the download was successful
   Future<void> downloadWalletAsJsonFile({
     required Wallet wallet,
+    void Function(bool success)? onDownloadComplete,
   }) async {
     if (wallet is ArConnectWallet) {
       throw Exception('ArConnect wallet not supported');
@@ -35,6 +41,17 @@ class ArDriveIOUtils {
       lastModifiedDate: DateTime.now(),
     );
 
-    io.saveFile(file);
+    try {
+      final result = await io.saveFile(file);
+      if (onDownloadComplete != null) {
+        onDownloadComplete(true);
+      }
+      return result;
+    } catch (e) {
+      if (onDownloadComplete != null) {
+        onDownloadComplete(false);
+      }
+      rethrow;
+    }
   }
 }

--- a/test/utils/io_utils_test.dart
+++ b/test/utils/io_utils_test.dart
@@ -56,4 +56,107 @@ void main() {
     // Then
     verify(() => mockArDriveIO.saveFile(expectedFile)).called(1);
   });
+
+  test('Should call success callback when download is successful', () async {
+    // Given
+    final mockWallet = MockWallet();
+    final mockArDriveIO = MockArDriveIO();
+    final mockIOFileAdapter = MockIOFileAdapter();
+    final walletJson = {'test': 'value'};
+    final jsonString = jsonEncode(walletJson);
+    final byteData = Uint8List.fromList(utf8.encode(jsonString));
+    bool? callbackResult;
+
+    final ardriveIOUtils = ArDriveIOUtils(
+      io: mockArDriveIO,
+      fileAdapter: mockIOFileAdapter,
+    );
+
+    final expectedFile = await IOFileAdapter().fromData(
+      byteData,
+      name: 'ardrive-wallet.json',
+      contentType: 'application/json',
+      lastModifiedDate: DateTime(2023),
+    );
+
+    // Setup MockWallet
+    when(() => mockWallet.toJwk()).thenReturn(walletJson);
+
+    // Setup MockIOFileAdapter
+    when(() => mockIOFileAdapter.fromData(
+          byteData,
+          name: 'ardrive-wallet.json',
+          contentType: 'application/json',
+          lastModifiedDate: any(named: 'lastModifiedDate'),
+        )).thenAnswer((_) async => expectedFile);
+
+    when(() => mockArDriveIO.saveFile(expectedFile)).thenAnswer((_) async {});
+
+    // When
+    await ardriveIOUtils.downloadWalletAsJsonFile(
+      wallet: mockWallet,
+      onDownloadComplete: (success) {
+        callbackResult = success;
+      },
+    );
+
+    // Then
+    verify(() => mockArDriveIO.saveFile(expectedFile)).called(1);
+    expect(callbackResult, true);
+  });
+
+  test('Should call failure callback when download throws an exception',
+      () async {
+    // Given
+    final mockWallet = MockWallet();
+    final mockArDriveIO = MockArDriveIO();
+    final mockIOFileAdapter = MockIOFileAdapter();
+    final walletJson = {'test': 'value'};
+    final jsonString = jsonEncode(walletJson);
+    final byteData = Uint8List.fromList(utf8.encode(jsonString));
+    bool? callbackResult;
+
+    final ardriveIOUtils = ArDriveIOUtils(
+      io: mockArDriveIO,
+      fileAdapter: mockIOFileAdapter,
+    );
+
+    final expectedFile = await IOFileAdapter().fromData(
+      byteData,
+      name: 'ardrive-wallet.json',
+      contentType: 'application/json',
+      lastModifiedDate: DateTime(2023),
+    );
+
+    // Setup MockWallet
+    when(() => mockWallet.toJwk()).thenReturn(walletJson);
+
+    // Setup MockIOFileAdapter
+    when(() => mockIOFileAdapter.fromData(
+          byteData,
+          name: 'ardrive-wallet.json',
+          contentType: 'application/json',
+          lastModifiedDate: any(named: 'lastModifiedDate'),
+        )).thenAnswer((_) async => expectedFile);
+
+    when(() => mockArDriveIO.saveFile(expectedFile))
+        .thenThrow(Exception('Failed to save file'));
+
+    // When
+    try {
+      await ardriveIOUtils.downloadWalletAsJsonFile(
+        wallet: mockWallet,
+        onDownloadComplete: (success) {
+          callbackResult = success;
+        },
+      );
+      fail('Expected an exception');
+    } catch (e) {
+      // Expected exception
+    }
+
+    // Then
+    verify(() => mockArDriveIO.saveFile(expectedFile)).called(1);
+    expect(callbackResult, false);
+  });
 }


### PR DESCRIPTION
fix: add download confirmation for wallet keyfiles on Android This commit adds a success notification when downloading wallet keyfiles on Android devices to prevent users from unknowingly downloading multiple copies.