### PR TITLE
PE-8434: feat: add file uploader display with ArNS integration to share page

### DIFF
--- a/lib/blocs/fs_entry_info/fs_entry_info_cubit.dart
+++ b/lib/blocs/fs_entry_info/fs_entry_info_cubit.dart
@@ -15,6 +15,7 @@ class FsEntryInfoCubit extends Cubit<FsEntryInfoState> {
 
   final DriveDao _driveDao;
   final LicenseService _licenseService;
+  final String? _ownerAddress;
 
   StreamSubscription? _entrySubscription;
 
@@ -27,8 +28,10 @@ class FsEntryInfoCubit extends Cubit<FsEntryInfoState> {
     // Supplied in the case isSharedFile == true
     List<FileRevision>? maybeRevisions,
     LicenseState? maybeLicenseState,
+    String? ownerAddress,
   })  : _driveDao = driveDao,
         _licenseService = licenseService,
+        _ownerAddress = ownerAddress,
         super(FsEntryInfoInitial()) {
     final selectedItem = maybeSelectedItem;
     if (selectedItem != null) {
@@ -98,12 +101,19 @@ class FsEntryInfoCubit extends Cubit<FsEntryInfoState> {
               }
             }
 
+            // For shared files, use the provided owner address
+            // For regular files, try to get it from the revision
+            final ownerAddress = _ownerAddress ?? 
+                latestRevision.originalOwner ?? 
+                latestRevision.pinnedDataOwnerAddress;
+            
             emit(FsEntryFileInfoSuccess(
               name: name,
               lastUpdated: lastUpdated,
               dateCreated: dateCreated,
               metadataTxId: latestRevision.metadataTxId,
               licenseState: licenseState,
+              ownerAddress: ownerAddress,
             ));
           }
           if (isSharedFile) {

--- a/lib/blocs/fs_entry_info/fs_entry_info_state.dart
+++ b/lib/blocs/fs_entry_info/fs_entry_info_state.dart
@@ -30,6 +30,7 @@ class FsEntryInfoSuccess<T> extends FsEntryInfoState {
 
 class FsEntryFileInfoSuccess extends FsEntryInfoSuccess<void> {
   final LicenseState? licenseState;
+  final String? ownerAddress;
 
   const FsEntryFileInfoSuccess({
     required super.name,
@@ -37,12 +38,13 @@ class FsEntryFileInfoSuccess extends FsEntryInfoSuccess<void> {
     required super.dateCreated,
     required super.metadataTxId,
     required this.licenseState,
+    this.ownerAddress,
   }) : super(
           entry: null,
         );
 
   @override
-  List<Object?> get props => [name, lastUpdated, dateCreated, licenseState];
+  List<Object?> get props => [name, lastUpdated, dateCreated, licenseState, ownerAddress];
 }
 
 class FsEntryDriveInfoSuccess extends FsEntryInfoSuccess<Drive> {

--- a/lib/blocs/shared_file/shared_file_state.dart
+++ b/lib/blocs/shared_file/shared_file_state.dart
@@ -18,15 +18,17 @@ class SharedFileLoadSuccess extends SharedFileState {
   final List<FileRevision> fileRevisions;
   final SecretKey? fileKey;
   final LicenseState? latestLicense;
+  final String? ownerAddress;
 
   const SharedFileLoadSuccess({
     required this.fileRevisions,
     this.fileKey,
     this.latestLicense,
+    this.ownerAddress,
   });
 
   @override
-  List<Object?> get props => [fileRevisions, fileKey];
+  List<Object?> get props => [fileRevisions, fileKey, ownerAddress];
 }
 
 class SharedFileKeyInvalid extends SharedFileState {}

--- a/lib/components/components.dart
+++ b/lib/components/components.dart
@@ -1,4 +1,5 @@
 export 'app_dialog.dart';
+export 'copy_button.dart';
 export 'create_manifest_form.dart';
 export 'drive_attach_form.dart';
 export 'drive_create_form.dart';

--- a/lib/components/copy_button.dart
+++ b/lib/components/copy_button.dart
@@ -1,0 +1,129 @@
+import 'package:ardrive/pages/drive_detail/components/hover_widget.dart';
+import 'package:ardrive/utils/app_localizations_wrapper.dart';
+import 'package:ardrive_ui/ardrive_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class CopyButton extends StatefulWidget {
+  final String text;
+  final double size;
+  final bool showCopyText;
+  final Widget? child;
+  final int positionY;
+  final int positionX;
+  final Color? copyMessageColor;
+
+  const CopyButton({
+    super.key,
+    required this.text,
+    this.size = 20,
+    this.showCopyText = true,
+    this.child,
+    this.positionY = 40,
+    this.positionX = 20,
+    this.copyMessageColor,
+  });
+
+  @override
+  State<CopyButton> createState() => _CopyButtonState();
+}
+
+class _CopyButtonState extends State<CopyButton> {
+  bool _showCheck = false;
+  OverlayEntry? _overlayEntry;
+
+  @override
+  void dispose() {
+    if (_overlayEntry != null && _overlayEntry!.mounted) {
+      _overlayEntry?.remove();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.child != null) {
+      return GestureDetector(
+        onTap: _copy,
+        child: HoverWidget(
+          hoverScale: 1,
+          child: widget.child!,
+        ),
+      );
+    }
+
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 200),
+      child: ArDriveIconButton(
+        tooltip: _showCheck ? '' : appLocalizationsOf(context).copyTooltip,
+        onPressed: _copy,
+        icon: _showCheck
+            ? ArDriveIcons.checkCirle(
+                size: widget.size,
+                color: ArDriveTheme.of(context)
+                    .themeData
+                    .colors
+                    .themeSuccessDefault,
+              )
+            : ArDriveIcons.copy(size: widget.size),
+      ),
+    );
+  }
+
+  void _copy() {
+    Clipboard.setData(ClipboardData(text: widget.text));
+    if (mounted) {
+      if (_showCheck) {
+        return;
+      }
+
+      setState(() {
+        _showCheck = true;
+        if (widget.showCopyText) {
+          _overlayEntry = _createOverlayEntry(context);
+          Overlay.of(context).insert(_overlayEntry!);
+        }
+
+        Future.delayed(const Duration(seconds: 2), () {
+          if (!mounted) {
+            return;
+          }
+
+          setState(() {
+            _showCheck = false;
+            if (_overlayEntry != null && _overlayEntry!.mounted) {
+              _overlayEntry?.remove();
+            }
+          });
+        });
+      });
+    }
+  }
+
+  OverlayEntry _createOverlayEntry(BuildContext parentContext) {
+    final RenderBox button = context.findRenderObject() as RenderBox;
+    final Offset buttonPosition = button.localToGlobal(Offset.zero);
+    final typography = ArDriveTypographyNew.of(context);
+    final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
+
+    return OverlayEntry(
+      builder: (context) => Positioned(
+        left: buttonPosition.dx - widget.positionX,
+        top: buttonPosition.dy - widget.positionY,
+        child: Material(
+          color: widget.copyMessageColor ?? colorTokens.containerL1,
+          borderRadius: BorderRadius.circular(20),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+            child: Center(
+              child: Text(
+                'Copied!',
+                style: typography.paragraphNormal(),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/components/drive_share_dialog.dart
+++ b/lib/components/drive_share_dialog.dart
@@ -1,6 +1,6 @@
 import 'package:ardrive/blocs/blocs.dart';
 import 'package:ardrive/blocs/feedback_survey/feedback_survey_cubit.dart';
-import 'package:ardrive/components/details_panel.dart';
+import 'package:ardrive/components/copy_button.dart';
 import 'package:ardrive/models/models.dart';
 import 'package:ardrive/theme/theme.dart';
 import 'package:ardrive/utils/app_localizations_wrapper.dart';

--- a/lib/components/file_share_dialog.dart
+++ b/lib/components/file_share_dialog.dart
@@ -1,5 +1,5 @@
 import 'package:ardrive/blocs/blocs.dart';
-import 'package:ardrive/components/details_panel.dart';
+import 'package:ardrive/components/copy_button.dart';
 import 'package:ardrive/models/models.dart';
 import 'package:ardrive/theme/theme.dart';
 import 'package:ardrive/utils/app_localizations_wrapper.dart';

--- a/lib/components/owner_field.dart
+++ b/lib/components/owner_field.dart
@@ -1,0 +1,162 @@
+import 'package:ardrive/arns/domain/arns_repository.dart';
+import 'package:ardrive/components/copy_button.dart';
+import 'package:ardrive/services/config/config_service.dart';
+import 'package:ardrive/utils/open_url.dart';
+import 'package:ardrive_ui/ardrive_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class OwnerField extends StatefulWidget {
+  final String? ownerAddress;
+  
+  const OwnerField({
+    super.key,
+    required this.ownerAddress,
+  });
+
+  @override
+  State<OwnerField> createState() => _OwnerFieldState();
+}
+
+class _OwnerFieldState extends State<OwnerField> {
+  String? _arnsName;
+  String? _arnsLogo;
+  bool _isLoading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.ownerAddress != null) {
+      _loadArnsName();
+    }
+  }
+
+  Future<void> _loadArnsName() async {
+    if (!mounted || widget.ownerAddress == null) return;
+    
+    setState(() {
+      _isLoading = true;
+    });
+
+    try {
+      final arnsRepository = context.read<ARNSRepository>();
+      final primaryName = await arnsRepository.getPrimaryName(
+        widget.ownerAddress!,
+        getLogo: true,
+      );
+      
+      if (mounted) {
+        setState(() {
+          _arnsName = primaryName.primaryName;
+          _arnsLogo = primaryName.logo;
+          _isLoading = false;
+        });
+      }
+    } catch (e) {
+      // If ArNS lookup fails, just show the address
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  void _openArnsLink() {
+    if (_arnsName != null) {
+      final configService = context.read<ConfigService>();
+      String gateway = configService.config.defaultArweaveGatewayUrl ?? 'arweave.net';
+      gateway = gateway
+          .replaceFirst('https://', '')
+          .replaceFirst('http://', '');
+      openUrl(url: 'https://$_arnsName.$gateway');
+    }
+  }
+
+  void _openViewBlockLink() {
+    if (widget.ownerAddress != null) {
+      openUrl(url: 'https://viewblock.io/arweave/address/${widget.ownerAddress}');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.ownerAddress == null) {
+      return const SizedBox.shrink();
+    }
+
+    final colors = ArDriveTheme.of(context).themeData.colors;
+    
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // Logo if available
+        if (_arnsLogo != null && _arnsLogo!.isNotEmpty) ...[
+          ClipRRect(
+            borderRadius: BorderRadius.circular(4),
+            child: Image.network(
+              _arnsLogo!.startsWith('http') 
+                  ? _arnsLogo! 
+                  : 'https://arweave.net/$_arnsLogo',
+              width: 28,
+              height: 28,
+              fit: BoxFit.cover,
+              errorBuilder: (context, error, stackTrace) => const SizedBox.shrink(),
+            ),
+          ),
+          const SizedBox(width: 8),
+        ],
+        
+        // Name or address - styled like transaction IDs
+        ArDriveClickArea(
+          child: GestureDetector(
+            onTap: _arnsName != null ? _openArnsLink : _openViewBlockLink,
+            child: _isLoading
+                ? SizedBox(
+                    width: 60,
+                    height: 16,
+                    child: LinearProgressIndicator(
+                      backgroundColor: colors.themeBgSurface,
+                      valueColor: AlwaysStoppedAnimation<Color>(colors.themeAccentBrand),
+                    ),
+                  )
+                : ArDriveTooltip(
+                    message: _arnsName != null 
+                        ? 'ar://$_arnsName' 
+                        : widget.ownerAddress!,
+                    child: Text(
+                      _arnsName != null 
+                          ? 'ar://$_arnsName'
+                          : '${widget.ownerAddress!.substring(0, 4)}...',
+                      style: ArDriveTypography.body.buttonNormalRegular().copyWith(
+                        decoration: TextDecoration.underline,
+                      ),
+                    ),
+                  ),
+          ),
+        ),
+        
+        // Copy button - always copies wallet address
+        const SizedBox(width: 12),
+        CopyButton(
+          text: widget.ownerAddress!,
+        ),
+        
+        // External link icon for ViewBlock (only when ArNS name is shown)
+        if (_arnsName != null) ...[
+          const SizedBox(width: 8),
+          ArDriveClickArea(
+            tooltip: 'View on ViewBlock',
+            child: GestureDetector(
+              onTap: _openViewBlockLink,
+              child: ArDriveIcons.newWindow(
+                size: 20,
+                color: colors.themeFgDefault,
+              ),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/lib/components/profile_card.dart
+++ b/lib/components/profile_card.dart
@@ -1,6 +1,6 @@
 import 'package:ardrive/authentication/ardrive_auth.dart';
 import 'package:ardrive/blocs/profile/profile_cubit.dart';
-import 'package:ardrive/components/details_panel.dart';
+import 'package:ardrive/components/copy_button.dart';
 import 'package:ardrive/components/icon_theme_switcher.dart';
 import 'package:ardrive/components/side_bar.dart';
 import 'package:ardrive/components/truncated_address.dart';

--- a/lib/pages/shared_file/shared_file_page.dart
+++ b/lib/pages/shared_file/shared_file_page.dart
@@ -56,6 +56,7 @@ class SharedFilePage extends StatelessWidget {
               fileKey: state.fileKey,
               revisions: state.fileRevisions,
               licenseState: state.latestLicense,
+              ownerAddress: state.ownerAddress,
               drivePrivacy: state.fileKey != null ? 'private' : 'public',
               canNavigateThroughImages: false,
             );


### PR DESCRIPTION
  - Add OwnerField component to display file uploader with ArNS name/logo
  - Show 'Uploaded By' field in details panel for shared files only
  - Integrate ArNS primary name and profile logo lookup
  - Display ar:// prefix for ArNS names with 28x28 logo
  - Add copy wallet address functionality with standard 'Copied!' feedback
  - Extract CopyButton as reusable component to reduce code duplication
  - Fix owner address extraction from FileEntity before revision conversion
  - Hide ArNS Name assignment field on share pages
  - Style consistently with existing transaction ID fields
  - Support ViewBlock link for both ArNS names and wallet addresses

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/7lgrqn9sr3nug