### PR TITLE
PE-8473: fix: sync process improvements

### DIFF
--- a/lib/authentication/ardrive_auth.dart
+++ b/lib/authentication/ardrive_auth.dart
@@ -373,6 +373,9 @@ class ArDriveAuthImpl implements ArDriveAuth {
     _userRepository.getBalance(currentUser.wallet).then((value) {
       _currentUser = _currentUser!.copyWith(walletBalance: value);
       _userStreamController.add(_currentUser);
+    }).catchError((e) {
+      logger.e('Error fetching wallet balance', e);
+      // Don't update balance on error - keep previous value
     });
   }
 

--- a/lib/components/sync_failure_test_panel.dart
+++ b/lib/components/sync_failure_test_panel.dart
@@ -1,0 +1,426 @@
+import 'package:ardrive/sync/domain/sync_failure_simulator.dart';
+import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
+import 'package:ardrive_ui/ardrive_ui.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+/// Debug panel for testing sync failure scenarios
+/// Only visible in debug mode
+class SyncFailureTestPanel extends StatefulWidget {
+  const SyncFailureTestPanel({super.key});
+
+  @override
+  State<SyncFailureTestPanel> createState() => _SyncFailureTestPanelState();
+}
+
+class _SyncFailureTestPanelState extends State<SyncFailureTestPanel> {
+  final _simulator = SyncFailureSimulator.instance;
+  FailureMode _selectedMode = FailureMode.none;
+  double _failureRate = 0.5;
+  bool _isExpanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    // Only show in debug mode
+    if (!kDebugMode) {
+      return const SizedBox.shrink();
+    }
+
+    final themeData = ArDriveTheme.of(context).themeData;
+    
+    return Positioned(
+      bottom: 20,
+      right: 20,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 200),
+        width: _isExpanded ? 360 : 56,
+        child: ArDriveCard(
+          backgroundColor: themeData.colors.themeBgCanvas,
+          contentPadding: EdgeInsets.zero,
+          content: _isExpanded ? _buildExpandedPanel(context) : _buildCollapsedPanel(context),
+          boxShadow: BoxShadowCard.shadow80,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCollapsedPanel(BuildContext context) {
+    final themeData = ArDriveTheme.of(context).themeData;
+    return SizedBox(
+      height: 40,
+      child: Center(
+        child: IconButton(
+          icon: Icon(
+            Icons.bug_report,
+            color: _simulator.isEnabled 
+                ? themeData.colors.themeErrorDefault
+                : themeData.colors.themeFgDefault,
+            size: 24,
+          ),
+          onPressed: () => setState(() => _isExpanded = true),
+          tooltip: 'Sync Failure Simulator',
+        ),
+      ),
+    );
+  }
+
+  Widget _buildExpandedPanel(BuildContext context) {
+    final themeData = ArDriveTheme.of(context).themeData;
+    final typography = ArDriveTypographyNew.of(context);
+    
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Header with red accent line
+        Container(
+          height: 4,
+          decoration: BoxDecoration(
+            color: _simulator.isEnabled 
+                ? themeData.colors.themeErrorDefault
+                : themeData.colors.themeFgMuted,
+            borderRadius: const BorderRadius.vertical(top: Radius.circular(8)),
+          ),
+        ),
+        
+        // Title Bar
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          decoration: BoxDecoration(
+            color: themeData.colors.themeBgSurface,
+            border: Border(
+              bottom: BorderSide(
+                color: themeData.colors.themeBorderDefault,
+                width: 1,
+              ),
+            ),
+          ),
+          child: Row(
+            children: [
+              Icon(
+                Icons.bug_report,
+                color: _simulator.isEnabled 
+                    ? themeData.colors.themeErrorDefault
+                    : themeData.colors.themeFgDefault,
+                size: 20,
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  'Sync Failure Simulator',
+                  style: typography.heading6(
+                    fontWeight: ArFontWeight.semiBold,
+                    color: themeData.colors.themeFgDefault,
+                  ),
+                ),
+              ),
+              IconButton(
+                icon: ArDriveIcons.x(
+                  size: 16,
+                  color: themeData.colors.themeFgMuted,
+                ),
+                onPressed: () => setState(() => _isExpanded = false),
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(),
+              ),
+            ],
+          ),
+        ),
+        
+        // Content
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Enable/Disable Section
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: themeData.colors.themeBgSubtle,
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(
+                    color: themeData.colors.themeBorderDefault,
+                    width: 1,
+                  ),
+                ),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        'Simulator Status',
+                        style: typography.paragraphNormal(
+                          fontWeight: ArFontWeight.semiBold,
+                          color: themeData.colors.themeFgDefault,
+                        ),
+                      ),
+                    ),
+                    ArDriveToggleSwitch(
+                      text: '',
+                      value: _simulator.isEnabled,
+                      onChanged: (value) {
+                        setState(() {
+                          if (value) {
+                            _simulator.enable(_selectedMode, failureRate: _failureRate);
+                          } else {
+                            _simulator.disable();
+                          }
+                        });
+                      },
+                    ),
+                    const SizedBox(width: 8),
+                    Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                      decoration: BoxDecoration(
+                        color: _simulator.isEnabled 
+                            ? themeData.colors.themeErrorSubtle
+                            : themeData.colors.themeBgSubtle,
+                        borderRadius: BorderRadius.circular(4),
+                        border: Border.all(
+                          color: _simulator.isEnabled 
+                              ? themeData.colors.themeErrorDefault
+                              : themeData.colors.themeBorderDefault,
+                          width: 1,
+                        ),
+                      ),
+                      child: Text(
+                        _simulator.isEnabled ? 'ON' : 'OFF',
+                        style: typography.paragraphSmall(
+                          color: _simulator.isEnabled 
+                              ? themeData.colors.themeErrorDefault
+                              : themeData.colors.themeFgMuted,
+                          fontWeight: ArFontWeight.bold,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              
+              const SizedBox(height: 16),
+              
+              // Failure Mode Selection
+              Text(
+                'Failure Mode',
+                style: typography.paragraphNormal(
+                  fontWeight: ArFontWeight.semiBold,
+                  color: themeData.colors.themeFgDefault,
+                ),
+              ),
+              const SizedBox(height: 8),
+              
+              Container(
+                decoration: BoxDecoration(
+                  color: themeData.colors.themeBgSubtle,
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(
+                    color: themeData.colors.themeBorderDefault,
+                    width: 1,
+                  ),
+                ),
+                child: Column(
+                  children: FailureMode.values.map((mode) {
+                    final isSelected = _selectedMode == mode;
+                    return InkWell(
+                      onTap: () {
+                        setState(() {
+                          _selectedMode = mode;
+                          if (_simulator.isEnabled) {
+                            _simulator.enable(_selectedMode, failureRate: _failureRate);
+                          }
+                        });
+                      },
+                      borderRadius: BorderRadius.circular(8),
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                        decoration: BoxDecoration(
+                          color: isSelected 
+                              ? themeData.colors.themeAccentSubtle
+                              : Colors.transparent,
+                          borderRadius: BorderRadius.circular(6),
+                        ),
+                        child: Row(
+                          children: [
+                            Container(
+                              width: 16,
+                              height: 16,
+                              decoration: BoxDecoration(
+                                shape: BoxShape.circle,
+                                border: Border.all(
+                                  color: isSelected 
+                                      ? themeData.colors.themeAccentDefault
+                                      : themeData.colors.themeBorderDefault,
+                                  width: 2,
+                                ),
+                              ),
+                              child: isSelected
+                                  ? Center(
+                                      child: Container(
+                                        width: 8,
+                                        height: 8,
+                                        decoration: BoxDecoration(
+                                          shape: BoxShape.circle,
+                                          color: themeData.colors.themeAccentDefault,
+                                        ),
+                                      ),
+                                    )
+                                  : null,
+                            ),
+                            const SizedBox(width: 12),
+                            Text(
+                              _getModeLabel(mode),
+                              style: typography.paragraphSmall(
+                                color: themeData.colors.themeFgDefault,
+                                fontWeight: isSelected ? ArFontWeight.semiBold : ArFontWeight.book,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    );
+                  }).toList(),
+                ),
+              ),
+              
+              // Failure Rate Slider (only for random mode)
+              if (_selectedMode == FailureMode.randomFailures) ...[
+                const SizedBox(height: 16),
+                Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: themeData.colors.themeBgSubtle,
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(
+                      color: themeData.colors.themeBorderDefault,
+                      width: 1,
+                    ),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Text(
+                            'Failure Rate',
+                            style: typography.paragraphNormal(
+                              fontWeight: ArFontWeight.semiBold,
+                              color: themeData.colors.themeFgDefault,
+                            ),
+                          ),
+                          Container(
+                            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                            decoration: BoxDecoration(
+                              color: themeData.colors.themeBgCanvas,
+                              borderRadius: BorderRadius.circular(4),
+                              border: Border.all(
+                                color: themeData.colors.themeBorderDefault,
+                                width: 1,
+                              ),
+                            ),
+                            child: Text(
+                              '${(_failureRate * 100).toInt()}%',
+                              style: typography.paragraphSmall(
+                                fontWeight: ArFontWeight.bold,
+                                color: themeData.colors.themeFgDefault,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 8),
+                      SliderTheme(
+                        data: SliderThemeData(
+                          activeTrackColor: themeData.colors.themeAccentDefault,
+                          inactiveTrackColor: themeData.colors.themeBorderDefault,
+                          thumbColor: themeData.colors.themeAccentDefault,
+                          overlayColor: themeData.colors.themeAccentDefault.withOpacity(0.2),
+                        ),
+                        child: Slider(
+                          value: _failureRate,
+                          min: 0.0,
+                          max: 1.0,
+                          divisions: 10,
+                          onChanged: (value) {
+                            setState(() {
+                              _failureRate = value;
+                              if (_simulator.isEnabled) {
+                                _simulator.enable(_selectedMode, failureRate: _failureRate);
+                              }
+                            });
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+              
+              const SizedBox(height: 16),
+              
+              // Test Actions
+              Text(
+                'Quick Actions',
+                style: typography.paragraphNormal(
+                  fontWeight: ArFontWeight.semiBold,
+                  color: themeData.colors.themeFgDefault,
+                ),
+              ),
+              const SizedBox(height: 8),
+              
+              // Trigger Sync Button
+              ArDriveButtonNew(
+                text: 'Trigger Sync Now',
+                onPressed: () {
+                  context.read<SyncCubit>().startSync();
+                  setState(() => _isExpanded = false);
+                },
+                variant: ButtonVariant.primary,
+                typography: typography,
+                maxHeight: 40,
+              ),
+              
+              const SizedBox(height: 8),
+              
+              // Cancel Sync Button
+              BlocBuilder<SyncCubit, SyncState>(
+                builder: (context, state) {
+                  final canCancel = state is SyncInProgress;
+                  return ArDriveButtonNew(
+                    text: 'Cancel Current Sync',
+                    onPressed: canCancel
+                        ? () {
+                            context.read<SyncCubit>().cancelSync();
+                            setState(() => _isExpanded = false);
+                          }
+                        : null,
+                    variant: ButtonVariant.secondary,
+                    typography: typography,
+                    isDisabled: !canCancel,
+                    maxHeight: 40,
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  String _getModeLabel(FailureMode mode) {
+    switch (mode) {
+      case FailureMode.none:
+        return 'No Failures';
+      case FailureMode.allFail:
+        return 'All Drives Fail';
+      case FailureMode.firstDriveFails:
+        return 'First Drive Fails';
+      case FailureMode.randomFailures:
+        return 'Random Failures';
+      case FailureMode.alternatingFailures:
+        return 'Alternating Failures';
+    }
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1860,6 +1860,56 @@
   "@syncingPleaseWait": {
     "description": "Syncing drives"
   },
+  "syncCancelled": "Sync Cancelled",
+  "@syncCancelled": {
+    "description": "Sync operation was cancelled"
+  },
+  "syncProgressSaved": "Sync was interrupted. Your drives may not show the latest files and folders.",
+  "@syncProgressSaved": {
+    "description": "Message shown when sync is cancelled"
+  },
+  "syncCancelledDetails": "Completed {completed} of {total} drives. Uploading files before a full sync may cause conflicts.",
+  "@syncCancelledDetails": {
+    "description": "Details about what was synced before cancellation",
+    "placeholders": {
+      "completed": {
+        "type": "int",
+        "example": "5"
+      },
+      "total": {
+        "type": "int",
+        "example": "10"
+      }
+    }
+  },
+  "syncErrorsDetected": "{count, plural, =1{1 error detected} other{{count} errors detected}}",
+  "@syncErrorsDetected": {
+    "description": "Number of sync errors detected",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "3"
+      }
+    }
+  },
+  "syncCompleteWithErrors": "Sync Incomplete - Errors Detected",
+  "@syncCompleteWithErrors": {
+    "description": "Title when sync completes but some drives failed"
+  },
+  "syncPartialSuccessMessage": "{failed} of {total} drives failed to sync. Your drives may not show the latest content. Uploading files now may cause conflicts.",
+  "@syncPartialSuccessMessage": {
+    "description": "Message explaining partial sync success and warning about uploads",
+    "placeholders": {
+      "failed": {
+        "type": "int",
+        "example": "2"
+      },
+      "total": {
+        "type": "int", 
+        "example": "5"
+      }
+    }
+  },
   "syncProgressPercentage": "{percentage}% complete",
   "@syncProgressPercentage": {
     "description": "The sync progress percentage",

--- a/lib/sync/domain/cubit/sync_state.dart
+++ b/lib/sync/domain/cubit/sync_state.dart
@@ -20,3 +20,35 @@ class SyncFailure extends SyncState {
 class SyncEmpty extends SyncState {}
 
 class SyncWalletMismatch extends SyncState {}
+
+class SyncCancelled extends SyncState {
+  final int drivesCompleted;
+  final int totalDrives;
+  final DateTime cancelledAt;
+
+  SyncCancelled({
+    required this.drivesCompleted,
+    required this.totalDrives,
+    required this.cancelledAt,
+  });
+
+  @override
+  List<Object> get props => [drivesCompleted, totalDrives, cancelledAt];
+}
+
+class SyncCompleteWithErrors extends SyncState {
+  final int failedDrives;
+  final int totalDrives;
+  final List<String> failedDriveIds;
+  final Map<String, String> errorMessages;
+
+  SyncCompleteWithErrors({
+    required this.failedDrives,
+    required this.totalDrives,
+    required this.failedDriveIds,
+    required this.errorMessages,
+  });
+
+  @override
+  List<Object> get props => [failedDrives, totalDrives, failedDriveIds, errorMessages];
+}

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -26,6 +26,8 @@ import 'package:ardrive/sync/constants.dart';
 import 'package:ardrive/sync/data/snapshot_validation_service.dart';
 import 'package:ardrive/sync/domain/ghost_folder.dart';
 import 'package:ardrive/sync/domain/models/drive_entity_history.dart';
+import 'package:ardrive/sync/domain/sync_cancellation_token.dart';
+import 'package:ardrive/sync/domain/sync_failure_simulator.dart';
 import 'package:ardrive/sync/domain/sync_progress.dart';
 import 'package:ardrive/sync/utils/batch_processor.dart';
 import 'package:ardrive/sync/utils/network_transaction_utils.dart';
@@ -62,6 +64,7 @@ abstract class SyncRepository {
     Wallet? wallet,
     String? password,
     SecretKey? cipherKey,
+    SyncCancellationToken? cancellationToken,
 
     /// This was required because the usage of the `PromptToSnapshotBloc` in the
     /// `SyncCubit` and the `PromptToSnapshotBloc` is not available in the `SyncRepository`
@@ -150,8 +153,10 @@ class _SyncRepository implements SyncRepository {
     Wallet? wallet,
     String? password,
     SecretKey? cipherKey,
+    SyncCancellationToken? cancellationToken,
     Function(String driveId, int txCount)? txFechedCallback,
   }) async* {
+    final token = cancellationToken ?? SyncCancellationToken();
     if (wallet != null) {
       final address = await wallet.getAddress();
 
@@ -185,33 +190,52 @@ class _SyncRepository implements SyncRepository {
       ),
     );
 
-    final driveSyncProcesses = drives.map((drive) async* {
-      yield* _syncDrive(
-        drive.id,
-        cipherKey: cipherKey,
-        lastBlockHeight: syncDeep
-            ? 0
-            : _calculateSyncLastBlockHeight(drive.lastBlockHeight!),
-        currentBlockHeight: currentBlockHeight,
-        transactionParseBatchSize:
-            200 ~/ (syncProgress.drivesCount - syncProgress.drivesSynced),
-        ownerAddress: drive.ownerAddress,
-        txFechedCallback: txFechedCallback,
-      );
-    });
-
     double totalProgress = 0;
 
     final StreamController<SyncProgress> syncProgressController =
         StreamController<SyncProgress>.broadcast();
 
+    // Reset the failure simulator for new sync session
+    if (SyncFailureSimulator.instance.isEnabled) {
+      SyncFailureSimulator.instance.resetFirstDrive();
+    }
+    
+    // Track if sync was cancelled
+    bool wasCancelled = false;
+    
+    // Start the async work but don't wait for it yet
+    // Using Future.wait with eagerError: false to continue even if some drives fail
     Future.wait(
-      driveSyncProcesses.map(
-        (driveSyncProgress) async {
+      drives.map((drive) async {
+        try {
+          // Check for cancellation before starting each drive
+          token.checkCancellation();
+          
+          // Inject simulated failure if enabled (for testing)
+          await SyncFailureSimulator.instance.maybeInjectFailure(drive.id);
+          
+          final driveSyncProgress = _syncDrive(
+            drive.id,
+            cipherKey: cipherKey,
+            lastBlockHeight: syncDeep
+                ? 0
+                : _calculateSyncLastBlockHeight(drive.lastBlockHeight!),
+            currentBlockHeight: currentBlockHeight,
+            transactionParseBatchSize:
+                200 ~/ (syncProgress.drivesCount - syncProgress.drivesSynced),
+            ownerAddress: drive.ownerAddress,
+            txFechedCallback: txFechedCallback,
+            cancellationToken: token,
+          );
+          
           double currentDriveProgress = 0;
           await for (var driveProgress in driveSyncProgress) {
+            // Check for cancellation during sync
+            token.checkCancellation();
+            
+            // Reserve 10% for post-sync operations (cap drive sync at 90%)
             currentDriveProgress =
-                (totalProgress + driveProgress) / numberOfDrivesToSync;
+                (totalProgress + driveProgress) / numberOfDrivesToSync * 0.9;
             if (currentDriveProgress > syncProgress.progress) {
               syncProgress = syncProgress.copyWith(
                 progress: currentDriveProgress,
@@ -222,13 +246,70 @@ class _SyncRepository implements SyncRepository {
           totalProgress += 1;
           syncProgress = syncProgress.copyWith(
             drivesSynced: syncProgress.drivesSynced + 1,
-            progress: totalProgress / numberOfDrivesToSync,
+            // Cap at 90% for drive syncing
+            progress: (totalProgress / numberOfDrivesToSync) * 0.9,
           );
           syncProgressController.add(syncProgress);
-        },
-      ),
-    ).then((value) async {
+        } catch (e) {
+          // Handle cancellation specially
+          if (e is SyncCancelledException) {
+            wasCancelled = true;
+            // Don't count as failure, just stop processing this drive
+            return;
+          }
+          
+          // Track the failure but continue with other drives
+          logger.e('Failed to sync drive ${drive.id}', e);
+          
+          final updatedFailedDrives = List<String>.from(syncProgress.failedDriveIds)
+            ..add(drive.id);
+          final updatedErrorMessages = Map<String, String>.from(syncProgress.errorMessages)
+            ..putIfAbsent(drive.id, () => _extractErrorMessage(e));
+            
+          // Still increment progress but mark as failed (cap at 90%)
+          totalProgress += 1;
+          syncProgress = syncProgress.copyWith(
+            drivesSynced: syncProgress.drivesSynced + 1,
+            progress: (totalProgress / numberOfDrivesToSync) * 0.9,
+            failedQueries: syncProgress.failedQueries + 1,
+            failedDriveIds: updatedFailedDrives,
+            errorMessages: updatedErrorMessages,
+          );
+          syncProgressController.add(syncProgress);
+        }
+      }),
+      eagerError: false, // Continue processing even if some drives fail
+    ).then((_) async {
+      try {
+        // If sync was cancelled during drive sync, add error to stream
+        if (wasCancelled) {
+          logger.d('Sync was cancelled during drive sync, adding error to stream');
+          syncProgressController.addError(SyncCancelledException());
+          await syncProgressController.close();
+          return; // Exit early
+        }
+        
+        // Check if we should skip post-sync operations due to failures
+        final successfulSyncs = syncProgress.drivesSynced - syncProgress.failedQueries;
+        if (successfulSyncs == 0) {
+          logger.w('All drives failed to sync. Skipping post-sync operations.');
+          logger.d('Closing sync progress controller due to all failures');
+          await syncProgressController.close();
+          return; // Exit early if all drives failed
+        }
+        
+        // Continue with post-sync operations only if at least some drives succeeded
       logger.i('Creating ghosts...');
+      
+      // Check for cancellation before ghost creation
+      token.checkCancellation();
+      
+      // Update progress to 92% for ghost creation
+      syncProgress = syncProgress.copyWith(
+        progress: 0.92,
+        statusMessage: 'Creating ghost folders...',
+      );
+      syncProgressController.add(syncProgress);
 
       await createGhosts(
         driveDao: _driveDao,
@@ -245,6 +326,16 @@ class _SyncRepository implements SyncRepository {
       logger.i('Ghosts created...');
 
       logger.i('Syncing licenses...');
+      
+      // Check for cancellation before license sync
+      token.checkCancellation();
+      
+      // Update progress to 94% for license sync
+      syncProgress = syncProgress.copyWith(
+        progress: 0.94,
+        statusMessage: 'Syncing licenses...',
+      );
+      syncProgressController.add(syncProgress);
 
       try {
         final licenseTxIds = <String>{};
@@ -258,12 +349,26 @@ class _SyncRepository implements SyncRepository {
           revisionsToSyncLicense: revisionsToSyncLicense,
         );
       } catch (e) {
+        // Re-throw cancellation exceptions
+        if (e is SyncCancelledException) {
+          rethrow;
+        }
         logger.e('Error syncing licenses. Proceeding.', e);
       }
 
       logger.i('Licenses synced');
 
       logger.i('Updating transaction statuses...');
+      
+      // Check for cancellation before transaction status updates
+      token.checkCancellation();
+      
+      // Update progress to 96% for transaction status updates
+      syncProgress = syncProgress.copyWith(
+        progress: 0.96,
+        statusMessage: 'Updating transaction statuses...',
+      );
+      syncProgressController.add(syncProgress);
 
       final allFileRevisions = await _getAllFileEntities(driveDao: _driveDao);
       final metadataTxsFromSnapshots =
@@ -278,21 +383,101 @@ class _SyncRepository implements SyncRepository {
       final hasHiddenItems = await _driveDao.hasHiddenItems().getSingle();
       await _userPreferencesRepository.saveUserHasHiddenItem(hasHiddenItems);
       await _userPreferencesRepository.load();
-      await Future.wait(
-        [
-          _updateTransactionStatuses(
-            driveDao: _driveDao,
-            arweave: _arweave,
-            txsIdsToSkip: confirmedFileTxIds,
-          ),
-        ],
-      );
+      // Wrap transaction status update with cancellation check and timeout
+      try {
+        await Future.wait(
+          [
+            _updateTransactionStatuses(
+              driveDao: _driveDao,
+              arweave: _arweave,
+              txsIdsToSkip: confirmedFileTxIds,
+              cancellationToken: token,
+            ).timeout(
+              const Duration(seconds: 10),
+              onTimeout: () {
+                // Check if cancelled before timing out
+                token.checkCancellation();
+                logger.w('Transaction status update timed out after 10 seconds');
+                // Update status message to indicate timeout but don't treat as error
+                syncProgress = syncProgress.copyWith(
+                  statusMessage: 'Completing sync...',
+                );
+                syncProgressController.add(syncProgress);
+                // Continue without updating transaction statuses
+              },
+            ),
+          ],
+        );
+      } catch (e) {
+        // Re-throw cancellation exceptions
+        if (e is SyncCancelledException) {
+          rethrow;
+        }
+        logger.w('Failed to update transaction statuses, continuing: $e');
+        // Don't fail the entire sync if transaction status update fails
+      }
 
       _lastSync = DateTime.now();
-      syncProgressController.close();
+      
+      // Update progress to 100% when truly complete
+      syncProgress = syncProgress.copyWith(
+        progress: 1.0,
+        statusMessage: 'Sync complete',
+      );
+      syncProgressController.add(syncProgress);
+      
+      // Close the controller when everything is done
+      logger.d('Sync completed successfully, closing controller');
+      await syncProgressController.close();
+      } catch (e) {
+        // Handle cancellation during post-sync operations
+        if (e is SyncCancelledException) {
+          logger.i('Sync cancelled during post-sync operations');
+          syncProgressController.addError(e); // Add error to stream so cubit sees it
+          await syncProgressController.close();
+          return; // Don't rethrow - error is in stream
+        }
+        // Other errors - log and add to stream
+        logger.e('Error during post-sync operations', e);
+        syncProgressController.addError(e);
+        await syncProgressController.close();
+        return;
+      }
+    }).catchError((error) async {
+      // Add error to stream and close
+      logger.d('Sync failed with error, closing controller: $error');
+      if (!syncProgressController.isClosed) {
+        syncProgressController.addError(error);
+        await syncProgressController.close();
+      }
     });
 
+    // Yield from the stream while the sync is happening
     yield* syncProgressController.stream;
+  }
+  
+  String _extractErrorMessage(dynamic error) {
+    if (error == null) return 'Unknown error';
+    
+    final errorStr = error.toString();
+    
+    // Check for common error patterns
+    if (errorStr.contains('504')) {
+      return 'Gateway timeout (504)';
+    } else if (errorStr.contains('502')) {
+      return 'Bad gateway (502)';
+    } else if (errorStr.contains('503')) {
+      return 'Service unavailable (503)';
+    } else if (errorStr.contains('timeout')) {
+      return 'Request timeout';
+    } else if (errorStr.contains('GraphQL')) {
+      return 'GraphQL query failed';
+    } else if (errorStr.contains('network')) {
+      return 'Network error';
+    }
+    
+    // Return a truncated version of the error message
+    return errorStr.length > 100 ? '${errorStr.substring(0, 100)}...' : errorStr;
   }
 
   @override
@@ -405,7 +590,10 @@ class _SyncRepository implements SyncRepository {
     required DriveDao driveDao,
     required ArweaveService arweave,
     List<TxID> txsIdsToSkip = const [],
+    SyncCancellationToken? cancellationToken,
   }) async {
+    // Check for cancellation at the start
+    cancellationToken?.checkCancellation();
     final pendingTxMap = {
       for (final tx in await driveDao.pendingTransactions().get()) tx.id: tx,
     };
@@ -429,6 +617,9 @@ class _SyncRepository implements SyncRepository {
     const page = 5000;
 
     for (var i = 0; i < length / page; i++) {
+      // Check for cancellation before each batch
+      cancellationToken?.checkCancellation();
+      
       final confirmations = <String?, int>{};
       final currentPage = <String>[];
 
@@ -440,8 +631,19 @@ class _SyncRepository implements SyncRepository {
         currentPage.add(list[j]);
       }
 
-      final map =
-          await arweave.getTransactionConfirmations(currentPage.toList());
+      // Check cancellation before making the GraphQL call
+      cancellationToken?.checkCancellation();
+      
+      // Use a shorter timeout for individual GraphQL calls
+      final map = await arweave.getTransactionConfirmations(currentPage.toList())
+          .timeout(
+            const Duration(seconds: 5),
+            onTimeout: () {
+              logger.w('Individual transaction confirmation timeout');
+              // Return empty map on timeout to continue with other transactions
+              return <String, int>{};
+            },
+          );
 
       map.forEach((key, value) {
         confirmations.putIfAbsent(key, () => value);
@@ -449,6 +651,8 @@ class _SyncRepository implements SyncRepository {
 
       await driveDao.transaction(() async {
         for (final txId in currentPage) {
+          // Check cancellation for each transaction
+          cancellationToken?.checkCancellation();
           final txConfirmed =
               confirmations[txId]! >= kRequiredTxConfirmationCount;
           final txNotFound = confirmations[txId]! < 0;
@@ -547,7 +751,9 @@ class _SyncRepository implements SyncRepository {
     required int transactionParseBatchSize,
     required String ownerAddress,
     Function(String driveId, int txCount)? txFechedCallback,
+    SyncCancellationToken? cancellationToken,
   }) async* {
+    final token = cancellationToken ?? SyncCancellationToken();
     /// Variables to count the current drive's progress information
     final drive = await _driveDao.driveById(driveId: driveId).getSingle();
     final startSyncDT = DateTime.now();
@@ -646,6 +852,8 @@ class _SyncRepository implements SyncRepository {
     /// First phase of the sync
     /// Here we get all transactions from its drive.
     await for (DriveEntityHistoryTransactionModel t in transactionsStream) {
+      // Check for cancellation periodically during transaction processing
+      token.checkCancellation();
       double calculatePercentageBasedOnBlockHeights() {
         final block = t.transactionCommonMixin.block;
 

--- a/lib/sync/domain/sync_cancellation_token.dart
+++ b/lib/sync/domain/sync_cancellation_token.dart
@@ -1,0 +1,43 @@
+import 'dart:async';
+
+/// Token used to cancel sync operations in progress
+class SyncCancellationToken {
+  bool _isCancelled = false;
+  final _cancelledController = StreamController<void>.broadcast();
+  
+  /// Whether the sync operation has been cancelled
+  bool get isCancelled => _isCancelled;
+  
+  /// Stream that emits when cancellation is requested
+  Stream<void> get onCancelled => _cancelledController.stream;
+  
+  /// Request cancellation of the sync operation
+  void cancel() {
+    if (!_isCancelled) {
+      _isCancelled = true;
+      _cancelledController.add(null);
+    }
+  }
+  
+  /// Check if cancelled and throw exception if so
+  void checkCancellation() {
+    if (_isCancelled) {
+      throw SyncCancelledException();
+    }
+  }
+  
+  /// Clean up resources
+  void dispose() {
+    _cancelledController.close();
+  }
+}
+
+/// Exception thrown when a sync operation is cancelled
+class SyncCancelledException implements Exception {
+  final String message;
+  
+  SyncCancelledException([this.message = 'Sync operation was cancelled']);
+  
+  @override
+  String toString() => message;
+}

--- a/lib/sync/domain/sync_failure_simulator.dart
+++ b/lib/sync/domain/sync_failure_simulator.dart
@@ -1,0 +1,113 @@
+import 'dart:math';
+import 'package:ardrive/utils/logger.dart';
+
+/// Simulator for testing sync failure scenarios
+/// Only active in debug mode or when explicitly enabled
+class SyncFailureSimulator {
+  static SyncFailureSimulator? _instance;
+  
+  static SyncFailureSimulator get instance {
+    _instance ??= SyncFailureSimulator._();
+    return _instance!;
+  }
+  
+  SyncFailureSimulator._();
+  
+  bool _enabled = false;
+  FailureMode _mode = FailureMode.none;
+  double _failureRate = 0.5; // 50% failure rate by default
+  final Random _random = Random();
+  
+  // Configuration
+  bool get isEnabled => _enabled;
+  FailureMode get mode => _mode;
+  
+  void enable(FailureMode mode, {double failureRate = 0.5}) {
+    _enabled = true;
+    _mode = mode;
+    _failureRate = failureRate.clamp(0.0, 1.0);
+    logger.w('🧪 Sync Failure Simulator ENABLED - Mode: $mode, Rate: ${(_failureRate * 100).toInt()}%');
+  }
+  
+  void disable() {
+    _enabled = false;
+    _mode = FailureMode.none;
+    logger.i('🧪 Sync Failure Simulator DISABLED');
+  }
+  
+  /// Check if we should simulate a failure for this drive
+  bool shouldFailDrive(String driveId) {
+    if (!_enabled || _mode == FailureMode.none) return false;
+    
+    switch (_mode) {
+      case FailureMode.allFail:
+        return true;
+      case FailureMode.firstDriveFails:
+        // Fail the first drive in the sync
+        return _isFirstDrive(driveId);
+      case FailureMode.randomFailures:
+        // Random chance of failure based on rate
+        return _random.nextDouble() < _failureRate;
+      case FailureMode.alternatingFailures:
+        // Fail every other drive
+        return driveId.hashCode % 2 == 0;
+      case FailureMode.none:
+        return false;
+    }
+  }
+  
+  /// Get the simulated error for testing
+  Exception getSimulatedError(String driveId) {
+    final errorType = _random.nextInt(5);
+    
+    switch (errorType) {
+      case 0:
+        return Exception('504 Gateway Timeout - The server did not respond in time');
+      case 1:
+        return Exception('502 Bad Gateway - Invalid response from upstream server');
+      case 2:
+        return Exception('503 Service Unavailable - Server is temporarily unavailable');
+      case 3:
+        return Exception('GraphQL Error: Network timeout after 30 seconds');
+      case 4:
+        return Exception('Network error: Failed to connect to gateway');
+      default:
+        return Exception('Unknown error occurred during sync');
+    }
+  }
+  
+  bool _isFirstDrive(String driveId) {
+    // Simple heuristic - you might want to track this more explicitly
+    _firstDriveId ??= driveId;
+    return _firstDriveId == driveId;
+  }
+  
+  String? _firstDriveId;
+  
+  void resetFirstDrive() {
+    _firstDriveId = null;
+  }
+}
+
+enum FailureMode {
+  none,
+  allFail,           // All drives fail
+  firstDriveFails,   // Only first drive fails
+  randomFailures,    // Random drives fail based on rate
+  alternatingFailures, // Every other drive fails
+}
+
+/// Extension to make it easy to use in the sync repository
+extension SyncFailureSimulatorX on SyncFailureSimulator {
+  /// Inject a failure if conditions are met
+  Future<void> maybeInjectFailure(String driveId) async {
+    if (shouldFailDrive(driveId)) {
+      logger.w('🧪 SIMULATING FAILURE for drive: $driveId');
+      
+      // Add a small delay to simulate network timeout
+      await Future.delayed(Duration(seconds: _random.nextInt(3) + 1));
+      
+      throw getSimulatedError(driveId);
+    }
+  }
+}

--- a/lib/sync/domain/sync_progress.dart
+++ b/lib/sync/domain/sync_progress.dart
@@ -10,6 +10,10 @@ class SyncProgress extends LinearProgress {
     required this.drivesCount,
     required this.drivesSynced,
     required this.numberOfDrivesAtGetMetadataPhase,
+    this.failedQueries = 0,
+    this.failedDriveIds = const [],
+    this.errorMessages = const {},
+    this.statusMessage,
   });
 
   factory SyncProgress.initial() {
@@ -20,6 +24,10 @@ class SyncProgress extends LinearProgress {
       drivesCount: 0,
       drivesSynced: 0,
       numberOfDrivesAtGetMetadataPhase: 0,
+      failedQueries: 0,
+      failedDriveIds: const [],
+      errorMessages: const {},
+      statusMessage: null,
     );
   }
 
@@ -31,6 +39,10 @@ class SyncProgress extends LinearProgress {
       drivesCount: 0,
       drivesSynced: 0,
       numberOfDrivesAtGetMetadataPhase: 0,
+      failedQueries: 0,
+      failedDriveIds: const [],
+      errorMessages: const {},
+      statusMessage: null,
     );
   }
 
@@ -41,6 +53,17 @@ class SyncProgress extends LinearProgress {
   final int drivesSynced;
   final int drivesCount;
   final int numberOfDrivesAtGetMetadataPhase;
+  
+  // New fields for tracking failures
+  final int failedQueries;
+  final List<String> failedDriveIds;
+  final Map<String, String> errorMessages; // driveId -> error message
+  final String? statusMessage; // Status message for post-sync operations
+  
+  // Helper getters
+  bool get hasErrors => failedQueries > 0;
+  bool get isPartialSync => hasErrors && progress >= 1.0;
+  bool get isCompleteWithErrors => progress >= 1.0 && hasErrors;
 
   SyncProgress copyWith({
     int? numberOfEntities,
@@ -49,6 +72,10 @@ class SyncProgress extends LinearProgress {
     int? drivesSynced,
     int? drivesCount,
     int? numberOfDrivesAtGetMetadataPhase,
+    int? failedQueries,
+    List<String>? failedDriveIds,
+    Map<String, String>? errorMessages,
+    String? statusMessage,
   }) {
     return SyncProgress(
       numberOfEntities: numberOfEntities ?? this.numberOfEntities,
@@ -58,6 +85,10 @@ class SyncProgress extends LinearProgress {
       drivesSynced: drivesSynced ?? this.drivesSynced,
       numberOfDrivesAtGetMetadataPhase: numberOfDrivesAtGetMetadataPhase ??
           this.numberOfDrivesAtGetMetadataPhase,
+      failedQueries: failedQueries ?? this.failedQueries,
+      failedDriveIds: failedDriveIds ?? this.failedDriveIds,
+      errorMessages: errorMessages ?? this.errorMessages,
+      statusMessage: statusMessage ?? this.statusMessage,
     );
   }
 }

--- a/lib/user/repositories/user_repository.dart
+++ b/lib/user/repositories/user_repository.dart
@@ -130,25 +130,28 @@ class _UserRepository implements UserRepository {
   Future<BigInt> getBalance(Wallet wallet) async {
     final walletAddress = await wallet.getAddress();
 
-    try {
-      final walletBalance = await Future.wait([
-        _arweave.getWalletBalance(walletAddress),
-        _arweave.getPendingTxFees(walletAddress),
-      ]).then((res) => res[0] - res[1]);
+    // Start both requests in parallel.
+    final balanceFuture = _arweave.getWalletBalance(walletAddress);
+    final pendingFeesFuture = _arweave.getPendingTxFees(walletAddress);
 
-      return walletBalance;
+    // Always await the balance; if it fails, propagate the error.
+    BigInt balance;
+    try {
+      balance = await balanceFuture;
     } catch (e) {
-      // If getPendingTxFees fails (e.g., 504 error), fall back to just wallet balance
+      logger.e('Failed to get wallet balance', e);
+
+      // We can't do much without the wallet balance so rethrow
+      rethrow;
+    }
+
+    // Try to subtract pending fees. On failure, fall back to balance only.
+    try {
+      final pending = await pendingFeesFuture;
+      return balance - pending;
+    } catch (e) {
       logger.w('Failed to get pending tx fees, using wallet balance only: $e');
-      
-      try {
-        // Try to at least get the wallet balance without pending fees
-        final walletBalance = await _arweave.getWalletBalance(walletAddress);
-        return walletBalance;
-      } catch (e) {
-        logger.e('Failed to get wallet balance', e);
-        rethrow;
-      }
+      return balance;
     }
   }
 }


### PR DESCRIPTION
fix: improve sync cancellation and UX during post-sync operations
  - Add status messages for post-sync operations (ghost folders, licenses, transaction updates)
  - Display descriptive messages instead of just percentages during final sync stages
  - Reduce transaction status update timeout from 30s to 10s for better responsiveness
  - Add 5s timeout for individual GraphQL calls to prevent blocking
  - Fix cancellation exception propagation to ensure cancel modal always appears
  - Add more frequent cancellation checks throughout post-sync operations
  - Handle timeouts gracefully without showing error modals
  - Ensure cancellation exceptions are re-thrown through try-catch blocks

  The sync process now provides clearer feedback about what's happening during the
  final stages (92-100%) and allows cancellation to work properly even during
  long-running transaction status updates. Users will see messages like 'Creating
  ghost folders...' and 'Updating transaction statuses...' instead of just percentages.

  Resolves the '100% sync stuck' issue where cancellation wasn't working during
  post-sync operations.

--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/742cbb95pt0j0