### PR TITLE
PE-8133: fix(login): check if user is an arconnect profile before checking wallet version compatibility

### DIFF
--- a/lib/authentication/login/blocs/login_bloc.dart
+++ b/lib/authentication/login/blocs/login_bloc.dart
@@ -438,11 +438,13 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
     UnlockUserWithPassword event,
     Emitter<LoginState> emit,
   ) async {
-    final arconnectVersionSupported =
-        await _arConnectService.isWalletVersionSupported();
-    if (!arconnectVersionSupported) {
-      emit(const LoginFailure(ArConnectVersionNotSupportedException()));
-      return;
+    if (_isArConnectWallet()) {
+      final arconnectVersionSupported =
+          await _arConnectService.isWalletVersionSupported();
+      if (!arconnectVersionSupported) {
+        emit(const LoginFailure(ArConnectVersionNotSupportedException()));
+        return;
+      }
     }
 
     emit(LoginCheckingPassword());


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/5fmjene1neahg