### PR TITLE
PE-7826: fix(sync) use `/info` endpoint to get the current block height

### DIFF
--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -105,7 +105,7 @@ class ArweaveService {
   Future<int> getCurrentBlockHeight() async {
     //TODO (Javed) Use GQL Query to fetch block height
     final blockHeight = await client.api
-        .get('/info')
+        .get('info')
         .then((res) => json.decode(res.body)['height']);
     if (blockHeight < 0) {
       throw Exception(

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -105,7 +105,7 @@ class ArweaveService {
   Future<int> getCurrentBlockHeight() async {
     //TODO (Javed) Use GQL Query to fetch block height
     final blockHeight = await client.api
-        .get('/')
+        .get('/info')
         .then((res) => json.decode(res.body)['height']);
     if (blockHeight < 0) {
       throw Exception(


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/49ujirg2asl4g