### PR TITLE
PE-9103: Remove redundant post-upload sync + wallet creation loader copy

### DIFF
--- a/lib/authentication/login/blocs/login_bloc.dart
+++ b/lib/authentication/login/blocs/login_bloc.dart
@@ -630,35 +630,40 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
       return;
     }
 
-    try {
-      // 1. Connect wallet (ArConnect handles its own popup)
-      bool hasPermissions = await _arConnectService.checkPermissions();
-      if (!hasPermissions) {
-        try {
-          // If we have partial permissions, we're gonna disconnect before
-          /// re-connecting again.
-          ignoreNextWaletSwitch = true;
-          await _arConnectService.disconnect();
-        } catch (_) {}
+    // 1. Connect wallet (ArConnect handles its own popup)
+    bool hasPermissions = await _arConnectService.checkPermissions();
+    if (!hasPermissions) {
+      try {
+        // If we have partial permissions, disconnect before reconnecting.
+        ignoreNextWaletSwitch = true;
+        await _arConnectService.disconnect();
+      } catch (_) {}
 
+      try {
         await _arConnectService.connect();
+      } catch (e) {
+        // User rejected or extension error — return silently
+        return;
       }
+    }
 
-      hasPermissions = await _arConnectService.checkPermissions();
-      if (!hasPermissions) {
-        throw Exception('ArConnect permissions not granted');
-      }
+    hasPermissions = await _arConnectService.checkPermissions();
+    if (!hasPermissions) {
+      // User didn't grant permissions — return silently
+      return;
+    }
 
-      final wallet = ArConnectWallet(_arConnectService);
+    final wallet = ArConnectWallet(_arConnectService);
 
-      profileType = ProfileType.arConnect;
+    profileType = ProfileType.arConnect;
 
-      lastKnownWalletAddress = await wallet.getAddress();
+    lastKnownWalletAddress = await wallet.getAddress();
 
-      // 2. Server-side check (user waits — show blocking dialog)
-      emit(const LoginShowBlockingDialog(
-          message: 'Setting up your account...'));
+    // 2. Server-side check (user waits — show blocking dialog)
+    emit(const LoginShowBlockingDialog(
+        message: 'Setting up your account...'));
 
+    try {
       if (await _arDriveAuth.userHasPassword(wallet)) {
         emit(LoginCloseBlockingDialog());
         emit(PromptPassword(wallet: wallet, showWalletCreated: false));
@@ -904,7 +909,7 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
     try {
       ethWallet = await _ethereumProviderService.connect();
     } catch (e) {
-      emit(LoginFailure(e));
+      // User rejected or extension error — return silently
       return;
     }
 
@@ -929,7 +934,7 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
 
       derivedEthWallet = EthereumProviderWallet(privateKey);
     } catch (e) {
-      emit(LoginFailure(e));
+      // User rejected signature or extension error — return silently
       return;
     }
 

--- a/lib/authentication/login/blocs/login_bloc.dart
+++ b/lib/authentication/login/blocs/login_bloc.dart
@@ -641,8 +641,13 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
         await _arConnectService.connect();
       } catch (e) {
         // User rejected or extension error — return silently
+        ignoreNextWaletSwitch = false;
         return;
       }
+
+      // Clear the flag after connect completes — if the wallet switch
+      // event was going to fire, it already did during disconnect/connect.
+      ignoreNextWaletSwitch = false;
     }
 
     hasPermissions = await _arConnectService.checkPermissions();

--- a/lib/authentication/login/blocs/login_bloc.dart
+++ b/lib/authentication/login/blocs/login_bloc.dart
@@ -631,8 +631,7 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
     }
 
     try {
-      emit(LoginLoadingIfUserAlreadyExists());
-
+      // 1. Connect wallet (ArConnect handles its own popup)
       bool hasPermissions = await _arConnectService.checkPermissions();
       if (!hasPermissions) {
         try {
@@ -656,12 +655,16 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
 
       lastKnownWalletAddress = await wallet.getAddress();
 
+      // 2. Server-side check (user waits — show blocking dialog)
+      emit(const LoginShowBlockingDialog(
+          message: 'Setting up your account...'));
+
       if (await _arDriveAuth.userHasPassword(wallet)) {
-        emit(LoginLoadingIfUserAlreadyExistsSuccess());
+        emit(LoginCloseBlockingDialog());
         emit(PromptPassword(wallet: wallet, showWalletCreated: false));
       } else {
-        emit(LoginLoadingIfUserAlreadyExistsSuccess());
         final hasDrives = await _arDriveAuth.isExistingUser(wallet);
+        emit(LoginCloseBlockingDialog());
         emit(
           CreateNewPassword(
             wallet: wallet,
@@ -671,8 +674,7 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
         );
       }
     } catch (e) {
-      emit(LoginLoadingIfUserAlreadyExistsSuccess());
-      emit(previousState);
+      emit(LoginCloseBlockingDialog());
       if (e is AuthenticationGatewayException) {
         emit(GatewayLoginFailure(e, _getGatewayUrl()));
       } else {
@@ -896,35 +898,24 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
       emit(const LoginFailure('Metamask not available'));
       return;
     }
-    emit(const LoginShowBlockingDialog(
-        message: 'Please connect your Ethereum wallet.'));
 
+    // 1. Connect wallet (MetaMask handles its own popup)
     EthereumWallet? ethWallet;
     try {
       ethWallet = await _ethereumProviderService.connect();
     } catch (e) {
-      emit(LoginCloseBlockingDialog());
       emit(LoginFailure(e));
       return;
     }
 
-    emit(LoginCloseBlockingDialog());
-
     if (ethWallet == null) {
-      emit(const LoginFailure('Unable to connect to Metamask'));
       return;
     }
 
     _sourceWalletAddress = await ethWallet.getAddress();
 
-    // Sign message to verify user address and use signature to derive in-memory
-    // ETH wallet
-
+    // 2. Sign verification message (MetaMask handles its own popup)
     const signMessage = 'Sign message to verify wallet address.';
-
-    emit(const LoginShowBlockingDialog(
-        message:
-            'Please approve the request in your Ethereum wallet.'));
 
     late EthereumProviderWallet derivedEthWallet;
     try {
@@ -938,12 +929,11 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
 
       derivedEthWallet = EthereumProviderWallet(privateKey);
     } catch (e) {
-      emit(LoginCloseBlockingDialog());
       emit(LoginFailure(e));
       return;
     }
 
-    emit(LoginCloseBlockingDialog());
+    // 3. Server-side check (user waits — show blocking dialog)
     emit(const LoginShowBlockingDialog(
         message: 'Setting up your account...'));
 

--- a/lib/authentication/login/blocs/login_bloc.dart
+++ b/lib/authentication/login/blocs/login_bloc.dart
@@ -618,7 +618,6 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
     AddWalletFromArConnect event,
     Emitter<LoginState> emit,
   ) async {
-    final previousState = state;
     usingSeedphrase = false;
     _sourceWalletAddress = null;
 
@@ -626,7 +625,6 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
         await _arConnectService.isWalletVersionSupported();
     if (!arconnectVersionSupported) {
       emit(const LoginFailure(ArConnectVersionNotSupportedException()));
-      emit(previousState);
       return;
     }
 
@@ -983,12 +981,9 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
     LoginWithSolana event,
     Emitter<LoginState> emit,
   ) async {
-    final previousState = state;
-
     if (!_solanaProviderService.isExtensionPresent()) {
       emit(const LoginFailure(
           'No Solana wallet detected. Please install Phantom or Solflare.'));
-      emit(previousState);
       return;
     }
 
@@ -999,7 +994,6 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
 
       if (connection == null) {
         await _solanaProviderService.disconnect();
-        emit(previousState);
         return;
       }
 
@@ -1013,7 +1007,6 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
       } catch (e) {
         await _solanaProviderService.disconnect();
         _sourceWalletAddress = null;
-        emit(previousState);
         return;
       }
 
@@ -1054,7 +1047,6 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
       } else {
         emit(LoginFailure(e));
       }
-      emit(previousState);
     }
   }
 

