### PR TITLE
PE-8981: bump arweave-dart version with chunked uploads fix

### DIFF
--- a/lib/blocs/create_snapshot/create_snapshot_cubit.dart
+++ b/lib/blocs/create_snapshot/create_snapshot_cubit.dart
@@ -596,7 +596,7 @@ class CreateSnapshotCubit extends Cubit<CreateSnapshotState> {
           dataItem: _preparedDataItem!,
         );
       } else {
-        await _arweave.postTx(_preparedTx!);
+        await _arweave.uploadTx(_preparedTx!, maxConcurrentUploadCount: 1);
       }
 
       final drive =

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -1442,6 +1442,24 @@ class ArweaveService {
         dryRun: dryRun,
       );
 
+  /// Uploads a transaction using the same chunked flow as file data uploads:
+  /// header then chunks with [maxConcurrentUploadCount] (default 1) to avoid
+  /// gateway 400s from data_root propagation when many chunk requests hit
+  /// before the tx is indexed.
+  Future<void> uploadTx(
+    Transaction transaction, {
+    int maxConcurrentUploadCount = 1,
+    bool dryRun = false,
+  }) async {
+    await client.transactions
+        .upload(
+          transaction,
+          maxConcurrentUploadCount: maxConcurrentUploadCount,
+          dryRun: dryRun,
+        )
+        .drain();
+  }
+
   // TODO: replace with the method on ardrive_utils
   Future<double?> getArUsdConversionRateOrNull() async {
     try {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -157,8 +157,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "v4.0.0"
-      resolved-ref: "60562fbb3d4293c03c7bea959b149307ddbacada"
+      ref: fix-chunked-uploads
+      resolved-ref: e94f3548ca4487b9c1a82414946b53817ababec7
       url: "https://github.com/ardriveapp/arweave-dart.git"
     source: git
     version: "4.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -158,7 +158,7 @@ packages:
     description:
       path: "."
       ref: fix-chunked-uploads
-      resolved-ref: e94f3548ca4487b9c1a82414946b53817ababec7
+      resolved-ref: e01998458cb5bf4498e5b959c2f2f89c6328af45
       url: "https://github.com/ardriveapp/arweave-dart.git"
     source: git
     version: "4.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -158,10 +158,10 @@ packages:
     description:
       path: "."
       ref: fix-chunked-uploads
-      resolved-ref: e01998458cb5bf4498e5b959c2f2f89c6328af45
+      resolved-ref: "4eb405b915167af31e43fd248c1c16442471d8b5"
       url: "https://github.com/ardriveapp/arweave-dart.git"
     source: git
-    version: "4.0.0"
+    version: "4.0.1"
   async:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -158,7 +158,7 @@ packages:
     description:
       path: "."
       ref: fix-chunked-uploads
-      resolved-ref: "4eb405b915167af31e43fd248c1c16442471d8b5"
+      resolved-ref: "1227db4b701f51039a99d196ecdbc9bd9dc126c2"
       url: "https://github.com/ardriveapp/arweave-dart.git"
     source: git
     version: "4.0.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,7 +53,7 @@ dependencies:
   arweave:
     git:
       url: https://github.com/ardriveapp/arweave-dart.git
-      ref: v4.0.0
+      ref: fix-chunked-uploads
   ario_sdk:
     path: ./packages/ario_sdk
   cryptography: ^2.0.5
@@ -167,7 +167,7 @@ dependency_overrides:
   arweave:
     git:
       url: https://github.com/ardriveapp/arweave-dart.git
-      ref: v4.0.0
+      ref: fix-chunked-uploads
 
   ardrive_io:
     path: ./packages/ardrive_io


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated arweave dependency to a newer git reference for improved stability.
* **New Features**
  * Added a dedicated upload flow that performs chunked uploads with configurable concurrency and dry-run support.
* **Bug Fixes / Improvements**
  * Snapshot creation now uses the new upload flow for non-turbo uploads, improving reliability of large uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->