### PR TITLE
PE-9075: Disable AO-dependent features for Ar.io Solana migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,7 @@ lib/
 - DAOs: `DriveDao`, `ProfileDao`, `ARNSDao`
 - After schema changes: bump `schemaVersion` in `database.dart` and run code generation
 - Pre-push hook validates schema version is incremented when `.drift` files change
+- Pre-commit hook validates the correct Flutter version is installed
 
 ### Key Services
 

--- a/lib/app_shell.dart
+++ b/lib/app_shell.dart
@@ -594,7 +594,7 @@ class AppShellState extends State<AppShell> {
                 children: [
                   const TextSpan(
                     text:
-                        'Ar.io is migrating to Solana! Register before the May 15, 2026 snapshot! Manage your ArNS names at arns.ar.io. ',
+                        'Ar.io is migrating to Solana! Register before the June 1, 2026 snapshot! Manage your ArNS names at arns.ar.io. ',
                   ),
                   TextSpan(
                     text: 'Learn More',

--- a/lib/app_shell.dart
+++ b/lib/app_shell.dart
@@ -14,6 +14,7 @@ import 'package:ardrive/shared/blocs/private_drive_migration/private_drive_migra
 import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
 import 'package:ardrive/sync/domain/sync_progress.dart';
 import 'package:ardrive/utils/logger.dart';
+import 'package:ardrive/utils/open_url.dart';
 import 'package:ardrive/utils/show_general_dialog.dart';
 import 'package:ardrive/utils/size_constants.dart';
 import 'package:ardrive_ui/ardrive_ui.dart';
@@ -501,6 +502,7 @@ class AppShellState extends State<AppShell> {
                   builder: (context, state) {
                     return Column(
                       children: [
+                        _buildSolanaMigrationBanner(context),
                         _buildAnnouncementBanner(
                         context,
                         message: '', // Configure message when enabling banner
@@ -540,6 +542,7 @@ class AppShellState extends State<AppShell> {
                 builder: (context, state) {
                   return Column(
                     children: [
+                      _buildSolanaMigrationBanner(context),
                       _buildAnnouncementBanner(
                         context,
                         message: '', // Configure message when enabling banner
@@ -568,6 +571,66 @@ class AppShellState extends State<AppShell> {
           );
         },
       );
+
+  Widget _buildSolanaMigrationBanner(BuildContext context) {
+    final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
+    final typography = ArDriveTypographyNew.of(context);
+
+    return Container(
+      width: double.maxFinite,
+      color: colorTokens.containerL3,
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Flexible(
+            child: RichText(
+              textAlign: TextAlign.center,
+              text: TextSpan(
+                style: typography.paragraphNormal(
+                  fontWeight: ArFontWeight.semiBold,
+                  color: colorTokens.textHigh,
+                ),
+                children: [
+                  const TextSpan(
+                    text:
+                        'Ar.io is migrating to Solana! Register before the May 15, 2026 snapshot! Manage your ArNS names at arns.ar.io. ',
+                  ),
+                  TextSpan(
+                    text: 'Learn More',
+                    style: typography
+                        .paragraphNormal(
+                          fontWeight: ArFontWeight.semiBold,
+                          color: colorTokens.textHigh,
+                        )
+                        .copyWith(
+                          decoration: TextDecoration.underline,
+                        ),
+                    recognizer: TapGestureRecognizer()
+                      ..onTap = () => openUrl(
+                            url: 'https://ar.io/solana-migration',
+                            webOnlyWindowName: '_blank',
+                          ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          GestureDetector(
+            onTap: () => openUrl(
+              url: 'https://ar.io/solana-migration',
+              webOnlyWindowName: '_blank',
+            ),
+            child: ArDriveIcons.newWindow(
+              size: 16,
+              color: colorTokens.textHigh,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
 
   Widget _buildAnnouncementBanner(
     BuildContext context, {

--- a/lib/authentication/ardrive_auth.dart
+++ b/lib/authentication/ardrive_auth.dart
@@ -359,20 +359,21 @@ class ArDriveAuthImpl implements ArDriveAuth {
   }
 
   void _updateBalance() {
-    _userRepository.getARIOTokens(currentUser.wallet).then((value) {
-      _currentUser = _currentUser!.copyWith(
-        ioTokens: value,
-        errorFetchingIOTokens: false,
-      );
-      _userStreamController.add(_currentUser);
-    }).catchError((e) {
-      _currentUser = _currentUser!.copyWith(
-        errorFetchingIOTokens: true,
-      );
-      _userStreamController.add(_currentUser);
-      logger.e('Error fetching ARIOTokens', e);
-      return Future.value(null);
-    });
+    // TODO(solana-migration): Re-enable ARIO token balance fetch once migrated to Solana
+    // _userRepository.getARIOTokens(currentUser.wallet).then((value) {
+    //   _currentUser = _currentUser!.copyWith(
+    //     ioTokens: value,
+    //     errorFetchingIOTokens: false,
+    //   );
+    //   _userStreamController.add(_currentUser);
+    // }).catchError((e) {
+    //   _currentUser = _currentUser!.copyWith(
+    //     errorFetchingIOTokens: true,
+    //   );
+    //   _userStreamController.add(_currentUser);
+    //   logger.e('Error fetching ARIOTokens', e);
+    //   return Future.value(null);
+    // });
     _userRepository.getBalance(currentUser.wallet).then((value) {
       _currentUser = _currentUser!.copyWith(walletBalance: value);
       _userStreamController.add(_currentUser);
@@ -433,11 +434,11 @@ class ArDriveAuthImpl implements ArDriveAuth {
 
   @override
   Future<void> refreshBalance() async {
-    _currentUser = _currentUser!.copyWith(
-      errorFetchingIOTokens: false,
-    );
-
-    _userStreamController.add(_currentUser);
+    // TODO(solana-migration): Re-enable IO token refresh once migrated to Solana
+    // _currentUser = _currentUser!.copyWith(
+    //   errorFetchingIOTokens: false,
+    // );
+    // _userStreamController.add(_currentUser);
 
     _updateBalance();
   }

--- a/lib/components/details_panel.dart
+++ b/lib/components/details_panel.dart
@@ -916,16 +916,16 @@ class _DetailsPanelState extends State<DetailsPanel> {
             ],
           ),
         ),
-      // Only show ArNS Name field for assigning names to files when not on share page
-      if (widget.drivePrivacy == DrivePrivacy.public.name &&
-          AppPlatform.isWeb() &&
-          !widget.isSharePage) ...[
-        sizedBoxHeight16px,
-        DetailsPanelItem(
-          leading: _ArnsNameDisplay(fileItem: item),
-          itemTitle: 'ArNS Name',
-        ),
-      ],
+      // TODO(solana-migration): Re-enable ArNS name display/assignment once migrated to Solana
+      // if (widget.drivePrivacy == DrivePrivacy.public.name &&
+      //     AppPlatform.isWeb() &&
+      //     !widget.isSharePage) ...[
+      //   sizedBoxHeight16px,
+      //   DetailsPanelItem(
+      //     leading: _ArnsNameDisplay(fileItem: item),
+      //     itemTitle: 'ArNS Name',
+      //   ),
+      // ],
       if (pinnedDataOwnerAddress != null) ...[
         sizedBoxHeight16px,
         DetailsPanelItem(
@@ -1721,6 +1721,7 @@ class _LicenseDetailsPopoverButtonState
   }
 }
 
+// ignore: unused_element
 class _ArnsNameDisplay extends StatelessWidget {
   final FileDataTableItem fileItem;
 

--- a/lib/components/profile_card.dart
+++ b/lib/components/profile_card.dart
@@ -167,8 +167,9 @@ class _ProfileCardState extends State<ProfileCard> {
                   endIndent: 16,
                 ),
                 _buildBalanceRow(context, state),
-                if (isArioSDKSupportedOnPlatform())
-                  _buildIOTokenRow(context, state),
+                // TODO(solana-migration): Re-enable ARIO balance once migrated to Solana
+                // if (isArioSDKSupportedOnPlatform())
+                //   _buildIOTokenRow(context, state),
                 if (context.read<PaymentService>().useTurboPayment) ...[
                   Padding(
                     padding: const EdgeInsets.only(top: 20.0),
@@ -494,6 +495,7 @@ class _ProfileCardState extends State<ProfileCard> {
     );
   }
 
+  // ignore: unused_element
   Widget _buildIOTokenRow(BuildContext context, ProfileLoggedIn state) {
     final typography = ArDriveTypographyNew.of(context);
     final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;

--- a/lib/components/upload_form.dart
+++ b/lib/components/upload_form.dart
@@ -273,12 +273,13 @@ class _UploadFormState extends State<UploadForm> {
                     );
                   }).toList();
 
+                  // TODO(solana-migration): Re-enable LoadAnts once migrated to Solana
                   return UploadManifestOptionsBloc(
                     manifestFiles: manifestSelections,
                     arnsRepository: context.read<ARNSRepository>(),
                     arDriveAuth: context.read<ArDriveAuth>(),
                     selectedManifestIds: selectedManifestIds,
-                  )..add(LoadAnts());
+                  );
                 },
                 child: BlocListener<UploadManifestOptionsBloc,
                     UploadManifestOptionsState>(
@@ -1864,27 +1865,28 @@ class _UploadReadyWidget extends StatelessWidget {
                     ],
                   ),
                 ),
-              if (state.showArnsCheckbox && !state.loadingArNSNames)
-                Padding(
-                  padding: const EdgeInsets.only(top: 8, bottom: 8),
-                  child: Row(
-                    children: [
-                      ArDriveCheckBox(
-                        title: 'Assign an ArNS name',
-                        checked: state.arnsCheckboxChecked,
-                        useNewIcons: true,
-                        titleStyle: typography.paragraphNormal(
-                          fontWeight: ArFontWeight.semiBold,
-                        ),
-                        onChange: (value) {
-                          context
-                              .read<UploadCubit>()
-                              .changeShowArnsNameSelection(value);
-                        },
-                      ),
-                    ],
-                  ),
-                ),
+              // TODO(solana-migration): Re-enable ArNS name assignment checkbox once migrated to Solana
+              // if (state.showArnsCheckbox && !state.loadingArNSNames)
+              //   Padding(
+              //     padding: const EdgeInsets.only(top: 8, bottom: 8),
+              //     child: Row(
+              //       children: [
+              //         ArDriveCheckBox(
+              //           title: 'Assign an ArNS name',
+              //           checked: state.arnsCheckboxChecked,
+              //           useNewIcons: true,
+              //           titleStyle: typography.paragraphNormal(
+              //             fontWeight: ArFontWeight.semiBold,
+              //           ),
+              //           onChange: (value) {
+              //             context
+              //                 .read<UploadCubit>()
+              //                 .changeShowArnsNameSelection(value);
+              //           },
+              //         ),
+              //       ],
+              //     ),
+              //   ),
               Padding(
                 padding: const EdgeInsets.only(top: 8),
                 child: Column(

--- a/lib/core/upload/view/manifest_options/manifest_options.dart
+++ b/lib/core/upload/view/manifest_options/manifest_options.dart
@@ -89,6 +89,7 @@ class __ManifestOptionTileState extends State<_ManifestOptionTile> {
       final showingName = !isExpanded &&
           (widget.manifestSelection.antRecord != null ||
               widget.manifestSelection.undername != null);
+      // ignore: unused_local_variable
       final hasSelectedAnt = widget.manifestSelection.antRecord != null;
 
       return SingleChildScrollView(
@@ -156,32 +157,34 @@ class __ManifestOptionTileState extends State<_ManifestOptionTile> {
                       ],
                     ),
                   ),
-                  ArDriveTooltip(
-                    message: (state.arnsNamesLoaded && state.ants!.isEmpty)
-                        ? 'No ArNS names found for your wallet'
-                        : '',
-                    child: ArDriveButtonNew(
-                      text: !state.arnsNamesLoaded
-                          ? 'Loading Names...'
-                          : hasSelectedAnt
-                              ? 'Change ArNS Name'
-                              : 'Add ArNS Name',
-                      typography: typography,
-                      isDisabled: isExpanded ||
-                          !widget.isSelected ||
-                          !state.arnsNamesLoaded ||
-                          (state.arnsNamesLoaded && state.ants!.isEmpty),
-                      fontStyle: typography.paragraphSmall(),
-                      variant: ButtonVariant.primary,
-                      maxWidth: state.arnsNamesLoaded ? 140 : 160,
-                      maxHeight: 30,
-                      onPressed: () {
-                        context
-                            .read<UploadManifestOptionsBloc>()
-                            .add(ShowArNSSelection(manifest: file));
-                      },
-                    ),
-                  )
+                  // TODO(solana-migration): Re-enable ArNS name selection button once migrated to Solana
+                  // ArDriveTooltip(
+                  //   message: (state.arnsNamesLoaded && state.ants!.isEmpty)
+                  //       ? 'No ArNS names found for your wallet'
+                  //       : '',
+                  //   child: ArDriveButtonNew(
+                  //     text: !state.arnsNamesLoaded
+                  //         ? 'Loading Names...'
+                  //         : hasSelectedAnt
+                  //             ? 'Change ArNS Name'
+                  //             : 'Add ArNS Name',
+                  //     typography: typography,
+                  //     isDisabled: isExpanded ||
+                  //         !widget.isSelected ||
+                  //         !state.arnsNamesLoaded ||
+                  //         (state.arnsNamesLoaded && state.ants!.isEmpty),
+                  //     fontStyle: typography.paragraphSmall(),
+                  //     variant: ButtonVariant.primary,
+                  //     maxWidth: state.arnsNamesLoaded ? 140 : 160,
+                  //     maxHeight: 30,
+                  //     onPressed: () {
+                  //       context
+                  //           .read<UploadManifestOptionsBloc>()
+                  //           .add(ShowArNSSelection(manifest: file));
+                  //     },
+                  //   ),
+                  // )
+                  const SizedBox.shrink()
                 ],
               ),
               if (showingName) ...[

--- a/lib/pages/drive_detail/components/drive_explorer_item_tile.dart
+++ b/lib/pages/drive_detail/components/drive_explorer_item_tile.dart
@@ -1,7 +1,8 @@
 import 'dart:convert';
 
 import 'package:ardrive/arns/presentation/ant_icon.dart';
-import 'package:ardrive/arns/presentation/assign_name_modal.dart';
+// TODO(solana-migration): Re-enable when ArNS assignment is restored
+// import 'package:ardrive/arns/presentation/assign_name_modal.dart';
 import 'package:ardrive/blocs/drive_detail/drive_detail_cubit.dart';
 import 'package:ardrive/blocs/profile/profile_cubit.dart';
 import 'package:ardrive/components/components.dart';
@@ -624,23 +625,24 @@ class _DriveExplorerItemTileTrailingState
               height: height,
             ),
           ),
-        if (widget.drive.isPublic && AppPlatform.isWeb())
-          ArDriveDropdownItem(
-            onClick: () {
-              showAssignArNSNameModal(
-                context,
-                file: item as FileDataTableItem,
-                driveDetailCubit: context.read<DriveDetailCubit>(),
-              );
-            },
-            content: _buildItem(
-              'Assign ArNS name',
-              ArDriveIcons.addArnsName(
-                size: defaultIconSize,
-              ),
-              height: height,
-            ),
-          ),
+        // TODO(solana-migration): Re-enable ArNS name assignment once migrated to Solana
+        // if (widget.drive.isPublic && AppPlatform.isWeb())
+        //   ArDriveDropdownItem(
+        //     onClick: () {
+        //       showAssignArNSNameModal(
+        //         context,
+        //         file: item as FileDataTableItem,
+        //         driveDetailCubit: context.read<DriveDetailCubit>(),
+        //       );
+        //     },
+        //     content: _buildItem(
+        //       'Assign ArNS name',
+        //       ArDriveIcons.addArnsName(
+        //         size: defaultIconSize,
+        //       ),
+        //       height: height,
+        //     ),
+        //   ),
         hideFileDropdownItem(context, item),
       ],
       ArDriveDropdownItem(

--- a/lib/turbo/topup/models/crypto_token.dart
+++ b/lib/turbo/topup/models/crypto_token.dart
@@ -331,15 +331,17 @@ class TokenGroup extends Equatable {
 
   /// Get all token groups for display in the token selection view
   static List<TokenGroup> get allGroups => [
+        // TODO(solana-migration): Re-enable ARIO on AO group once migrated to Solana
         // Arweave wallet tokens (no label needed - uses existing wallet)
-        const TokenGroup(
-          tokens: [CryptoToken.arioAO],
-        ),
+        // const TokenGroup(
+        //   tokens: [CryptoToken.arioAO],
+        // ),
         // Ethereum wallet tokens
         const TokenGroup(
           label: 'Requires Ethereum Wallet',
           tokens: [
-            CryptoToken.arioAOViaEth,
+            // TODO(solana-migration): Re-enable arioAOViaEth once migrated to Solana
+            // CryptoToken.arioAOViaEth,
             CryptoToken.arioBase,
             CryptoToken.usdcBase,
             CryptoToken.ethBase,

--- a/lib/turbo/topup/views/crypto_topup/token_selection_view.dart
+++ b/lib/turbo/topup/views/crypto_topup/token_selection_view.dart
@@ -111,15 +111,15 @@ class _TokenSelectionContent extends StatelessWidget {
             const SizedBox(height: 16),
           ],
 
-          // ===== RECOMMENDED SECTION =====
-          _RecommendedSection(
-            arioBalance: state.arioBalance,
-            isLoadingBalances: state.isLoadingBalances,
-            onTokenSelected: (token) {
-              bloc.add(CryptoTopupSelectToken(token));
-            },
-          ),
-          const SizedBox(height: 24),
+          // TODO(solana-migration): Re-enable ARIO on AO recommended section once migrated to Solana
+          // _RecommendedSection(
+          //   arioBalance: state.arioBalance,
+          //   isLoadingBalances: state.isLoadingBalances,
+          //   onTokenSelected: (token) {
+          //     bloc.add(CryptoTopupSelectToken(token));
+          //   },
+          // ),
+          // const SizedBox(height: 24),
 
           // ===== OTHER OPTIONS SECTION =====
           _OtherOptionsSection(
@@ -136,14 +136,17 @@ class _TokenSelectionContent extends StatelessWidget {
 }
 
 /// Recommended section featuring ARIO on AO
+// ignore: unused_element
 class _RecommendedSection extends StatelessWidget {
+  // ignore: unused_element
   final TokenBalance? arioBalance;
+  // ignore: unused_element
   final bool isLoadingBalances;
   final ValueChanged<CryptoToken> onTokenSelected;
 
   const _RecommendedSection({
-    this.arioBalance,
-    this.isLoadingBalances = false,
+    this.arioBalance, // ignore: unused_element
+    this.isLoadingBalances = false, // ignore: unused_element
     required this.onTokenSelected,
   });
 
@@ -398,7 +401,8 @@ class _OtherOptionsSection extends StatelessWidget {
           title: 'Ethereum',
           description: 'Higher fees, more liquidity',
           tokens: const [
-            CryptoToken.arioAOViaEth,
+            // TODO(solana-migration): Re-enable arioAOViaEth once migrated to Solana
+            // CryptoToken.arioAOViaEth,
             CryptoToken.ethL1,
             CryptoToken.usdcEth,
           ],

--- a/lib/turbo/topup/views/unified/inline_crypto_payment.dart
+++ b/lib/turbo/topup/views/unified/inline_crypto_payment.dart
@@ -229,8 +229,9 @@ class _TokenSelector extends StatelessWidget {
             ),
             itemBuilder: (context) => [
               // ARIO options (no fees)
-              _buildTokenMenuItem(context, CryptoToken.arioAO),
-              _buildTokenMenuItem(context, CryptoToken.arioAOViaEth),
+              // TODO(solana-migration): Re-enable ARIO on AO options once migrated to Solana
+              // _buildTokenMenuItem(context, CryptoToken.arioAO),
+              // _buildTokenMenuItem(context, CryptoToken.arioAOViaEth),
               _buildTokenMenuItem(context, CryptoToken.arioBase),
               // Base L2 tokens (fast, low fees)
               _buildTokenMenuItem(context, CryptoToken.ethBase),


### PR DESCRIPTION
## Summary
- Disable ARIO token balance fetching in user profile
- Disable ArNS name assignment (details panel, file context menu, upload flow)
- Remove ARIO on AO and ARIO on AO via ETH top-up options (ARIO on Base remains)
- Add persistent Solana migration banner directing users to ar.io/solana-migration and arns.ar.io

## What's preserved
- ArNS primary name display (profile header)
- GAR gateway fetching
- ARIO on Base top-up
- AR wallet balance
- Existing ArNS name icons on files (read-only, local DB)

## Notes
- All disabled code tagged with `// TODO(solana-migration):` for easy re-enablement
- Analyzer passes clean (0 issues)

## Test plan
- [ ] Verify profile card no longer shows ARIO token balance
- [ ] Verify "Assign ArNS name" option is gone from file context menu
- [ ] Verify ArNS name section is gone from file details panel
- [ ] Verify "Assign an ArNS name" checkbox is gone from upload flow
- [ ] Verify "Add ArNS Name" button is gone from manifest options in upload
- [ ] Verify ARIO on AO and ARIO on AO (via Ethereum) are gone from crypto top-up token selection
- [ ] Verify ARIO on Base still appears and works in crypto top-up
- [ ] Verify Solana migration banner appears at top of app (desktop + mobile)
- [ ] Verify "Learn More" link opens https://ar.io/solana-migration
- [ ] Verify primary name still displays in profile header
- [ ] Verify AR balance still displays in profile card

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Solana migration announcement banner with an external “Learn More” link.

* **Removals**
  * Disabled ARIO/IO token balance displays in profile and related UI.
  * Removed ArNS name assignment and selection flows across upload and file-management screens.
  * Removed ARIO-on-AO and related ARIO token options from payment/token selection.

* **Documentation**
  * Added a pre-commit check requiring Flutter 3.19.6.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ardriveapp/ardrive-web/pull/2116)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->