### PR TITLE
PE-7848: feat(drive explorer) add sync button to no drives page

### DIFF
--- a/lib/pages/no_drives/no_drives_page.dart
+++ b/lib/pages/no_drives/no_drives_page.dart
@@ -1,6 +1,7 @@
 import 'package:ardrive/app_shell.dart';
 import 'package:ardrive/authentication/components/login_modal.dart';
 import 'package:ardrive/blocs/drive_detail/drive_detail_cubit.dart';
+import 'package:ardrive/components/app_top_bar.dart';
 import 'package:ardrive/components/drive_create_form.dart';
 import 'package:ardrive/components/profile_card.dart';
 import 'package:ardrive/components/topbar/help_button.dart';
@@ -64,6 +65,8 @@ class NoDrivesPage extends StatelessWidget {
             const Row(
               mainAxisAlignment: MainAxisAlignment.end,
               children: [
+                SyncButton(),
+                SizedBox(width: 8),
                 HelpButtonTopBar(),
                 SizedBox(width: 8),
                 ProfileCard(),


### PR DESCRIPTION
- Add SyncButton to desktop layout in top row of buttons
- Utilize existing SyncButton in MobileAppBar for mobile layout

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/3hq3u46thv3a8