### PR TITLE
PE-9013: Add individual drive sync and sync-on-login toggle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,11 +7,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 **Required Flutter version: 3.19.6** - Run `scr check-flutter` to verify.
 
 ```bash
-# First-time setup: install lefthook for git hooks
+# First-time setup: install lefthook for git hooks (https://github.com/evilmartians/lefthook)
 lefthook install
 
 # Activate script_runner globally (needed for scr commands)
 flutter pub global activate script_runner
+# Ensure scr is in your PATH (add via export if needed)
 
 # Initial setup (clean, get deps, run code generation)
 scr setup
@@ -80,6 +81,7 @@ PR titles must follow the pattern `PE-{number}: {description}` (enforced by CI).
 
 - Use single quotes for strings (`prefer_single_quotes` lint rule is enabled)
 - Generated files (`**.g.dart`) and GraphQL files (`lib/services/arweave/graphql/`) are excluded from analysis
+- Platform-specific directories (`macos/`, `ios/`, `android/`, `web/`) are also excluded from analysis
 
 ## Architecture Overview
 
@@ -130,6 +132,8 @@ lib/
 | `flutter_file_picker` | File picker fork |
 | `build` | Build utilities |
 
+Note: The `ario_sdk` package requires separate code generation - `scr setup` handles this automatically.
+
 ### Database (Drift ORM)
 
 - Main database: `lib/models/database/database.dart`
@@ -175,7 +179,14 @@ The app supports multiple languages via ARB files in `lib/l10n/`: English, Spani
 - Unit tests use `mocktail` for mocking
 - BLoC tests use `bloc_test` package
 - Test utilities in `test/test_utils/`
-- `scr test` runs `flutter pub get`, `flutter analyze`, and `flutter test` for main app + all packages with test directories
+- `scr test` runs main app tests (`flutter test`) plus all packages with test directories
+
+### CI Pipeline
+CI runs `scr setup` → `flutter analyze` → `scr test`. Ensure these all pass locally before pushing.
+
+### Git Hooks (Lefthook)
+- **Pre-commit**: Validates Flutter version matches 3.19.6
+- **Pre-push**: Validates database schema version is incremented when `.drift` files change
 
 ## Deployment
 
@@ -190,3 +201,5 @@ For testing with a custom Arweave gateway, set in browser console:
 localStorage.setItem('flutter.arweaveGatewayUrl', '"https://my.custom.url"');
 // Remove with: localStorage.removeItem('flutter.arweaveGatewayUrl');
 ```
+
+Reload the page after changing the gateway URL.

--- a/lib/app_shell.dart
+++ b/lib/app_shell.dart
@@ -407,6 +407,24 @@ class AppShellState extends State<AppShell> {
                                                         ArFontWeight.bold,
                                                   ),
                                                 ),
