### PR TITLE
PE-9012: fix: ensure drives are discovered before tab visibility check

### DIFF
--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -85,9 +85,10 @@ class SyncCubit extends Cubit<SyncState> {
     logger.d('Creating sync stream to periodically call sync automatically');
 
     // Start initial sync immediately without waiting for async operations.
-    // This ensures sync runs while the tab is still focused after login,
-    // avoiding race conditions with tab visibility checks.
-    startSync();
+    // Skip tab visibility check for initial sync because the user just logged in
+    // (which requires wallet interaction, proving they're active). The wallet popup
+    // may cause the browser to consider the tab unfocused momentarily.
+    startSync(skipTabVisibilityCheck: true);
 
     // Cancel any existing subscription before creating a new one
     await _syncSub?.cancel();
@@ -177,7 +178,10 @@ class SyncCubit extends Cubit<SyncState> {
 
   var ghostFolders = <FolderID, GhostFolder>{};
 
-  Future<void> startSync({bool deepSync = false}) async {
+  Future<void> startSync({
+    bool deepSync = false,
+    bool skipTabVisibilityCheck = false,
+  }) async {
     logger.i('Starting Sync');
 
     if (state is SyncInProgress) {
@@ -217,7 +221,11 @@ class SyncCubit extends Cubit<SyncState> {
         // For ArConnect users, check tab visibility before any operations
         // that require signing. If tab is not focused, skip sync entirely
         // and let the next periodic sync or manual sync handle it.
-        if (isArConnect && !_tabVisibility.isTabFocused()) {
+        // Skip this check for initial sync after login since wallet interaction
+        // may momentarily cause the browser to consider the tab unfocused.
+        if (isArConnect &&
+            !skipTabVisibilityCheck &&
+            !_tabVisibility.isTabFocused()) {
           logger.d('Tab hidden for ArConnect user, skipping sync...');
           emit(SyncIdle());
           return;

--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -84,6 +84,12 @@ class SyncCubit extends Cubit<SyncState> {
   void createSyncStream() async {
     logger.d('Creating sync stream to periodically call sync automatically');
 
+    // Start initial sync immediately without waiting for async operations.
+    // This ensures sync runs while the tab is still focused after login,
+    // avoiding race conditions with tab visibility checks.
+    startSync();
+
+    // Cancel any existing subscription before creating a new one
     await _syncSub?.cancel();
 
     _syncSub = Stream.periodic(
@@ -97,8 +103,6 @@ class SyncCubit extends Cubit<SyncState> {
     }).listen((_) {
       logger.d('Listening to startSync periodic stream');
     });
-
-    startSync();
   }
 
   void restartSyncOnFocus() {
@@ -182,7 +186,7 @@ class SyncCubit extends Cubit<SyncState> {
     }
 
     _syncProgress = SyncProgress.initial();
-    
+
     // Create a new cancellation token for this sync
     _currentSyncToken?.dispose(); // Clean up any previous token
     _currentSyncToken = SyncCancellationToken();
@@ -202,19 +206,19 @@ class SyncCubit extends Cubit<SyncState> {
       if (profile is ProfileLoggedIn) {
         logger.d('User is logged in');
 
-        //Check if profile is ArConnect to skip sync while tab is hidden
         wallet = profile.user.wallet;
         password = profile.user.password;
         cipherKey = profile.user.cipherKey;
 
         logger.d('Checking if user is from arconnect...');
-
         final isArConnect = await _profileCubit.isCurrentProfileArConnect();
-
         logger.d('User using arconnect: $isArConnect');
 
+        // For ArConnect users, check tab visibility before any operations
+        // that require signing. If tab is not focused, skip sync entirely
+        // and let the next periodic sync or manual sync handle it.
         if (isArConnect && !_tabVisibility.isTabFocused()) {
-          logger.d('Tab hidden, skipping sync...');
+          logger.d('Tab hidden for ArConnect user, skipping sync...');
           emit(SyncIdle());
           return;
         }
@@ -225,6 +229,8 @@ class SyncCubit extends Cubit<SyncState> {
           return;
         }
 
+        // Update user drives to discover all drives owned by the user.
+        // This must complete before syncAllDrives so drives exist in DB.
         await _syncRepository.updateUserDrives(
           wallet: wallet,
           password: password,
@@ -264,7 +270,7 @@ class SyncCubit extends Cubit<SyncState> {
         // Clean up the cancellation token
         _currentSyncToken?.dispose();
         _currentSyncToken = null;
-        
+
         emit(SyncCancelled(
           drivesCompleted: _syncProgress.drivesSynced,
           totalDrives: _syncProgress.drivesCount,
@@ -344,21 +350,21 @@ class SyncCubit extends Cubit<SyncState> {
       _currentSyncToken!.cancel();
     }
   }
-  
+
   /// Clear the cancelled state and return to idle
   void clearCancelledState() {
     if (state is SyncCancelled) {
       emit(SyncIdle());
     }
   }
-  
+
   /// Clear the error state and return to idle
   void clearErrorState() {
     if (state is SyncCompleteWithErrors) {
       emit(SyncIdle());
     }
   }
-  
+
   /// Get the current sync progress
   SyncProgress get syncProgress => _syncProgress;
 

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -179,6 +179,7 @@ class _SyncRepository implements SyncRepository {
     if (drives.isEmpty) {
       yield SyncProgress.emptySyncCompleted();
       _lastSync = DateTime.now();
+      return;
     }
 
     final numberOfDrivesToSync = drives.length;
@@ -851,176 +852,89 @@ class _SyncRepository implements SyncRepository {
           arweave: _arweave,
         ).toList();
 
-        List<SnapshotItem> snapshotsVerified =
-            await _snapshotValidationService.validateSnapshotItems(snapshotItems);
+        List<SnapshotItem> snapshotsVerified = await _snapshotValidationService
+            .validateSnapshotItems(snapshotItems);
 
         snapshotItems = snapshotsVerified;
       }
 
       final SnapshotDriveHistory snapshotDriveHistory = SnapshotDriveHistory(
-      items: snapshotItems,
-    );
+        items: snapshotItems,
+      );
 
-    final totalRangeToQueryFor = HeightRange(
-      rangeSegments: [
-        Range(
-          start: lastBlockHeight,
-          end: currentBlockHeight,
-        ),
-      ],
-    );
+      final totalRangeToQueryFor = HeightRange(
+        rangeSegments: [
+          Range(
+            start: lastBlockHeight,
+            end: currentBlockHeight,
+          ),
+        ],
+      );
 
-    final HeightRange gqlDriveHistorySubRanges = HeightRange.difference(
-      totalRangeToQueryFor,
-      snapshotDriveHistory.subRanges,
-    );
+      final HeightRange gqlDriveHistorySubRanges = HeightRange.difference(
+        totalRangeToQueryFor,
+        snapshotDriveHistory.subRanges,
+      );
 
-    final GQLDriveHistory gqlDriveHistory = GQLDriveHistory(
-      subRanges: gqlDriveHistorySubRanges,
-      arweave: _arweave,
-      driveId: driveId,
-      ownerAddress: ownerAddress,
-    );
-
-    logger.d('Total range to query for: ${totalRangeToQueryFor.rangeSegments}\n'
-        'Sub ranges in snapshots (DRIVE ID: $driveId): ${snapshotDriveHistory.subRanges.rangeSegments}\n'
-        'Sub ranges in GQL (DRIVE ID: $driveId): ${gqlDriveHistorySubRanges.rangeSegments}');
-
-    final DriveHistoryComposite driveHistory = DriveHistoryComposite(
-      subRanges: totalRangeToQueryFor,
-      gqlDriveHistory: gqlDriveHistory,
-      snapshotDriveHistory: snapshotDriveHistory,
-    );
-
-    final transactionsStream = driveHistory.getNextStream();
-
-    /// The first block height of this drive.
-    int? firstBlockHeight;
-
-    /// In order to measure the sync progress by the block height, we use the difference
-    /// between the first block and the `currentBlockHeight`
-    late int totalBlockHeightDifference;
-
-    /// This percentage is based on block heights.
-    var fetchPhasePercentage = 0.0;
-
-    /// Streaming phase: fetch and parse in chunks to reduce memory usage
-    await for (DriveEntityHistoryTransactionModel t in transactionsStream) {
-      // Check for cancellation periodically
-      token.checkCancellation();
-
-      /// Initialize only once `firstBlockHeight` and `totalBlockHeightDifference`
-      if (firstBlockHeight == null) {
-        final block = t.transactionCommonMixin.block;
-        if (block != null) {
-          firstBlockHeight = block.height;
-          totalBlockHeightDifference = currentBlockHeight - firstBlockHeight;
-          logger.d(
-            'First height: $firstBlockHeight, totalHeightDiff: $totalBlockHeightDifference',
-          );
-        } else {
-          logger.d(
-            'The transaction block is null. Transaction node id: ${t.transactionCommonMixin.id}',
-          );
-        }
-      }
-
-      // Add transaction to buffer
-      transactionBuffer.add(t);
-      totalTransactionsReceived++;
-
-      // Process chunk when buffer is full
-      if (transactionBuffer.length >= kStreamTransactionChunkSize) {
-        await _processTransactionChunk(
-          transactions: List.from(transactionBuffer),
-          drive: drive,
-          driveKey: driveKey?.key,
-          currentBlockHeight: currentBlockHeight,
-          lastBlockHeight: lastBlockHeight,
-          transactionParseBatchSize: transactionParseBatchSize,
-          snapshotDriveHistory: snapshotDriveHistory,
-          ownerAddress: ownerAddress,
-        );
-
-        totalTransactionsProcessed += transactionBuffer.length;
-        transactionBuffer.clear();
-
-        logger.d(
-            'Processed $totalTransactionsProcessed / $totalTransactionsReceived transactions');
-      }
-
-      // Calculate and yield progress based on block heights
-      if (firstBlockHeight != null && totalBlockHeightDifference > 0) {
-        final block = t.transactionCommonMixin.block;
-        if (block != null) {
-          fetchPhasePercentage =
-              1 - ((currentBlockHeight - block.height) / totalBlockHeightDifference);
-        }
-
-        // Yield progress (80% for streaming, 20% reserved for final operations)
-        final streamProgress = fetchPhasePercentage * 0.8;
-        yield streamProgress;
-      }
-    }
-
-    // Process remaining transactions in buffer
-    if (transactionBuffer.isNotEmpty) {
-      logger.d(
-          'Processing final chunk of ${transactionBuffer.length} transactions');
-
-      try {
-        await _processTransactionChunk(
-          transactions: transactionBuffer,
-          drive: drive,
-          driveKey: driveKey?.key,
-          currentBlockHeight: currentBlockHeight,
-          lastBlockHeight: lastBlockHeight,
-          transactionParseBatchSize: transactionParseBatchSize,
-          snapshotDriveHistory: snapshotDriveHistory,
-          ownerAddress: ownerAddress,
-        );
-
-        totalTransactionsProcessed += transactionBuffer.length;
-        transactionBuffer.clear();
-      } catch (e) {
-        logger.e('[Sync Drive] Error while parsing final transaction chunk', e);
-        rethrow;
-      }
-    }
-
-    logger.d(
-        'Done processing all $totalTransactionsProcessed transactions - ${gqlDriveHistory.driveId}');
-
-    txFechedCallback?.call(drive.id, gqlDriveHistory.txCount);
-
-    final fetchPhaseTotalTime =
-        DateTime.now().difference(fetchPhaseStartDT).inMilliseconds;
-
-    logger.d(
-        'Duration of streaming phase for ${drive.name}: $fetchPhaseTotalTime ms. Processed $totalTransactionsProcessed transactions');
-
-    // Fetch pending (unmined) transactions to show Turbo uploads immediately
-    // This is best-effort: errors here should not fail the drive sync
-    logger.d('Fetching pending transactions for drive ${drive.id}');
-    int pendingTransactionCount = 0;
-
-    try {
-      await for (final pendingTxBatch
-          in _arweave.getPendingTransactionsForDrive(
-        driveId,
+      final GQLDriveHistory gqlDriveHistory = GQLDriveHistory(
+        subRanges: gqlDriveHistorySubRanges,
+        arweave: _arweave,
+        driveId: driveId,
         ownerAddress: ownerAddress,
-      )) {
-        // Check for cancellation before processing each batch
-        if (token.isCancelled) {
-          logger.d('Pending transactions fetch cancelled for drive ${drive.id}');
-          break;
+      );
+
+      logger.d(
+          'Total range to query for: ${totalRangeToQueryFor.rangeSegments}\n'
+          'Sub ranges in snapshots (DRIVE ID: $driveId): ${snapshotDriveHistory.subRanges.rangeSegments}\n'
+          'Sub ranges in GQL (DRIVE ID: $driveId): ${gqlDriveHistorySubRanges.rangeSegments}');
+
+      final DriveHistoryComposite driveHistory = DriveHistoryComposite(
+        subRanges: totalRangeToQueryFor,
+        gqlDriveHistory: gqlDriveHistory,
+        snapshotDriveHistory: snapshotDriveHistory,
+      );
+
+      final transactionsStream = driveHistory.getNextStream();
+
+      /// The first block height of this drive.
+      int? firstBlockHeight;
+
+      /// In order to measure the sync progress by the block height, we use the difference
+      /// between the first block and the `currentBlockHeight`
+      late int totalBlockHeightDifference;
+
+      /// This percentage is based on block heights.
+      var fetchPhasePercentage = 0.0;
+
+      /// Streaming phase: fetch and parse in chunks to reduce memory usage
+      await for (DriveEntityHistoryTransactionModel t in transactionsStream) {
+        // Check for cancellation periodically
+        token.checkCancellation();
+
+        /// Initialize only once `firstBlockHeight` and `totalBlockHeightDifference`
+        if (firstBlockHeight == null) {
+          final block = t.transactionCommonMixin.block;
+          if (block != null) {
+            firstBlockHeight = block.height;
+            totalBlockHeightDifference = currentBlockHeight - firstBlockHeight;
+            logger.d(
+              'First height: $firstBlockHeight, totalHeightDiff: $totalBlockHeightDifference',
+            );
+          } else {
+            logger.d(
+              'The transaction block is null. Transaction node id: ${t.transactionCommonMixin.id}',
+            );
+          }
         }
 
-        if (pendingTxBatch.isNotEmpty) {
-          logger.d('Processing ${pendingTxBatch.length} pending transactions');
+        // Add transaction to buffer
+        transactionBuffer.add(t);
+        totalTransactionsReceived++;
 
+        // Process chunk when buffer is full
+        if (transactionBuffer.length >= kStreamTransactionChunkSize) {
           await _processTransactionChunk(
-            transactions: pendingTxBatch,
+            transactions: List.from(transactionBuffer),
             drive: drive,
             driveKey: driveKey?.key,
             currentBlockHeight: currentBlockHeight,
@@ -1030,17 +944,111 @@ class _SyncRepository implements SyncRepository {
             ownerAddress: ownerAddress,
           );
 
-          pendingTransactionCount += pendingTxBatch.length;
+          totalTransactionsProcessed += transactionBuffer.length;
+          transactionBuffer.clear();
+
+          logger.d(
+              'Processed $totalTransactionsProcessed / $totalTransactionsReceived transactions');
+        }
+
+        // Calculate and yield progress based on block heights
+        if (firstBlockHeight != null && totalBlockHeightDifference > 0) {
+          final block = t.transactionCommonMixin.block;
+          if (block != null) {
+            fetchPhasePercentage = 1 -
+                ((currentBlockHeight - block.height) /
+                    totalBlockHeightDifference);
+          }
+
+          // Yield progress (80% for streaming, 20% reserved for final operations)
+          final streamProgress = fetchPhasePercentage * 0.8;
+          yield streamProgress;
         }
       }
-    } catch (e) {
-      // Log but don't rethrow - pending tx fetch is best-effort
-      logger.w('Error fetching pending transactions for drive ${drive.id}: $e');
-    }
 
-    if (pendingTransactionCount > 0) {
-      logger.i('Processed $pendingTransactionCount pending transactions for drive ${drive.name}');
-    }
+      // Process remaining transactions in buffer
+      if (transactionBuffer.isNotEmpty) {
+        logger.d(
+            'Processing final chunk of ${transactionBuffer.length} transactions');
+
+        try {
+          await _processTransactionChunk(
+            transactions: transactionBuffer,
+            drive: drive,
+            driveKey: driveKey?.key,
+            currentBlockHeight: currentBlockHeight,
+            lastBlockHeight: lastBlockHeight,
+            transactionParseBatchSize: transactionParseBatchSize,
+            snapshotDriveHistory: snapshotDriveHistory,
+            ownerAddress: ownerAddress,
+          );
+
+          totalTransactionsProcessed += transactionBuffer.length;
+          transactionBuffer.clear();
+        } catch (e) {
+          logger.e(
+              '[Sync Drive] Error while parsing final transaction chunk', e);
+          rethrow;
+        }
+      }
+
+      logger.d(
+          'Done processing all $totalTransactionsProcessed transactions - ${gqlDriveHistory.driveId}');
+
+      txFechedCallback?.call(drive.id, gqlDriveHistory.txCount);
+
+      final fetchPhaseTotalTime =
+          DateTime.now().difference(fetchPhaseStartDT).inMilliseconds;
+
+      logger.d(
+          'Duration of streaming phase for ${drive.name}: $fetchPhaseTotalTime ms. Processed $totalTransactionsProcessed transactions');
+
+      // Fetch pending (unmined) transactions to show Turbo uploads immediately
+      // This is best-effort: errors here should not fail the drive sync
+      logger.d('Fetching pending transactions for drive ${drive.id}');
+      int pendingTransactionCount = 0;
+
+      try {
+        await for (final pendingTxBatch
+            in _arweave.getPendingTransactionsForDrive(
+          driveId,
+          ownerAddress: ownerAddress,
+        )) {
+          // Check for cancellation before processing each batch
+          if (token.isCancelled) {
+            logger.d(
+                'Pending transactions fetch cancelled for drive ${drive.id}');
+            break;
+          }
+
+          if (pendingTxBatch.isNotEmpty) {
+            logger
+                .d('Processing ${pendingTxBatch.length} pending transactions');
+
+            await _processTransactionChunk(
+              transactions: pendingTxBatch,
+              drive: drive,
+              driveKey: driveKey?.key,
+              currentBlockHeight: currentBlockHeight,
+              lastBlockHeight: lastBlockHeight,
+              transactionParseBatchSize: transactionParseBatchSize,
+              snapshotDriveHistory: snapshotDriveHistory,
+              ownerAddress: ownerAddress,
+            );
+
+            pendingTransactionCount += pendingTxBatch.length;
+          }
+        }
+      } catch (e) {
+        // Log but don't rethrow - pending tx fetch is best-effort
+        logger
+            .w('Error fetching pending transactions for drive ${drive.id}: $e');
+      }
+
+      if (pendingTransactionCount > 0) {
+        logger.i(
+            'Processed $pendingTransactionCount pending transactions for drive ${drive.name}');
+      }
 
       // Yield final progress before cleanup
       yield 0.8;
@@ -1048,7 +1056,8 @@ class _SyncRepository implements SyncRepository {
       final syncDriveTotalTime =
           DateTime.now().difference(startSyncDT).inMilliseconds;
 
-      final averageBetweenFetchAndGet = fetchPhaseTotalTime / syncDriveTotalTime;
+      final averageBetweenFetchAndGet =
+          fetchPhaseTotalTime / syncDriveTotalTime;
 
       logger.i(
           'Drive ${drive.name} completed parse phase. Progress by block height: $fetchPhasePercentage%. Starting parse phase. Sync duration: $syncDriveTotalTime ms. Fetching used ${(averageBetweenFetchAndGet * 100).toStringAsFixed(2)}% of drive sync process');
@@ -1173,8 +1182,8 @@ class _SyncRepository implements SyncRepository {
     }
 
     // Insert all licenses in a single transaction to minimize database exports
-    final totalLicenses =
-        allLicenseAssertionCompanions.length + allLicenseComposedCompanions.length;
+    final totalLicenses = allLicenseAssertionCompanions.length +
+        allLicenseComposedCompanions.length;
     final totalSkipped = skippedLicenseAssertions + skippedLicenseComposed;
 
     if (totalLicenses > 0) {


### PR DESCRIPTION
Moves updateUserDrives() call before the ArConnect tab visibility and activity checks in startSync(). This ensures user drives are always discovered and stored in the database when logged in, even if the full sync is skipped due to tab not being focused.

Previously, for ArConnect users, if the tab lost focus during the brief window between login and sync starting, updateUserDrives() was never called, leaving the database empty and showing the "Getting Started" empty state.

Also adds early return after empty drives check in syncAllDrives() to avoid unnecessary processing when no drives exist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Sync now triggers immediately when appropriate and avoids unnecessary restarts, with clearer tab-focus skipping behavior.
  * Drive discovery is enforced before syncing; empty-drive cases complete immediately without extra work.
  * Transaction streaming refined: buffered chunk streaming with a final-chunk flush and post-sync best-effort uploads; progress, cancellation, and logging flows clarified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->