--- a/lib/authentication/login/views/modals/blocking_modals.dart
+++ b/lib/authentication/login/views/modals/blocking_modals.dart
@@ -31,7 +31,7 @@ void showLoaderDialog({required BuildContext context}) {
           ),
           const SizedBox(height: 16),
           Text(
-            'Setting up your account...',
+            'Setting up your account.\nThis may take a moment.',
             style: ArDriveTypographyNew.of(context).paragraphNormal(
                 color: colorTokens.textLow,
                 fontWeight: ArFontWeight.semiBold),

--- a/lib/authentication/login/views/modals/blocking_modals.dart
+++ b/lib/authentication/login/views/modals/blocking_modals.dart
@@ -31,7 +31,7 @@ void showLoaderDialog({required BuildContext context}) {
           ),
           const SizedBox(height: 16),
           Text(
-            'Generating wallet...',
+            'Setting up your account...',
             style: ArDriveTypographyNew.of(context).paragraphNormal(
                 color: colorTokens.textLow,
                 fontWeight: ArFontWeight.semiBold),

--- a/lib/authentication/login/views/modals/solana_wallet_picker_modal.dart
+++ b/lib/authentication/login/views/modals/solana_wallet_picker_modal.dart
@@ -88,14 +88,6 @@ class SolanaWalletPickerModal extends StatelessWidget {
                 loginBloc.add(const LoginWithSolana(provider: 'solflare'));
               },
             ),
-            const SizedBox(height: 12),
-            ArDriveButtonNew(
-              text: 'Cancel',
-              typography: typography,
-              variant: ButtonVariant.outline,
-              maxWidth: double.maxFinite,
-              onPressed: () => Navigator.pop(context),
-            ),
           ],
         ),
       ),