+                                                if (isCurrentProfileArConnect) ...[
+                                                  const SizedBox(height: 8),
+                                                  Text(
+                                                    appLocalizationsOf(context)
+                                                        .syncingPleaseRemainOnThisTab,
+                                                    style: typography
+                                                        .paragraphSmall(
+                                                      fontWeight:
+                                                          ArFontWeight.semiBold,
+                                                      color: ArDriveTheme.of(
+                                                              context)
+                                                          .themeData
+                                                          .colorTokens
+                                                          .textLow,
+                                                    ),
+                                                    textAlign: TextAlign.center,
+                                                  ),
+                                                ],
                                                 if (syncProgress.hasErrors) ...[
                                                   const SizedBox(height: 8),
                                                   Container(
@@ -700,21 +718,17 @@ class AppShellState extends State<AppShell> {
       );
 
   /// Returns the appropriate title for the sync modal based on sync type.
+  /// ArConnect warning is handled separately in the modal content.
   String _getSyncTitle(
     BuildContext context,
     SyncProgress syncProgress,
     bool isArConnect,
   ) {
+    // Always show sync-specific title regardless of ArConnect status
     if (syncProgress.isSingleDriveSync) {
-      // For single drive sync, show "Syncing Drive" or with ArConnect warning
-      return isArConnect
-          ? appLocalizationsOf(context).syncingPleaseRemainOnThisTab
-          : appLocalizationsOf(context).syncingSingleDrive;
+      return appLocalizationsOf(context).syncingSingleDrive;
     } else {
-      // For all drives sync, show "Syncing All Drives" or with ArConnect warning
-      return isArConnect
-          ? appLocalizationsOf(context).syncingPleaseRemainOnThisTab
-          : appLocalizationsOf(context).syncingAllDrives;
+      return appLocalizationsOf(context).syncingAllDrives;
     }
   }
 
@@ -723,24 +737,27 @@ class AppShellState extends State<AppShell> {
     BuildContext context,
     SyncProgress syncProgress,
   ) {
-    if (syncProgress.drivesCount == 0) {
-      return '';
-    }
-
-    if (syncProgress.isSingleDriveSync && syncProgress.driveName != null) {
-      // Single drive sync with name - show "Syncing 'Drive Name'..."
-      return appLocalizationsOf(context).syncingDriveWithName(
-        syncProgress.driveName!,
-      );
+    if (syncProgress.isSingleDriveSync) {
+      // Single drive sync - show drive name if available, otherwise fallback
+      if (syncProgress.driveName != null) {
+        return appLocalizationsOf(context).syncingDriveWithName(
+          syncProgress.driveName!,
+        );
+      } else {
+        return appLocalizationsOf(context).syncingOnlyOneDrive;
+      }
     } else if (syncProgress.drivesCount > 1) {
       // Multiple drives - show "X of Y Drives Synced"
       return appLocalizationsOf(context).driveSyncedOfDrivesCount(
         syncProgress.drivesSynced,
         syncProgress.drivesCount,
       );
-    } else {
-      // Fallback for single drive without name
+    } else if (syncProgress.drivesCount == 1) {
+      // Single drive in all-drives sync
       return appLocalizationsOf(context).syncingOnlyOneDrive;
+    } else {
+      // drivesCount == 0, initial state
+      return '';
     }
   }
 

--- a/lib/app_shell.dart
+++ b/lib/app_shell.dart
@@ -101,6 +101,28 @@ class AppShellState extends State<AppShell> {
                   builder: (context, syncState) {
                     return Stack(children: [
                       scaffold,
+                      // Show loading modal for metadata-only sync
+                      if (syncState is SyncLoadingDrives)
+                        Stack(
+                          children: [
+                            SizedBox.expand(
+                              child: Container(
+                                color: Colors.black.withOpacity(0.5),
+                              ),
+                            ),
+                            Align(
+                              alignment: Alignment.center,
+                              child: Material(
+                                borderRadius: BorderRadius.circular(8),
+                                child: ProgressDialog(
+                                  useNewArDriveUI: true,
+                                  title: appLocalizationsOf(context)
+                                      .loadingYourDrives,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
                       if (syncState is SyncInProgress ||
                           syncState is SyncCancelled ||
                           syncState is SyncCompleteWithErrors)

--- a/lib/app_shell.dart
+++ b/lib/app_shell.dart
@@ -375,21 +375,10 @@ class AppShellState extends State<AppShell> {
                                               mainAxisSize: MainAxisSize.min,
                                               children: [
                                                 Text(
-                                                  syncProgress.drivesCount == 0
-                                                      ? ''
-                                                      : syncProgress
-                                                                  .drivesCount >
-                                                              1
-                                                          ? appLocalizationsOf(
-                                                                  context)
-                                                              .driveSyncedOfDrivesCount(
-                                                                  syncProgress
-                                                                      .drivesSynced,
-                                                                  syncProgress
-                                                                      .drivesCount)
-                                                          : appLocalizationsOf(
-                                                                  context)
-                                                              .syncingOnlyOneDrive,
+                                                  _getSyncProgressDescription(
+                                                    context,
+                                                    syncProgress,
+                                                  ),
                                                   style: typography
                                                       .paragraphNormal(
                                                     fontWeight:
@@ -449,11 +438,19 @@ class AppShellState extends State<AppShell> {
                                               ],
                                             ),
                                           ),
-                                          title: isCurrentProfileArConnect
-                                              ? appLocalizationsOf(context)
-                                                  .syncingPleaseRemainOnThisTab
-                                              : appLocalizationsOf(context)
-                                                  .syncingPleaseWait,
+                                          titleWidget: _syncStreamBuilder(
+                                            builderWithData: (syncProgress) =>
+                                                Text(
+                                              _getSyncTitle(
+                                                context,
+                                                syncProgress,
+                                                isCurrentProfileArConnect,
+                                              ),
+                                              style: typography.heading5(
+                                                fontWeight: ArFontWeight.bold,
+                                              ),
+                                            ),
+                                          ),
                                           actions: [
                                             ModalAction(
                                               action: () {
@@ -674,9 +671,56 @@ class AppShellState extends State<AppShell> {
   }) =>
       StreamBuilder<SyncProgress>(
         stream: context.read<SyncCubit>().syncProgressController.stream,
+        // Use current sync progress as initial data to prevent empty state flash
+        initialData: context.read<SyncCubit>().syncProgress,
         builder: (context, snapshot) =>
             snapshot.hasData ? builderWithData(snapshot.data!) : Container(),
       );
+
+  /// Returns the appropriate title for the sync modal based on sync type.
+  String _getSyncTitle(
+    BuildContext context,
+    SyncProgress syncProgress,
+    bool isArConnect,
+  ) {
+    if (syncProgress.isSingleDriveSync) {
+      // For single drive sync, show "Syncing Drive" or with ArConnect warning
+      return isArConnect
+          ? appLocalizationsOf(context).syncingPleaseRemainOnThisTab
+          : appLocalizationsOf(context).syncingSingleDrive;
+    } else {
+      // For all drives sync, show "Syncing All Drives" or with ArConnect warning
+      return isArConnect
+          ? appLocalizationsOf(context).syncingPleaseRemainOnThisTab
+          : appLocalizationsOf(context).syncingAllDrives;
+    }
+  }
+
+  /// Returns the appropriate progress description for the sync modal.
+  String _getSyncProgressDescription(
+    BuildContext context,
+    SyncProgress syncProgress,
+  ) {
+    if (syncProgress.drivesCount == 0) {
+      return '';
+    }
+
+    if (syncProgress.isSingleDriveSync && syncProgress.driveName != null) {
+      // Single drive sync with name - show "Syncing 'Drive Name'..."
+      return appLocalizationsOf(context).syncingDriveWithName(
+        syncProgress.driveName!,
+      );
+    } else if (syncProgress.drivesCount > 1) {
+      // Multiple drives - show "X of Y Drives Synced"
+      return appLocalizationsOf(context).driveSyncedOfDrivesCount(
+        syncProgress.drivesSynced,
+        syncProgress.drivesCount,
+      );
+    } else {
+      // Fallback for single drive without name
+      return appLocalizationsOf(context).syncingOnlyOneDrive;
+    }
+  }
 
   void toggleProfileOverlay() =>
       setState(() => _showProfileOverlay = !_showProfileOverlay);

--- a/lib/authentication/login/views/tutorials_view.dart
+++ b/lib/authentication/login/views/tutorials_view.dart
@@ -124,6 +124,10 @@ class TutorialsViewState extends State<TutorialsView> {
   }
 
   void _goToPage(int page) {
+    // Bounds check to prevent RangeError on rapid clicks
+    if (page < 0 || page >= _list.length) {
+      return;
+    }
     setState(() {
       _currentPage = page;
     });

--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -82,8 +82,11 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
         final folder = await _driveDao
             .folderById(folderId: initialFolderId)
             .getSingleOrNull();
-        // Open the root folder if the deep-linked folder could not be found.
 
+        // Abort if user switched drives during the async operation
+        if (_driveId != driveId) return;
+
+        // Open the root folder if the deep-linked folder could not be found.
         openFolder(folderId: folder?.id);
         // The empty string here is required to open the root folder
       }).whenComplete(() {
@@ -94,8 +97,14 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
         // Wait for any current sync to complete before checking drive state
         await _syncCubit.waitCurrentSync();
 
+        // Abort if user switched drives during sync wait
+        if (_driveId != driveId) return;
+
         final drive =
             await _driveDao.driveById(driveId: driveId).getSingleOrNull();
+
+        // Abort if user switched drives during the async operation
+        if (_driveId != driveId) return;
 
         // Check if drive exists and has been content-synced
         if (drive == null) {
@@ -130,10 +139,20 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
 
     final currentState = state;
     if (currentState is DriveDetailLoadUnsynced) {
+      // Capture the drive ID before awaiting to detect if user switches drives
+      final capturedDriveId = currentState.drive.id;
+
       final drive =
-          await _driveDao.driveById(driveId: _driveId).getSingleOrNull();
+          await _driveDao.driveById(driveId: capturedDriveId).getSingleOrNull();
 
       if (isClosed) return;
+
+      // Re-check state after await - user may have switched drives
+      final newState = state;
+      if (newState is! DriveDetailLoadUnsynced ||
+          newState.drive.id != capturedDriveId) {
+        return;
+      }
 
       if (drive == null) {
         emit(DriveDetailLoadNotFound());
@@ -142,7 +161,7 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
 
       // If drive is now synced, open it
       if (drive.lastBlockHeight != null && drive.lastBlockHeight! > 0) {
-        openFolder(folderId: drive.rootFolderId);
+        openFolder(folderId: drive.rootFolderId, otherDriveId: capturedDriveId);
       }
     }
   }
@@ -693,7 +712,25 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
         return;
       }
 
-      // Sync completed successfully and we're still on the same drive
+      // Verify the drive was actually synced by checking lastBlockHeight
+      final drive =
+          await _driveDao.driveById(driveId: driveId).getSingleOrNull();
+
+      // Re-check state after the async operation
+      if (isClosed || _driveId != driveId) return;
+
+      if (drive == null) {
+        emit(DriveDetailLoadNotFound());
+        return;
+      }
+
+      if (drive.lastBlockHeight == null || drive.lastBlockHeight == 0) {
+        // Sync reported success but drive content wasn't actually synced
+        emit(DriveDetailLoadUnsynced(drive: drive));
+        return;
+      }
+
+      // Sync completed successfully and drive is verified synced
       openFolder(folderId: rootFolderId);
     }
   }

--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -97,32 +97,49 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
       });
     } else {
       Future.microtask(() async {
+        logger.d('[DriveDetailCubit] Constructor microtask starting for driveId: $driveId');
+        logger.d('[DriveDetailCubit] SyncCubit state before wait: ${_syncCubit.state}');
+
         // Wait for any current sync to complete before checking drive state
         await _syncCubit.waitCurrentSync();
 
+        logger.d('[DriveDetailCubit] waitCurrentSync returned, SyncCubit state: ${_syncCubit.state}');
+
         // Abort if user switched drives during sync wait
-        if (_driveId != driveId) return;
+        if (_driveId != driveId) {
+          logger.d('[DriveDetailCubit] Aborting: driveId changed from $driveId to $_driveId');
+          return;
+        }
 
         final drive =
             await _driveDao.driveById(driveId: driveId).getSingleOrNull();
 
+        logger.d('[DriveDetailCubit] Drive query result: ${drive?.name}, lastBlockHeight: ${drive?.lastBlockHeight}');
+
         // Abort if user switched drives during the async operation
-        if (_driveId != driveId) return;
+        if (_driveId != driveId) {
+          logger.d('[DriveDetailCubit] Aborting: driveId changed during query');
+          return;
+        }
 
         // Check if drive exists and has been content-synced
         if (drive == null) {
+          logger.d('[DriveDetailCubit] Drive is null, emitting DriveDetailLoadNotFound');
           emit(DriveDetailLoadNotFound());
           return;
         }
 
         // If drive has only metadata (not content-synced), show unsynced state
         if (drive.lastBlockHeight == null || drive.lastBlockHeight == 0) {
+          logger.d('[DriveDetailCubit] Drive not synced (lastBlockHeight=${drive.lastBlockHeight}), emitting DriveDetailLoadUnsynced');
           emit(DriveDetailLoadUnsynced(drive: drive));
           return;
         }
 
+        logger.d('[DriveDetailCubit] Drive synced, calling openFolder with rootFolderId: ${drive.rootFolderId}');
         openFolder(folderId: drive.rootFolderId);
       }).whenComplete(() {
+        logger.d('[DriveDetailCubit] Constructor microtask completed, _initialLoadComplete = true');
         _initialLoadComplete = true;
       });
     }
@@ -184,7 +201,9 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
   }
 
   Future<void> changeDrive(String driveId) async {
+    logger.d('[DriveDetailCubit] changeDrive called with driveId: $driveId (current: $_driveId)');
     final drive = await _driveDao.driveById(driveId: driveId).getSingleOrNull();
+    logger.d('[DriveDetailCubit] changeDrive: drive=${drive?.name}, lastBlockHeight=${drive?.lastBlockHeight}');
 
     if (drive == null) {
       await _syncCubit.waitCurrentSync();

--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -247,13 +247,22 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
           orderingMode: contentOrderingMode,
           folderId: folderId,
         )
-            .handleError((error, stack) {
+            .handleError((error, stack) async {
           logger.e('Error watching folder contents', error, stack);
           if (error is DriveNotFoundException) {
             emit(DriveDetailLoadNotFound());
+          } else if (error is FolderNotFoundInDriveException) {
+            // Check if the drive is unsynced (metadata only, no content)
+            final drive = await _driveDao
+                .driveById(driveId: error.driveId)
+                .getSingleOrNull();
+            if (drive != null &&
+                (drive.lastBlockHeight == null || drive.lastBlockHeight == 0)) {
+              emit(DriveDetailLoadUnsynced(drive: drive));
+            } else {
+              emit(DriveInitialLoading());
+            }
           }
-
-          return null;
         }),
         _profileCubit.stream.startWith(ProfileCheckingAvailability()),
         (drive, folderContents, _) async {
@@ -391,9 +400,19 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
       logger.e('An error occured mouting the drive explorer', e, stacktrace);
     }
 
-    _folderSubscription?.onError((e) {
+    _folderSubscription?.onError((e) async {
       if (e is FolderNotFoundInDriveException) {
-        emit(DriveInitialLoading());
+        // Check if the drive is unsynced (metadata only, no content)
+        final drive =
+            await _driveDao.driveById(driveId: e.driveId).getSingleOrNull();
+        if (drive != null &&
+            (drive.lastBlockHeight == null || drive.lastBlockHeight == 0)) {
+          // Drive exists but content hasn't been synced - show sync options
+          emit(DriveDetailLoadUnsynced(drive: drive));
+        } else {
+          // Drive is being set up or has an issue
+          emit(DriveInitialLoading());
+        }
         return;
       }
 

--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -27,6 +27,9 @@ part 'drive_detail_state.dart';
 
 class DriveDetailCubit extends Cubit<DriveDetailState> {
   String _driveId;
+
+  /// The ID of the drive currently being viewed or loaded.
+  String get currentDriveId => _driveId;
   final ProfileCubit _profileCubit;
   final DriveDao _driveDao;
   final ConfigService _configService;

--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -109,6 +109,14 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
       return;
     }
 
+    // Check if drive content has been synced (lastBlockHeight > 0 means synced)
+    if (drive.lastBlockHeight == null || drive.lastBlockHeight == 0) {
+      await _folderSubscription?.cancel();
+      _driveId = driveId;
+      emit(DriveDetailLoadUnsynced(drive: drive));
+      return;
+    }
+
     await _folderSubscription?.cancel();
 
     // If the drive info panel is open (selectedItem is a DriveDataItem),
@@ -589,6 +597,20 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
 
   Future<LocalKeyValueStore> _store() async {
     return LocalKeyValueStore.getInstance();
+  }
+
+  /// Syncs the current unsynced drive and then opens it.
+  Future<void> syncCurrentDrive() async {
+    final state = this.state;
+    if (state is DriveDetailLoadUnsynced) {
+      emit(DriveDetailLoadInProgress());
+      await _syncCubit.startSyncForDrive(
+        driveId: state.drive.id,
+        deepSync: false,
+      );
+      // After sync completes, open the drive's root folder
+      openFolder(folderId: state.drive.rootFolderId);
+    }
   }
 
   @override

--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -38,6 +38,8 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
   final DriveRepository _driveRepository;
 
   StreamSubscription? _folderSubscription;
+  StreamSubscription? _syncSubscription;
+  bool _initialLoadComplete = false;
   final _defaultAvailableRowsPerPage = [25, 50, 75, 100];
 
   List<ArDriveDataTableItem> _selectedItems = [];
@@ -84,18 +86,77 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
 
         openFolder(folderId: folder?.id);
         // The empty string here is required to open the root folder
+      }).whenComplete(() {
+        _initialLoadComplete = true;
       });
     } else {
       Future.microtask(() async {
+        // Wait for any current sync to complete before checking drive state
+        await _syncCubit.waitCurrentSync();
+
         final drive =
             await _driveDao.driveById(driveId: driveId).getSingleOrNull();
-        openFolder(folderId: drive?.rootFolderId);
+
+        // Check if drive exists and has been content-synced
+        if (drive == null) {
+          emit(DriveDetailLoadNotFound());
+          return;
+        }
+
+        // If drive has only metadata (not content-synced), show unsynced state
+        if (drive.lastBlockHeight == null || drive.lastBlockHeight == 0) {
+          emit(DriveDetailLoadUnsynced(drive: drive));
+          return;
+        }
+
+        openFolder(folderId: drive.rootFolderId);
+      }).whenComplete(() {
+        _initialLoadComplete = true;
       });
+    }
+
+    // Listen for sync completion to auto-refresh if we're in an unsynced/loading state
+    _syncSubscription = _syncCubit.stream.listen((syncState) {
+      if (syncState is SyncIdle && _initialLoadComplete) {
+        _onSyncCompleted();
+      }
+    });
+  }
+
+  /// Called when sync completes. Re-checks drive state if we're showing
+  /// unsynced or loading state, and loads the drive content if now available.
+  Future<void> _onSyncCompleted() async {
+    if (isClosed) return;
+
+    final currentState = state;
+    if (currentState is DriveDetailLoadUnsynced) {
+      final drive =
+          await _driveDao.driveById(driveId: _driveId).getSingleOrNull();
+
+      if (isClosed) return;
+
+      if (drive == null) {
+        emit(DriveDetailLoadNotFound());
+        return;
+      }
+
+      // If drive is now synced, open it
+      if (drive.lastBlockHeight != null && drive.lastBlockHeight! > 0) {
+        openFolder(folderId: drive.rootFolderId);
+      }
     }
   }
 
   void showEmptyDriveDetail() async {
     await _syncCubit.waitCurrentSync();
+
+    // Check if state has already changed (e.g., drives were loaded during sync)
+    // Don't overwrite a more specific state with the empty state
+    if (state is DriveDetailLoadSuccess ||
+        state is DriveDetailLoadUnsynced ||
+        state is DriveDetailLoadInProgress) {
+      return;
+    }
 
     emit(DriveDetailLoadEmpty());
   }
@@ -607,13 +668,33 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
   Future<void> syncCurrentDrive() async {
     final state = this.state;
     if (state is DriveDetailLoadUnsynced) {
+      final driveId = state.drive.id;
+      final rootFolderId = state.drive.rootFolderId;
+
       emit(DriveDetailLoadInProgress());
       await _syncCubit.startSyncForDrive(
-        driveId: state.drive.id,
+        driveId: driveId,
         deepSync: false,
       );
-      // After sync completes, open the drive's root folder
-      openFolder(folderId: state.drive.rootFolderId);
+
+      // Guard: Only proceed if sync completed successfully and we're still
+      // viewing the same drive (user hasn't navigated away during sync)
+      final syncState = _syncCubit.state;
+      final currentState = this.state;
+
+      // Check if sync was cancelled or had errors
+      if (syncState is SyncCancelled || syncState is SyncFailure) {
+        // Sync was cancelled or failed, don't navigate
+        return;
+      }
+
+      // Check if we're still on the same drive (user might have navigated away)
+      if (currentState is! DriveDetailLoadInProgress || _driveId != driveId) {
+        return;
+      }
+
+      // Sync completed successfully and we're still on the same drive
+      openFolder(folderId: rootFolderId);
     }
   }
 
@@ -643,6 +724,7 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
   @override
   Future<void> close() {
     _folderSubscription?.cancel();
+    _syncSubscription?.cancel();
     _allImagesOfCurrentFolder = null;
     return super.close();
   }

--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -97,49 +97,36 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
       });
     } else {
       Future.microtask(() async {
-        logger.d('[DriveDetailCubit] Constructor microtask starting for driveId: $driveId');
-        logger.d('[DriveDetailCubit] SyncCubit state before wait: ${_syncCubit.state}');
-
         // Wait for any current sync to complete before checking drive state
         await _syncCubit.waitCurrentSync();
 
-        logger.d('[DriveDetailCubit] waitCurrentSync returned, SyncCubit state: ${_syncCubit.state}');
-
         // Abort if user switched drives during sync wait
         if (_driveId != driveId) {
-          logger.d('[DriveDetailCubit] Aborting: driveId changed from $driveId to $_driveId');
           return;
         }
 
         final drive =
             await _driveDao.driveById(driveId: driveId).getSingleOrNull();
 
-        logger.d('[DriveDetailCubit] Drive query result: ${drive?.name}, lastBlockHeight: ${drive?.lastBlockHeight}');
-
         // Abort if user switched drives during the async operation
         if (_driveId != driveId) {
-          logger.d('[DriveDetailCubit] Aborting: driveId changed during query');
           return;
         }
 
         // Check if drive exists and has been content-synced
         if (drive == null) {
-          logger.d('[DriveDetailCubit] Drive is null, emitting DriveDetailLoadNotFound');
           emit(DriveDetailLoadNotFound());
           return;
         }
 
         // If drive has only metadata (not content-synced), show unsynced state
         if (drive.lastBlockHeight == null || drive.lastBlockHeight == 0) {
-          logger.d('[DriveDetailCubit] Drive not synced (lastBlockHeight=${drive.lastBlockHeight}), emitting DriveDetailLoadUnsynced');
           emit(DriveDetailLoadUnsynced(drive: drive));
           return;
         }
 
-        logger.d('[DriveDetailCubit] Drive synced, calling openFolder with rootFolderId: ${drive.rootFolderId}');
         openFolder(folderId: drive.rootFolderId);
       }).whenComplete(() {
-        logger.d('[DriveDetailCubit] Constructor microtask completed, _initialLoadComplete = true');
         _initialLoadComplete = true;
       });
     }
@@ -201,12 +188,19 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
   }
 
   Future<void> changeDrive(String driveId) async {
-    logger.d('[DriveDetailCubit] changeDrive called with driveId: $driveId (current: $_driveId)');
-    final drive = await _driveDao.driveById(driveId: driveId).getSingleOrNull();
-    logger.d('[DriveDetailCubit] changeDrive: drive=${drive?.name}, lastBlockHeight=${drive?.lastBlockHeight}');
+    // First check current drive state before waiting for sync
+    var drive = await _driveDao.driveById(driveId: driveId).getSingleOrNull();
+
+    // If drive isn't synced yet, wait for sync to complete then re-check
+    if (drive == null || drive.lastBlockHeight == null || drive.lastBlockHeight == 0) {
+      emit(DriveDetailLoadInProgress());
+      await _syncCubit.waitCurrentSync();
+
+      // Re-query drive after sync completes
+      drive = await _driveDao.driveById(driveId: driveId).getSingleOrNull();
+    }
 
     if (drive == null) {
-      await _syncCubit.waitCurrentSync();
       emit(DriveDetailLoadNotFound());
       return;
     }

--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -113,6 +113,10 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
     if (drive.lastBlockHeight == null || drive.lastBlockHeight == 0) {
       await _folderSubscription?.cancel();
       _driveId = driveId;
+      // Clear selection state to avoid stale data leaking into sync/openFolder
+      _selectedItem = null;
+      _selectedItems.clear();
+      _refreshSelectedItem = false;
       emit(DriveDetailLoadUnsynced(drive: drive));
       return;
     }

--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -25,6 +25,9 @@ import 'package:rxdart/rxdart.dart';
 
 part 'drive_detail_state.dart';
 
+/// Sentinel used by copyWith to distinguish "not provided" from "explicitly null".
+const _driveDetailAbsent = Object();
+
 class DriveDetailCubit extends Cubit<DriveDetailState> {
   String _driveId;
 
@@ -43,6 +46,7 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
   StreamSubscription? _folderSubscription;
   StreamSubscription? _syncSubscription;
   bool _initialLoadComplete = false;
+  bool _isExplicitSync = false;
   final _defaultAvailableRowsPerPage = [25, 50, 75, 100];
 
   List<ArDriveDataTableItem> _selectedItems = [];
@@ -142,7 +146,7 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
   /// Called when sync completes. Re-checks drive state if we're showing
   /// unsynced or loading state, and loads the drive content if now available.
   Future<void> _onSyncCompleted() async {
-    if (isClosed) return;
+    if (isClosed || _isExplicitSync) return;
 
     final currentState = state;
     if (currentState is DriveDetailLoadUnsynced) {
@@ -263,21 +267,12 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
           orderingMode: contentOrderingMode,
           folderId: folderId,
         )
-            .handleError((error, stack) async {
+            .handleError((error, stack) {
           logger.e('Error watching folder contents', error, stack);
           if (error is DriveNotFoundException) {
             emit(DriveDetailLoadNotFound());
           } else if (error is FolderNotFoundInDriveException) {
-            // Check if the drive is unsynced (metadata only, no content)
-            final drive = await _driveDao
-                .driveById(driveId: error.driveId)
-                .getSingleOrNull();
-            if (drive != null &&
-                (drive.lastBlockHeight == null || drive.lastBlockHeight == 0)) {
-              emit(DriveDetailLoadUnsynced(drive: drive));
-            } else {
-              emit(DriveInitialLoading());
-            }
+            _handleFolderNotFound(error.driveId);
           }
         }),
         _profileCubit.stream.startWith(ProfileCheckingAvailability()),
@@ -725,11 +720,13 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
       final driveId = state.drive.id;
       final rootFolderId = state.drive.rootFolderId;
 
+      _isExplicitSync = true;
       emit(DriveDetailLoadInProgress());
       await _syncCubit.startSyncForDrive(
         driveId: driveId,
         deepSync: false,
       );
+      _isExplicitSync = false;
 
       // Guard: Only proceed if sync completed successfully and we're still
       // viewing the same drive (user hasn't navigated away during sync)
@@ -790,6 +787,18 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
         showDriveInfo: false,
         selectedItem: null,
       ));
+    }
+  }
+
+  Future<void> _handleFolderNotFound(String driveId) async {
+    final drive =
+        await _driveDao.driveById(driveId: driveId).getSingleOrNull();
+    if (isClosed) return;
+    if (drive != null &&
+        (drive.lastBlockHeight == null || drive.lastBlockHeight == 0)) {
+      emit(DriveDetailLoadUnsynced(drive: drive));
+    } else {
+      emit(DriveInitialLoading());
     }
   }
 

--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -613,6 +613,29 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
     }
   }
 
+  /// Shows the drive info panel for an unsynced drive.
+  void selectDriveInfoForUnsyncedDrive(ArDriveDataTableItem driveItem) {
+    final state = this.state;
+    if (state is DriveDetailLoadUnsynced) {
+      emit(state.copyWith(
+        showDriveInfo: true,
+        selectedItem: driveItem,
+      ));
+    }
+  }
+
+  /// Hides the drive info panel for an unsynced drive.
+  void closeDriveInfoForUnsyncedDrive() {
+    final state = this.state;
+    if (state is DriveDetailLoadUnsynced) {
+      emit(DriveDetailLoadUnsynced(
+        drive: state.drive,
+        showDriveInfo: false,
+        selectedItem: null,
+      ));
+    }
+  }
+
   @override
   Future<void> close() {
     _folderSubscription?.cancel();

--- a/lib/blocs/drive_detail/drive_detail_state.dart
+++ b/lib/blocs/drive_detail/drive_detail_state.dart
@@ -142,11 +142,29 @@ class DriveDetailLoadNotFound extends DriveDetailState {}
 /// has not been synced yet (lastBlockHeight == 0 or null).
 class DriveDetailLoadUnsynced extends DriveDetailState {
   final Drive drive;
+  final bool showDriveInfo;
+  final ArDriveDataTableItem? selectedItem;
 
-  DriveDetailLoadUnsynced({required this.drive});
+  DriveDetailLoadUnsynced({
+    required this.drive,
+    this.showDriveInfo = false,
+    this.selectedItem,
+  });
+
+  DriveDetailLoadUnsynced copyWith({
+    Drive? drive,
+    bool? showDriveInfo,
+    ArDriveDataTableItem? selectedItem,
+  }) {
+    return DriveDetailLoadUnsynced(
+      drive: drive ?? this.drive,
+      showDriveInfo: showDriveInfo ?? this.showDriveInfo,
+      selectedItem: selectedItem ?? this.selectedItem,
+    );
+  }
 
   @override
-  List<Object?> get props => [drive];
+  List<Object?> get props => [drive, showDriveInfo, selectedItem];
 }
 
 class DriveDetailLoadEmpty extends DriveDetailState {}

--- a/lib/blocs/drive_detail/drive_detail_state.dart
+++ b/lib/blocs/drive_detail/drive_detail_state.dart
@@ -154,12 +154,14 @@ class DriveDetailLoadUnsynced extends DriveDetailState {
   DriveDetailLoadUnsynced copyWith({
     Drive? drive,
     bool? showDriveInfo,
-    ArDriveDataTableItem? selectedItem,
+    Object? selectedItem = _driveDetailAbsent,
   }) {
     return DriveDetailLoadUnsynced(
       drive: drive ?? this.drive,
       showDriveInfo: showDriveInfo ?? this.showDriveInfo,
-      selectedItem: selectedItem ?? this.selectedItem,
+      selectedItem: identical(selectedItem, _driveDetailAbsent)
+          ? this.selectedItem
+          : selectedItem as ArDriveDataTableItem?,
     );
   }
 

--- a/lib/blocs/drive_detail/drive_detail_state.dart
+++ b/lib/blocs/drive_detail/drive_detail_state.dart
@@ -138,6 +138,17 @@ class DriveDetailLoadSuccess extends DriveDetailState {
 /// the user's profile.
 class DriveDetailLoadNotFound extends DriveDetailState {}
 
+/// [DriveDetailLoadUnsynced] means that the drive metadata exists but its content
+/// has not been synced yet (lastBlockHeight == 0 or null).
+class DriveDetailLoadUnsynced extends DriveDetailState {
+  final Drive drive;
+
+  DriveDetailLoadUnsynced({required this.drive});
+
+  @override
+  List<Object?> get props => [drive];
+}
+
 class DriveDetailLoadEmpty extends DriveDetailState {}
 
 class DriveInitialLoading extends DriveDetailState {}

--- a/lib/blocs/hide/global_hide_bloc.dart
+++ b/lib/blocs/hide/global_hide_bloc.dart
@@ -16,11 +16,20 @@ class GlobalHideBloc extends Bloc<GlobalHideEvent, GlobalHideState> {
   })  : _userPreferencesRepository = userPreferencesRepository,
         _driveDao = driveDao,
         super(const GlobalHideInitial(userHasHiddenDrive: false)) {
+    // Listen to preferences stream to update state when preferences change.
+    // Note: We only update local state here, NOT save back to preferences.
+    // Saving is done only in response to user actions (ToggleShowHiddenFiles).
     _userPreferencesRepository.watch().listen((userPreferences) async {
       if (userPreferences.showHiddenFiles) {
-        add(ShowItems(userHasHiddenItems: userPreferences.userHasHiddenDrive));
+        add(SyncShowHiddenState(
+          showHidden: true,
+          userHasHiddenItems: userPreferences.userHasHiddenDrive,
+        ));
       } else {
-        add(HideItems(userHasHiddenItems: userPreferences.userHasHiddenDrive));
+        add(SyncShowHiddenState(
+          showHidden: false,
+          userHasHiddenItems: userPreferences.userHasHiddenDrive,
+        ));
       }
     });
 
@@ -33,6 +42,13 @@ class GlobalHideBloc extends Bloc<GlobalHideEvent, GlobalHideState> {
       } else if (event is HideItems) {
         emit(HiddingItems(userHasHiddenDrive: event.userHasHiddenItems));
         await _userPreferencesRepository.saveShowHiddenFiles(false);
+      } else if (event is SyncShowHiddenState) {
+        // Only update local state from stream updates, don't save back
+        if (event.showHidden) {
+          emit(ShowingHiddenItems(userHasHiddenDrive: event.userHasHiddenItems));
+        } else {
+          emit(HiddingItems(userHasHiddenDrive: event.userHasHiddenItems));
+        }
       } else if (event is RefreshOptions) {
         final hasHiddenItems = await _driveDao.userHasHiddenItems();
         emit(state.copyWith(userHasHiddenDrive: hasHiddenItems));

--- a/lib/blocs/hide/global_hide_bloc.dart
+++ b/lib/blocs/hide/global_hide_bloc.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:ardrive/models/daos/drive_dao/drive_dao.dart';
 import 'package:ardrive/user/repositories/user_preferences_repository.dart';
+import 'package:ardrive/user/user_preferences.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -9,6 +12,7 @@ part 'global_hide_state.dart';
 class GlobalHideBloc extends Bloc<GlobalHideEvent, GlobalHideState> {
   final UserPreferencesRepository _userPreferencesRepository;
   final DriveDao _driveDao;
+  StreamSubscription<UserPreferences>? _prefsSubscription;
 
   GlobalHideBloc({
     required UserPreferencesRepository userPreferencesRepository,
@@ -19,7 +23,8 @@ class GlobalHideBloc extends Bloc<GlobalHideEvent, GlobalHideState> {
     // Listen to preferences stream to update state when preferences change.
     // Note: We only update local state here, NOT save back to preferences.
     // Saving is done only in response to user actions (ToggleShowHiddenFiles).
-    _userPreferencesRepository.watch().listen((userPreferences) async {
+    _prefsSubscription =
+        _userPreferencesRepository.watch().listen((userPreferences) async {
       if (userPreferences.showHiddenFiles) {
         add(SyncShowHiddenState(
           showHidden: true,
@@ -54,5 +59,11 @@ class GlobalHideBloc extends Bloc<GlobalHideEvent, GlobalHideState> {
         emit(state.copyWith(userHasHiddenDrive: hasHiddenItems));
       }
     });
+  }
+
+  @override
+  Future<void> close() async {
+    await _prefsSubscription?.cancel();
+    return super.close();
   }
 }

--- a/lib/blocs/hide/global_hide_event.dart
+++ b/lib/blocs/hide/global_hide_event.dart
@@ -24,3 +24,18 @@ class RefreshOptions extends GlobalHideEvent {
 
   const RefreshOptions({required this.userHasHiddenItems});
 }
+
+/// Event to sync local state with preferences stream without saving back.
+/// This prevents infinite loops when the preferences stream emits updates.
+class SyncShowHiddenState extends GlobalHideEvent {
+  final bool showHidden;
+  final bool userHasHiddenItems;
+
+  const SyncShowHiddenState({
+    required this.showHidden,
+    required this.userHasHiddenItems,
+  });
+
+  @override
+  List<Object> get props => [showHidden, userHasHiddenItems];
+}

--- a/lib/components/details_panel.dart
+++ b/lib/components/details_panel.dart
@@ -288,12 +288,15 @@ class _DetailsPanelState extends State<DetailsPanel> {
                     children: [
                       BlocBuilder<DriveDetailCubit, DriveDetailState>(
                         builder: (context, driveDetailState) {
-                          final driveDetailLoadSuccess =
-                              driveDetailState as DriveDetailLoadSuccess;
-                          return DetailsPanelToolbar(
-                            item: widget.item,
-                            driveDetailLoadSuccess: driveDetailLoadSuccess,
-                          );
+                          if (driveDetailState is DriveDetailLoadSuccess) {
+                            return DetailsPanelToolbar(
+                              item: widget.item,
+                              driveDetailLoadSuccess: driveDetailState,
+                            );
+                          }
+                          // For DriveDetailLoadUnsynced or other states,
+                          // don't show the toolbar
+                          return const SizedBox.shrink();
                         },
                       ),
                       const SizedBox(

--- a/lib/components/details_panel.dart
+++ b/lib/components/details_panel.dart
@@ -1589,6 +1589,8 @@ class DetailsPanelToolbar extends StatelessWidget {
                 );
               },
             ),
+          // Note: Sync/Deep Sync/Snapshot actions are in the drive kebab menu
+          // to avoid redundant UI elements
           const Spacer(),
           _buildActionIcon(
             tooltip: appLocalizationsOf(context).close,

--- a/lib/components/new_button/new_button.dart
+++ b/lib/components/new_button/new_button.dart
@@ -88,17 +88,13 @@ class NewButton extends StatelessWidget {
     final subMenuChild = child ??
         Padding(
           padding: const EdgeInsets.only(top: 8),
-          child: ArDriveFAB(
+          child: _HoverableNewButton(
+            tooltip: appLocalizationsOf(context).createNew,
             onPressed: () {
               PlausibleEventTracker.trackNewButton(
                 location: NewButtonLocation.sidebar,
               );
             },
-            backgroundColor:
-                ArDriveTheme.of(context).themeData.colors.themeAccentBrand,
-            child: ArDriveIcons.plus(
-              color: Colors.white,
-            ),
           ),
         );
 
@@ -658,4 +654,66 @@ class ArDriveNewButtonItem extends ArDriveNewButtonComponent {
 
 class ArDriveNewButtonDivider extends ArDriveNewButtonComponent {
   const ArDriveNewButtonDivider();
+}
+
+/// A hoverable FAB for the New button with visible hover effect.
+class _HoverableNewButton extends StatefulWidget {
+  final String tooltip;
+  final VoidCallback onPressed;
+
+  const _HoverableNewButton({
+    required this.tooltip,
+    required this.onPressed,
+  });
+
+  @override
+  State<_HoverableNewButton> createState() => _HoverableNewButtonState();
+}
+
+class _HoverableNewButtonState extends State<_HoverableNewButton> {
+  bool _isHovering = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final baseColor =
+        ArDriveTheme.of(context).themeData.colors.themeAccentBrand;
+    final hoverColor = Color.lerp(baseColor, Colors.black, 0.15)!;
+
+    return ArDriveTooltip(
+      message: widget.tooltip,
+      child: MouseRegion(
+        onEnter: (_) => setState(() => _isHovering = true),
+        onExit: (_) => setState(() => _isHovering = false),
+        cursor: SystemMouseCursors.click,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 150),
+          width: 56,
+          height: 56,
+          decoration: BoxDecoration(
+            color: _isHovering ? hoverColor : baseColor,
+            shape: BoxShape.circle,
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withOpacity(_isHovering ? 0.3 : 0.2),
+                blurRadius: _isHovering ? 8 : 6,
+                offset: Offset(0, _isHovering ? 4 : 2),
+              ),
+            ],
+          ),
+          child: Material(
+            color: Colors.transparent,
+            child: InkWell(
+              onTap: widget.onPressed,
+              customBorder: const CircleBorder(),
+              child: Center(
+                child: ArDriveIcons.plus(
+                  color: Colors.white,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
 }

--- a/lib/components/profile_card.dart
+++ b/lib/components/profile_card.dart
@@ -265,8 +265,11 @@ class _ProfileCardState extends State<ProfileCard> {
                           .read<UserPreferencesRepository>()
                           .watch(),
                       builder: (context, snapshot) {
+                        final repo = context.read<UserPreferencesRepository>();
                         final syncAllDrivesOnLogin =
-                            snapshot.data?.syncAllDrivesOnLogin ?? true;
+                            snapshot.data?.syncAllDrivesOnLogin ??
+                                repo.currentPreferences?.syncAllDrivesOnLogin ??
+                                true;
                         return ArDriveToggleSwitch(
                           alignRight: true,
                           value: syncAllDrivesOnLogin,

--- a/lib/components/profile_card.dart
+++ b/lib/components/profile_card.dart
@@ -75,6 +75,7 @@ class _ProfileCardState extends State<ProfileCard> {
 
   Widget _loggedInView(BuildContext context) {
     return ArDriveClickArea(
+      tooltip: appLocalizationsOf(context).userProfile,
       child: ScreenTypeLayout.builder(
         mobile: (context) => _buildLoggedInViewForPlatform(
           context,

--- a/lib/components/profile_card.dart
+++ b/lib/components/profile_card.dart
@@ -23,6 +23,8 @@ import 'package:ardrive/turbo/utils/utils.dart';
 import 'package:ardrive/user/balance/user_balance_bloc.dart';
 import 'package:ardrive/user/download_wallet/download_wallet_modal.dart';
 import 'package:ardrive/user/name/presentation/bloc/profile_name_bloc.dart';
+import 'package:ardrive/user/repositories/user_preferences_repository.dart';
+import 'package:ardrive/user/user_preferences.dart';
 import 'package:ardrive/utils/app_localizations_wrapper.dart';
 import 'package:ardrive/utils/open_url.dart';
 import 'package:ardrive/utils/plausible_event_tracker/plausible_event_tracker.dart';
@@ -251,6 +253,33 @@ class _ProfileCardState extends State<ProfileCard> {
                                 autoSync: value,
                               ),
                             );
+                      },
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Padding(
+                    padding: const EdgeInsets.only(left: 16.0, right: 16),
+                    child: StreamBuilder<UserPreferences>(
+                      stream: context
+                          .read<UserPreferencesRepository>()
+                          .watch(),
+                      builder: (context, snapshot) {
+                        final syncAllDrivesOnLogin =
+                            snapshot.data?.syncAllDrivesOnLogin ?? true;
+                        return ArDriveToggleSwitch(
+                          alignRight: true,
+                          value: syncAllDrivesOnLogin,
+                          text: appLocalizationsOf(context).syncAllDrivesOnLogin,
+                          textStyle: typography.paragraphNormal(
+                            fontWeight: ArFontWeight.semiBold,
+                            color: colorTokens.textMid,
+                          ),
+                          onChanged: (value) {
+                            context
+                                .read<UserPreferencesRepository>()
+                                .saveSyncAllDrivesOnLogin(value);
+                          },
+                        );
                       },
                     ),
                   ),

--- a/lib/components/progress_dialog.dart
+++ b/lib/components/progress_dialog.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
 
+import 'package:ardrive/misc/resources.dart';
 import 'package:ardrive/utils/show_general_dialog.dart';
 import 'package:ardrive_ui/ardrive_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:lottie/lottie.dart';
 
 Future<void> showProgressDialog(
   BuildContext context, {
@@ -55,14 +57,15 @@ class ProgressDialog extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.center,
           mainAxisSize: MainAxisSize.min,
           children: [
-            const Padding(
-              padding: EdgeInsets.symmetric(vertical: 32),
-              child: SizedBox(
-                width: 74,
-                height: 74,
-                child: CircularProgressIndicator(
-                  strokeWidth: 8,
-                ),
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 32),
+              child: LottieBuilder.asset(
+                Resources.images.login.ardriveLoader,
+                filterQuality: FilterQuality.high,
+                frameRate: FrameRate.max,
+                addRepaintBoundary: true,
+                height: 75,
+                width: 75,
               ),
             ),
             if (progressDescription != null)

--- a/lib/components/progress_dialog.dart
+++ b/lib/components/progress_dialog.dart
@@ -85,7 +85,8 @@ class ProgressDialog extends StatelessWidget {
 
     if (useNewArDriveUI) {
       return ArDriveStandardModalNew(
-        title: title ?? '',
+        // Pass null if titleWidget is provided, otherwise use title or empty string
+        title: titleWidget != null ? title : (title ?? ''),
         titleWidget: titleWidget,
         content: content,
         actions: actions,

--- a/lib/components/progress_dialog.dart
+++ b/lib/components/progress_dialog.dart
@@ -32,13 +32,15 @@ class ProgressDialog extends StatelessWidget {
     this.progressBar,
     this.percentageDetails,
     this.useNewArDriveUI = false,
-  }) : assert(title != null || titleWidget != null,
-            'Either title or titleWidget must be provided');
+  })  : assert(title != null || titleWidget != null,
+            'Either title or titleWidget must be provided'),
+        assert(!(title != null && titleWidget != null),
+            'Provide only one of title or titleWidget, not both');
 
-  /// The title text. If [titleWidget] is provided, this is ignored.
+  /// The title text. Must not be provided if [titleWidget] is provided.
   final String? title;
 
-  /// A widget to display as the title. Takes precedence over [title].
+  /// A widget to display as the title. Must not be provided if [title] is provided.
   final Widget? titleWidget;
 
   final List<ModalAction> actions;
@@ -85,14 +87,15 @@ class ProgressDialog extends StatelessWidget {
 
     if (useNewArDriveUI) {
       return ArDriveStandardModalNew(
-        // Pass null if titleWidget is provided, otherwise use title or empty string
-        title: titleWidget != null ? title : (title ?? ''),
+        // title and titleWidget are mutually exclusive per constructor assertion
+        title: title,
         titleWidget: titleWidget,
         content: content,
         actions: actions,
       );
     }
 
+    // Legacy UI only supports title (not titleWidget)
     return ArDriveStandardModal(
       title: title ?? '',
       content: content,

--- a/lib/components/progress_dialog.dart
+++ b/lib/components/progress_dialog.dart
@@ -23,20 +23,28 @@ Future<void> showProgressDialog(
 class ProgressDialog extends StatelessWidget {
   const ProgressDialog({
     super.key,
-    required this.title,
+    this.title,
+    this.titleWidget,
     this.actions = const [],
     this.progressDescription,
     this.progressBar,
     this.percentageDetails,
     this.useNewArDriveUI = false,
-  });
+  }) : assert(title != null || titleWidget != null,
+            'Either title or titleWidget must be provided');
 
-  final String title;
+  /// The title text. If [titleWidget] is provided, this is ignored.
+  final String? title;
+
+  /// A widget to display as the title. Takes precedence over [title].
+  final Widget? titleWidget;
+
   final List<ModalAction> actions;
   final Widget? progressDescription;
   final Widget? progressBar;
   final Widget? percentageDetails;
   final bool useNewArDriveUI;
+
   @override
   Widget build(BuildContext context) {
     final content = Padding(
@@ -74,14 +82,15 @@ class ProgressDialog extends StatelessWidget {
 
     if (useNewArDriveUI) {
       return ArDriveStandardModalNew(
-        title: title,
+        title: title ?? '',
+        titleWidget: titleWidget,
         content: content,
         actions: actions,
       );
     }
 
     return ArDriveStandardModal(
-      title: title,
+      title: title ?? '',
       content: content,
       actions: actions,
     );

--- a/lib/components/settings_popover.dart
+++ b/lib/components/settings_popover.dart
@@ -4,6 +4,9 @@ import 'package:ardrive/gar/presentation/widgets/gateway_input_modal.dart';
 import 'package:ardrive/pages/drive_detail/components/dropdown_item.dart';
 import 'package:ardrive/services/arweave/arweave_service.dart';
 import 'package:ardrive/services/config/config.dart';
+import 'package:ardrive/user/repositories/user_preferences_repository.dart';
+import 'package:ardrive/user/user_preferences.dart';
+import 'package:ardrive/utils/app_localizations_wrapper.dart';
 import 'package:ardrive/utils/constants.dart';
 import 'package:ardrive/utils/show_general_dialog.dart';
 import 'package:ardrive_http/ardrive_http.dart';
@@ -55,6 +58,50 @@ class SettingsSubmenu extends StatelessWidget {
             child: const ArDriveDropdownItemTile(
               name: 'Set GraphQL Server',
             ),
+          ),
+        ),
+        ArDriveSubmenuItem(
+          widget: StreamBuilder<UserPreferences>(
+            stream: context.read<UserPreferencesRepository>().watch(),
+            builder: (context, streamSnapshot) {
+              final repo = context.read<UserPreferencesRepository>();
+              final syncAllDrivesOnLogin =
+                  streamSnapshot.data?.syncAllDrivesOnLogin ??
+                      repo.currentPreferences?.syncAllDrivesOnLogin ??
+                      true;
+              return GestureDetector(
+                onTap: () {
+                  repo.saveSyncAllDrivesOnLogin(!syncAllDrivesOnLogin);
+                },
+                child: ArDriveHoverWidget(
+                  hoverColor: ArDriveTheme.of(context)
+                      .themeData
+                      .dropdownTheme
+                      .hoverColor,
+                  defaultColor: ArDriveTheme.of(context)
+                      .themeData
+                      .dropdownTheme
+                      .backgroundColor,
+                  child: SizedBox(
+                    height: 48,
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 18.0),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(
+                            appLocalizationsOf(context).syncAllDrivesOnLogin,
+                            style: ArDriveTypography.body.buttonNormalBold(),
+                          ),
+                          const SizedBox(width: 12),
+                          _SyncToggle(value: syncAllDrivesOnLogin),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              );
+            },
           ),
         ),
       ],
@@ -110,6 +157,40 @@ class SettingsSubmenu extends StatelessWidget {
               .read<ArweaveService>()
               .updateGraphQLEndpoint(normalizedEndpoint);
         },
+      ),
+    );
+  }
+}
+
+/// A simple toggle widget matching the ArDrive design
+class _SyncToggle extends StatelessWidget {
+  final bool value;
+
+  const _SyncToggle({required this.value});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ArDriveTheme.of(context).themeData.toggleTheme;
+    return Container(
+      width: 36,
+      height: 20,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(10),
+        color: value ? theme.backgroundOnColor : theme.backgroundOffColor,
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 2),
+        child: Align(
+          alignment: value ? Alignment.centerRight : Alignment.centerLeft,
+          child: Container(
+            width: 12,
+            height: 12,
+            decoration: BoxDecoration(
+              color: value ? theme.indicatorColorOn : theme.indicatorColorOff,
+              borderRadius: BorderRadius.circular(90),
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/lib/components/settings_popover.dart
+++ b/lib/components/settings_popover.dart
@@ -69,34 +69,26 @@ class SettingsSubmenu extends StatelessWidget {
                   streamSnapshot.data?.syncAllDrivesOnLogin ??
                       repo.currentPreferences?.syncAllDrivesOnLogin ??
                       true;
-              return GestureDetector(
-                onTap: () {
-                  repo.saveSyncAllDrivesOnLogin(!syncAllDrivesOnLogin);
-                },
-                child: ArDriveHoverWidget(
-                  hoverColor: ArDriveTheme.of(context)
-                      .themeData
-                      .dropdownTheme
-                      .hoverColor,
-                  defaultColor: ArDriveTheme.of(context)
-                      .themeData
-                      .dropdownTheme
-                      .backgroundColor,
-                  child: SizedBox(
-                    height: 48,
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 18.0),
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Text(
-                            appLocalizationsOf(context).syncAllDrivesOnLogin,
-                            style: ArDriveTypography.body.buttonNormalBold(),
-                          ),
-                          const SizedBox(width: 12),
-                          _SyncToggle(value: syncAllDrivesOnLogin),
-                        ],
-                      ),
+              return ArDriveHoverWidget(
+                hoverColor: ArDriveTheme.of(context)
+                    .themeData
+                    .dropdownTheme
+                    .hoverColor,
+                defaultColor: ArDriveTheme.of(context)
+                    .themeData
+                    .dropdownTheme
+                    .backgroundColor,
+                child: SizedBox(
+                  height: 48,
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 18.0),
+                    child: ArDriveToggleSwitch(
+                      value: syncAllDrivesOnLogin,
+                      text: appLocalizationsOf(context).syncAllDrivesOnLogin,
+                      textStyle: ArDriveTypography.body.buttonNormalBold(),
+                      onChanged: (value) {
+                        repo.saveSyncAllDrivesOnLogin(value);
+                      },
                     ),
                   ),
                 ),
@@ -157,40 +149,6 @@ class SettingsSubmenu extends StatelessWidget {
               .read<ArweaveService>()
               .updateGraphQLEndpoint(normalizedEndpoint);
         },
-      ),
-    );
-  }
-}
-
-/// A simple toggle widget matching the ArDrive design
-class _SyncToggle extends StatelessWidget {
-  final bool value;
-
-  const _SyncToggle({required this.value});
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = ArDriveTheme.of(context).themeData.toggleTheme;
-    return Container(
-      width: 36,
-      height: 20,
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(10),
-        color: value ? theme.backgroundOnColor : theme.backgroundOffColor,
-      ),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 2),
-        child: Align(
-          alignment: value ? Alignment.centerRight : Alignment.centerLeft,
-          child: Container(
-            width: 12,
-            height: 12,
-            decoration: BoxDecoration(
-              color: value ? theme.indicatorColorOn : theme.indicatorColorOff,
-              borderRadius: BorderRadius.circular(90),
-            ),
-          ),
-        ),
       ),
     );
   }

--- a/lib/components/upload_form.dart
+++ b/lib/components/upload_form.dart
@@ -35,7 +35,6 @@ import 'package:ardrive/manifest/domain/manifest_repository.dart';
 import 'package:ardrive/models/models.dart';
 import 'package:ardrive/pages/drive_detail/components/hover_widget.dart';
 import 'package:ardrive/services/services.dart';
-import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
 import 'package:ardrive/theme/theme.dart';
 import 'package:ardrive/utils/app_localizations_wrapper.dart';
 import 'package:ardrive/utils/filesize.dart';
@@ -214,7 +213,6 @@ class _UploadFormState extends State<UploadForm> {
               if (!_isShowingCancelDialog) {
                 Navigator.pop(context);
                 context.read<ActivityTracker>().setUploading(false);
-                context.read<SyncCubit>().startSync();
               }
 
               widget.driveDetailCubit.refreshDriveDataTable();

--- a/lib/components/upload_form.dart
+++ b/lib/components/upload_form.dart
@@ -20,6 +20,7 @@ import 'package:ardrive/components/license/view_license_definition.dart';
 import 'package:ardrive/components/license_details_popover.dart';
 import 'package:ardrive/components/progress_dialog.dart';
 import 'package:ardrive/core/activity_tracker.dart';
+import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
 import 'package:ardrive/core/arfs/entities/arfs_entities.dart';
 import 'package:ardrive/core/arfs/repository/file_repository.dart';
 import 'package:ardrive/core/arfs/repository/folder_repository.dart';
@@ -213,6 +214,7 @@ class _UploadFormState extends State<UploadForm> {
               if (!_isShowingCancelDialog) {
                 Navigator.pop(context);
                 context.read<ActivityTracker>().setUploading(false);
+                context.read<SyncCubit>().startSync();
               }
 
               widget.driveDetailCubit.refreshDriveDataTable();

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -390,6 +390,18 @@
       }
     }
   },
+  "syncThisDrive": "Sync This Drive",
+  "@syncThisDrive": {
+    "description": "Menu option to sync only the current drive"
+  },
+  "deepSyncThisDrive": "Deep Sync This Drive",
+  "@deepSyncThisDrive": {
+    "description": "Menu option to deep sync only the current drive"
+  },
+  "syncAllDrivesOnLogin": "Sync All Drives on Login",
+  "@syncAllDrivesOnLogin": {
+    "description": "Toggle to enable/disable syncing all drives when logging in"
+  },
   "creatingDriveEmphasized": "CREATING DRIVE...",
   "@creatingDriveEmphasized": {
     "description": "The drive is being created. Emphasized with upper case"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -444,7 +444,7 @@
   "@deepResync": {
     "description": "Deep Sync Button Text"
   },
-  "deepResyncTooltip": "Empty cache & refresh all drives",
+  "deepResyncTooltip": "Empty cache & resync all drives",
   "@deepResyncTooltip": {
     "description": "Deep Sync Tooltip Text"
   },
@@ -551,6 +551,18 @@
   },
   "driveDoingInitialSetupMessage": "Your drive is doing it's initial setup. This may take a few minutes. Please wait before taking any action.",
   "@driveDoingInitialSetupMessage": {},
+  "driveNotSynced": "Drive Not Synced",
+  "@driveNotSynced": {
+    "description": "Title shown when a drive has metadata but content has not been synced"
+  },
+  "driveNotSyncedDescription": "This drive needs to be synced before you can view its contents. Sync now to see your files and folders.",
+  "@driveNotSyncedDescription": {
+    "description": "Description shown when a drive has not been synced yet"
+  },
+  "syncThisDriveDescription": "Fetch the latest files and folders from this drive.",
+  "@syncThisDriveDescription": {
+    "description": "Description for the sync drive action card"
+  },
   "driveID": "Drive ID",
   "@driveID": {
     "description": "The Drive-ID tag"
@@ -1882,7 +1894,7 @@
   "@resync": {
     "description": "Sync button Text"
   },
-  "resyncTooltip": "Refresh All Drives",
+  "resyncTooltip": "Drive Synchronization",
   "@resyncTooltip": {
     "description": "resync tooltip text"
   },
@@ -2122,9 +2134,31 @@
   "@sync": {
     "description": "Sync button tooltip"
   },
+  "syncNow": "Sync Now",
+  "@syncNow": {
+    "description": "Button text to sync an unsynced drive"
+  },
   "syncingOnlyOneDrive": "Syncing your drive...",
   "@syncingOnlyOneDrive": {
     "description": "Show the message when the user has only one drive"
+  },
+  "syncingDriveWithName": "Syncing '{driveName}'...",
+  "@syncingDriveWithName": {
+    "description": "Show the message when syncing a specific drive by name",
+    "placeholders": {
+      "driveName": {
+        "type": "String",
+        "example": "My Drive"
+      }
+    }
+  },
+  "syncingAllDrives": "Syncing All Drives",
+  "@syncingAllDrives": {
+    "description": "Title shown when syncing all user drives"
+  },
+  "syncingSingleDrive": "Syncing Drive",
+  "@syncingSingleDrive": {
+    "description": "Title shown when syncing a single drive"
   },
   "syncingPleaseRemainOnThisTab": "Syncing... Please remain on this tab.",
   "@syncingPleaseRemainOnThisTab": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1600,6 +1600,14 @@
   "@newStringEmphasized": {
     "description": "New entity (folder, file, drive, manifest, attached drive). Emphasized with upper case"
   },
+  "createNew": "Create New",
+  "@createNew": {
+    "description": "Tooltip for the New button to create new items"
+  },
+  "userProfile": "User Profile",
+  "@userProfile": {
+    "description": "Tooltip for the user profile button"
+  },
   "next": "Next",
   "@next": {
     "description": "Action of going to the next page"
@@ -2163,6 +2171,10 @@
   "syncingAllDrives": "Syncing All Drives",
   "@syncingAllDrives": {
     "description": "Title shown when syncing all user drives"
+  },
+  "loadingYourDrives": "Loading your drives...",
+  "@loadingYourDrives": {
+    "description": "Title shown when loading drive metadata on login"
   },
   "syncingSingleDrive": "Syncing Drive",
   "@syncingSingleDrive": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -563,6 +563,14 @@
   "@syncThisDriveDescription": {
     "description": "Description for the sync drive action card"
   },
+  "syncAllDrives": "Sync All Drives",
+  "@syncAllDrives": {
+    "description": "Button and title text for syncing all drives"
+  },
+  "syncAllDrivesDescription": "Sync all your drives at once to ensure all content is up to date.",
+  "@syncAllDrivesDescription": {
+    "description": "Description for the sync all drives action card"
+  },
   "driveID": "Drive ID",
   "@driveID": {
     "description": "The Drive-ID tag"

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -527,6 +527,14 @@
   "@syncThisDriveDescription": {
     "description": "Description for the sync drive action card"
   },
+  "syncAllDrives": "Sincronizar Todas las Unidades",
+  "@syncAllDrives": {
+    "description": "Button and title text for syncing all drives"
+  },
+  "syncAllDrivesDescription": "Sincroniza todas tus unidades a la vez para asegurarte de que todo el contenido esté actualizado.",
+  "@syncAllDrivesDescription": {
+    "description": "Description for the sync all drives action card"
+  },
   "driveID": "ID de la unidad",
   "@driveID": {
     "description": "The Drive-ID tag"

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1752,6 +1752,10 @@
   "@syncingSingleDrive": {
     "description": "Title shown when syncing a single drive"
   },
+  "loadingYourDrives": "Cargando tus unidades...",
+  "@loadingYourDrives": {
+    "description": "Title shown when loading drive metadata on login"
+  },
   "syncingPleaseRemainOnThisTab": "Sincronizando... Por favor, permanece en esta pestaña.",
   "@syncingPleaseRemainOnThisTab": {
     "description": "Syncing drives"

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1298,6 +1298,14 @@
   "@newStringEmphasized": {
     "description": "New entity (folder, file, drive, manifest, attached drive). Emphasized with upper case"
   },
+  "createNew": "Crear Nuevo",
+  "@createNew": {
+    "description": "Tooltip for the New button to create new items"
+  },
+  "userProfile": "Perfil de Usuario",
+  "@userProfile": {
+    "description": "Tooltip for the user profile button"
+  },
   "next": "Siguiente",
   "@next": {
     "description": "Action of going to the next page"

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -515,6 +515,18 @@
   },
   "driveDoingInitialSetupMessage": "Tu disco está realizando la configuración inicial. Puede tardar unos minutos. Espera antes de realizar cualquier acción.",
   "@driveDoingInitialSetupMessage": {},
+  "driveNotSynced": "Unidad No Sincronizada",
+  "@driveNotSynced": {
+    "description": "Title shown when a drive has metadata but content has not been synced"
+  },
+  "driveNotSyncedDescription": "Esta unidad necesita ser sincronizada antes de poder ver su contenido. Sincroniza ahora para ver tus archivos y carpetas.",
+  "@driveNotSyncedDescription": {
+    "description": "Description shown when a drive has not been synced yet"
+  },
+  "syncThisDriveDescription": "Obtener los archivos y carpetas más recientes de esta unidad.",
+  "@syncThisDriveDescription": {
+    "description": "Description for the sync drive action card"
+  },
   "driveID": "ID de la unidad",
   "@driveID": {
     "description": "The Drive-ID tag"
@@ -1698,9 +1710,31 @@
   "@sync": {
     "description": "Sync button tooltip"
   },
+  "syncNow": "Sincronizar Ahora",
+  "@syncNow": {
+    "description": "Button text to sync an unsynced drive"
+  },
   "syncingOnlyOneDrive": "Sincronizando la unidad...",
   "@syncingOnlyOneDrive": {
     "description": "Show the message when the user has only one drive"
+  },
+  "syncingDriveWithName": "Sincronizando '{driveName}'...",
+  "@syncingDriveWithName": {
+    "description": "Show the message when syncing a specific drive by name",
+    "placeholders": {
+      "driveName": {
+        "type": "String",
+        "example": "My Drive"
+      }
+    }
+  },
+  "syncingAllDrives": "Sincronizando Todas las Unidades",
+  "@syncingAllDrives": {
+    "description": "Title shown when syncing all user drives"
+  },
+  "syncingSingleDrive": "Sincronizando Unidad",
+  "@syncingSingleDrive": {
+    "description": "Title shown when syncing a single drive"
   },
   "syncingPleaseRemainOnThisTab": "Sincronizando... Por favor, permanece en esta pestaña.",
   "@syncingPleaseRemainOnThisTab": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -366,6 +366,18 @@
       }
     }
   },
+  "syncThisDrive": "Sincronizar esta unidad",
+  "@syncThisDrive": {
+    "description": "Menu option to sync only the current drive"
+  },
+  "deepSyncThisDrive": "Sincronización profunda de esta unidad",
+  "@deepSyncThisDrive": {
+    "description": "Menu option to deep sync only the current drive"
+  },
+  "syncAllDrivesOnLogin": "Sincronizar todas las unidades al iniciar sesión",
+  "@syncAllDrivesOnLogin": {
+    "description": "Toggle to enable/disable syncing all drives when logging in"
+  },
   "creatingDriveEmphasized": "CREANDO UNIDAD...",
   "@creatingDriveEmphasized": {
     "description": "The drive is being created. Emphasized with upper case"

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -527,6 +527,14 @@
   "@syncThisDriveDescription": {
     "description": "Description for the sync drive action card"
   },
+  "syncAllDrives": "सभी ड्राइव सिंक करें",
+  "@syncAllDrives": {
+    "description": "Button and title text for syncing all drives"
+  },
+  "syncAllDrivesDescription": "सभी सामग्री अप-टू-डेट रखने के लिए अपनी सभी ड्राइव एक साथ सिंक करें।",
+  "@syncAllDrivesDescription": {
+    "description": "Description for the sync all drives action card"
+  },
   "driveID": "ड्राइव ID",
   "@driveID": {
     "description": "The Drive-ID tag"

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -515,6 +515,18 @@
   },
   "driveDoingInitialSetupMessage": "आपका ड्राइव इसका इनिशियल सेटअप कर रहा है. इसमें कुछ मिनट्स लग सकते हैं. कोई एक्शन लेने से पहले कृप्या इंतज़ार करें. ",
   "@driveDoingInitialSetupMessage": {},
+  "driveNotSynced": "ड्राइव सिंक नहीं हुई",
+  "@driveNotSynced": {
+    "description": "Title shown when a drive has metadata but content has not been synced"
+  },
+  "driveNotSyncedDescription": "इस ड्राइव की सामग्री देखने से पहले इसे सिंक करना आवश्यक है। अपनी फ़ाइलें और फ़ोल्डर देखने के लिए अभी सिंक करें।",
+  "@driveNotSyncedDescription": {
+    "description": "Description shown when a drive has not been synced yet"
+  },
+  "syncThisDriveDescription": "इस ड्राइव से नवीनतम फ़ाइलें और फ़ोल्डर प्राप्त करें।",
+  "@syncThisDriveDescription": {
+    "description": "Description for the sync drive action card"
+  },
   "driveID": "ड्राइव ID",
   "@driveID": {
     "description": "The Drive-ID tag"
@@ -1698,9 +1710,31 @@
   "@sync": {
     "description": "Sync button tooltip"
   },
+  "syncNow": "अभी सिंक करें",
+  "@syncNow": {
+    "description": "Button text to sync an unsynced drive"
+  },
   "syncingOnlyOneDrive": "आपकी ड्राइव सिंक हो रही है...",
   "@syncingOnlyOneDrive": {
     "description": "Show the message when the user has only one drive"
+  },
+  "syncingDriveWithName": "'{driveName}' सिंक हो रहा है...",
+  "@syncingDriveWithName": {
+    "description": "Show the message when syncing a specific drive by name",
+    "placeholders": {
+      "driveName": {
+        "type": "String",
+        "example": "My Drive"
+      }
+    }
+  },
+  "syncingAllDrives": "सभी ड्राइव सिंक हो रही हैं",
+  "@syncingAllDrives": {
+    "description": "Title shown when syncing all user drives"
+  },
+  "syncingSingleDrive": "ड्राइव सिंक हो रही है",
+  "@syncingSingleDrive": {
+    "description": "Title shown when syncing a single drive"
   },
   "syncingPleaseRemainOnThisTab": "सिंक हो रही है... कृपया इस टैब पर बने रहें।",
   "@syncingPleaseRemainOnThisTab": {

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -1752,6 +1752,10 @@
   "@syncingSingleDrive": {
     "description": "Title shown when syncing a single drive"
   },
+  "loadingYourDrives": "आपकी ड्राइव लोड हो रही हैं...",
+  "@loadingYourDrives": {
+    "description": "Title shown when loading drive metadata on login"
+  },
   "syncingPleaseRemainOnThisTab": "सिंक हो रही है... कृपया इस टैब पर बने रहें।",
   "@syncingPleaseRemainOnThisTab": {
     "description": "Syncing drives"

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -366,6 +366,18 @@
       }
     }
   },
+  "syncThisDrive": "इस ड्राइव को सिंक करें",
+  "@syncThisDrive": {
+    "description": "Menu option to sync only the current drive"
+  },
+  "deepSyncThisDrive": "इस ड्राइव को डीप सिंक करें",
+  "@deepSyncThisDrive": {
+    "description": "Menu option to deep sync only the current drive"
+  },
+  "syncAllDrivesOnLogin": "लॉगिन पर सभी ड्राइव सिंक करें",
+  "@syncAllDrivesOnLogin": {
+    "description": "Toggle to enable/disable syncing all drives when logging in"
+  },
   "creatingDriveEmphasized": "ड्राइव बनाया जा रहा है...",
   "@creatingDriveEmphasized": {
     "description": "The drive is being created. Emphasized with upper case"

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -1298,6 +1298,14 @@
   "@newStringEmphasized": {
     "description": "New entity (folder, file, drive, manifest, attached drive). Emphasized with upper case"
   },
+  "createNew": "नया बनाएं",
+  "@createNew": {
+    "description": "Tooltip for the New button to create new items"
+  },
+  "userProfile": "उपयोगकर्ता प्रोफ़ाइल",
+  "@userProfile": {
+    "description": "Tooltip for the user profile button"
+  },
   "next": "अगला",
   "@next": {
     "description": "Action of going to the next page"

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -366,6 +366,18 @@
       }
     }
   },
+  "syncThisDrive": "このドライブを同期",
+  "@syncThisDrive": {
+    "description": "Menu option to sync only the current drive"
+  },
+  "deepSyncThisDrive": "このドライブをディープ同期",
+  "@deepSyncThisDrive": {
+    "description": "Menu option to deep sync only the current drive"
+  },
+  "syncAllDrivesOnLogin": "ログイン時にすべてのドライブを同期",
+  "@syncAllDrivesOnLogin": {
+    "description": "Toggle to enable/disable syncing all drives when logging in"
+  },
   "creatingDriveEmphasized": "ドライブを作成中…",
   "@creatingDriveEmphasized": {
     "description": "The drive is being created. Emphasized with upper case"

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -515,6 +515,18 @@
   },
   "driveDoingInitialSetupMessage": "ドライブが初期設定を行っています。数分かかる場合があります。操作を行う前にしばらくお待ちください。",
   "@driveDoingInitialSetupMessage": {},
+  "driveNotSynced": "ドライブ未同期",
+  "@driveNotSynced": {
+    "description": "Title shown when a drive has metadata but content has not been synced"
+  },
+  "driveNotSyncedDescription": "このドライブのコンテンツを表示するには同期が必要です。今すぐ同期してファイルとフォルダを表示してください。",
+  "@driveNotSyncedDescription": {
+    "description": "Description shown when a drive has not been synced yet"
+  },
+  "syncThisDriveDescription": "このドライブから最新のファイルとフォルダを取得します。",
+  "@syncThisDriveDescription": {
+    "description": "Description for the sync drive action card"
+  },
   "driveID": "ドライブID",
   "@driveID": {
     "description": "The Drive-ID tag"
@@ -1698,9 +1710,31 @@
   "@sync": {
     "description": "Sync button tooltip"
   },
+  "syncNow": "今すぐ同期",
+  "@syncNow": {
+    "description": "Button text to sync an unsynced drive"
+  },
   "syncingOnlyOneDrive": "ドライブの同期中…",
   "@syncingOnlyOneDrive": {
     "description": "Show the message when the user has only one drive"
+  },
+  "syncingDriveWithName": "'{driveName}'を同期中...",
+  "@syncingDriveWithName": {
+    "description": "Show the message when syncing a specific drive by name",
+    "placeholders": {
+      "driveName": {
+        "type": "String",
+        "example": "My Drive"
+      }
+    }
+  },
+  "syncingAllDrives": "すべてのドライブを同期中",
+  "@syncingAllDrives": {
+    "description": "Title shown when syncing all user drives"
+  },
+  "syncingSingleDrive": "ドライブを同期中",
+  "@syncingSingleDrive": {
+    "description": "Title shown when syncing a single drive"
   },
   "syncingPleaseRemainOnThisTab": "同期中... このタブにとどまっていてください。",
   "@syncingPleaseRemainOnThisTab": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -527,6 +527,14 @@
   "@syncThisDriveDescription": {
     "description": "Description for the sync drive action card"
   },
+  "syncAllDrives": "すべてのドライブを同期",
+  "@syncAllDrives": {
+    "description": "Button and title text for syncing all drives"
+  },
+  "syncAllDrivesDescription": "すべてのドライブを一度に同期して、すべてのコンテンツを最新の状態に保ちます。",
+  "@syncAllDrivesDescription": {
+    "description": "Description for the sync all drives action card"
+  },
   "driveID": "ドライブID",
   "@driveID": {
     "description": "The Drive-ID tag"

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1298,6 +1298,14 @@
   "@newStringEmphasized": {
     "description": "New entity (folder, file, drive, manifest, attached drive). Emphasized with upper case"
   },
+  "createNew": "新規作成",
+  "@createNew": {
+    "description": "Tooltip for the New button to create new items"
+  },
+  "userProfile": "ユーザープロフィール",
+  "@userProfile": {
+    "description": "Tooltip for the user profile button"
+  },
   "next": "次へ",
   "@next": {
     "description": "Action of going to the next page"

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1752,6 +1752,10 @@
   "@syncingSingleDrive": {
     "description": "Title shown when syncing a single drive"
   },
+  "loadingYourDrives": "ドライブを読み込んでいます...",
+  "@loadingYourDrives": {
+    "description": "Title shown when loading drive metadata on login"
+  },
   "syncingPleaseRemainOnThisTab": "同期中... このタブにとどまっていてください。",
   "@syncingPleaseRemainOnThisTab": {
     "description": "Syncing drives"

--- a/lib/l10n/app_zh-HK.arb
+++ b/lib/l10n/app_zh-HK.arb
@@ -515,6 +515,18 @@
   },
   "driveDoingInitialSetupMessage": "你的硬碟正在進行初步設定。這可能需要幾分鐘的時間。請等待後再作出行動。",
   "@driveDoingInitialSetupMessage": {},
+  "driveNotSynced": "磁碟機未同步",
+  "@driveNotSynced": {
+    "description": "Title shown when a drive has metadata but content has not been synced"
+  },
+  "driveNotSyncedDescription": "此磁碟機需要同步後才能查看其內容。立即同步以查看您的檔案和資料夾。",
+  "@driveNotSyncedDescription": {
+    "description": "Description shown when a drive has not been synced yet"
+  },
+  "syncThisDriveDescription": "獲取此磁碟機的最新檔案和資料夾。",
+  "@syncThisDriveDescription": {
+    "description": "Description for the sync drive action card"
+  },
   "driveID": "檔案盤識別碼",
   "@driveID": {
     "description": "The Drive-ID tag"
@@ -1698,9 +1710,31 @@
   "@sync": {
     "description": "Sync button tooltip"
   },
+  "syncNow": "立即同步",
+  "@syncNow": {
+    "description": "Button text to sync an unsynced drive"
+  },
   "syncingOnlyOneDrive": "正在同步處理你的檔案盤 ...",
   "@syncingOnlyOneDrive": {
     "description": "Show the message when the user has only one drive"
+  },
+  "syncingDriveWithName": "正在同步'{driveName}'...",
+  "@syncingDriveWithName": {
+    "description": "Show the message when syncing a specific drive by name",
+    "placeholders": {
+      "driveName": {
+        "type": "String",
+        "example": "My Drive"
+      }
+    }
+  },
+  "syncingAllDrives": "正在同步所有磁碟機",
+  "@syncingAllDrives": {
+    "description": "Title shown when syncing all user drives"
+  },
+  "syncingSingleDrive": "正在同步磁碟機",
+  "@syncingSingleDrive": {
+    "description": "Title shown when syncing a single drive"
   },
   "syncingPleaseRemainOnThisTab": "正在同步處理, 請停留在現處頁介面。",
   "@syncingPleaseRemainOnThisTab": {

--- a/lib/l10n/app_zh-HK.arb
+++ b/lib/l10n/app_zh-HK.arb
@@ -1752,6 +1752,10 @@
   "@syncingSingleDrive": {
     "description": "Title shown when syncing a single drive"
   },
+  "loadingYourDrives": "正在載入您的磁碟機...",
+  "@loadingYourDrives": {
+    "description": "Title shown when loading drive metadata on login"
+  },
   "syncingPleaseRemainOnThisTab": "正在同步處理, 請停留在現處頁介面。",
   "@syncingPleaseRemainOnThisTab": {
     "description": "Syncing drives"

--- a/lib/l10n/app_zh-HK.arb
+++ b/lib/l10n/app_zh-HK.arb
@@ -527,6 +527,14 @@
   "@syncThisDriveDescription": {
     "description": "Description for the sync drive action card"
   },
+  "syncAllDrives": "同步所有磁碟機",
+  "@syncAllDrives": {
+    "description": "Button and title text for syncing all drives"
+  },
+  "syncAllDrivesDescription": "一次同步所有磁碟機，確保所有內容都是最新的。",
+  "@syncAllDrivesDescription": {
+    "description": "Description for the sync all drives action card"
+  },
   "driveID": "檔案盤識別碼",
   "@driveID": {
     "description": "The Drive-ID tag"

--- a/lib/l10n/app_zh-HK.arb
+++ b/lib/l10n/app_zh-HK.arb
@@ -1298,6 +1298,14 @@
   "@newStringEmphasized": {
     "description": "New entity (folder, file, drive, manifest, attached drive). Emphasized with upper case"
   },
+  "createNew": "新建",
+  "@createNew": {
+    "description": "Tooltip for the New button to create new items"
+  },
+  "userProfile": "用戶資料",
+  "@userProfile": {
+    "description": "Tooltip for the user profile button"
+  },
   "next": "後一頁",
   "@next": {
     "description": "Action of going to the next page"

--- a/lib/l10n/app_zh-HK.arb
+++ b/lib/l10n/app_zh-HK.arb
@@ -366,6 +366,18 @@
       }
     }
   },
+  "syncThisDrive": "同步此磁碟機",
+  "@syncThisDrive": {
+    "description": "Menu option to sync only the current drive"
+  },
+  "deepSyncThisDrive": "深度同步此磁碟機",
+  "@deepSyncThisDrive": {
+    "description": "Menu option to deep sync only the current drive"
+  },
+  "syncAllDrivesOnLogin": "登入時同步所有磁碟機",
+  "@syncAllDrivesOnLogin": {
+    "description": "Toggle to enable/disable syncing all drives when logging in"
+  },
   "creatingDriveEmphasized": "正在建立檔案盤",
   "@creatingDriveEmphasized": {
     "description": "The drive is being created. Emphasized with upper case"

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -366,6 +366,18 @@
       }
     }
   },
+  "syncThisDrive": "同步此驱动器",
+  "@syncThisDrive": {
+    "description": "Menu option to sync only the current drive"
+  },
+  "deepSyncThisDrive": "深度同步此驱动器",
+  "@deepSyncThisDrive": {
+    "description": "Menu option to deep sync only the current drive"
+  },
+  "syncAllDrivesOnLogin": "登录时同步所有驱动器",
+  "@syncAllDrivesOnLogin": {
+    "description": "Toggle to enable/disable syncing all drives when logging in"
+  },
   "creatingDriveEmphasized": "创建网盘中...",
   "@creatingDriveEmphasized": {
     "description": "The drive is being created. Emphasized with upper case"

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1752,6 +1752,10 @@
   "@syncingSingleDrive": {
     "description": "Title shown when syncing a single drive"
   },
+  "loadingYourDrives": "正在加载您的驱动器...",
+  "@loadingYourDrives": {
+    "description": "Title shown when loading drive metadata on login"
+  },
   "syncingPleaseRemainOnThisTab": "同步中... 请留在本页面.",
   "@syncingPleaseRemainOnThisTab": {
     "description": "Syncing drives"

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -366,15 +366,15 @@
       }
     }
   },
-  "syncThisDrive": "同步此驱动器",
+  "syncThisDrive": "同步此网盘",
   "@syncThisDrive": {
     "description": "Menu option to sync only the current drive"
   },
-  "deepSyncThisDrive": "深度同步此驱动器",
+  "deepSyncThisDrive": "深度同步此网盘",
   "@deepSyncThisDrive": {
     "description": "Menu option to deep sync only the current drive"
   },
-  "syncAllDrivesOnLogin": "登录时同步所有驱动器",
+  "syncAllDrivesOnLogin": "登录时同步所有网盘",
   "@syncAllDrivesOnLogin": {
     "description": "Toggle to enable/disable syncing all drives when logging in"
   },
@@ -515,23 +515,23 @@
   },
   "driveDoingInitialSetupMessage": "你的驱动正在进行初始设置。这可能需要几分钟。请在采取任何动作之前先等待。",
   "@driveDoingInitialSetupMessage": {},
-  "driveNotSynced": "驱动器未同步",
+  "driveNotSynced": "网盘未同步",
   "@driveNotSynced": {
     "description": "Title shown when a drive has metadata but content has not been synced"
   },
-  "driveNotSyncedDescription": "此驱动器需要同步后才能查看其内容。立即同步以查看您的文件和文件夹。",
+  "driveNotSyncedDescription": "此网盘需要同步后才能查看其内容。立即同步以查看您的文件和文件夹。",
   "@driveNotSyncedDescription": {
     "description": "Description shown when a drive has not been synced yet"
   },
-  "syncThisDriveDescription": "获取此驱动器的最新文件和文件夹。",
+  "syncThisDriveDescription": "获取此网盘的最新文件和文件夹。",
   "@syncThisDriveDescription": {
     "description": "Description for the sync drive action card"
   },
-  "syncAllDrives": "同步所有驱动器",
+  "syncAllDrives": "同步所有网盘",
   "@syncAllDrives": {
     "description": "Button and title text for syncing all drives"
   },
-  "syncAllDrivesDescription": "一次同步所有驱动器，确保所有内容都是最新的。",
+  "syncAllDrivesDescription": "一次同步所有网盘，确保所有内容都是最新的。",
   "@syncAllDrivesDescription": {
     "description": "Description for the sync all drives action card"
   },
@@ -1744,15 +1744,15 @@
       }
     }
   },
-  "syncingAllDrives": "正在同步所有驱动器",
+  "syncingAllDrives": "正在同步所有网盘",
   "@syncingAllDrives": {
     "description": "Title shown when syncing all user drives"
   },
-  "syncingSingleDrive": "正在同步驱动器",
+  "syncingSingleDrive": "正在同步网盘",
   "@syncingSingleDrive": {
     "description": "Title shown when syncing a single drive"
   },
-  "loadingYourDrives": "正在加载您的驱动器...",
+  "loadingYourDrives": "正在加载您的网盘...",
   "@loadingYourDrives": {
     "description": "Title shown when loading drive metadata on login"
   },

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -527,6 +527,14 @@
   "@syncThisDriveDescription": {
     "description": "Description for the sync drive action card"
   },
+  "syncAllDrives": "同步所有驱动器",
+  "@syncAllDrives": {
+    "description": "Button and title text for syncing all drives"
+  },
+  "syncAllDrivesDescription": "一次同步所有驱动器，确保所有内容都是最新的。",
+  "@syncAllDrivesDescription": {
+    "description": "Description for the sync all drives action card"
+  },
   "driveID": "网盘ID",
   "@driveID": {
     "description": "The Drive-ID tag"

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -515,6 +515,18 @@
   },
   "driveDoingInitialSetupMessage": "你的驱动正在进行初始设置。这可能需要几分钟。请在采取任何动作之前先等待。",
   "@driveDoingInitialSetupMessage": {},
+  "driveNotSynced": "驱动器未同步",
+  "@driveNotSynced": {
+    "description": "Title shown when a drive has metadata but content has not been synced"
+  },
+  "driveNotSyncedDescription": "此驱动器需要同步后才能查看其内容。立即同步以查看您的文件和文件夹。",
+  "@driveNotSyncedDescription": {
+    "description": "Description shown when a drive has not been synced yet"
+  },
+  "syncThisDriveDescription": "获取此驱动器的最新文件和文件夹。",
+  "@syncThisDriveDescription": {
+    "description": "Description for the sync drive action card"
+  },
   "driveID": "网盘ID",
   "@driveID": {
     "description": "The Drive-ID tag"
@@ -1698,9 +1710,31 @@
   "@sync": {
     "description": "Sync button tooltip"
   },
+  "syncNow": "立即同步",
+  "@syncNow": {
+    "description": "Button text to sync an unsynced drive"
+  },
   "syncingOnlyOneDrive": "同步你的网盘中...",
   "@syncingOnlyOneDrive": {
     "description": "Show the message when the user has only one drive"
+  },
+  "syncingDriveWithName": "正在同步'{driveName}'...",
+  "@syncingDriveWithName": {
+    "description": "Show the message when syncing a specific drive by name",
+    "placeholders": {
+      "driveName": {
+        "type": "String",
+        "example": "My Drive"
+      }
+    }
+  },
+  "syncingAllDrives": "正在同步所有驱动器",
+  "@syncingAllDrives": {
+    "description": "Title shown when syncing all user drives"
+  },
+  "syncingSingleDrive": "正在同步驱动器",
+  "@syncingSingleDrive": {
+    "description": "Title shown when syncing a single drive"
   },
   "syncingPleaseRemainOnThisTab": "同步中... 请留在本页面.",
   "@syncingPleaseRemainOnThisTab": {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1298,6 +1298,14 @@
   "@newStringEmphasized": {
     "description": "New entity (folder, file, drive, manifest, attached drive). Emphasized with upper case"
   },
+  "createNew": "新建",
+  "@createNew": {
+    "description": "Tooltip for the New button to create new items"
+  },
+  "userProfile": "用户资料",
+  "@userProfile": {
+    "description": "Tooltip for the user profile button"
+  },
   "next": "下一页",
   "@next": {
     "description": "Action of going to the next page"

--- a/lib/misc/resources.dart
+++ b/lib/misc/resources.dart
@@ -46,7 +46,7 @@ class Brand {
 class Login {
   const Login();
 
-  final String ardriveLogoOnboarding = 'assets/images/brand/2x.png';
+  final String ardriveLogoOnboarding = 'assets/images/brand/ArDrive.png';
   final String wanderLogo = 'assets/images/login/wander.svg';
   final String lattice = 'assets/images/login/lattice.svg';
   final String latticeLight = 'assets/images/login/lattice_light.svg';

--- a/lib/pages/app_router_delegate.dart
+++ b/lib/pages/app_router_delegate.dart
@@ -298,6 +298,8 @@ class AppRouterDelegate extends RouterDelegate<AppRoutePath>
                         promptToSnapshotBloc:
                             context.read<PromptToSnapshotBloc>(),
                         tabVisibility: TabVisibilitySingleton(),
+                        userPreferencesRepository:
+                            context.read<UserPreferencesRepository>(),
                       ),
                     ),
                     BlocProvider(

--- a/lib/pages/drive_detail/components/drive_detail_unsynced_card.dart
+++ b/lib/pages/drive_detail/components/drive_detail_unsynced_card.dart
@@ -126,7 +126,7 @@ class _UnsyncedDriveHeader extends StatelessWidget {
       ArDriveDropdownItem(
         onClick: () {
           final bloc = context.read<DriveDetailCubit>();
-          bloc.selectDataItem(
+          bloc.selectDriveInfoForUnsyncedDrive(
             DriveDataTableItemMapper.fromDrive(
               drive,
               (_) => null,
@@ -267,7 +267,7 @@ class _UnsyncedDriveMobileView extends StatelessWidget {
       ArDriveDropdownItem(
         onClick: () {
           final bloc = context.read<DriveDetailCubit>();
-          bloc.selectDataItem(
+          bloc.selectDriveInfoForUnsyncedDrive(
             DriveDataTableItemMapper.fromDrive(
               drive,
               (_) => null,
@@ -301,6 +301,7 @@ class _UnsyncedDriveMobileView extends StatelessWidget {
 }
 
 /// Content card shown for drives that haven't been synced yet.
+/// Matches the sleek design of DriveDetailFolderEmptyCard.
 class DriveDetailUnsyncedCard extends StatelessWidget {
   final Drive drive;
 
@@ -322,21 +323,18 @@ class DriveDetailUnsyncedCard extends StatelessWidget {
     final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
 
     return SingleChildScrollView(
-      child: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const SizedBox(height: 40),
-            ArDriveIcons.cloudSync(size: 48, color: colorTokens.textMid),
-            const SizedBox(height: 24),
-            Text(
-              appLocalizationsOf(context).driveNotSynced,
-              style: typography.heading4(fontWeight: ArFontWeight.bold),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 12),
-            Text(
+      child: Column(
+        children: [
+          const SizedBox(height: 40),
+          Text(
+            appLocalizationsOf(context).driveNotSynced,
+            style: typography.heading4(fontWeight: ArFontWeight.bold),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 10),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Text(
               appLocalizationsOf(context).driveNotSyncedDescription,
               style: typography.paragraphLarge(
                 color: colorTokens.textLow,
@@ -344,10 +342,13 @@ class DriveDetailUnsyncedCard extends StatelessWidget {
               ),
               textAlign: TextAlign.center,
             ),
-            const SizedBox(height: 32),
-            _buildSyncActionCard(context),
-          ],
-        ),
+          ),
+          const SizedBox(height: 20),
+          _buildSyncThisDriveCard(context),
+          const SizedBox(height: 20),
+          _buildSyncAllDrivesCard(context),
+          const SizedBox(height: 20),
+        ],
       ),
     );
   }
@@ -364,33 +365,52 @@ class DriveDetailUnsyncedCard extends StatelessWidget {
           width: double.infinity,
           backgroundColor: colorTokens.containerL1,
           content: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
             children: [
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 66),
-                child: Column(
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                   children: [
-                    ArDriveIcons.cloudSync(size: 48, color: colorTokens.textMid),
-                    const SizedBox(height: 24),
-                    Text(
-                      appLocalizationsOf(context).driveNotSynced,
-                      style: typography.display(fontWeight: ArFontWeight.bold),
-                      textAlign: TextAlign.center,
+                    ArDriveImage(
+                      image: AssetImage(Resources.images.login.confetti),
                     ),
-                    const SizedBox(height: 16),
-                    Text(
-                      appLocalizationsOf(context).driveNotSyncedDescription,
-                      style: typography.heading5(
-                        color: colorTokens.textLow,
-                        fontWeight: ArFontWeight.semiBold,
+                    Flexible(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: [
+                          Text(
+                            appLocalizationsOf(context).driveNotSynced,
+                            style: typography.display(
+                              fontWeight: ArFontWeight.bold,
+                            ),
+                          ),
+                          const SizedBox(height: 10),
+                          Text(
+                            appLocalizationsOf(context)
+                                .driveNotSyncedDescription,
+                            style: typography.heading5(
+                              color: colorTokens.textLow,
+                              fontWeight: ArFontWeight.semiBold,
+                            ),
+                            textAlign: TextAlign.center,
+                          ),
+                        ],
                       ),
-                      textAlign: TextAlign.center,
+                    ),
+                    ArDriveImage(
+                      image: AssetImage(Resources.images.login.confetti),
                     ),
                   ],
                 ),
               ),
-              const SizedBox(height: 40),
-              _buildSyncActionCard(context),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: [
+                  _buildSyncThisDriveCard(context),
+                  _buildSyncAllDrivesCard(context),
+                ],
+              ),
             ],
           ),
         ),
@@ -398,8 +418,8 @@ class DriveDetailUnsyncedCard extends StatelessWidget {
     );
   }
 
-  /// Builds a sync action card matching the style of other action cards in the app.
-  Widget _buildSyncActionCard(BuildContext context) {
+  /// Builds the "Sync This Drive" action card.
+  Widget _buildSyncThisDriveCard(BuildContext context) {
     final typography = ArDriveTypographyNew.of(context);
     final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
 
@@ -414,7 +434,8 @@ class DriveDetailUnsyncedCard extends StatelessWidget {
           ArDriveIcons.refresh(size: 25),
           Text(
             appLocalizationsOf(context).syncThisDrive,
-            style: typography.paragraphXLarge(fontWeight: ArFontWeight.semiBold),
+            style:
+                typography.paragraphXLarge(fontWeight: ArFontWeight.semiBold),
           ),
           const SizedBox(height: 10),
           Text(
@@ -433,6 +454,48 @@ class DriveDetailUnsyncedCard extends StatelessWidget {
               context.read<DriveDetailCubit>().syncCurrentDrive();
             },
             variant: ButtonVariant.primary,
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// Builds the "Sync All Drives" action card.
+  Widget _buildSyncAllDrivesCard(BuildContext context) {
+    final typography = ArDriveTypographyNew.of(context);
+    final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
+
+    return ArDriveCard(
+      width: 283,
+      height: 283,
+      backgroundColor: colorTokens.containerL2,
+      contentPadding: const EdgeInsets.all(31),
+      content: Column(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: [
+          ArDriveIcons.cloudSync(size: 25),
+          Text(
+            appLocalizationsOf(context).syncAllDrives,
+            style:
+                typography.paragraphXLarge(fontWeight: ArFontWeight.semiBold),
+          ),
+          const SizedBox(height: 10),
+          Text(
+            appLocalizationsOf(context).syncAllDrivesDescription,
+            style: typography.paragraphNormal(
+              color: colorTokens.textMid,
+              fontWeight: ArFontWeight.semiBold,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 20),
+          ArDriveButtonNew(
+            text: appLocalizationsOf(context).syncAllDrives,
+            typography: typography,
+            onPressed: () {
+              context.read<SyncCubit>().startSync();
+            },
+            variant: ButtonVariant.secondary,
           ),
         ],
       ),

--- a/lib/pages/drive_detail/components/drive_detail_unsynced_card.dart
+++ b/lib/pages/drive_detail/components/drive_detail_unsynced_card.dart
@@ -1,0 +1,441 @@
+part of '../drive_detail_page.dart';
+
+/// Header card for unsynced drive view with drive name and limited kebab menu.
+class _UnsyncedDriveHeader extends StatelessWidget {
+  final Drive drive;
+  final bool isOwner;
+
+  const _UnsyncedDriveHeader({
+    required this.drive,
+    required this.isOwner,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ArDriveCard(
+      backgroundColor:
+          ArDriveTheme.of(context).themeData.tableTheme.backgroundColor,
+      contentPadding: const EdgeInsets.symmetric(
+        horizontal: 16,
+        vertical: 8,
+      ),
+      content: Row(
+        children: [
+          // Drive name as breadcrumb (just the root since it's unsynced)
+          Expanded(
+            child: Row(
+              children: [
+                ArDriveClickArea(
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      ArDriveIcons.folderOutline(
+                        size: 18,
+                        color: ArDriveTheme.of(context)
+                            .themeData
+                            .colors
+                            .themeFgDefault,
+                      ),
+                      const SizedBox(width: 8),
+                      Text(
+                        drive.name,
+                        style: ArDriveTypography.body.buttonLargeBold(
+                          color: ArDriveTheme.of(context)
+                              .themeData
+                              .colors
+                              .themeFgDefault,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+          // Kebab menu with limited options for unsynced drive
+          Padding(
+            padding: const EdgeInsets.only(right: 16.0),
+            child: ArDriveClickArea(
+              tooltip: appLocalizationsOf(context).showMenu,
+              child: ArDriveDropdown(
+                anchor: const Aligned(
+                  follower: Alignment.topRight,
+                  target: Alignment.bottomRight,
+                ),
+                items: _buildMenuItems(context),
+                child: HoverWidget(
+                  child: ArDriveIcons.kebabMenu(),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  List<ArDriveDropdownItem> _buildMenuItems(BuildContext context) {
+    return [
+      // Sync This Drive
+      ArDriveDropdownItem(
+        onClick: () {
+          context.read<DriveDetailCubit>().syncCurrentDrive();
+        },
+        content: ArDriveDropdownItemTile(
+          name: appLocalizationsOf(context).syncThisDrive,
+          icon: ArDriveIcons.refresh(size: defaultIconSize),
+        ),
+      ),
+      // Hide (only for owner)
+      if (isOwner)
+        ArDriveDropdownItem(
+          onClick: () {
+            promptToToggleHideState(
+              context,
+              item: DriveDataTableItemMapper.fromDrive(
+                drive,
+                (_) => null,
+                0,
+                isOwner,
+              ),
+            );
+          },
+          content: ArDriveDropdownItemTile(
+            name: drive.isHidden
+                ? appLocalizationsOf(context).unhide
+                : appLocalizationsOf(context).hide,
+            icon: drive.isHidden
+                ? ArDriveIcons.eyeOpen(size: defaultIconSize)
+                : ArDriveIcons.eyeClosed(size: defaultIconSize),
+          ),
+        ),
+      // Share Drive
+      ArDriveDropdownItem(
+        onClick: () {
+          promptToShareDrive(
+            context: context,
+            drive: drive,
+          );
+        },
+        content: ArDriveDropdownItemTile(
+          name: appLocalizationsOf(context).shareDrive,
+          icon: ArDriveIcons.share(size: defaultIconSize),
+        ),
+      ),
+      // More Info
+      ArDriveDropdownItem(
+        onClick: () {
+          final bloc = context.read<DriveDetailCubit>();
+          bloc.selectDataItem(
+            DriveDataTableItemMapper.fromDrive(
+              drive,
+              (_) => null,
+              0,
+              isOwner,
+            ),
+          );
+        },
+        content: ArDriveDropdownItemTile(
+          name: appLocalizationsOf(context).moreInfo,
+          icon: ArDriveIcons.info(size: defaultIconSize),
+        ),
+      ),
+      // Detach Drive (for non-owners who are logged in)
+      if (!isOwner && context.read<ProfileCubit>().state is ProfileLoggedIn)
+        ArDriveDropdownItem(
+          onClick: () {
+            showDetachDriveDialog(
+              context: context,
+              driveID: drive.id,
+              driveName: drive.name,
+            );
+          },
+          content: ArDriveDropdownItemTile(
+            name: appLocalizationsOf(context).detachDrive,
+            icon: ArDriveIcons.detach(),
+          ),
+        ),
+    ];
+  }
+}
+
+/// Mobile view for unsynced drive with folder navigation header and content.
+class _UnsyncedDriveMobileView extends StatelessWidget {
+  final Drive drive;
+  final bool isOwner;
+
+  const _UnsyncedDriveMobileView({
+    required this.drive,
+    required this.isOwner,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        // Mobile folder navigation header with kebab menu
+        SizedBox(
+          height: 45,
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.only(left: 16, top: 6, bottom: 6),
+                  child: Text(
+                    drive.name,
+                    style: ArDriveTypography.body.buttonNormalBold(),
+                  ),
+                ),
+              ),
+              ArDriveDropdown(
+                anchor: const Aligned(
+                  follower: Alignment.topRight,
+                  target: Alignment.bottomRight,
+                ),
+                items: _buildMobileMenuItems(context),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 24.0,
+                    vertical: 8,
+                  ),
+                  child: HoverWidget(
+                    child: ArDriveIcons.kebabMenu(),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        // Content area
+        Expanded(
+          child: DriveDetailUnsyncedCard(drive: drive),
+        ),
+      ],
+    );
+  }
+
+  List<ArDriveDropdownItem> _buildMobileMenuItems(BuildContext context) {
+    return [
+      // Sync This Drive
+      ArDriveDropdownItem(
+        onClick: () {
+          context.read<DriveDetailCubit>().syncCurrentDrive();
+        },
+        content: ArDriveDropdownItemTile(
+          name: appLocalizationsOf(context).syncThisDrive,
+          icon: ArDriveIcons.refresh(size: defaultIconSize),
+        ),
+      ),
+      // Hide (only for owner)
+      if (isOwner)
+        ArDriveDropdownItem(
+          onClick: () {
+            promptToToggleHideState(
+              context,
+              item: DriveDataTableItemMapper.fromDrive(
+                drive,
+                (_) => null,
+                0,
+                isOwner,
+              ),
+            );
+          },
+          content: ArDriveDropdownItemTile(
+            name: drive.isHidden
+                ? appLocalizationsOf(context).unhide
+                : appLocalizationsOf(context).hide,
+            icon: drive.isHidden
+                ? ArDriveIcons.eyeOpen(size: defaultIconSize)
+                : ArDriveIcons.eyeClosed(size: defaultIconSize),
+          ),
+        ),
+      // Share Drive
+      ArDriveDropdownItem(
+        onClick: () {
+          promptToShareDrive(
+            context: context,
+            drive: drive,
+          );
+        },
+        content: ArDriveDropdownItemTile(
+          name: appLocalizationsOf(context).shareDrive,
+          icon: ArDriveIcons.share(size: defaultIconSize),
+        ),
+      ),
+      // More Info
+      ArDriveDropdownItem(
+        onClick: () {
+          final bloc = context.read<DriveDetailCubit>();
+          bloc.selectDataItem(
+            DriveDataTableItemMapper.fromDrive(
+              drive,
+              (_) => null,
+              0,
+              isOwner,
+            ),
+          );
+        },
+        content: ArDriveDropdownItemTile(
+          name: appLocalizationsOf(context).moreInfo,
+          icon: ArDriveIcons.info(size: defaultIconSize),
+        ),
+      ),
+      // Detach Drive (for non-owners who are logged in)
+      if (!isOwner && context.read<ProfileCubit>().state is ProfileLoggedIn)
+        ArDriveDropdownItem(
+          onClick: () {
+            showDetachDriveDialog(
+              context: context,
+              driveID: drive.id,
+              driveName: drive.name,
+            );
+          },
+          content: ArDriveDropdownItemTile(
+            name: appLocalizationsOf(context).detachDrive,
+            icon: ArDriveIcons.detach(),
+          ),
+        ),
+    ];
+  }
+}
+
+/// Content card shown for drives that haven't been synced yet.
+class DriveDetailUnsyncedCard extends StatelessWidget {
+  final Drive drive;
+
+  const DriveDetailUnsyncedCard({
+    super.key,
+    required this.drive,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ScreenTypeLayout.builder(
+      mobile: (context) => _buildMobileContent(context),
+      desktop: (context) => _buildDesktopContent(context),
+    );
+  }
+
+  Widget _buildMobileContent(BuildContext context) {
+    final typography = ArDriveTypographyNew.of(context);
+    final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
+
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const SizedBox(height: 40),
+            ArDriveIcons.cloudSync(size: 48, color: colorTokens.textMid),
+            const SizedBox(height: 24),
+            Text(
+              appLocalizationsOf(context).driveNotSynced,
+              style: typography.heading4(fontWeight: ArFontWeight.bold),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              appLocalizationsOf(context).driveNotSyncedDescription,
+              style: typography.paragraphLarge(
+                color: colorTokens.textLow,
+                fontWeight: ArFontWeight.semiBold,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 32),
+            _buildSyncActionCard(context),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDesktopContent(BuildContext context) {
+    final typography = ArDriveTypographyNew.of(context);
+    final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 20),
+      child: SizedBox(
+        height: MediaQuery.of(context).size.height * 0.8,
+        child: ArDriveCard(
+          width: double.infinity,
+          backgroundColor: colorTokens.containerL1,
+          content: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 66),
+                child: Column(
+                  children: [
+                    ArDriveIcons.cloudSync(size: 48, color: colorTokens.textMid),
+                    const SizedBox(height: 24),
+                    Text(
+                      appLocalizationsOf(context).driveNotSynced,
+                      style: typography.display(fontWeight: ArFontWeight.bold),
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      appLocalizationsOf(context).driveNotSyncedDescription,
+                      style: typography.heading5(
+                        color: colorTokens.textLow,
+                        fontWeight: ArFontWeight.semiBold,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 40),
+              _buildSyncActionCard(context),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Builds a sync action card matching the style of other action cards in the app.
+  Widget _buildSyncActionCard(BuildContext context) {
+    final typography = ArDriveTypographyNew.of(context);
+    final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
+
+    return ArDriveCard(
+      width: 283,
+      height: 283,
+      backgroundColor: colorTokens.containerL2,
+      contentPadding: const EdgeInsets.all(31),
+      content: Column(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: [
+          ArDriveIcons.refresh(size: 25),
+          Text(
+            appLocalizationsOf(context).syncThisDrive,
+            style: typography.paragraphXLarge(fontWeight: ArFontWeight.semiBold),
+          ),
+          const SizedBox(height: 10),
+          Text(
+            appLocalizationsOf(context).syncThisDriveDescription,
+            style: typography.paragraphNormal(
+              color: colorTokens.textMid,
+              fontWeight: ArFontWeight.semiBold,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 20),
+          ArDriveButtonNew(
+            text: appLocalizationsOf(context).syncNow,
+            typography: typography,
+            onPressed: () {
+              context.read<DriveDetailCubit>().syncCurrentDrive();
+            },
+            variant: ButtonVariant.primary,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/drive_detail/components/drive_detail_unsynced_card.dart
+++ b/lib/pages/drive_detail/components/drive_detail_unsynced_card.dart
@@ -369,37 +369,22 @@ class DriveDetailUnsyncedCard extends StatelessWidget {
             children: [
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 66),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                child: Column(
                   children: [
-                    ArDriveImage(
-                      image: AssetImage(Resources.images.login.confetti),
-                    ),
-                    Flexible(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.center,
-                        children: [
-                          Text(
-                            appLocalizationsOf(context).driveNotSynced,
-                            style: typography.display(
-                              fontWeight: ArFontWeight.bold,
-                            ),
-                          ),
-                          const SizedBox(height: 10),
-                          Text(
-                            appLocalizationsOf(context)
-                                .driveNotSyncedDescription,
-                            style: typography.heading5(
-                              color: colorTokens.textLow,
-                              fontWeight: ArFontWeight.semiBold,
-                            ),
-                            textAlign: TextAlign.center,
-                          ),
-                        ],
+                    Text(
+                      appLocalizationsOf(context).driveNotSynced,
+                      style: typography.display(
+                        fontWeight: ArFontWeight.bold,
                       ),
                     ),
-                    ArDriveImage(
-                      image: AssetImage(Resources.images.login.confetti),
+                    const SizedBox(height: 10),
+                    Text(
+                      appLocalizationsOf(context).driveNotSyncedDescription,
+                      style: typography.heading5(
+                        color: colorTokens.textLow,
+                        fontWeight: ArFontWeight.semiBold,
+                      ),
+                      textAlign: TextAlign.center,
                     ),
                   ],
                 ),

--- a/lib/pages/drive_detail/components/drive_explorer_item_tile.dart
+++ b/lib/pages/drive_detail/components/drive_explorer_item_tile.dart
@@ -928,7 +928,7 @@ class EntityActionsMenu extends StatelessWidget {
                 size: defaultIconSize,
               ),
             )),
-        if (isOwner)
+        if (isOwner && drive != null)
           ArDriveDropdownItem(
             onClick: () {
               promptToRenameDrive(
@@ -944,7 +944,7 @@ class EntityActionsMenu extends StatelessWidget {
               ),
             ),
           ),
-        if (isOwner)
+        if (isOwner && drive != null)
           ArDriveDropdownItem(
             onClick: () {
               promptToCreateSnapshot(context, drive!);
@@ -956,34 +956,36 @@ class EntityActionsMenu extends StatelessWidget {
               ),
             ),
           ),
-        ArDriveDropdownItem(
-          onClick: () {
-            context.read<SyncCubit>().startSyncForDrive(
-                  driveId: drive!.id,
-                  deepSync: false,
-                );
-          },
-          content: ArDriveDropdownItemTile(
-            name: appLocalizationsOf(context).syncThisDrive,
-            icon: ArDriveIcons.refresh(
-              size: defaultIconSize,
+        if (drive != null)
+          ArDriveDropdownItem(
+            onClick: () {
+              context.read<SyncCubit>().startSyncForDrive(
+                    driveId: drive!.id,
+                    deepSync: false,
+                  );
+            },
+            content: ArDriveDropdownItemTile(
+              name: appLocalizationsOf(context).syncThisDrive,
+              icon: ArDriveIcons.refresh(
+                size: defaultIconSize,
+              ),
             ),
           ),
-        ),
-        ArDriveDropdownItem(
-          onClick: () {
-            context.read<SyncCubit>().startSyncForDrive(
-                  driveId: drive!.id,
-                  deepSync: true,
-                );
-          },
-          content: ArDriveDropdownItemTile(
-            name: appLocalizationsOf(context).deepSyncThisDrive,
-            icon: ArDriveIcons.cloudSync(
-              size: defaultIconSize,
+        if (drive != null)
+          ArDriveDropdownItem(
+            onClick: () {
+              context.read<SyncCubit>().startSyncForDrive(
+                    driveId: drive!.id,
+                    deepSync: true,
+                  );
+            },
+            content: ArDriveDropdownItemTile(
+              name: appLocalizationsOf(context).deepSyncThisDrive,
+              icon: ArDriveIcons.cloudSync(
+                size: defaultIconSize,
+              ),
             ),
           ),
-        ),
         if (isOwner)
           ArDriveDropdownItem(
             onClick: () {

--- a/lib/pages/drive_detail/components/drive_explorer_item_tile.dart
+++ b/lib/pages/drive_detail/components/drive_explorer_item_tile.dart
@@ -8,9 +8,11 @@ import 'package:ardrive/components/components.dart';
 import 'package:ardrive/components/csv_export_dialog.dart';
 import 'package:ardrive/components/drive_rename_form.dart';
 import 'package:ardrive/components/fs_entry_license_form.dart';
+import 'package:ardrive/components/create_snapshot_dialog.dart';
 import 'package:ardrive/components/ghost_fixer_form.dart';
 import 'package:ardrive/components/hide_dialog.dart';
 import 'package:ardrive/components/pin_indicator.dart';
+import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
 import 'package:ardrive/core/crypto/crypto.dart';
 import 'package:ardrive/download/multiple_file_download_modal.dart';
 import 'package:ardrive/drive_explorer/thumbnail/repository/thumbnail_repository.dart';
@@ -926,17 +928,58 @@ class EntityActionsMenu extends StatelessWidget {
                 size: defaultIconSize,
               ),
             )),
+        if (isOwner)
+          ArDriveDropdownItem(
+            onClick: () {
+              promptToRenameDrive(
+                context,
+                driveId: drive!.id,
+                driveName: drive!.name,
+              );
+            },
+            content: ArDriveDropdownItemTile(
+              name: appLocalizationsOf(context).renameDrive,
+              icon: ArDriveIcons.edit(
+                size: defaultIconSize,
+              ),
+            ),
+          ),
+        if (isOwner)
+          ArDriveDropdownItem(
+            onClick: () {
+              promptToCreateSnapshot(context, drive!);
+            },
+            content: ArDriveDropdownItemTile(
+              name: appLocalizationsOf(context).createSnapshot,
+              icon: ArDriveIcons.iconCreateSnapshot(
+                size: defaultIconSize,
+              ),
+            ),
+          ),
         ArDriveDropdownItem(
           onClick: () {
-            promptToRenameDrive(
-              context,
-              driveId: drive!.id,
-              driveName: drive!.name,
-            );
+            context.read<SyncCubit>().startSyncForDrive(
+                  driveId: drive!.id,
+                  deepSync: false,
+                );
           },
           content: ArDriveDropdownItemTile(
-            name: appLocalizationsOf(context).renameDrive,
-            icon: ArDriveIcons.edit(
+            name: appLocalizationsOf(context).syncThisDrive,
+            icon: ArDriveIcons.refresh(
+              size: defaultIconSize,
+            ),
+          ),
+        ),
+        ArDriveDropdownItem(
+          onClick: () {
+            context.read<SyncCubit>().startSyncForDrive(
+                  driveId: drive!.id,
+                  deepSync: true,
+                );
+          },
+          content: ArDriveDropdownItemTile(
+            name: appLocalizationsOf(context).deepSyncThisDrive,
+            icon: ArDriveIcons.cloudSync(
               size: defaultIconSize,
             ),
           ),

--- a/lib/pages/drive_detail/drive_detail_page.dart
+++ b/lib/pages/drive_detail/drive_detail_page.dart
@@ -520,6 +520,42 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
                                             ),
                                           ),
                                         ),
+                                        ArDriveDropdownItem(
+                                          onClick: () {
+                                            context
+                                                .read<SyncCubit>()
+                                                .startSyncForDrive(
+                                                  driveId: driveDetailState
+                                                      .currentDrive.id,
+                                                  deepSync: false,
+                                                );
+                                          },
+                                          content: ArDriveDropdownItemTile(
+                                            name: appLocalizationsOf(context)
+                                                .syncThisDrive,
+                                            icon: ArDriveIcons.refresh(
+                                              size: defaultIconSize,
+                                            ),
+                                          ),
+                                        ),
+                                        ArDriveDropdownItem(
+                                          onClick: () {
+                                            context
+                                                .read<SyncCubit>()
+                                                .startSyncForDrive(
+                                                  driveId: driveDetailState
+                                                      .currentDrive.id,
+                                                  deepSync: true,
+                                                );
+                                          },
+                                          content: ArDriveDropdownItemTile(
+                                            name: appLocalizationsOf(context)
+                                                .deepSyncThisDrive,
+                                            icon: ArDriveIcons.cloudSync(
+                                              size: defaultIconSize,
+                                            ),
+                                          ),
+                                        ),
                                         if (isDriveOwner)
                                           ArDriveDropdownItem(
                                             onClick: () {
@@ -1207,6 +1243,34 @@ class MobileFolderNavigation extends StatelessWidget {
                         ),
                       ),
                     ],
+                    ArDriveDropdownItem(
+                      onClick: () {
+                        context.read<SyncCubit>().startSyncForDrive(
+                              driveId: state.currentDrive.id,
+                              deepSync: false,
+                            );
+                      },
+                      content: ArDriveDropdownItemTile(
+                        name: appLocalizationsOf(context).syncThisDrive,
+                        icon: ArDriveIcons.refresh(
+                          size: defaultIconSize,
+                        ),
+                      ),
+                    ),
+                    ArDriveDropdownItem(
+                      onClick: () {
+                        context.read<SyncCubit>().startSyncForDrive(
+                              driveId: state.currentDrive.id,
+                              deepSync: true,
+                            );
+                      },
+                      content: ArDriveDropdownItemTile(
+                        name: appLocalizationsOf(context).deepSyncThisDrive,
+                        icon: ArDriveIcons.cloudSync(
+                          size: defaultIconSize,
+                        ),
+                      ),
+                    ),
                     ArDriveDropdownItem(
                       onClick: () {
                         promptToShareDrive(

--- a/lib/pages/drive_detail/drive_detail_page.dart
+++ b/lib/pages/drive_detail/drive_detail_page.dart
@@ -141,11 +141,15 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
                   state.sharedDrives.isNotEmpty) {
                 final cubit = context.read<DriveDetailCubit>();
 
+                logger.d('[BlocListener] DrivesLoadSuccess: selectedDriveId=${state.selectedDriveId}, cubit.currentDriveId=${cubit.currentDriveId}');
+
                 // Don't re-trigger changeDrive if we're already viewing/loading this drive
                 if (cubit.currentDriveId == state.selectedDriveId) {
+                  logger.d('[BlocListener] Skipping changeDrive - already handling this driveId');
                   return;
                 }
 
+                logger.d('[BlocListener] Calling changeDrive(${state.selectedDriveId})');
                 cubit.changeDrive(state.selectedDriveId!);
               } else {
                 context.read<DriveDetailCubit>().showEmptyDriveDetail();

--- a/lib/pages/drive_detail/drive_detail_page.dart
+++ b/lib/pages/drive_detail/drive_detail_page.dart
@@ -272,38 +272,86 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
                           ),
                         ],
                         child: ScreenTypeLayout.builder(
-                          mobile: (context) => Scaffold(
-                            drawerScrimColor: Colors.transparent,
-                            drawer: const AppSideBar(),
-                            appBar: const MobileAppBar(),
-                            body: _UnsyncedDriveMobileView(
-                              drive: driveDetailState.drive,
-                              isOwner: isOwner,
-                            ),
-                          ),
+                          mobile: (context) {
+                            // Show full-screen DetailsPanel on mobile when drive info is selected
+                            if (driveDetailState.showDriveInfo &&
+                                driveDetailState.selectedItem != null) {
+                              return Material(
+                                child: PopScope(
+                                  canPop: false,
+                                  onPopInvoked: (didPop) {
+                                    context
+                                        .read<DriveDetailCubit>()
+                                        .closeDriveInfoForUnsyncedDrive();
+                                  },
+                                  child: DetailsPanel(
+                                    currentDrive: driveDetailState.drive,
+                                    isSharePage: false,
+                                    drivePrivacy:
+                                        driveDetailState.drive.privacy,
+                                    item: driveDetailState.selectedItem!,
+                                    canNavigateThroughImages: false,
+                                  ),
+                                ),
+                              );
+                            }
+                            return Scaffold(
+                              drawerScrimColor: Colors.transparent,
+                              drawer: const AppSideBar(),
+                              appBar: const MobileAppBar(),
+                              body: _UnsyncedDriveMobileView(
+                                drive: driveDetailState.drive,
+                                isOwner: isOwner,
+                              ),
+                            );
+                          },
                           desktop: (context) => Column(
                             children: [
                               const AppTopBar(),
                               Expanded(
-                                child: Padding(
-                                  padding:
-                                      const EdgeInsets.fromLTRB(0, 0, 16, 0),
-                                  child: Column(
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.start,
-                                    children: [
-                                      _UnsyncedDriveHeader(
-                                        drive: driveDetailState.drive,
-                                        isOwner: isOwner,
-                                      ),
-                                      const SizedBox(height: 30),
-                                      Expanded(
-                                        child: DriveDetailUnsyncedCard(
-                                          drive: driveDetailState.drive,
+                                child: Row(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Expanded(
+                                      child: Padding(
+                                        padding: const EdgeInsets.fromLTRB(
+                                            0, 0, 16, 0),
+                                        child: Column(
+                                          crossAxisAlignment:
+                                              CrossAxisAlignment.start,
+                                          children: [
+                                            _UnsyncedDriveHeader(
+                                              drive: driveDetailState.drive,
+                                              isOwner: isOwner,
+                                            ),
+                                            const SizedBox(height: 30),
+                                            Expanded(
+                                              child: DriveDetailUnsyncedCard(
+                                                drive: driveDetailState.drive,
+                                              ),
+                                            ),
+                                          ],
                                         ),
                                       ),
-                                    ],
-                                  ),
+                                    ),
+                                    // Details panel for unsynced drive
+                                    if (driveDetailState.showDriveInfo &&
+                                        driveDetailState.selectedItem != null)
+                                      ConstrainedBox(
+                                        constraints: const BoxConstraints(
+                                          maxWidth: 420,
+                                          minWidth: 310,
+                                        ),
+                                        child: DetailsPanel(
+                                          item: driveDetailState.selectedItem!,
+                                          isSharePage: false,
+                                          drivePrivacy:
+                                              driveDetailState.drive.privacy,
+                                          canNavigateThroughImages: false,
+                                          currentDrive: driveDetailState.drive,
+                                        ),
+                                      ),
+                                  ],
                                 ),
                               ),
                             ],

--- a/lib/pages/drive_detail/drive_detail_page.dart
+++ b/lib/pages/drive_detail/drive_detail_page.dart
@@ -76,6 +76,7 @@ import 'package:visibility_detector/visibility_detector.dart';
 part 'components/drive_detail_breadcrumb_row.dart';
 part 'components/drive_detail_data_list.dart';
 part 'components/drive_detail_folder_empty_card.dart';
+part 'components/drive_detail_unsynced_card.dart';
 part 'components/fs_entry_preview_widget.dart';
 
 class DriveDetailPage extends StatefulWidget {
@@ -186,7 +187,22 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
                             widget.anonymouslyShowDriveDetail,
                       );
                     } else if (driveDetailState is DriveDetailLoadInProgress) {
-                      return const Center(child: CircularProgressIndicator());
+                      return ScreenTypeLayout.builder(
+                        mobile: (context) => const Scaffold(
+                          drawerScrimColor: Colors.transparent,
+                          drawer: AppSideBar(),
+                          appBar: MobileAppBar(),
+                          body: Center(child: CircularProgressIndicator()),
+                        ),
+                        desktop: (context) => const Column(
+                          children: [
+                            AppTopBar(),
+                            Expanded(
+                              child: Center(child: CircularProgressIndicator()),
+                            ),
+                          ],
+                        ),
+                      );
                     } else if (driveDetailState is DriveInitialLoading) {
                       return ArDriveDevToolsShortcuts(
                         customShortcuts: [
@@ -235,6 +251,62 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
                                 ),
                               ],
                             ),
+                          ),
+                        ),
+                      );
+                    } else if (driveDetailState is DriveDetailLoadUnsynced) {
+                      final isOwner = isDriveOwner(
+                        context.read<ArDriveAuth>(),
+                        driveDetailState.drive.ownerAddress,
+                      );
+
+                      return ArDriveDevToolsShortcuts(
+                        customShortcuts: [
+                          Shortcut(
+                            modifier: LogicalKeyboardKey.shiftLeft,
+                            key: LogicalKeyboardKey.keyH,
+                            action: () {
+                              ArDriveDevTools.instance
+                                  .showDevTools(optionalContext: context);
+                            },
+                          ),
+                        ],
+                        child: ScreenTypeLayout.builder(
+                          mobile: (context) => Scaffold(
+                            drawerScrimColor: Colors.transparent,
+                            drawer: const AppSideBar(),
+                            appBar: const MobileAppBar(),
+                            body: _UnsyncedDriveMobileView(
+                              drive: driveDetailState.drive,
+                              isOwner: isOwner,
+                            ),
+                          ),
+                          desktop: (context) => Column(
+                            children: [
+                              const AppTopBar(),
+                              Expanded(
+                                child: Padding(
+                                  padding:
+                                      const EdgeInsets.fromLTRB(0, 0, 16, 0),
+                                  child: Column(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
+                                    children: [
+                                      _UnsyncedDriveHeader(
+                                        drive: driveDetailState.drive,
+                                        isOwner: isOwner,
+                                      ),
+                                      const SizedBox(height: 30),
+                                      Expanded(
+                                        child: DriveDetailUnsyncedCard(
+                                          drive: driveDetailState.drive,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              ),
+                            ],
                           ),
                         ),
                       );

--- a/lib/pages/drive_detail/drive_detail_page.dart
+++ b/lib/pages/drive_detail/drive_detail_page.dart
@@ -141,15 +141,11 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
                   state.sharedDrives.isNotEmpty) {
                 final cubit = context.read<DriveDetailCubit>();
 
-                logger.d('[BlocListener] DrivesLoadSuccess: selectedDriveId=${state.selectedDriveId}, cubit.currentDriveId=${cubit.currentDriveId}');
-
                 // Don't re-trigger changeDrive if we're already viewing/loading this drive
                 if (cubit.currentDriveId == state.selectedDriveId) {
-                  logger.d('[BlocListener] Skipping changeDrive - already handling this driveId');
                   return;
                 }
 
-                logger.d('[BlocListener] Calling changeDrive(${state.selectedDriveId})');
                 cubit.changeDrive(state.selectedDriveId!);
               } else {
                 context.read<DriveDetailCubit>().showEmptyDriveDetail();

--- a/lib/pages/drive_detail/drive_detail_page.dart
+++ b/lib/pages/drive_detail/drive_detail_page.dart
@@ -139,21 +139,14 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
             if (state is DrivesLoadSuccess) {
               if (state.userDrives.isNotEmpty ||
                   state.sharedDrives.isNotEmpty) {
-                final driveDetailState = context.read<DriveDetailCubit>().state;
+                final cubit = context.read<DriveDetailCubit>();
 
-                // Don't re-trigger changeDrive if we're already viewing this drive
-                if (driveDetailState is DriveDetailLoadSuccess &&
-                    driveDetailState.currentDrive.id == state.selectedDriveId) {
-                  return;
-                }
-                if (driveDetailState is DriveDetailLoadUnsynced &&
-                    driveDetailState.drive.id == state.selectedDriveId) {
+                // Don't re-trigger changeDrive if we're already viewing/loading this drive
+                if (cubit.currentDriveId == state.selectedDriveId) {
                   return;
                 }
 
-                context
-                    .read<DriveDetailCubit>()
-                    .changeDrive(state.selectedDriveId!);
+                cubit.changeDrive(state.selectedDriveId!);
               } else {
                 context.read<DriveDetailCubit>().showEmptyDriveDetail();
               }

--- a/lib/pages/drive_detail/drive_detail_page.dart
+++ b/lib/pages/drive_detail/drive_detail_page.dart
@@ -141,8 +141,13 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
                   state.sharedDrives.isNotEmpty) {
                 final driveDetailState = context.read<DriveDetailCubit>().state;
 
+                // Don't re-trigger changeDrive if we're already viewing this drive
                 if (driveDetailState is DriveDetailLoadSuccess &&
                     driveDetailState.currentDrive.id == state.selectedDriveId) {
+                  return;
+                }
+                if (driveDetailState is DriveDetailLoadUnsynced &&
+                    driveDetailState.drive.id == state.selectedDriveId) {
                   return;
                 }
 

--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -190,14 +190,14 @@ class SyncCubit extends Cubit<SyncState> {
 
   /// Fetches only drive metadata without full content sync.
   /// Used when syncAllDrivesOnLogin is disabled to populate the sidebar.
-  /// This runs silently without emitting SyncInProgress to avoid blocking
-  /// code that waits for sync via waitCurrentSync().
+  /// Emits SyncLoadingDrives for UI feedback but doesn't block waitCurrentSync().
   Future<void> syncMetadataOnly() async {
     logger.d('Starting metadata-only sync');
     final profile = _profileCubit.state;
     if (profile is ProfileLoggedIn) {
-      // Don't emit SyncInProgress - this is a lightweight background operation
-      // and we don't want to block waitCurrentSync() callers
+      // Emit SyncLoadingDrives for UI feedback (shows "Loading your drives...")
+      // This is separate from SyncInProgress so it doesn't block waitCurrentSync()
+      emit(SyncLoadingDrives());
       try {
         await _syncRepository.updateUserDrives(
           wallet: profile.user.wallet,
@@ -208,6 +208,7 @@ class SyncCubit extends Cubit<SyncState> {
       } catch (e, stackTrace) {
         logger.e('Error fetching drive metadata', e, stackTrace);
       }
+      emit(SyncIdle());
     } else {
       logger.d('Profile not logged in yet, skipping metadata sync');
     }

--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -96,7 +96,8 @@ class SyncCubit extends Cubit<SyncState> {
       // avoiding race conditions with tab visibility checks.
       startSync();
     } else {
-      logger.d('Skipping initial sync: syncAllDrivesOnLogin is disabled');
+      logger.d('Skipping full sync: syncAllDrivesOnLogin is disabled');
+      syncMetadataOnly();
     }
 
     // Cancel any existing subscription before creating a new one
@@ -187,6 +188,31 @@ class SyncCubit extends Cubit<SyncState> {
 
   var ghostFolders = <FolderID, GhostFolder>{};
 
+  /// Fetches only drive metadata without full content sync.
+  /// Used when syncAllDrivesOnLogin is disabled to populate the sidebar.
+  /// This runs silently without emitting SyncInProgress to avoid blocking
+  /// code that waits for sync via waitCurrentSync().
+  Future<void> syncMetadataOnly() async {
+    logger.d('Starting metadata-only sync');
+    final profile = _profileCubit.state;
+    if (profile is ProfileLoggedIn) {
+      // Don't emit SyncInProgress - this is a lightweight background operation
+      // and we don't want to block waitCurrentSync() callers
+      try {
+        await _syncRepository.updateUserDrives(
+          wallet: profile.user.wallet,
+          password: profile.user.password,
+          cipherKey: profile.user.cipherKey,
+        );
+        logger.d('Metadata-only sync completed successfully');
+      } catch (e, stackTrace) {
+        logger.e('Error fetching drive metadata', e, stackTrace);
+      }
+    } else {
+      logger.d('Profile not logged in yet, skipping metadata sync');
+    }
+  }
+
   Future<void> startSync({bool deepSync = false}) async {
     logger.i('Starting Sync');
 
@@ -210,6 +236,10 @@ class SyncCubit extends Cubit<SyncState> {
       _initSync = DateTime.now();
 
       emit(SyncInProgress());
+      // Emit initial progress AFTER SyncInProgress so the modal is already
+      // listening to the stream when we emit
+      syncProgressController.add(_syncProgress);
+
       // Only sync in drives owned by the user if they're logged in.
       logger.d('Checking if user is logged in...');
 
@@ -339,7 +369,11 @@ class SyncCubit extends Cubit<SyncState> {
       return;
     }
 
-    _syncProgress = SyncProgress.initial();
+    // Mark as single drive sync from the start so the UI shows the right title
+    _syncProgress = SyncProgress.initial().copyWith(
+      isSingleDriveSync: true,
+      drivesCount: 1,
+    );
 
     // Create a new cancellation token for this sync
     _currentSyncToken?.dispose();
@@ -354,6 +388,9 @@ class SyncCubit extends Cubit<SyncState> {
       _initSync = DateTime.now();
 
       emit(SyncInProgress());
+      // Emit initial progress AFTER SyncInProgress so the modal is already
+      // listening to the stream when we emit
+      syncProgressController.add(_syncProgress);
 
       if (profile is ProfileLoggedIn) {
         wallet = profile.user.wallet;

--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -46,7 +46,7 @@ class SyncCubit extends Cubit<SyncState> {
       StreamController<SyncProgress>.broadcast();
   DateTime? _lastSync;
   late DateTime _initSync;
-  late SyncProgress _syncProgress;
+  SyncProgress _syncProgress = SyncProgress.initial();
   SyncCancellationToken? _currentSyncToken;
 
   SyncCubit({
@@ -77,14 +77,15 @@ class SyncCubit extends Cubit<SyncState> {
   }
 
   /// Waits for the current sync to finish.
+  /// SyncLoadingDrives is treated as non-blocking (metadata-only loading).
   Future<void> waitCurrentSync() async {
-    if (state is! SyncIdle) {
+    if (state is! SyncIdle && state is! SyncLoadingDrives) {
       await for (var state in stream) {
-        // Break on any terminal state (sync finished, failed, cancelled, or completed with errors)
         if (state is SyncIdle ||
             state is SyncFailure ||
             state is SyncCancelled ||
-            state is SyncCompleteWithErrors) {
+            state is SyncCompleteWithErrors ||
+            state is SyncLoadingDrives) {
           break;
         }
       }
@@ -444,6 +445,13 @@ class SyncCubit extends Cubit<SyncState> {
           emit(SyncIdle());
           return;
         }
+
+        // Load drive keys so private drives can be decrypted
+        await _syncRepository.updateUserDrives(
+          wallet: wallet,
+          password: password,
+          cipherKey: cipherKey,
+        );
       }
 
       _promptToSnapshotBloc.add(const SyncRunning(isRunning: true));

--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -88,6 +88,13 @@ class SyncCubit extends Cubit<SyncState> {
   void createSyncStream() async {
     logger.d('Creating sync stream to periodically call sync automatically');
 
+    // Emit SyncLoadingDrives immediately to prevent race conditions where
+    // DriveDetailCubit's waitCurrentSync() returns early before sync starts.
+    // This ensures any code waiting for sync to complete will actually wait.
+    // Using SyncLoadingDrives (not SyncInProgress) to avoid triggering the
+    // abort guard in startSync().
+    emit(SyncLoadingDrives());
+
     // Check if syncAllDrivesOnLogin preference is enabled before initial sync
     final preferences = await _userPreferencesRepository.load();
     if (preferences.syncAllDrivesOnLogin) {

--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -12,6 +12,7 @@ import 'package:ardrive/sync/domain/ghost_folder.dart';
 import 'package:ardrive/sync/domain/repositories/sync_repository.dart';
 import 'package:ardrive/sync/domain/sync_cancellation_token.dart';
 import 'package:ardrive/sync/domain/sync_progress.dart';
+import 'package:ardrive/user/repositories/user_preferences_repository.dart';
 import 'package:ardrive/utils/logger.dart';
 import 'package:ardrive_utils/ardrive_utils.dart';
 import 'package:arweave/arweave.dart';
@@ -35,6 +36,7 @@ class SyncCubit extends Cubit<SyncState> {
   final TabVisibilitySingleton _tabVisibility;
   final ConfigService _configService;
   final SyncRepository _syncRepository;
+  final UserPreferencesRepository _userPreferencesRepository;
 
   StreamSubscription? _restartOnFocusStreamSubscription;
   StreamSubscription? _restartArConnectOnFocusStreamSubscription;
@@ -55,12 +57,14 @@ class SyncCubit extends Cubit<SyncState> {
     required ConfigService configService,
     required ActivityTracker activityTracker,
     required SyncRepository syncRepository,
+    required UserPreferencesRepository userPreferencesRepository,
   })  : _profileCubit = profileCubit,
         _activityCubit = activityCubit,
         _promptToSnapshotBloc = promptToSnapshotBloc,
         _configService = configService,
         _tabVisibility = tabVisibility,
         _syncRepository = syncRepository,
+        _userPreferencesRepository = userPreferencesRepository,
         super(SyncIdle()) {
     // Sync the user's drives on start and periodically.
     createSyncStream();
@@ -84,10 +88,16 @@ class SyncCubit extends Cubit<SyncState> {
   void createSyncStream() async {
     logger.d('Creating sync stream to periodically call sync automatically');
 
-    // Start initial sync immediately without waiting for async operations.
-    // This ensures sync runs while the tab is still focused after login,
-    // avoiding race conditions with tab visibility checks.
-    startSync();
+    // Check if syncAllDrivesOnLogin preference is enabled before initial sync
+    final preferences = await _userPreferencesRepository.load();
+    if (preferences.syncAllDrivesOnLogin) {
+      // Start initial sync immediately without waiting for async operations.
+      // This ensures sync runs while the tab is still focused after login,
+      // avoiding race conditions with tab visibility checks.
+      startSync();
+    } else {
+      logger.d('Skipping initial sync: syncAllDrivesOnLogin is disabled');
+    }
 
     // Cancel any existing subscription before creating a new one
     await _syncSub?.cancel();
@@ -305,6 +315,129 @@ class SyncCubit extends Cubit<SyncState> {
     // Check if sync completed with errors (only for non-cancelled syncs)
     if (_syncProgress.hasErrors) {
       logger.w('Sync completed with ${_syncProgress.failedQueries} errors');
+      emit(SyncCompleteWithErrors(
+        failedDrives: _syncProgress.failedQueries,
+        totalDrives: _syncProgress.drivesCount,
+        failedDriveIds: _syncProgress.failedDriveIds,
+        errorMessages: _syncProgress.errorMessages,
+      ));
+    } else {
+      emit(SyncIdle());
+    }
+  }
+
+  /// Syncs a single drive by its ID with optional deep sync.
+  /// Similar to startSync but only syncs the specified drive.
+  Future<void> startSyncForDrive({
+    required String driveId,
+    bool deepSync = false,
+  }) async {
+    logger.i('Starting Sync for drive: $driveId, deepSync: $deepSync');
+
+    if (state is SyncInProgress) {
+      logger.d('Sync state is SyncInProgress, aborting single drive sync...');
+      return;
+    }
+
+    _syncProgress = SyncProgress.initial();
+
+    // Create a new cancellation token for this sync
+    _currentSyncToken?.dispose();
+    _currentSyncToken = SyncCancellationToken();
+
+    try {
+      final profile = _profileCubit.state;
+      Wallet? wallet;
+      String? password;
+      SecretKey? cipherKey;
+
+      _initSync = DateTime.now();
+
+      emit(SyncInProgress());
+
+      if (profile is ProfileLoggedIn) {
+        wallet = profile.user.wallet;
+        password = profile.user.password;
+        cipherKey = profile.user.cipherKey;
+
+        final isArConnect = await _profileCubit.isCurrentProfileArConnect();
+
+        // For ArConnect users, check tab visibility
+        if (isArConnect && !_tabVisibility.isTabFocused()) {
+          logger.d('Tab hidden for ArConnect user, skipping single drive sync...');
+          emit(SyncIdle());
+          return;
+        }
+
+        if (_activityCubit.state is ActivityInProgress) {
+          logger.d('Uninterruptible activity in progress, skipping single drive sync...');
+          emit(SyncIdle());
+          return;
+        }
+      }
+
+      _promptToSnapshotBloc.add(const SyncRunning(isRunning: true));
+
+      await for (var syncProgress in _syncRepository.syncSingleDrive(
+        driveId: driveId,
+        wallet: wallet,
+        password: password,
+        cipherKey: cipherKey,
+        syncDeep: deepSync,
+        cancellationToken: _currentSyncToken,
+        txFechedCallback: (driveId, txCount) {
+          _promptToSnapshotBloc.add(
+            CountSyncedTxs(
+              driveId: driveId,
+              txsSyncedWithGqlCount: txCount,
+              wasDeepSync: deepSync,
+            ),
+          );
+        },
+      )) {
+        _syncProgress = syncProgress;
+        syncProgressController.add(_syncProgress);
+      }
+
+      if (profile is ProfileLoggedIn) {
+        _profileCubit.refreshBalance();
+      }
+
+      logger.i('Single drive sync completed');
+    } catch (err, stackTrace) {
+      if (err is SyncCancelledException) {
+        logger.i('Single drive sync cancelled by user');
+        _currentSyncToken?.dispose();
+        _currentSyncToken = null;
+
+        emit(SyncCancelled(
+          drivesCompleted: _syncProgress.drivesSynced,
+          totalDrives: _syncProgress.drivesCount,
+          cancelledAt: DateTime.now(),
+        ));
+        _promptToSnapshotBloc.add(const SyncRunning(isRunning: false));
+        return;
+      }
+      logger.e('Error syncing single drive', err, stackTrace);
+      addError(err);
+    } finally {
+      if (_currentSyncToken != null) {
+        _currentSyncToken?.dispose();
+        _currentSyncToken = null;
+      }
+    }
+
+    _lastSync = DateTime.now();
+
+    logger.i(
+      'Single drive sync finished. Sync took: ${_lastSync!.difference(_initSync).inMilliseconds}ms',
+    );
+
+    _promptToSnapshotBloc.add(const SyncRunning(isRunning: false));
+
+    // Check if sync completed with errors
+    if (_syncProgress.hasErrors) {
+      logger.w('Single drive sync completed with errors');
       emit(SyncCompleteWithErrors(
         failedDrives: _syncProgress.failedQueries,
         totalDrives: _syncProgress.drivesCount,

--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -92,9 +92,10 @@ class SyncCubit extends Cubit<SyncState> {
     final preferences = await _userPreferencesRepository.load();
     if (preferences.syncAllDrivesOnLogin) {
       // Start initial sync immediately without waiting for async operations.
-      // This ensures sync runs while the tab is still focused after login,
-      // avoiding race conditions with tab visibility checks.
-      startSync();
+      // Skip tab visibility check for initial sync because the user just logged in
+      // (which requires wallet interaction, proving they're active). The wallet popup
+      // may cause the browser to consider the tab unfocused momentarily.
+      startSync(skipTabVisibilityCheck: true);
     } else {
       logger.d('Skipping full sync: syncAllDrivesOnLogin is disabled');
       syncMetadataOnly();
@@ -214,7 +215,10 @@ class SyncCubit extends Cubit<SyncState> {
     }
   }
 
-  Future<void> startSync({bool deepSync = false}) async {
+  Future<void> startSync({
+    bool deepSync = false,
+    bool skipTabVisibilityCheck = false,
+  }) async {
     logger.i('Starting Sync');
 
     if (state is SyncInProgress) {
@@ -258,7 +262,11 @@ class SyncCubit extends Cubit<SyncState> {
         // For ArConnect users, check tab visibility before any operations
         // that require signing. If tab is not focused, skip sync entirely
         // and let the next periodic sync or manual sync handle it.
-        if (isArConnect && !_tabVisibility.isTabFocused()) {
+        // Skip this check for initial sync after login since wallet interaction
+        // may momentarily cause the browser to consider the tab unfocused.
+        if (isArConnect &&
+            !skipTabVisibilityCheck &&
+            !_tabVisibility.isTabFocused()) {
           logger.d('Tab hidden for ArConnect user, skipping sync...');
           emit(SyncIdle());
           return;

--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -65,7 +65,9 @@ class SyncCubit extends Cubit<SyncState> {
         _tabVisibility = tabVisibility,
         _syncRepository = syncRepository,
         _userPreferencesRepository = userPreferencesRepository,
-        super(SyncIdle()) {
+        // Initialize with SyncLoadingDrives (not SyncIdle) to prevent race conditions
+        // where DriveDetailCubit's waitCurrentSync() returns early before sync starts.
+        super(SyncLoadingDrives()) {
     // Sync the user's drives on start and periodically.
     createSyncStream();
     restartSyncOnFocus();
@@ -88,12 +90,8 @@ class SyncCubit extends Cubit<SyncState> {
   void createSyncStream() async {
     logger.d('Creating sync stream to periodically call sync automatically');
 
-    // Emit SyncLoadingDrives immediately to prevent race conditions where
-    // DriveDetailCubit's waitCurrentSync() returns early before sync starts.
-    // This ensures any code waiting for sync to complete will actually wait.
-    // Using SyncLoadingDrives (not SyncInProgress) to avoid triggering the
-    // abort guard in startSync().
-    emit(SyncLoadingDrives());
+    // Note: Initial state is already SyncLoadingDrives (set in constructor)
+    // to prevent race conditions with waitCurrentSync()
 
     // Check if syncAllDrivesOnLogin preference is enabled before initial sync
     final preferences = await _userPreferencesRepository.load();

--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -281,11 +281,23 @@ class SyncCubit extends Cubit<SyncState> {
 
         // Update user drives to discover all drives owned by the user.
         // This must complete before syncAllDrives so drives exist in DB.
+        // Emit status message so user sees feedback during this phase
+        _syncProgress = _syncProgress.copyWith(
+          statusMessage: 'Discovering your drives...',
+        );
+        syncProgressController.add(_syncProgress);
+
         await _syncRepository.updateUserDrives(
           wallet: wallet,
           password: password,
           cipherKey: profile.user.cipherKey,
         );
+
+        // Clear status message after discovery completes
+        _syncProgress = _syncProgress.copyWith(
+          statusMessage: null,
+        );
+        syncProgressController.add(_syncProgress);
       }
 
       _promptToSnapshotBloc.add(const SyncRunning(isRunning: true));

--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -80,7 +80,11 @@ class SyncCubit extends Cubit<SyncState> {
   Future<void> waitCurrentSync() async {
     if (state is! SyncIdle) {
       await for (var state in stream) {
-        if (state is SyncIdle || state is SyncFailure) {
+        // Break on any terminal state (sync finished, failed, cancelled, or completed with errors)
+        if (state is SyncIdle ||
+            state is SyncFailure ||
+            state is SyncCancelled ||
+            state is SyncCompleteWithErrors) {
           break;
         }
       }
@@ -217,6 +221,8 @@ class SyncCubit extends Cubit<SyncState> {
       emit(SyncIdle());
     } else {
       logger.d('Profile not logged in yet, skipping metadata sync');
+      // Still emit SyncIdle so waitCurrentSync() doesn't hang
+      emit(SyncIdle());
     }
   }
 

--- a/lib/sync/domain/cubit/sync_state.dart
+++ b/lib/sync/domain/cubit/sync_state.dart
@@ -8,6 +8,11 @@ abstract class SyncState extends Equatable {
 
 class SyncIdle extends SyncState {}
 
+/// Loading drive metadata only (not full sync).
+/// Used when syncAllDrivesOnLogin is disabled.
+/// This is a lightweight UI-only state that doesn't block waitCurrentSync().
+class SyncLoadingDrives extends SyncState {}
+
 class SyncInProgress extends SyncState {}
 
 class SyncFailure extends SyncState {

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -237,7 +237,7 @@ class _SyncRepository implements SyncRepository {
             cipherKey: cipherKey,
             lastBlockHeight: syncDeep
                 ? 0
-                : _calculateSyncLastBlockHeight(drive.lastBlockHeight!),
+                : _calculateSyncLastBlockHeight(drive.lastBlockHeight ?? 0),
             currentBlockHeight: currentBlockHeight,
             transactionParseBatchSize:
                 200 ~/ (syncProgress.drivesCount - syncProgress.drivesSynced),
@@ -588,7 +588,7 @@ class _SyncRepository implements SyncRepository {
           cipherKey: cipherKey,
           lastBlockHeight: syncDeep
               ? 0
-              : _calculateSyncLastBlockHeight(drive.lastBlockHeight!),
+              : _calculateSyncLastBlockHeight(drive.lastBlockHeight ?? 0),
           currentBlockHeight: currentBlockHeight,
           transactionParseBatchSize: 200,
           ownerAddress: drive.ownerAddress,
@@ -760,7 +760,11 @@ class _SyncRepository implements SyncRepository {
       } catch (e) {
         if (e is SyncCancelledException) {
           logger.i('Single drive sync cancelled');
+          // Clear per-sync state to prevent leaking into subsequent runs
           driveGhostFolders.clear();
+          _folderIds.clear();
+          // Remove any ghost folders for this drive from the instance map
+          _ghostFolders.removeWhere((_, v) => v.driveId == driveId);
           syncProgressController.addError(e);
           await syncProgressController.close();
           return;
@@ -768,6 +772,12 @@ class _SyncRepository implements SyncRepository {
 
         // Track the failure
         logger.e('Failed to sync drive $driveId', e);
+
+        // Clear per-sync state on error to prevent leaking into subsequent runs
+        driveGhostFolders.clear();
+        _folderIds.clear();
+        // Remove any ghost folders for this drive from the instance map
+        _ghostFolders.removeWhere((_, v) => v.driveId == driveId);
 
         final updatedErrorMessages =
             Map<String, String>.from(syncProgress.errorMessages)
@@ -784,7 +794,11 @@ class _SyncRepository implements SyncRepository {
         await syncProgressController.close();
       }
     }).catchError((error) async {
+      // Clear per-sync state on error to prevent leaking into subsequent runs
       driveGhostFolders.clear();
+      _folderIds.clear();
+      // Remove any ghost folders for this drive from the instance map
+      _ghostFolders.removeWhere((_, v) => v.driveId == driveId);
       logger.d('Single drive sync failed with error, closing controller: $error');
       if (!syncProgressController.isClosed) {
         syncProgressController.addError(error);

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -174,6 +174,11 @@ class _SyncRepository implements SyncRepository {
     Function(String driveId, int txCount)? txFechedCallback,
   }) async* {
     final token = cancellationToken ?? SyncCancellationToken();
+
+    // Clear shared state from any previous sync to prevent stale data
+    _ghostFolders.clear();
+    _folderIds.clear();
+
     if (wallet != null) {
       final address = await wallet.getAddress();
 
@@ -548,6 +553,10 @@ class _SyncRepository implements SyncRepository {
     Function(String driveId, int txCount)? txFechedCallback,
   }) async* {
     final token = cancellationToken ?? SyncCancellationToken();
+
+    // Clear shared state from any previous sync to prevent stale data
+    _ghostFolders.clear();
+    _folderIds.clear();
 
     // Get the specific drive
     final drive =

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -557,8 +557,11 @@ class _SyncRepository implements SyncRepository {
       return;
     }
 
-    SyncProgress syncProgress =
-        SyncProgress.initial().copyWith(drivesCount: 1);
+    SyncProgress syncProgress = SyncProgress.initial().copyWith(
+      drivesCount: 1,
+      isSingleDriveSync: true,
+      driveName: drive.name,
+    );
     yield syncProgress;
 
     final currentBlockHeight = await retry(

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -59,6 +59,18 @@ abstract class SyncRepository {
     Function(String driveId, int txCount)? txFechedCallback,
   });
 
+  /// Syncs a single drive by its ID, with optional deep sync.
+  /// Returns a stream of SyncProgress that can be used to track progress.
+  Stream<SyncProgress> syncSingleDrive({
+    required String driveId,
+    bool syncDeep = false,
+    Wallet? wallet,
+    String? password,
+    SecretKey? cipherKey,
+    SyncCancellationToken? cancellationToken,
+    Function(String driveId, int txCount)? txFechedCallback,
+  });
+
   Stream<SyncProgress> syncAllDrives({
     bool syncDeep = false,
     Wallet? wallet,
@@ -523,6 +535,384 @@ class _SyncRepository implements SyncRepository {
       transactionParseBatchSize: 200,
       txFechedCallback: txFechedCallback,
     );
+  }
+
+  @override
+  Stream<SyncProgress> syncSingleDrive({
+    required String driveId,
+    bool syncDeep = false,
+    Wallet? wallet,
+    String? password,
+    SecretKey? cipherKey,
+    SyncCancellationToken? cancellationToken,
+    Function(String driveId, int txCount)? txFechedCallback,
+  }) async* {
+    final token = cancellationToken ?? SyncCancellationToken();
+
+    // Get the specific drive
+    final drive =
+        await _driveDao.driveById(driveId: driveId).getSingleOrNull();
+    if (drive == null) {
+      yield SyncProgress.emptySyncCompleted();
+      return;
+    }
+
+    SyncProgress syncProgress =
+        SyncProgress.initial().copyWith(drivesCount: 1);
+    yield syncProgress;
+
+    final currentBlockHeight = await retry(
+      () async => await _arweave.getCurrentBlockHeight(),
+      onRetry: (exception) => logger.w(
+        'Retrying for get the current block height',
+      ),
+    );
+
+    final StreamController<SyncProgress> syncProgressController =
+        StreamController<SyncProgress>.broadcast();
+
+    // Store ghost folders for this drive only
+    final driveGhostFolders = <String, GhostFolder>{};
+
+    // Start the async work
+    Future.microtask(() async {
+      try {
+        // Check for cancellation before starting
+        token.checkCancellation();
+
+        final driveSyncProgress = _syncDrive(
+          drive.id,
+          cipherKey: cipherKey,
+          lastBlockHeight: syncDeep
+              ? 0
+              : _calculateSyncLastBlockHeight(drive.lastBlockHeight!),
+          currentBlockHeight: currentBlockHeight,
+          transactionParseBatchSize: 200,
+          ownerAddress: drive.ownerAddress,
+          txFechedCallback: txFechedCallback,
+          cancellationToken: token,
+        );
+
+        await for (var driveProgress in driveSyncProgress) {
+          // Check for cancellation during sync
+          token.checkCancellation();
+
+          // Reserve 10% for post-sync operations (cap drive sync at 90%)
+          final currentProgress = driveProgress * 0.9;
+          if (currentProgress > syncProgress.progress) {
+            syncProgress = syncProgress.copyWith(progress: currentProgress);
+          }
+          syncProgressController.add(syncProgress);
+        }
+
+        syncProgress = syncProgress.copyWith(
+          drivesSynced: 1,
+          progress: 0.9,
+        );
+        syncProgressController.add(syncProgress);
+
+        // Copy ghost folders for this drive only
+        for (final entry in _ghostFolders.entries) {
+          if (entry.value.driveId == driveId) {
+            driveGhostFolders[entry.key] = entry.value;
+          }
+        }
+
+        // Check for cancellation before ghost creation
+        token.checkCancellation();
+
+        // Update progress to 92% for ghost creation
+        syncProgress = syncProgress.copyWith(
+          progress: 0.92,
+          statusMessage: 'Creating ghost folders...',
+        );
+        syncProgressController.add(syncProgress);
+
+        logger.i('Creating ghosts for single drive sync...');
+
+        await createGhosts(
+          driveDao: _driveDao,
+          ownerAddress: await wallet?.getAddress(),
+          ghostFolders: driveGhostFolders,
+        );
+
+        // Remove processed ghost folders from the main map
+        for (final key in driveGhostFolders.keys) {
+          _ghostFolders.remove(key);
+        }
+
+        logger.i('Ghosts created for single drive...');
+
+        // Check for cancellation before license sync
+        token.checkCancellation();
+
+        // Update progress to 94% for license sync
+        syncProgress = syncProgress.copyWith(
+          progress: 0.94,
+          statusMessage: 'Syncing licenses...',
+        );
+        syncProgressController.add(syncProgress);
+
+        logger.i('Syncing licenses for single drive...');
+
+        try {
+          final licenseTxIds = <String>{};
+          // Filter to only revisions for this drive
+          final revisionsToSyncLicense = (await _driveDao
+              .allFileRevisionsWithLicenseReferencedButNotSynced()
+              .get())
+            ..retainWhere((rev) =>
+                rev.driveId == driveId && licenseTxIds.add(rev.licenseTxId!));
+
+          logger.d(
+              'Found ${revisionsToSyncLicense.length} licenses to sync for drive $driveId');
+
+          await _updateLicenses(
+            revisionsToSyncLicense: revisionsToSyncLicense,
+          );
+        } catch (e) {
+          if (e is SyncCancelledException) {
+            rethrow;
+          }
+          logger.e('Error syncing licenses for single drive. Proceeding.', e);
+        }
+
+        logger.i('Licenses synced for single drive');
+
+        // Check for cancellation before transaction status updates
+        token.checkCancellation();
+
+        // Update progress to 96% for transaction status updates
+        syncProgress = syncProgress.copyWith(
+          progress: 0.96,
+          statusMessage: 'Updating transaction statuses...',
+        );
+        syncProgressController.add(syncProgress);
+
+        logger.i('Updating transaction statuses for single drive...');
+
+        // Get file revisions for this specific drive to scope transaction updates
+        final driveFileRevisions =
+            await _driveDao.db.fileRevisions.select().get();
+        final driveDataTxIds = driveFileRevisions
+            .where((r) => r.driveId == driveId)
+            .map((r) => r.dataTxId)
+            .toSet();
+
+        final metadataTxsFromSnapshots =
+            await SnapshotItemOnChain.getAllCachedTransactionIds();
+        final confirmedFileTxIds = driveFileRevisions
+            .where((file) =>
+                file.driveId == driveId &&
+                metadataTxsFromSnapshots.contains(file.metadataTxId))
+            .map((file) => file.dataTxId)
+            .toList();
+
+        // Clear cached transaction IDs for this drive
+        SnapshotItemOnChain.clearAllCachedTransactionIds();
+
+        // Check for hidden items in this drive and update preferences
+        final hasHiddenItems = await _driveDao.hasHiddenItems().getSingle();
+        await _userPreferencesRepository.saveUserHasHiddenItem(hasHiddenItems);
+        await _userPreferencesRepository.load();
+
+        try {
+          await _updateTransactionStatusesForDrive(
+            driveDao: _driveDao,
+            arweave: _arweave,
+            driveDataTxIds: driveDataTxIds,
+            txsIdsToSkip: confirmedFileTxIds,
+            cancellationToken: token,
+          ).timeout(
+            const Duration(seconds: 10),
+            onTimeout: () {
+              token.checkCancellation();
+              logger.w(
+                  'Transaction status update timed out after 10 seconds for single drive');
+              syncProgress = syncProgress.copyWith(
+                statusMessage: 'Completing sync...',
+              );
+              syncProgressController.add(syncProgress);
+            },
+          );
+        } catch (e) {
+          if (e is SyncCancelledException) {
+            rethrow;
+          }
+          logger.w(
+              'Failed to update transaction statuses for single drive, continuing: $e');
+        }
+
+        _lastSync = DateTime.now();
+
+        // Update progress to 100% when truly complete
+        syncProgress = syncProgress.copyWith(
+          progress: 1.0,
+          statusMessage: 'Sync complete',
+        );
+        syncProgressController.add(syncProgress);
+
+        logger.d('Single drive sync completed successfully, closing controller');
+        await syncProgressController.close();
+      } catch (e) {
+        if (e is SyncCancelledException) {
+          logger.i('Single drive sync cancelled');
+          driveGhostFolders.clear();
+          syncProgressController.addError(e);
+          await syncProgressController.close();
+          return;
+        }
+
+        // Track the failure
+        logger.e('Failed to sync drive $driveId', e);
+
+        final updatedErrorMessages =
+            Map<String, String>.from(syncProgress.errorMessages)
+              ..putIfAbsent(driveId, () => _extractErrorMessage(e));
+
+        syncProgress = syncProgress.copyWith(
+          drivesSynced: 1,
+          progress: 1.0,
+          failedQueries: 1,
+          failedDriveIds: [driveId],
+          errorMessages: updatedErrorMessages,
+        );
+        syncProgressController.add(syncProgress);
+        await syncProgressController.close();
+      }
+    }).catchError((error) async {
+      driveGhostFolders.clear();
+      logger.d('Single drive sync failed with error, closing controller: $error');
+      if (!syncProgressController.isClosed) {
+        syncProgressController.addError(error);
+        await syncProgressController.close();
+      }
+    });
+
+    // Yield from the stream while the sync is happening
+    yield* syncProgressController.stream;
+  }
+
+  /// Updates transaction statuses scoped to a specific drive's transactions
+  Future<void> _updateTransactionStatusesForDrive({
+    required DriveDao driveDao,
+    required ArweaveService arweave,
+    required Set<String> driveDataTxIds,
+    List<TxID> txsIdsToSkip = const [],
+    SyncCancellationToken? cancellationToken,
+  }) async {
+    cancellationToken?.checkCancellation();
+
+    // Load all pending transactions and filter to this drive
+    final allPendingTxs = await driveDao.pendingTransactions().get();
+    final drivePendingTxs = allPendingTxs
+        .where((tx) => driveDataTxIds.contains(tx.id))
+        .toList();
+
+    logger.i(
+        'Loaded ${drivePendingTxs.length} pending transactions for drive (from ${allPendingTxs.length} total)');
+
+    final pendingTxMap = <String, NetworkTransaction>{
+      for (final tx in drivePendingTxs) tx.id: tx,
+    };
+
+    // Remove transactions to skip
+    for (final txId in txsIdsToSkip) {
+      pendingTxMap.remove(txId);
+    }
+
+    final length = pendingTxMap.length;
+    final list = pendingTxMap.keys.toList();
+    const page = 5000;
+
+    for (var i = 0; i < length / page; i++) {
+      cancellationToken?.checkCancellation();
+
+      final confirmations = <String?, int>{};
+      final currentPage = <String>[];
+
+      for (var j = i * page; j < ((i + 1) * page); j++) {
+        if (j >= length) {
+          break;
+        }
+        currentPage.add(list[j]);
+      }
+
+      cancellationToken?.checkCancellation();
+
+      final map = await arweave
+          .getTransactionConfirmations(currentPage.toList())
+          .timeout(
+        const Duration(seconds: 5),
+        onTimeout: () {
+          logger.w('Individual transaction confirmation timeout');
+          return <String, int>{};
+        },
+      );
+
+      map.forEach((key, value) {
+        confirmations.putIfAbsent(key, () => value);
+      });
+
+      await driveDao.transaction(() async {
+        for (final txId in currentPage) {
+          cancellationToken?.checkCancellation();
+          final txConfirmed =
+              confirmations[txId]! >= kRequiredTxConfirmationCount;
+          final txNotFound = confirmations[txId]! < 0;
+
+          String? txStatus;
+          DateTime? transactionDateCreated;
+
+          if (pendingTxMap[txId]!.transactionDateCreated != null) {
+            transactionDateCreated =
+                pendingTxMap[txId]!.transactionDateCreated!;
+          } else {
+            transactionDateCreated = await _getDateCreatedByDataTx(
+              driveDao: driveDao,
+              dataTx: txId,
+            );
+          }
+
+          if (txConfirmed) {
+            txStatus = TransactionStatus.confirmed;
+          } else if (txNotFound) {
+            final abovePendingThreshold = DateTime.now()
+                    .difference(pendingTxMap[txId]!.dateCreated)
+                    .inMinutes >
+                kRequiredTxConfirmationPendingThreshold;
+
+            if (abovePendingThreshold ||
+                _isOverThePendingTime(transactionDateCreated)) {
+              txStatus = TransactionStatus.failed;
+            }
+          }
+          if (txStatus != null) {
+            await driveDao.writeToTransaction(
+              NetworkTransactionsCompanion(
+                transactionDateCreated: Value(transactionDateCreated),
+                id: Value(txId),
+                status: Value(txStatus),
+              ),
+            );
+          }
+        }
+      });
+
+      await Future.delayed(const Duration(milliseconds: 200));
+    }
+
+    // Mark skipped transactions as confirmed
+    await driveDao.transaction(() async {
+      for (final txId in txsIdsToSkip) {
+        await driveDao.writeToTransaction(
+          NetworkTransactionsCompanion(
+            id: Value(txId),
+            status: const Value(TransactionStatus.confirmed),
+          ),
+        );
+      }
+    });
   }
 
   @override

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -860,9 +860,16 @@ class _SyncRepository implements SyncRepository {
       await driveDao.transaction(() async {
         for (final txId in currentPage) {
           cancellationToken?.checkCancellation();
+
+          // Skip if confirmation data is missing (e.g., timeout or partial response)
+          final confirmationCount = confirmations[txId];
+          if (confirmationCount == null) {
+            continue;
+          }
+
           final txConfirmed =
-              confirmations[txId]! >= kRequiredTxConfirmationCount;
-          final txNotFound = confirmations[txId]! < 0;
+              confirmationCount >= kRequiredTxConfirmationCount;
+          final txNotFound = confirmationCount < 0;
 
           String? txStatus;
           DateTime? transactionDateCreated;
@@ -1096,9 +1103,16 @@ class _SyncRepository implements SyncRepository {
         for (final txId in currentPage) {
           // Check cancellation for each transaction
           cancellationToken?.checkCancellation();
+
+          // Skip if confirmation data is missing (e.g., timeout or partial response)
+          final confirmationCount = confirmations[txId];
+          if (confirmationCount == null) {
+            continue;
+          }
+
           final txConfirmed =
-              confirmations[txId]! >= kRequiredTxConfirmationCount;
-          final txNotFound = confirmations[txId]! < 0;
+              confirmationCount >= kRequiredTxConfirmationCount;
+          final txNotFound = confirmationCount < 0;
 
           String? txStatus;
 

--- a/lib/sync/domain/sync_progress.dart
+++ b/lib/sync/domain/sync_progress.dart
@@ -2,6 +2,9 @@ abstract class LinearProgress {
   double get progress;
 }
 
+/// Sentinel used by copyWith to distinguish "not provided" from "explicitly null".
+const _absent = Object();
+
 class SyncProgress extends LinearProgress {
   SyncProgress({
     required this.numberOfEntities,
@@ -85,9 +88,9 @@ class SyncProgress extends LinearProgress {
     int? failedQueries,
     List<String>? failedDriveIds,
     Map<String, String>? errorMessages,
-    String? statusMessage,
+    Object? statusMessage = _absent,
     bool? isSingleDriveSync,
-    String? driveName,
+    Object? driveName = _absent,
   }) {
     return SyncProgress(
       numberOfEntities: numberOfEntities ?? this.numberOfEntities,
@@ -100,9 +103,12 @@ class SyncProgress extends LinearProgress {
       failedQueries: failedQueries ?? this.failedQueries,
       failedDriveIds: failedDriveIds ?? this.failedDriveIds,
       errorMessages: errorMessages ?? this.errorMessages,
-      statusMessage: statusMessage ?? this.statusMessage,
+      statusMessage: statusMessage == _absent
+          ? this.statusMessage
+          : statusMessage as String?,
       isSingleDriveSync: isSingleDriveSync ?? this.isSingleDriveSync,
-      driveName: driveName ?? this.driveName,
+      driveName:
+          driveName == _absent ? this.driveName : driveName as String?,
     );
   }
 }

--- a/lib/sync/domain/sync_progress.dart
+++ b/lib/sync/domain/sync_progress.dart
@@ -14,6 +14,8 @@ class SyncProgress extends LinearProgress {
     this.failedDriveIds = const [],
     this.errorMessages = const {},
     this.statusMessage,
+    this.isSingleDriveSync = false,
+    this.driveName,
   });
 
   factory SyncProgress.initial() {
@@ -28,6 +30,8 @@ class SyncProgress extends LinearProgress {
       failedDriveIds: const [],
       errorMessages: const {},
       statusMessage: null,
+      isSingleDriveSync: false,
+      driveName: null,
     );
   }
 
@@ -43,6 +47,8 @@ class SyncProgress extends LinearProgress {
       failedDriveIds: const [],
       errorMessages: const {},
       statusMessage: null,
+      isSingleDriveSync: false,
+      driveName: null,
     );
   }
 
@@ -53,13 +59,17 @@ class SyncProgress extends LinearProgress {
   final int drivesSynced;
   final int drivesCount;
   final int numberOfDrivesAtGetMetadataPhase;
-  
+
   // New fields for tracking failures
   final int failedQueries;
   final List<String> failedDriveIds;
   final Map<String, String> errorMessages; // driveId -> error message
   final String? statusMessage; // Status message for post-sync operations
-  
+
+  // Fields for distinguishing sync type
+  final bool isSingleDriveSync; // true if syncing a single drive
+  final String? driveName; // name of the drive being synced (for single drive sync)
+
   // Helper getters
   bool get hasErrors => failedQueries > 0;
   bool get isPartialSync => hasErrors && progress >= 1.0;
@@ -76,6 +86,8 @@ class SyncProgress extends LinearProgress {
     List<String>? failedDriveIds,
     Map<String, String>? errorMessages,
     String? statusMessage,
+    bool? isSingleDriveSync,
+    String? driveName,
   }) {
     return SyncProgress(
       numberOfEntities: numberOfEntities ?? this.numberOfEntities,
@@ -89,6 +101,8 @@ class SyncProgress extends LinearProgress {
       failedDriveIds: failedDriveIds ?? this.failedDriveIds,
       errorMessages: errorMessages ?? this.errorMessages,
       statusMessage: statusMessage ?? this.statusMessage,
+      isSingleDriveSync: isSingleDriveSync ?? this.isSingleDriveSync,
+      driveName: driveName ?? this.driveName,
     );
   }
 }

--- a/lib/user/repositories/user_preferences_repository.dart
+++ b/lib/user/repositories/user_preferences_repository.dart
@@ -9,6 +9,7 @@ import 'package:ardrive_ui/ardrive_ui.dart';
 abstract class UserPreferencesRepository {
   Future<UserPreferences> load();
   Stream<UserPreferences> watch();
+  UserPreferences? get currentPreferences;
   Future<void> saveTheme(ArDriveThemes theme);
   Future<void> saveLastSelectedDriveId(String driveId);
   Future<void> saveShowHiddenFiles(bool showHiddenFiles);
@@ -52,6 +53,9 @@ class _UserPreferencesRepository implements UserPreferencesRepository {
   UserPreferences? _currentUserPreferences;
   final StreamController<UserPreferences> _userPreferencesController =
       StreamController.broadcast();
+
+  @override
+  UserPreferences? get currentPreferences => _currentUserPreferences;
 
   @override
   Stream<UserPreferences> watch() {
@@ -143,13 +147,14 @@ class _UserPreferencesRepository implements UserPreferencesRepository {
     (await _getStore()).remove('lastSelectedDriveId');
     (await _getStore()).remove('showHiddenFiles');
     (await _getStore()).remove('userHasHiddenDrive');
-    (await _getStore()).remove('syncAllDrivesOnLogin');
+    // Note: syncAllDrivesOnLogin is NOT cleared - it's a global preference
+    // that should persist across sessions and logins
 
     _currentUserPreferences = _currentUserPreferences!.copyWith(
       lastSelectedDriveId: null,
       showHiddenFiles: false,
       userHasHiddenDrive: false,
-      syncAllDrivesOnLogin: true,
+      // Keep syncAllDrivesOnLogin unchanged
     );
 
     _userPreferencesController.sink.add(_currentUserPreferences!);
@@ -181,6 +186,11 @@ class _UserPreferencesRepository implements UserPreferencesRepository {
       await store.putBool(key, value as bool);
     } else {
       throw ArgumentError('Unsupported type for preference value');
+    }
+
+    // Notify listeners after save completes
+    if (_currentUserPreferences != null) {
+      _userPreferencesController.sink.add(_currentUserPreferences!);
     }
   }
 }

--- a/lib/user/repositories/user_preferences_repository.dart
+++ b/lib/user/repositories/user_preferences_repository.dart
@@ -35,6 +35,9 @@ class _UserPreferencesRepository implements UserPreferencesRepository {
   final ThemeDetector _themeDetector;
   final ArDriveAuth _auth;
 
+  /// Serializes auth state operations to prevent race conditions
+  Future<void>? _authStateWork;
+
   _UserPreferencesRepository({
     LocalKeyValueStore? store,
     required ThemeDetector themeDetector,
@@ -44,12 +47,15 @@ class _UserPreferencesRepository implements UserPreferencesRepository {
         _auth = auth,
         super() {
     _auth.onAuthStateChanged().listen((user) {
-      if (user == null) {
-        clear();
-      } else {
-        // When user logs in, reload preferences to emit current values to stream
-        load();
-      }
+      // Chain auth state operations to ensure ordered execution
+      _authStateWork = (_authStateWork ?? Future.value()).then((_) {
+        if (user == null) {
+          return clear();
+        } else {
+          // When user logs in, reload preferences to emit current values to stream
+          return load();
+        }
+      });
     });
   }
 

--- a/lib/user/repositories/user_preferences_repository.dart
+++ b/lib/user/repositories/user_preferences_repository.dart
@@ -14,6 +14,7 @@ abstract class UserPreferencesRepository {
   Future<void> saveShowHiddenFiles(bool showHiddenFiles);
   Future<void> clear();
   Future<void> saveUserHasHiddenItem(bool userHasHiddenDrive);
+  Future<void> saveSyncAllDrivesOnLogin(bool syncAllDrivesOnLogin);
 
   factory UserPreferencesRepository({
     LocalKeyValueStore? store,
@@ -65,12 +66,15 @@ class _UserPreferencesRepository implements UserPreferencesRepository {
         _themeDetector.getOSDefaultTheme().name;
     final lastSelectedDriveId = _store!.getString('lastSelectedDriveId');
     final showHiddenFiles = _store!.getBool('showHiddenFiles') ?? false;
+    final syncAllDrivesOnLogin =
+        _store!.getBool('syncAllDrivesOnLogin') ?? true;
 
     _currentUserPreferences = UserPreferences(
       currentTheme: _parseThemeFromLocalStorage(currentTheme),
       lastSelectedDriveId: lastSelectedDriveId,
       showHiddenFiles: showHiddenFiles,
       userHasHiddenDrive: _store!.getBool('userHasHiddenDrive') ?? false,
+      syncAllDrivesOnLogin: syncAllDrivesOnLogin,
     );
 
     _userPreferencesController.sink.add(_currentUserPreferences!);
@@ -118,6 +122,16 @@ class _UserPreferencesRepository implements UserPreferencesRepository {
     );
   }
 
+  @override
+  Future<void> saveSyncAllDrivesOnLogin(bool syncAllDrivesOnLogin) async {
+    await _updatePreference(
+      key: 'syncAllDrivesOnLogin',
+      value: syncAllDrivesOnLogin,
+      updateFunction: (value) =>
+          _currentUserPreferences!.copyWith(syncAllDrivesOnLogin: value),
+    );
+  }
+
   Future<LocalKeyValueStore> _getStore() async {
     _store ??= await LocalKeyValueStore.getInstance();
 
@@ -129,11 +143,13 @@ class _UserPreferencesRepository implements UserPreferencesRepository {
     (await _getStore()).remove('lastSelectedDriveId');
     (await _getStore()).remove('showHiddenFiles');
     (await _getStore()).remove('userHasHiddenDrive');
+    (await _getStore()).remove('syncAllDrivesOnLogin');
 
     _currentUserPreferences = _currentUserPreferences!.copyWith(
       lastSelectedDriveId: null,
       showHiddenFiles: false,
       userHasHiddenDrive: false,
+      syncAllDrivesOnLogin: true,
     );
 
     _userPreferencesController.sink.add(_currentUserPreferences!);

--- a/lib/user/repositories/user_preferences_repository.dart
+++ b/lib/user/repositories/user_preferences_repository.dart
@@ -46,6 +46,9 @@ class _UserPreferencesRepository implements UserPreferencesRepository {
     _auth.onAuthStateChanged().listen((user) {
       if (user == null) {
         clear();
+      } else {
+        // When user logs in, reload preferences to emit current values to stream
+        load();
       }
     });
   }
@@ -183,6 +186,11 @@ class _UserPreferencesRepository implements UserPreferencesRepository {
     required T value,
     required UserPreferences Function(T) updateFunction,
   }) async {
+    // Ensure preferences are loaded before updating
+    if (_currentUserPreferences == null) {
+      await load();
+    }
+
     _currentUserPreferences = updateFunction(value);
 
     final store = await _getStore();

--- a/lib/user/repositories/user_preferences_repository.dart
+++ b/lib/user/repositories/user_preferences_repository.dart
@@ -150,6 +150,12 @@ class _UserPreferencesRepository implements UserPreferencesRepository {
     // Note: syncAllDrivesOnLogin is NOT cleared - it's a global preference
     // that should persist across sessions and logins
 
+    // If preferences haven't been loaded yet, load them first
+    if (_currentUserPreferences == null) {
+      await load();
+      return; // load() already emits to stream
+    }
+
     _currentUserPreferences = _currentUserPreferences!.copyWith(
       lastSelectedDriveId: null,
       showHiddenFiles: false,

--- a/lib/user/user_preferences.dart
+++ b/lib/user/user_preferences.dart
@@ -1,6 +1,9 @@
 import 'package:ardrive_ui/ardrive_ui.dart';
 import 'package:equatable/equatable.dart';
 
+/// Sentinel used by copyWith to distinguish "not provided" from "explicitly null".
+const _absent = Object();
+
 class UserPreferences extends Equatable {
   final ArDriveThemes currentTheme;
   final String? lastSelectedDriveId;
@@ -27,14 +30,16 @@ class UserPreferences extends Equatable {
 
   UserPreferences copyWith({
     ArDriveThemes? currentTheme,
-    String? lastSelectedDriveId,
+    Object? lastSelectedDriveId = _absent,
     bool? showHiddenFiles,
     bool? userHasHiddenDrive,
     bool? syncAllDrivesOnLogin,
   }) {
     return UserPreferences(
       currentTheme: currentTheme ?? this.currentTheme,
-      lastSelectedDriveId: lastSelectedDriveId ?? this.lastSelectedDriveId,
+      lastSelectedDriveId: lastSelectedDriveId == _absent
+          ? this.lastSelectedDriveId
+          : lastSelectedDriveId as String?,
       showHiddenFiles: showHiddenFiles ?? this.showHiddenFiles,
       userHasHiddenDrive: userHasHiddenDrive ?? this.userHasHiddenDrive,
       syncAllDrivesOnLogin: syncAllDrivesOnLogin ?? this.syncAllDrivesOnLogin,

--- a/lib/user/user_preferences.dart
+++ b/lib/user/user_preferences.dart
@@ -6,12 +6,14 @@ class UserPreferences extends Equatable {
   final String? lastSelectedDriveId;
   final bool showHiddenFiles;
   final bool userHasHiddenDrive;
+  final bool syncAllDrivesOnLogin;
 
   const UserPreferences({
     required this.currentTheme,
     required this.lastSelectedDriveId,
     this.showHiddenFiles = false,
     this.userHasHiddenDrive = false,
+    this.syncAllDrivesOnLogin = true,
   });
 
   @override
@@ -20,6 +22,7 @@ class UserPreferences extends Equatable {
         lastSelectedDriveId,
         showHiddenFiles,
         userHasHiddenDrive,
+        syncAllDrivesOnLogin,
       ];
 
   UserPreferences copyWith({
@@ -27,12 +30,14 @@ class UserPreferences extends Equatable {
     String? lastSelectedDriveId,
     bool? showHiddenFiles,
     bool? userHasHiddenDrive,
+    bool? syncAllDrivesOnLogin,
   }) {
     return UserPreferences(
       currentTheme: currentTheme ?? this.currentTheme,
       lastSelectedDriveId: lastSelectedDriveId ?? this.lastSelectedDriveId,
       showHiddenFiles: showHiddenFiles ?? this.showHiddenFiles,
       userHasHiddenDrive: userHasHiddenDrive ?? this.userHasHiddenDrive,
+      syncAllDrivesOnLogin: syncAllDrivesOnLogin ?? this.syncAllDrivesOnLogin,
     );
   }
 }

--- a/packages/ardrive_ui/lib/src/components/modal.dart
+++ b/packages/ardrive_ui/lib/src/components/modal.dart
@@ -686,6 +686,7 @@ class ArDriveStandardModalNew extends StatelessWidget {
   const ArDriveStandardModalNew({
     super.key,
     this.title,
+    this.titleWidget,
     this.description,
     this.content,
     this.actions,
@@ -695,6 +696,10 @@ class ArDriveStandardModalNew extends StatelessWidget {
   });
 
   final String? title;
+
+  /// A widget to display as the title. Takes precedence over [title].
+  final Widget? titleWidget;
+
   final String? description;
   final List<ModalAction>? actions;
   final Widget? content;
@@ -726,17 +731,18 @@ class ArDriveStandardModalNew extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisSize: MainAxisSize.min,
           children: [
-            if (title != null) ...[
+            if (title != null || titleWidget != null) ...[
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
                   Flexible(
-                    child: Text(
-                      title!,
-                      style: typography.heading3(
-                        fontWeight: ArFontWeight.bold,
-                      ),
-                    ),
+                    child: titleWidget ??
+                        Text(
+                          title!,
+                          style: typography.heading3(
+                            fontWeight: ArFontWeight.bold,
+                          ),
+                        ),
                   ),
                   if (hasCloseButton)
                     ArDriveClickArea(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -190,10 +190,10 @@ packages:
     dependency: transitive
     description:
       name: base32
-      sha256: ddad4ebfedf93d4500818ed8e61443b734ffe7cf8a45c668c9b34ef6adde02e2
+      sha256: "37548444aaee8bd5e91db442ce69ee3a79d3652ed47c1fa7568aa3bb9af0aea5"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.2.0"
   base58check:
     dependency: transitive
     description:

--- a/test/sync/domain/sync_progress_test.dart
+++ b/test/sync/domain/sync_progress_test.dart
@@ -1,0 +1,66 @@
+import 'package:ardrive/sync/domain/sync_progress.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('SyncProgress copyWith', () {
+    test('retains statusMessage when not provided', () {
+      final progress = SyncProgress.initial().copyWith(
+        statusMessage: 'Loading...',
+      );
+
+      final updated = progress.copyWith(drivesCount: 5);
+
+      expect(updated.statusMessage, 'Loading...');
+      expect(updated.drivesCount, 5);
+    });
+
+    test('clears statusMessage when null is passed explicitly', () {
+      final progress = SyncProgress.initial().copyWith(
+        statusMessage: 'Loading...',
+      );
+
+      final updated = progress.copyWith(statusMessage: null);
+
+      expect(updated.statusMessage, isNull);
+    });
+
+    test('retains driveName when not provided', () {
+      final progress = SyncProgress.initial().copyWith(
+        driveName: 'My Drive',
+      );
+
+      final updated = progress.copyWith(drivesCount: 3);
+
+      expect(updated.driveName, 'My Drive');
+      expect(updated.drivesCount, 3);
+    });
+
+    test('clears driveName when null is passed explicitly', () {
+      final progress = SyncProgress.initial().copyWith(
+        driveName: 'My Drive',
+      );
+
+      final updated = progress.copyWith(driveName: null);
+
+      expect(updated.driveName, isNull);
+    });
+
+    test('sets statusMessage from null to a value', () {
+      final progress = SyncProgress.initial();
+      expect(progress.statusMessage, isNull);
+
+      final updated = progress.copyWith(statusMessage: 'Syncing...');
+
+      expect(updated.statusMessage, 'Syncing...');
+    });
+
+    test('sets driveName from null to a value', () {
+      final progress = SyncProgress.initial();
+      expect(progress.driveName, isNull);
+
+      final updated = progress.copyWith(driveName: 'Test Drive');
+
+      expect(updated.driveName, 'Test Drive');
+    });
+  });
+}

--- a/test/user/repositories/user_preferences_repository_test.dart
+++ b/test/user/repositories/user_preferences_repository_test.dart
@@ -168,14 +168,31 @@ void main() {
       verify(() => mockStore.putBool('userHasHiddenDrive', true)).called(1);
     });
 
-    test('should clear last selected drive id from storage', () async {
+    test('should save sync all drives on login preference to storage', () async {
+      // Setup initial load
+      when(() => mockStore.getString('currentTheme')).thenReturn('dark');
+      when(() => mockStore.getString('lastSelectedDriveId')).thenReturn(null);
+      when(() => mockStore.getBool('showHiddenFiles')).thenReturn(false);
+      when(() => mockStore.getBool('userHasHiddenDrive')).thenReturn(false);
+      when(() => mockStore.getBool('syncAllDrivesOnLogin')).thenReturn(true);
+      await repository.load();
+
+      when(() => mockStore.putBool('syncAllDrivesOnLogin', false))
+          .thenAnswer((_) async => true);
+
+      await repository.saveSyncAllDrivesOnLogin(false);
+
+      verify(() => mockStore.putBool('syncAllDrivesOnLogin', false)).called(1);
+    });
+
+    test('should clear preferences but preserve syncAllDrivesOnLogin', () async {
       // Setup initial load
       when(() => mockStore.getString('currentTheme')).thenReturn('dark');
       when(() => mockStore.getString('lastSelectedDriveId'))
           .thenReturn('drive_id');
       when(() => mockStore.getBool('showHiddenFiles')).thenReturn(true);
       when(() => mockStore.getBool('userHasHiddenDrive')).thenReturn(true);
-      when(() => mockStore.getBool('syncAllDrivesOnLogin')).thenReturn(null);
+      when(() => mockStore.getBool('syncAllDrivesOnLogin')).thenReturn(false);
       await repository.load();
 
       when(() => mockStore.remove('lastSelectedDriveId'))
@@ -187,7 +204,12 @@ void main() {
 
       await repository.clear();
 
+      // Verify cleared preferences
       verify(() => mockStore.remove('lastSelectedDriveId')).called(1);
+      verify(() => mockStore.remove('showHiddenFiles')).called(1);
+      verify(() => mockStore.remove('userHasHiddenDrive')).called(1);
+      // Verify syncAllDrivesOnLogin is NOT removed (should persist)
+      verifyNever(() => mockStore.remove('syncAllDrivesOnLogin'));
     });
 
     test(
@@ -218,47 +240,36 @@ void main() {
           equals(initialPreferences),
         );
 
-        when(() => mockStore.putString('currentTheme', ArDriveThemes.dark.name))
-            .thenAnswer((_) async => true);
-        when(() => mockStore.putString('lastSelectedDriveId', 'new_drive_id'))
-            .thenAnswer((_) async => true);
-        when(() => mockStore.putBool('showHiddenFiles', true))
-            .thenAnswer((_) async => true);
-        when(() => mockStore.putBool('userHasHiddenDrive', true))
-            .thenAnswer((_) async => true);
+        // Clean up
+        await queue.cancel();
+      },
+    );
 
-        // Simulate changes in preferences
-        when(() => mockStore.getString('currentTheme')).thenReturn('dark');
-        when(() => mockStore.getString('lastSelectedDriveId'))
-            .thenReturn('new_drive_id');
-        when(() => mockStore.getBool('showHiddenFiles')).thenReturn(true);
-        when(() => mockStore.getBool('userHasHiddenDrive')).thenReturn(true);
-
-        // Trigger preference changes
-        await repository.saveTheme(ArDriveThemes.dark);
-        await repository.saveLastSelectedDriveId('new_drive_id');
-        await repository.saveShowHiddenFiles(true);
-        await repository.saveUserHasHiddenItem(true);
-
-        // Skip intermediate emissions from save methods (4 emissions)
-        // and get the final state after load()
+    test(
+      'should emit updated preferences after save operations',
+      () async {
+        // Setup initial state
+        when(() => mockStore.getString('currentTheme')).thenReturn('light');
+        when(() => mockStore.getString('lastSelectedDriveId')).thenReturn(null);
+        when(() => mockStore.getBool('showHiddenFiles')).thenReturn(false);
+        when(() => mockStore.getBool('userHasHiddenDrive')).thenReturn(false);
+        when(() => mockStore.getBool('syncAllDrivesOnLogin')).thenReturn(true);
         await repository.load();
 
-        // Skip the 4 intermediate emissions from save* methods
-        await queue.skip(4);
+        // Setup save stubs
+        when(() => mockStore.putString('currentTheme', ArDriveThemes.dark.name))
+            .thenAnswer((_) async => true);
 
-        expect(
-          await queue.next,
-          const UserPreferences(
-            currentTheme: ArDriveThemes.dark,
-            lastSelectedDriveId: 'new_drive_id',
-            showHiddenFiles: true,
-            userHasHiddenDrive: true,
-            syncAllDrivesOnLogin: true,
-          ),
-        );
+        // Listen to stream and collect the emission from saveTheme
+        final stream = repository.watch();
+        final queue = StreamQueue(stream);
 
-        // Clean up
+        await repository.saveTheme(ArDriveThemes.dark);
+
+        // Verify the emitted preferences reflect the change
+        final emitted = await queue.next;
+        expect(emitted.currentTheme, equals(ArDriveThemes.dark));
+
         await queue.cancel();
       },
     );

--- a/test/user/repositories/user_preferences_repository_test.dart
+++ b/test/user/repositories/user_preferences_repository_test.dart
@@ -20,7 +20,7 @@ void main() {
     late MockThemeDetector mockThemeDetector;
     late MockArDriveAuth mockAuth;
 
-    setUpAll(() {
+    setUp(() {
       mockStore = MockLocalKeyValueStore();
       mockThemeDetector = MockThemeDetector();
       mockAuth = MockArDriveAuth();
@@ -36,10 +36,12 @@ void main() {
     test('should return default OS theme if no theme is saved in storage',
         () async {
       when(() => mockStore.getString('currentTheme')).thenReturn(null);
+      when(() => mockStore.getString('lastSelectedDriveId')).thenReturn(null);
       when(() => mockThemeDetector.getOSDefaultTheme())
           .thenReturn(ArDriveThemes.light);
       when(() => mockStore.getBool('showHiddenFiles')).thenReturn(false);
       when(() => mockStore.getBool('userHasHiddenDrive')).thenReturn(false);
+      when(() => mockStore.getBool('syncAllDrivesOnLogin')).thenReturn(null);
 
       final result = await repository.load();
 
@@ -50,15 +52,16 @@ void main() {
             lastSelectedDriveId: null,
             showHiddenFiles: false,
             userHasHiddenDrive: false,
+            syncAllDrivesOnLogin: true,
           ));
     });
 
     test('should return saved theme from storage', () async {
       when(() => mockStore.getString('currentTheme')).thenReturn('dark');
+      when(() => mockStore.getString('lastSelectedDriveId')).thenReturn(null);
       when(() => mockStore.getBool('showHiddenFiles')).thenReturn(false);
       when(() => mockStore.getBool('userHasHiddenDrive')).thenReturn(false);
-      when(() => mockAuth.onAuthStateChanged())
-          .thenAnswer((_) => Stream.value(getFakeUser()));
+      when(() => mockStore.getBool('syncAllDrivesOnLogin')).thenReturn(null);
 
       final result = await repository.load();
 
@@ -69,10 +72,19 @@ void main() {
             lastSelectedDriveId: null,
             showHiddenFiles: false,
             userHasHiddenDrive: false,
+            syncAllDrivesOnLogin: true,
           ));
     });
 
     test('should save theme to storage', () async {
+      // Setup initial load
+      when(() => mockStore.getString('currentTheme')).thenReturn('dark');
+      when(() => mockStore.getString('lastSelectedDriveId')).thenReturn(null);
+      when(() => mockStore.getBool('showHiddenFiles')).thenReturn(false);
+      when(() => mockStore.getBool('userHasHiddenDrive')).thenReturn(false);
+      when(() => mockStore.getBool('syncAllDrivesOnLogin')).thenReturn(null);
+      await repository.load();
+
       when(() => mockStore.putString('currentTheme', ArDriveThemes.light.name))
           .thenAnswer((_) async => true);
 
@@ -84,6 +96,14 @@ void main() {
     });
 
     test('should save last selected drive id to storage', () async {
+      // Setup initial load
+      when(() => mockStore.getString('currentTheme')).thenReturn('dark');
+      when(() => mockStore.getString('lastSelectedDriveId')).thenReturn(null);
+      when(() => mockStore.getBool('showHiddenFiles')).thenReturn(false);
+      when(() => mockStore.getBool('userHasHiddenDrive')).thenReturn(false);
+      when(() => mockStore.getBool('syncAllDrivesOnLogin')).thenReturn(null);
+      await repository.load();
+
       when(() => mockStore.putString('lastSelectedDriveId', 'drive_id'))
           .thenAnswer((_) async => true);
 
@@ -99,6 +119,7 @@ void main() {
       when(() => mockStore.getString('currentTheme')).thenReturn('dark');
       when(() => mockStore.getBool('showHiddenFiles')).thenReturn(false);
       when(() => mockStore.getBool('userHasHiddenDrive')).thenReturn(false);
+      when(() => mockStore.getBool('syncAllDrivesOnLogin')).thenReturn(null);
 
       final result = await repository.load();
 
@@ -109,10 +130,19 @@ void main() {
             lastSelectedDriveId: 'drive_id',
             showHiddenFiles: false,
             userHasHiddenDrive: false,
+            syncAllDrivesOnLogin: true,
           ));
     });
 
     test('should save show hidden files preference to storage', () async {
+      // Setup initial load
+      when(() => mockStore.getString('currentTheme')).thenReturn('dark');
+      when(() => mockStore.getString('lastSelectedDriveId')).thenReturn(null);
+      when(() => mockStore.getBool('showHiddenFiles')).thenReturn(false);
+      when(() => mockStore.getBool('userHasHiddenDrive')).thenReturn(false);
+      when(() => mockStore.getBool('syncAllDrivesOnLogin')).thenReturn(null);
+      await repository.load();
+
       when(() => mockStore.putBool('showHiddenFiles', true))
           .thenAnswer((_) async => true);
 
@@ -122,6 +152,14 @@ void main() {
     });
 
     test('should save user has hidden item preference to storage', () async {
+      // Setup initial load
+      when(() => mockStore.getString('currentTheme')).thenReturn('dark');
+      when(() => mockStore.getString('lastSelectedDriveId')).thenReturn(null);
+      when(() => mockStore.getBool('showHiddenFiles')).thenReturn(false);
+      when(() => mockStore.getBool('userHasHiddenDrive')).thenReturn(false);
+      when(() => mockStore.getBool('syncAllDrivesOnLogin')).thenReturn(null);
+      await repository.load();
+
       when(() => mockStore.putBool('userHasHiddenDrive', true))
           .thenAnswer((_) async => true);
 
@@ -131,6 +169,15 @@ void main() {
     });
 
     test('should clear last selected drive id from storage', () async {
+      // Setup initial load
+      when(() => mockStore.getString('currentTheme')).thenReturn('dark');
+      when(() => mockStore.getString('lastSelectedDriveId'))
+          .thenReturn('drive_id');
+      when(() => mockStore.getBool('showHiddenFiles')).thenReturn(true);
+      when(() => mockStore.getBool('userHasHiddenDrive')).thenReturn(true);
+      when(() => mockStore.getBool('syncAllDrivesOnLogin')).thenReturn(null);
+      await repository.load();
+
       when(() => mockStore.remove('lastSelectedDriveId'))
           .thenAnswer((_) async => true);
       when(() => mockStore.remove('showHiddenFiles'))
@@ -151,12 +198,14 @@ void main() {
           lastSelectedDriveId: null,
           showHiddenFiles: false,
           userHasHiddenDrive: false,
+          syncAllDrivesOnLogin: true,
         );
 
         when(() => mockStore.getString('currentTheme')).thenReturn('light');
         when(() => mockStore.getString('lastSelectedDriveId')).thenReturn(null);
         when(() => mockStore.getBool('showHiddenFiles')).thenReturn(false);
         when(() => mockStore.getBool('userHasHiddenDrive')).thenReturn(false);
+        when(() => mockStore.getBool('syncAllDrivesOnLogin')).thenReturn(true);
 
         final stream = repository.watch();
         // Use a StreamQueue to easily work with the stream in tests
@@ -191,7 +240,12 @@ void main() {
         await repository.saveShowHiddenFiles(true);
         await repository.saveUserHasHiddenItem(true);
 
+        // Skip intermediate emissions from save methods (4 emissions)
+        // and get the final state after load()
         await repository.load();
+
+        // Skip the 4 intermediate emissions from save* methods
+        await queue.skip(4);
 
         expect(
           await queue.next,
@@ -200,6 +254,7 @@ void main() {
             lastSelectedDriveId: 'new_drive_id',
             showHiddenFiles: true,
             userHasHiddenDrive: true,
+            syncAllDrivesOnLogin: true,
           ),
         );
 

--- a/test/user/repositories/user_preferences_repository_test.dart
+++ b/test/user/repositories/user_preferences_repository_test.dart
@@ -20,10 +20,25 @@ void main() {
     late MockThemeDetector mockThemeDetector;
     late MockArDriveAuth mockAuth;
 
+    /// Helper to set up default stubs that are needed when auth emits a user
+    /// (which triggers load() in the repository constructor)
+    void setUpDefaultStubs() {
+      when(() => mockStore.getString('currentTheme')).thenReturn(null);
+      when(() => mockStore.getString('lastSelectedDriveId')).thenReturn(null);
+      when(() => mockStore.getBool('showHiddenFiles')).thenReturn(false);
+      when(() => mockStore.getBool('userHasHiddenDrive')).thenReturn(false);
+      when(() => mockStore.getBool('syncAllDrivesOnLogin')).thenReturn(null);
+      when(() => mockThemeDetector.getOSDefaultTheme())
+          .thenReturn(ArDriveThemes.light);
+    }
+
     setUp(() {
       mockStore = MockLocalKeyValueStore();
       mockThemeDetector = MockThemeDetector();
       mockAuth = MockArDriveAuth();
+      // Set up default stubs BEFORE creating repository, since auth listener
+      // triggers load() when user is emitted
+      setUpDefaultStubs();
       when(() => mockAuth.onAuthStateChanged())
           .thenAnswer((_) => Stream.value(getFakeUser()));
       repository = UserPreferencesRepository(

--- a/test/user/repositories/user_preferences_repository_test.dart
+++ b/test/user/repositories/user_preferences_repository_test.dart
@@ -225,6 +225,13 @@ void main() {
       verify(() => mockStore.remove('userHasHiddenDrive')).called(1);
       // Verify syncAllDrivesOnLogin is NOT removed (should persist)
       verifyNever(() => mockStore.remove('syncAllDrivesOnLogin'));
+
+      // Verify the actual preferences object has correct values
+      final prefs = repository.currentPreferences!;
+      expect(prefs.lastSelectedDriveId, isNull);
+      expect(prefs.showHiddenFiles, false);
+      expect(prefs.userHasHiddenDrive, false);
+      expect(prefs.syncAllDrivesOnLogin, false);
     });
 
     test(


### PR DESCRIPTION
## Summary

This PR adds the ability to sync individual drives and introduces a toggle to control automatic sync behavior on login.

### New Features
- **Individual Drive Sync**: Sync a single drive from the kebab menu (Sync / Deep Sync options)
- **Sync-on-Login Toggle**: User preference to enable/disable automatic full sync on login
  - When OFF: Only drive metadata loads (fast), drives show "needs syncing" state
  - When ON: Full sync of all drives on login (existing behavior)
- **Unsynced Drive UI**: New sleek card design with "Sync This Drive" and "Sync All Drives" action cards
- **More Info for Unsynced Drives**: View drive details even before syncing

### UI/UX Improvements
- Branded Lottie animation (plate stacking) for all progress dialogs
- "Loading your drives..." modal during metadata-only sync (prevents "Getting Started" flash)
- Hover effects and tooltips for New button and Profile card
- Removed redundant sync actions from drive info panel (available in kebab menu)

### Bug Fixes
- Fixed login freeze caused by GlobalHideBloc infinite loop
- Fixed sync modal not showing "Syncing All Drives" immediately
- Fixed `syncAllDrivesOnLogin` preference being reset on logout
- Fixed missing asset error (`2x.png` → `ArDrive.png`)
- Fixed tutorial RangeError on rapid clicking
- Fixed tab visibility race condition for initial sync after login
- Fixed null pointer in `clear()` method for preferences
- Removed redundant full-sync after file upload

### Technical Changes
- New `SyncLoadingDrives` state for metadata-only sync UI feedback
- New `DriveDetailLoadUnsynced` state with `showDriveInfo` support
- `SyncProgress` now tracks `isSingleDriveSync` and `driveName`
- `startSyncForDrive()` method for individual drive sync
- `syncMetadataOnly()` method for lightweight drive list loading

## Test plan

- [ ] Login with "Automatic drive sync" ON → should show "Syncing All Drives" modal
- [ ] Login with "Automatic drive sync" OFF → should show "Loading your drives..." modal briefly, then drives appear with "needs syncing" state
- [ ] Click on unsynced drive → shows sleek UI with "Sync This Drive" and "Sync All Drives" cards
- [ ] Use kebab menu to sync individual drive → syncs only that drive
- [ ] Use "More Info" on unsynced drive → details panel shows
- [ ] Toggle "Automatic drive sync" in profile dropdown → persists across sessions
- [ ] Rapid-click through tutorial → no crash
- [ ] Check progress dialogs show branded Lottie animation

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unsynced-drive UI with details panel, action cards, single-drive sync & deep-sync, plus “Sync this drive” actions in drive menus and a profile/settings toggle to sync all drives on login.

* **Improvements**
  * Full-screen dimmed loading overlay and animated progress dialog with clearer sync titles/progress.
  * Hoverable “New” button with tooltip and updated onboarding logo.
  * Faster metadata-only startup sync path and improved single-drive sync flow.

* **Bug Fixes**
  * Prevented out-of-range tutorial page navigation.

* **Localization**
  * Added translations for sync flows and new tooltips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->