### PR TITLE
PE-7836: fix(login) improve login error handling for private drive verification

### DIFF
--- a/lib/authentication/ardrive_auth.dart
+++ b/lib/authentication/ardrive_auth.dart
@@ -315,15 +315,22 @@ class ArDriveAuthImpl implements ArDriveAuth {
         throw WrongPasswordException('Password is incorrect');
       }
 
-      final privateDrive = await _arweave.getLatestDriveEntityWithId(
-        firstDrivePrivateDriveTxId,
-        driveKey: checkDriveKey,
-        driveOwner: await wallet.getAddress(),
-        maxRetries: profileQueryMaxRetries,
-      );
+      try {
+        final privateDrive = await _arweave.getLatestDriveEntityWithId(
+          firstDrivePrivateDriveTxId,
+          driveKey: checkDriveKey,
+          driveOwner: await wallet.getAddress(),
+          maxRetries: profileQueryMaxRetries,
+        );
 
-      if (privateDrive == null) {
-        throw WrongPasswordException('Password is incorrect');
+        if (privateDrive == null) {
+          throw WrongPasswordException('Password is incorrect');
+        }
+      } catch (e) {
+        if (e is TransactionNotFound) {
+          throw const PrivateDriveNotFoundException();
+        }
+        rethrow;
       }
     }
   }
@@ -447,6 +454,10 @@ class AuthenticationUnknownException implements Exception {
   final String message;
 
   AuthenticationUnknownException(this.message);
+}
+
+class PrivateDriveNotFoundException implements Exception {
+  const PrivateDriveNotFoundException();
 }
 
 class AuthenticationUserIsNotLoggedInException implements UntrackedException {

--- a/lib/authentication/login/blocs/login_bloc.dart
+++ b/lib/authentication/login/blocs/login_bloc.dart
@@ -244,6 +244,11 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
         return;
       }
 
+      if (e is PrivateDriveNotFoundException) {
+        emit(LoginPasswordFailedWithPrivateDriveNotFound());
+        return;
+      }
+
       emit(LoginUnknownFailure(e));
     }
   }

--- a/lib/authentication/login/blocs/login_state.dart
+++ b/lib/authentication/login/blocs/login_state.dart
@@ -134,4 +134,6 @@ class LoginCheckingPassword extends LoginState {}
 
 class LoginPasswordFailed extends LoginState {}
 
+class LoginPasswordFailedWithPrivateDriveNotFound extends LoginState {}
+
 class LoginCreatePasswordComplete extends LoginState {}

--- a/lib/authentication/login/views/login_page.dart
+++ b/lib/authentication/login/views/login_page.dart
@@ -193,6 +193,14 @@ class _LoginPageState extends State<LoginPage> {
               message:
                   'There was a problem communicating with the gateway at ${loginState.gatewayUrl}.\nPlease try again later.',
             );
+          } else if (loginState
+              is LoginPasswordFailedWithPrivateDriveNotFound) {
+            showErrorDialog(
+              context: context,
+              title: appLocalizationsOf(context).loginFailed,
+              message:
+                  'Your drive is still processing on Arweave. Please wait a few minutes for the transaction to confirm, then try again.',
+            );
           }
         },
         buildWhen: (previous, current) {

--- a/lib/authentication/login/views/modals/enter_your_password_modal.dart
+++ b/lib/authentication/login/views/modals/enter_your_password_modal.dart
@@ -313,6 +313,7 @@ void showEnterYourPasswordDialog(
             return false;
           }
           return (current is GatewayLoginFailure ||
+              current is LoginPasswordFailedWithPrivateDriveNotFound ||
               current is LoginCheckingPassword ||
               current is LoginPasswordFailed ||
               current is LoginWithPassword ||

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -704,7 +704,7 @@ class ArweaveService {
       final fileTx = filteredEdges.first.node;
       final fileDataRes = await client.api.getSandboxedTx(fileTx.id);
 
-      if (fileDataRes.statusCode != 200) {
+      if (fileDataRes.statusCode == 404) {
         throw TransactionNotFound(fileTx.id);
       }
 

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -704,6 +704,10 @@ class ArweaveService {
       final fileTx = filteredEdges.first.node;
       final fileDataRes = await client.api.getSandboxedTx(fileTx.id);
 
+      if (fileDataRes.statusCode != 200) {
+        throw TransactionNotFound(fileTx.id);
+      }
+
       try {
         return await DriveEntity.fromTransaction(
             fileTx, _crypto, fileDataRes.bodyBytes, driveKey);
@@ -1363,4 +1367,10 @@ class UploadTransactions {
   Transaction dataTx;
 
   UploadTransactions(this.entityTx, this.dataTx);
+}
+
+class TransactionNotFound implements Exception {
+  final String txId;
+
+  TransactionNotFound(this.txId);
 }


### PR DESCRIPTION
- add proper error handling when private drive transaction is not found during login
- add new PrivateDriveNotFoundException and TransactionNotFound exceptions
- show user-friendly error message when private drive is still processing
- add additional logging in drive detail cubit and drive dao for better debugging
- improve error handling in arweave service for transaction fetching

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/35b30u4l8pkmg