### PR TITLE
PE-7867: refactor(upload cubit): add closed state check before emitting ant records

### DIFF
--- a/lib/blocs/upload/upload_cubit.dart
+++ b/lib/blocs/upload/upload_cubit.dart
@@ -892,6 +892,11 @@ class UploadCubit extends Cubit<UploadState> {
     _arnsRepository.getAntRecordsForWallet(walletAddress!).then((value) {
       _ants = value;
       if (state is UploadReady) {
+        if (isClosed) {
+          logger.i('Upload cubit closed. Not emitting ant records.');
+          return;
+        }
+
         emit((state as UploadReady).copyWith(arnsRecords: value));
       }
     }).catchError((e) {


### PR DESCRIPTION
- add check for isClosed before emitting new state in upload cubit
- prevent potential state emission after cubit is closed