--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -117,18 +117,14 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
           return;
         }
 
-        // Check if drive exists and has been content-synced
+        // Check if drive exists
         if (drive == null) {
           emit(DriveDetailLoadNotFound());
           return;
         }
 
-        // If drive has only metadata (not content-synced), show unsynced state
-        if (drive.lastBlockHeight == null || drive.lastBlockHeight == 0) {
-          emit(DriveDetailLoadUnsynced(drive: drive));
-          return;
-        }
-
+        // Open the drive regardless of lastBlockHeight.
+        // Background sync will update via Drift streams.
         openFolder(folderId: drive.rootFolderId);
       }).whenComplete(() {
         _initialLoadComplete = true;
@@ -195,12 +191,10 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
     // First check current drive state before waiting for sync
     var drive = await _driveDao.driveById(driveId: driveId).getSingleOrNull();
 
-    // If drive isn't synced yet, wait for sync to complete then re-check
-    if (drive == null || drive.lastBlockHeight == null || drive.lastBlockHeight == 0) {
+    // If drive doesn't exist locally at all, wait for sync to discover it
+    if (drive == null) {
       emit(DriveDetailLoadInProgress());
       await _syncCubit.waitCurrentSync();
-
-      // Re-query drive after sync completes
       drive = await _driveDao.driveById(driveId: driveId).getSingleOrNull();
     }
 
@@ -209,17 +203,9 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
       return;
     }
 
-    // Check if drive content has been synced (lastBlockHeight > 0 means synced)
-    if (drive.lastBlockHeight == null || drive.lastBlockHeight == 0) {
-      await _folderSubscription?.cancel();
-      _driveId = driveId;
-      // Clear selection state to avoid stale data leaking into sync/openFolder
-      _selectedItem = null;
-      _selectedItems.clear();
-      _refreshSelectedItem = false;
-      emit(DriveDetailLoadUnsynced(drive: drive));
-      return;
-    }
+    // Proceed to open the drive regardless of lastBlockHeight.
+    // The local DB has whatever the user created or last synced.
+    // Background sync will update via Drift streams if anything new appears.
 
     await _folderSubscription?.cancel();
 

--- a/lib/components/upload_form.dart
+++ b/lib/components/upload_form.dart
@@ -20,7 +20,6 @@ import 'package:ardrive/components/license/view_license_definition.dart';
 import 'package:ardrive/components/license_details_popover.dart';
 import 'package:ardrive/components/progress_dialog.dart';
 import 'package:ardrive/core/activity_tracker.dart';
-import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
 import 'package:ardrive/core/arfs/entities/arfs_entities.dart';
 import 'package:ardrive/core/arfs/repository/file_repository.dart';
 import 'package:ardrive/core/arfs/repository/folder_repository.dart';
@@ -214,7 +213,8 @@ class _UploadFormState extends State<UploadForm> {
               if (!_isShowingCancelDialog) {
                 Navigator.pop(context);
                 context.read<ActivityTracker>().setUploading(false);
-                context.read<SyncCubit>().startSync();
+                // No sync needed — local DB already has the uploaded file.
+                // Background periodic sync will update lastBlockHeight naturally.
               }
 
               widget.driveDetailCubit.refreshDriveDataTable();

--- a/test/authentication/login/blocs/login_bloc_test.dart
+++ b/test/authentication/login/blocs/login_bloc_test.dart
@@ -669,8 +669,8 @@ void main() {
         bloc.add(const AddWalletFromArConnect());
       },
       expect: () => [
-        LoginLoadingIfUserAlreadyExists(),
-        LoginLoadingIfUserAlreadyExistsSuccess(),
+        const TypeMatcher<LoginShowBlockingDialog>(),
+        LoginCloseBlockingDialog(),
         const TypeMatcher<PromptPassword>()
       ],
     );
@@ -697,8 +697,8 @@ void main() {
         bloc.add(const AddWalletFromArConnect());
       },
       expect: () => [
-        LoginLoadingIfUserAlreadyExists(),
-        LoginLoadingIfUserAlreadyExistsSuccess(),
+        const TypeMatcher<LoginShowBlockingDialog>(),
+        LoginCloseBlockingDialog(),
         predicate<CreateNewPassword>((cnp) {
           return cnp.showWalletCreated == false &&
               cnp.mnemonic == null &&
@@ -729,8 +729,8 @@ void main() {
         bloc.add(const AddWalletFromArConnect());
       },
       expect: () => [
-        LoginLoadingIfUserAlreadyExists(),
-        LoginLoadingIfUserAlreadyExistsSuccess(),
+        const TypeMatcher<LoginShowBlockingDialog>(),
+        LoginCloseBlockingDialog(),
         predicate<CreateNewPassword>((cnp) {
           return cnp.showWalletCreated == false &&
               cnp.mnemonic == null &&
@@ -752,16 +752,10 @@ void main() {
             .thenAnswer((invocation) => Future.value(false));
       },
       act: (bloc) async {
-        // when an error occurs we go back to the last state, so use it to test
-        bloc.emit(const PromptPassword());
-
         bloc.add(const AddWalletFromArConnect());
       },
       expect: () => [
-        const PromptPassword(),
-        LoginLoadingIfUserAlreadyExists(),
-        LoginLoadingIfUserAlreadyExistsSuccess(),
-        const PromptPassword(),
+        LoginCloseBlockingDialog(),
         const TypeMatcher<LoginFailure>(),
       ],
     );

--- a/test/authentication/login/blocs/login_bloc_test.dart
+++ b/test/authentication/login/blocs/login_bloc_test.dart
@@ -1038,18 +1038,15 @@ void main() {
             .thenReturn(false);
       },
       act: (bloc) async {
-        bloc.emit(const PromptPassword());
         bloc.add(const LoginWithSolana());
       },
       expect: () => [
-        const PromptPassword(),
         const TypeMatcher<LoginFailure>(),
-        const PromptPassword(),
       ],
     );
 
     blocTest(
-      'should stay on current state when user rejects wallet connection',
+      'should return silently when user rejects wallet connection',
       build: () => createSolanaBloc(),
       setUp: () {
         when(() => mockSolanaProviderService.connect(
@@ -1059,11 +1056,11 @@ void main() {
       act: (bloc) async {
         bloc.add(const LoginWithSolana());
       },
-      expect: () => [LoginLoading()],
+      expect: () => [],
     );
 
     blocTest(
-      'should stay on current state when user rejects signature',
+      'should return silently when user rejects signature',
       build: () => createSolanaBloc(),
       setUp: () {
         when(() => mockSolanaProviderService.connect(
@@ -1078,7 +1075,7 @@ void main() {
       act: (bloc) async {
         bloc.add(const LoginWithSolana());
       },
-      expect: () => [LoginLoading()],
+      expect: () => [],
     );
   });
 }

--- a/test/authentication/login/blocs/login_bloc_test.dart
+++ b/test/authentication/login/blocs/login_bloc_test.dart
@@ -740,7 +740,7 @@ void main() {
     );
 
     blocTest(
-      'should emit a failure when user doesnt have permissions',
+      'should return silently when user doesnt grant permissions',
       build: () {
         return createBloc();
       },
@@ -754,10 +754,8 @@ void main() {
       act: (bloc) async {
         bloc.add(const AddWalletFromArConnect());
       },
-      expect: () => [
-        LoginCloseBlockingDialog(),
-        const TypeMatcher<LoginFailure>(),
-      ],
+      // User rejected — silent return, no error dialog
+      expect: () => [],
     );
   });
 


### PR DESCRIPTION
## Summary
- Remove sync trigger after file upload — local DB already has the file, Drift streams update the UI
- Add time expectation to wallet creation loader: "This may take a moment."

## Test plan
- [ ] Upload file → no sync overlay → file visible immediately
- [ ] Upload to new empty drive → works without sync gate
- [ ] Wallet creation modal shows "This may take a moment."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced wallet authentication flows with better connection/permission handling and quieter failure behavior for ArConnect, MetaMask, and Solana.
  * Updated account setup messaging to “Setting up your account. This may take a moment.”

* **Behavior**
  * Drive access now opens unsynced drives immediately for faster access.
  * Upload completion no longer forces an immediate manual sync; relies on background syncing.

* **UI**
  * Solana wallet picker no longer shows a Cancel button.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->