### PR TITLE
PE-6990: fix(arns mobile) hide ArNS name assignment on mobile platforms

### DIFF
--- a/lib/components/details_panel.dart
+++ b/lib/components/details_panel.dart
@@ -1813,32 +1813,37 @@ class _ArnsNameDisplay extends StatelessWidget {
             return Row(
               mainAxisSize: MainAxisSize.min,
               children: [
-                ArDriveButton(
-                  text: 'Assign',
-                  icon: ArDriveIcons.arnsName(
-                    size: 16,
-                    color: ArDriveTheme.of(context).themeData.backgroundColor,
+                if (AppPlatform.isWeb())
+                  ArDriveButton(
+                    text: 'Assign',
+                    icon: ArDriveIcons.arnsName(
+                      size: 16,
+                      color: ArDriveTheme.of(context).themeData.backgroundColor,
+                    ),
+                    fontStyle: ArDriveTypography.body.buttonNormalBold(
+                      color: ArDriveTheme.of(context).themeData.backgroundColor,
+                    ),
+                    backgroundColor: ArDriveTheme.of(context)
+                        .themeData
+                        .colors
+                        .themeFgDefault,
+                    maxHeight: 32,
+                    onPressed: () {
+                      showAssignArNSNameModal(
+                        context,
+                        file: fileItem,
+                        driveDetailCubit: context.read<DriveDetailCubit>(),
+                      ).then((_) {
+                        // Refresh both the verify name bloc and the file info cubit
+                        context
+                            .read<VerifyNameBloc>()
+                            .add(VerifyName(fileId: fileItem.fileId));
+                        context
+                            .read<DriveDetailCubit>()
+                            .refreshDriveDataTable();
+                      });
+                    },
                   ),
-                  fontStyle: ArDriveTypography.body.buttonNormalBold(
-                    color: ArDriveTheme.of(context).themeData.backgroundColor,
-                  ),
-                  backgroundColor:
-                      ArDriveTheme.of(context).themeData.colors.themeFgDefault,
-                  maxHeight: 32,
-                  onPressed: () {
-                    showAssignArNSNameModal(
-                      context,
-                      file: fileItem,
-                      driveDetailCubit: context.read<DriveDetailCubit>(),
-                    ).then((_) {
-                      // Refresh both the verify name bloc and the file info cubit
-                      context
-                          .read<VerifyNameBloc>()
-                          .add(VerifyName(fileId: fileItem.fileId));
-                      context.read<DriveDetailCubit>().refreshDriveDataTable();
-                    });
-                  },
-                ),
               ],
             );
           }

--- a/lib/components/details_panel.dart
+++ b/lib/components/details_panel.dart
@@ -1095,6 +1095,7 @@ class _DetailsPanelState extends State<DetailsPanel> {
           title = 'Imported from manifest';
         } else {
           final typography = ArDriveTypographyNew.of(context);
+          final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
 
           return Column(
             mainAxisSize: MainAxisSize.min,
@@ -1118,6 +1119,7 @@ class _DetailsPanelState extends State<DetailsPanel> {
                                   text: 'Imported from manifest ',
                                   style: typography.paragraphNormal(
                                     fontWeight: ArFontWeight.semiBold,
+                                    color: colorTokens.textHigh,
                                   ),
                                 ),
                                 WidgetSpan(
@@ -1131,9 +1133,10 @@ class _DetailsPanelState extends State<DetailsPanel> {
                                   ),
                                 ),
                                 TextSpan(
-                                  text: ' and owner',
+                                  text: ' and owner ',
                                   style: typography.paragraphNormal(
                                     fontWeight: ArFontWeight.semiBold,
+                                    color: colorTokens.textHigh,
                                   ),
                                 ),
                                 // opens in new tab
@@ -1152,6 +1155,7 @@ class _DetailsPanelState extends State<DetailsPanel> {
                                         style: typography
                                             .paragraphNormal(
                                               fontWeight: ArFontWeight.bold,
+                                              color: colorTokens.textHigh,
                                             )
                                             .copyWith(
                                                 decoration:

--- a/lib/components/details_panel.dart
+++ b/lib/components/details_panel.dart
@@ -13,7 +13,6 @@ import 'package:ardrive/components/fs_entry_license_form.dart';
 import 'package:ardrive/components/hide_dialog.dart';
 import 'package:ardrive/components/license_details_popover.dart';
 import 'package:ardrive/components/pin_indicator.dart';
-import 'package:ardrive/components/profile_card.dart';
 import 'package:ardrive/components/sizes.dart';
 import 'package:ardrive/components/truncated_address.dart';
 import 'package:ardrive/core/arfs/entities/arfs_entities.dart';
@@ -38,6 +37,7 @@ import 'package:ardrive/utils/num_to_string_parsers.dart';
 import 'package:ardrive/utils/open_url.dart';
 import 'package:ardrive/utils/show_general_dialog.dart';
 import 'package:ardrive/utils/size_constants.dart';
+import 'package:ardrive/utils/truncate_string.dart';
 import 'package:ardrive/utils/user_utils.dart';
 import 'package:ardrive_ui/ardrive_ui.dart';
 import 'package:ardrive_utils/ardrive_utils.dart';
@@ -866,7 +866,8 @@ class _DetailsPanelState extends State<DetailsPanel> {
             ],
           ),
         ),
-      if (widget.drivePrivacy == DrivePrivacy.public.name) ...[
+      if (widget.drivePrivacy == DrivePrivacy.public.name &&
+          AppPlatform.isWeb()) ...[
         sizedBoxHeight16px,
         DetailsPanelItem(
           leading: _ArnsNameDisplay(fileItem: item),
@@ -1150,8 +1151,11 @@ class _DetailsPanelState extends State<DetailsPanel> {
                                                 'https://viewblock.io/arweave/address/${file.originalOwner}');
                                       },
                                       child: Text(
-                                        getTruncatedWalletAddress(
-                                            file.name, file.originalOwner!),
+                                        truncateString(
+                                          file.originalOwner!,
+                                          offsetStart: 6,
+                                          offsetEnd: 6,
+                                        ),
                                         style: typography
                                             .paragraphNormal(
                                               fontWeight: ArFontWeight.bold,

--- a/lib/pages/drive_detail/components/drive_explorer_item_tile.dart
+++ b/lib/pages/drive_detail/components/drive_explorer_item_tile.dart
@@ -608,7 +608,7 @@ class _DriveExplorerItemTileTrailingState
               height: height,
             ),
           ),
-        if (widget.drive.isPublic)
+        if (widget.drive.isPublic && AppPlatform.isWeb())
           ArDriveDropdownItem(
             onClick: () {
               showAssignArNSNameModal(


### PR DESCRIPTION
- Added AppPlatform.isWeb() conditional checks to hide ArNS name assignment in context menus
- Added conditional check in details panel to only show ArNS assignment button on web

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/5vqabvrkndca8