### PR TITLE
PE-8450: fix: improve UX for network congestion warnings

### DIFF
--- a/lib/components/drive_create_form.dart
+++ b/lib/components/drive_create_form.dart
@@ -3,7 +3,6 @@ import 'package:ardrive/blocs/blocs.dart';
 import 'package:ardrive/core/arfs/entities/arfs_entities.dart';
 import 'package:ardrive/l11n/l11n.dart';
 import 'package:ardrive/models/models.dart';
-import 'package:ardrive/pages/congestion_warning_wrapper.dart';
 import 'package:ardrive/services/services.dart';
 import 'package:ardrive/theme/theme.dart';
 import 'package:ardrive/turbo/services/upload_service.dart';
@@ -22,21 +21,18 @@ Future<void> promptToCreateDrive(
   BuildContext context, {
   DrivePrivacy? privacy,
 }) =>
-    showCongestionDependentModalDialog(
+    showArDriveDialog(
       context,
-      () => showArDriveDialog(
-        context,
-        content: BlocProvider(
-          create: (_) => DriveCreateCubit(
-            privacy: privacy ?? DrivePrivacy.private,
-            arweave: context.read<ArweaveService>(),
-            turboUploadService: context.read<TurboUploadService>(),
-            driveDao: context.read<DriveDao>(),
-            profileCubit: context.read<ProfileCubit>(),
-            drivesCubit: context.read<DrivesCubit>(),
-          ),
-          child: const DriveCreateForm(),
+      content: BlocProvider(
+        create: (_) => DriveCreateCubit(
+          privacy: privacy ?? DrivePrivacy.private,
+          arweave: context.read<ArweaveService>(),
+          turboUploadService: context.read<TurboUploadService>(),
+          driveDao: context.read<DriveDao>(),
+          profileCubit: context.read<ProfileCubit>(),
+          drivesCubit: context.read<DrivesCubit>(),
         ),
+        child: const DriveCreateForm(),
       ),
     );
 

--- a/lib/components/drive_rename_form.dart
+++ b/lib/components/drive_rename_form.dart
@@ -1,7 +1,6 @@
 import 'package:ardrive/blocs/blocs.dart';
 import 'package:ardrive/blocs/drive_rename/drive_rename_cubit.dart';
 import 'package:ardrive/models/models.dart';
-import 'package:ardrive/pages/congestion_warning_wrapper.dart';
 import 'package:ardrive/services/services.dart';
 import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
 import 'package:ardrive/theme/theme.dart';
@@ -20,29 +19,26 @@ Future<void> promptToRenameDrive(
   required String driveId,
   required String driveName,
 }) =>
-    showCongestionDependentModalDialog(
+    showArDriveDialog(
       context,
-      () => showArDriveDialog(
-        context,
-        content: MultiBlocProvider(
-          providers: [
-            BlocProvider(
-              create: (context) => DriveRenameCubit(
-                driveId: driveId,
-                arweave: context.read<ArweaveService>(),
-                turboUploadService: context.read<TurboUploadService>(),
-                driveDao: context.read<DriveDao>(),
-                profileCubit: context.read<ProfileCubit>(),
-                syncCubit: context.read<SyncCubit>(),
-              ),
+      content: MultiBlocProvider(
+        providers: [
+          BlocProvider(
+            create: (context) => DriveRenameCubit(
+              driveId: driveId,
+              arweave: context.read<ArweaveService>(),
+              turboUploadService: context.read<TurboUploadService>(),
+              driveDao: context.read<DriveDao>(),
+              profileCubit: context.read<ProfileCubit>(),
+              syncCubit: context.read<SyncCubit>(),
             ),
-            BlocProvider.value(
-              value: context.read<DriveDetailCubit>(),
-            ),
-          ],
-          child: DriveRenameForm(
-            driveName: driveName,
           ),
+          BlocProvider.value(
+            value: context.read<DriveDetailCubit>(),
+          ),
+        ],
+        child: DriveRenameForm(
+          driveName: driveName,
         ),
       ),
     );

--- a/lib/components/folder_create_form.dart
+++ b/lib/components/folder_create_form.dart
@@ -1,6 +1,5 @@
 import 'package:ardrive/blocs/blocs.dart';
 import 'package:ardrive/models/models.dart';
-import 'package:ardrive/pages/congestion_warning_wrapper.dart';
 import 'package:ardrive/services/services.dart';
 import 'package:ardrive/theme/theme.dart';
 import 'package:ardrive/turbo/services/upload_service.dart';
@@ -18,21 +17,18 @@ Future<void> promptToCreateFolder(
   required String driveId,
   required String parentFolderId,
 }) =>
-    showCongestionDependentModalDialog(
+    showArDriveDialog(
       context,
-      () => showArDriveDialog(
-        context,
-        content: BlocProvider(
-          create: (context) => FolderCreateCubit(
-            driveId: driveId,
-            parentFolderId: parentFolderId,
-            profileCubit: context.read<ProfileCubit>(),
-            arweave: context.read<ArweaveService>(),
-            turboUploadService: context.read<TurboUploadService>(),
-            driveDao: context.read<DriveDao>(),
-          ),
-          child: const FolderCreateForm(),
+      content: BlocProvider(
+        create: (context) => FolderCreateCubit(
+          driveId: driveId,
+          parentFolderId: parentFolderId,
+          profileCubit: context.read<ProfileCubit>(),
+          arweave: context.read<ArweaveService>(),
+          turboUploadService: context.read<TurboUploadService>(),
+          driveDao: context.read<DriveDao>(),
         ),
+        child: const FolderCreateForm(),
       ),
     );
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -258,6 +258,10 @@
   "@congestionWarning": {
     "description": "Congestion warning"
   },
+  "congestionWarningShort": "Network congestion detected - uploads may be slower or fail",
+  "@congestionWarningShort": {
+    "description": "Concise message shown inline when network is congested"
+  },
   "continueEmphasized": "CONTINUE",
   "@continueEmphasized": {
     "description": "To go ahead. Emphasized with upper case"

--- a/lib/pages/drive_detail/components/drive_explorer_item_tile.dart
+++ b/lib/pages/drive_detail/components/drive_explorer_item_tile.dart
@@ -13,7 +13,6 @@ import 'package:ardrive/drive_explorer/thumbnail/repository/thumbnail_repository
 import 'package:ardrive/drive_explorer/thumbnail/thumbnail_bloc.dart';
 import 'package:ardrive/l11n/l11n.dart';
 import 'package:ardrive/models/models.dart';
-import 'package:ardrive/pages/congestion_warning_wrapper.dart';
 import 'package:ardrive/pages/drive_detail/components/dropdown_item.dart';
 import 'package:ardrive/pages/drive_detail/components/hover_widget.dart';
 import 'package:ardrive/pages/drive_detail/models/data_table_item.dart';
@@ -352,12 +351,9 @@ class _DriveExplorerItemTileTrailingState
           ArDriveButton(
             maxHeight: 36,
             style: ArDriveButtonStyle.primary,
-            onPressed: () => showCongestionDependentModalDialog(
+            onPressed: () => promptToReCreateFolder(
               context,
-              () => promptToReCreateFolder(
-                context,
-                ghostFolder: item,
-              ),
+              ghostFolder: item,
             ),
             fontStyle: ArDriveTypography.body.smallRegular(),
             text: appLocalizationsOf(context).fix,


### PR DESCRIPTION
  - Remove blocking modal congestion warnings from auto-Turbo operations (folder/drive create/rename)
  - Add non-blocking inline warning that only appears when AR payment method is selected
  - Warning now shows below payment selector with localized text: 'Network congestion detected - uploads may be slower or fail'
  - Eliminate unnecessary mempool API calls for operations that always use Turbo
  - Support both dropdown and radio button payment selectors
  - Ensure proper display in both light and dark modes

  BREAKING CHANGE: Removes showCongestionDependentModalDialog from folder and drive operations <- these default to Turbo and the user cannot even spend AR and go direct to network anyway.

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/5cleksdilerv8