### PR TITLE
PE-8464: chore - bump version; add fastlane notes 

### DIFF
--- a/android/fastlane/metadata/android/en-US/changelogs/199.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/199.txt
@@ -1,0 +1,1 @@
+- Modified multi part upload handoff to prevent intermittent large upload failures

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Secure, permanent storage
 
 publish_to: 'none'
 
-version: 2.70.0
+version: 2.70.1
 
 environment:
   sdk: '>=3.2.0 <4.0.0'


### PR DESCRIPTION


--- Releases ---
Android release: https://appdistribution.firebase.google.com/testerapps/1:305132849030:android:6cf0cd5ec064fad3ffce07/releases/007o9spm5v480