### PR TITLE
PE-9103: Fix GraphQL endpoint change overriding data gateway

### DIFF
--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -108,18 +108,9 @@ class ArweaveService {
     client = Arweave(api: ArweaveApi(gatewayUrl: getGatewayUri(gateway)));
   }
 
-  static Uri _baseGatewayUriFromUrl(String gatewayUrl) {
-    final uri = Uri.parse(gatewayUrl);
-    final path = uri.path;
-    if (path.endsWith('/graphql')) {
-      final basePath = path.substring(0, path.length - 8);
-      return uri.replace(path: basePath.isEmpty ? '/' : basePath);
-    }
-    return uri;
-  }
-
-  /// Updates the GraphQL endpoint and Arweave API client to use [gatewayUrl],
-  /// then notifies so uploader and other dependents can rebuild.
+  /// Updates ONLY the GraphQL endpoint. Does NOT change the data gateway.
+  /// Data requests (GET /tx/{id}/data, wallet balance, etc.) continue using
+  /// the configured arweaveGatewayForDataRequest.
   void updateGraphQLEndpoint(String gatewayUrl) {
     final previousClient = _gql;
     final graphqlUrl = _graphqlUrlFromGateway(gatewayUrl);
@@ -132,10 +123,6 @@ class ArweaveService {
       arioSDK: ArioSDKFactory().create(),
     );
     previousClient.dispose();
-
-    client = Arweave(
-      api: ArweaveApi(gatewayUrl: _baseGatewayUriFromUrl(gatewayUrl)),
-    );
   }
 
   int bytesToChunks(int bytes) {


### PR DESCRIPTION
## Summary
- `updateGraphQLEndpoint()` was changing both the GraphQL client AND the Arweave data client
- Setting GraphQL to a query-only endpoint (e.g., Goldsky) broke data access (login, file downloads)
- Now only updates the GraphQL client — data requests stay on the configured gateway

## Test plan
- [ ] Change GraphQL endpoint to Goldsky in settings
- [ ] Login still works (data fetches go to ardrive.net, not Goldsky)
- [ ] File downloads still work
- [ ] Change GraphQL back to default — still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where updating the GraphQL endpoint would inadvertently affect data connections. GraphQL endpoint updates now operate independently while maintaining existing data gateway configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->