### PR TITLE
PE-7868: refactor(drive attach): add state checks to prevent actions after unmount

### DIFF
--- a/lib/blocs/drive_attach/drive_attach_cubit.dart
+++ b/lib/blocs/drive_attach/drive_attach_cubit.dart
@@ -69,6 +69,11 @@ class DriveAttachCubit extends Cubit<DriveAttachState> {
 
         if (state is! DriveAttachPrivate) {
           await driveNameLoader();
+
+          if (isClosed) {
+            return;
+          }
+
           if (driveNameController.text.isNotEmpty) {
             submit();
           }
@@ -105,6 +110,12 @@ class DriveAttachCubit extends Cubit<DriveAttachState> {
 
       if (state is DriveAttachPrivate) {
         if (await driveKeyValidator() != null) {
+          if (isClosed) {
+            logger.i(
+                'Drive attach cubit closed. Not emitting invalid drive key.');
+            return;
+          }
+
           emit(DriveAttachInvalidDriveKey());
           emit(previousState);
           return;
@@ -116,6 +127,11 @@ class DriveAttachCubit extends Cubit<DriveAttachState> {
       }
 
       if (!await driveNameLoader()) {
+        if (isClosed) {
+          logger.i('Drive attach cubit closed. Not emitting drive not found.');
+          return;
+        }
+
         emit(DriveAttachDriveNotFound());
         emit(previousState);
         return;

--- a/lib/components/drive_attach_form.dart
+++ b/lib/components/drive_attach_form.dart
@@ -5,6 +5,7 @@ import 'package:ardrive/services/services.dart';
 import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
 import 'package:ardrive/theme/theme.dart';
 import 'package:ardrive/utils/app_localizations_wrapper.dart';
+import 'package:ardrive/utils/logger.dart';
 import 'package:ardrive/utils/validate_folder_name.dart';
 import 'package:ardrive_ui/ardrive_ui.dart';
 import 'package:ardrive_utils/ardrive_utils.dart';
@@ -77,6 +78,10 @@ class _DriveAttachFormState extends State<DriveAttachForm> {
   }
 
   void _onDriveNameChange() {
+    if (!mounted) {
+      return;
+    }
+
     setState(() {
       _isFormValid =
           context.read<DriveAttachCubit>().driveNameController.text.isNotEmpty;
@@ -133,6 +138,12 @@ class _DriveAttachFormState extends State<DriveAttachForm> {
                     if (context.read<DriveAttachCubit>().state
                         is! DriveAttachPrivate) {
                       debounce(() {
+                        if (!mounted) {
+                          logger.i(
+                              'Drive attach form closed. Not loading drive name.');
+                          return;
+                        }
+
                         context.read<DriveAttachCubit>().driveNameLoader();
                       });
                     }
@@ -151,6 +162,12 @@ class _DriveAttachFormState extends State<DriveAttachForm> {
                       final cubit = context.read<DriveAttachCubit>();
 
                       final validation = await cubit.driveKeyValidator();
+
+                      if (!mounted) {
+                        logger.i(
+                            'Drive attach form closed. Not validating drive key.');
+                        return null;
+                      }
 
                       return validation;
                     },


### PR DESCRIPTION

- add mounted checks in DriveAttachForm to prevent state updates after unmount
- add isClosed checks in DriveAttachCubit to prevent emit calls after closure
- add logging statements to track when operations are skipped due to state
- improve error handling for drive key validation and name loading

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/75ujs3jn5g0p8