### PR TITLE
PE-9103: Add data gateway fallback resilience

### DIFF
--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -9,6 +9,7 @@ import 'package:ardrive/entities/drive_signature_type.dart';
 import 'package:ardrive/entities/entities.dart';
 import 'package:ardrive/models/daos/drive_dao/drive_dao.dart';
 import 'package:ardrive/services/arweave/arweave_service_exception.dart';
+import 'package:ardrive/services/arweave/data_gateway_fallback.dart';
 import 'package:ardrive/services/arweave/error/gateway_error.dart';
 import 'package:ardrive/services/arweave/get_segmented_transaction_from_drive_strategy.dart';
 import 'package:ardrive/services/services.dart';
@@ -31,7 +32,6 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:cryptography/cryptography.dart';
 import 'package:http/http.dart';
 import 'package:package_info_plus/package_info_plus.dart';
-import 'package:retry/retry.dart';
 import 'package:stash_shared_preferences/stash_shared_preferences.dart';
 
 import 'error/gateway_response_handler.dart';
@@ -49,6 +49,7 @@ class ArweaveService {
   final ArDriveCrypto _crypto;
   final DriveDao _driveDao;
   late ArtemisClient _gql;
+  late DataGatewayFallback _gatewayFallback;
 
   static String _graphqlUrlFromGateway(String gatewayUrl) {
     final uri = Uri.parse(gatewayUrl);
@@ -100,6 +101,9 @@ class ArweaveService {
           return exception is! RateLimitError;
         },
       ),
+    );
+    _gatewayFallback = DataGatewayFallback(
+      arioSDK: ArioSDKFactory().create(),
     );
   }
 
@@ -596,9 +600,7 @@ class ArweaveService {
   }
 
   Future<Uint8List> getEntityDataFromNetwork({required String txId}) async {
-    final Response data =
-        (await httpRetry.processRequest(() => client.api.getSandboxedTx(txId)));
-
+    final Response data = await _gatewayFallback.fetchData(txId, client);
     return data.bodyBytes;
   }
 
@@ -681,8 +683,7 @@ class ArweaveService {
     final driveSignatureTx = await getDriveSignatureTxForDrive(wallet, driveId);
 
     final driveSignatureData = driveSignatureTx != null
-        ? (await httpRetry.processRequest(
-            () => client.api.getSandboxedTx(driveSignatureTx.id)))
+        ? await _gatewayFallback.fetchData(driveSignatureTx.id, client)
         : null;
 
     final driveSignature =
@@ -702,16 +703,17 @@ class ArweaveService {
       final userAddress = await wallet.getAddress();
       final driveTxs = await getUniqueUserDriveEntityTxs(userAddress);
 
-      final driveResponses = await retry(
-          () async => await Future.wait(
-                driveTxs.map((e) => client.api.getSandboxedTx(e.id)),
-              ), onRetry: (Exception err) {
-        logger.w('Retrying for get unique user drive entities');
-      });
+      final driveResponses = await Future.wait(
+        driveTxs.map((e) => _gatewayFallback
+            .fetchData(e.id, client)
+            .then<Response?>((r) => r)
+            .catchError((_) => null)),
+      );
 
       final drivesById = <String?, DriveEntity>{};
       final drivesWithKey = <DriveEntity, DriveKey?>{};
       for (var i = 0; i < driveTxs.length; i++) {
+        if (driveResponses[i] == null) continue;
         final driveTx = driveTxs[i];
 
         // Ignore drive entity transactions which we already have newer entities for.
@@ -752,7 +754,7 @@ class ArweaveService {
           final drive = await DriveEntity.fromTransaction(
             driveTx,
             _crypto,
-            driveResponses[i].bodyBytes,
+            driveResponses[i]!.bodyBytes,
             driveKey?.key,
           );
 
@@ -835,11 +837,7 @@ class ArweaveService {
       }
 
       final fileTx = filteredEdges.first.node;
-      final fileDataRes = await client.api.getSandboxedTx(fileTx.id);
-
-      if (fileDataRes.statusCode == 404) {
-        throw TransactionNotFound(fileTx.id);
-      }
+      final fileDataRes = await _gatewayFallback.fetchData(fileTx.id, client);
 
       try {
         return await DriveEntity.fromTransaction(
@@ -1064,7 +1062,7 @@ class ArweaveService {
       }
 
       final fileTx = filteredEdges.first.node;
-      final fileDataRes = await client.api.getSandboxedTx(fileTx.id);
+      final fileDataRes = await _gatewayFallback.fetchData(fileTx.id, client);
 
       try {
         return await FileEntity.fromTransaction(
@@ -1120,7 +1118,8 @@ class ArweaveService {
       }
       for (var edge in queryEdges) {
         final fileTx = edge.node;
-        final fileDataRes = await client.api.getSandboxedTx(fileTx.id);
+        final fileDataRes =
+            await _gatewayFallback.fetchData(fileTx.id, client);
 
         try {
           fileEntities.add(
@@ -1472,8 +1471,7 @@ class ArweaveService {
   ) async {
     // TODO: PE-2917
 
-    final Response data =
-        (await httpRetry.processRequest(() => client.api.getSandboxedTx(txId)));
+    final Response data = await _gatewayFallback.fetchData(txId, client);
     final metadata = data.bodyBytes;
     return metadata;
   }

--- a/lib/services/arweave/data_gateway_fallback.dart
+++ b/lib/services/arweave/data_gateway_fallback.dart
@@ -1,0 +1,168 @@
+import 'dart:async';
+
+import 'package:ardrive/services/arweave/arweave_service.dart';
+import 'package:ardrive/utils/logger.dart';
+import 'package:ario_sdk/ario_sdk.dart';
+import 'package:arweave/arweave.dart';
+import 'package:http/http.dart';
+
+/// Provides data gateway fallback resilience.
+///
+/// When the primary gateway fails (404, 429, 5xx, timeout), automatically
+/// tries gateways from the AR.IO GAR list, then arweave.net as last resort.
+/// Fallback is per-request — the primary gateway is always tried first.
+class DataGatewayFallback {
+  final ArioSDK _arioSDK;
+  final Map<String, Arweave> _clientCache = {};
+
+  static const _lastResortGateway = 'https://arweave.net';
+  static const _maxGarFallbacks = 3;
+  static const _retryPerGateway = 2;
+  static const _garListTimeout = Duration(seconds: 5);
+
+  DataGatewayFallback({
+    required ArioSDK arioSDK,
+  }) : _arioSDK = arioSDK;
+
+  /// Fetch transaction data with automatic gateway fallback.
+  ///
+  /// Tries: primary → up to 3 GAR gateways → arweave.net
+  ///
+  /// If ALL gateways return 404, throws [TransactionNotFound] to preserve
+  /// upstream error handling (e.g. private drive detection during login).
+  Future<Response> fetchData(String txId, Arweave primaryClient) async {
+    var all404 = true;
+
+    // 1. Try primary gateway
+    try {
+      return await _tryGateway(primaryClient, txId);
+    } on _ErrorFromStatus catch (e) {
+      if (!e.retryable) rethrow;
+      if (e.statusCode != 404) all404 = false;
+      logger.w(
+        'Primary gateway failed for tx $txId '
+        '(${primaryClient.api.gatewayUrl}): $e',
+      );
+    } catch (e) {
+      all404 = false;
+      logger.w(
+        'Primary gateway failed for tx $txId '
+        '(${primaryClient.api.gatewayUrl}): $e',
+      );
+    }
+
+    // 2. Try GAR gateways (with timeout on list fetch)
+    try {
+      final gateways = await _arioSDK
+          .getGateways()
+          .timeout(_garListTimeout, onTimeout: () => <Gateway>[]);
+      final primaryHost = primaryClient.api.gatewayUrl.host;
+
+      var tried = 0;
+      for (final gw in gateways) {
+        if (tried >= _maxGarFallbacks) break;
+        if (gw.settings.fqdn == primaryHost) continue;
+
+        try {
+          final client = _getOrCreateClient(gw.settings.fqdn);
+          final response = await _tryGateway(client, txId);
+          logger.i(
+            'Fallback gateway ${gw.settings.fqdn} succeeded for tx $txId',
+          );
+          return response;
+        } on _ErrorFromStatus catch (e) {
+          if (!e.retryable) rethrow;
+          if (e.statusCode != 404) all404 = false;
+          logger.w(
+            'Fallback gateway ${gw.settings.fqdn} failed for tx $txId: $e',
+          );
+          tried++;
+          continue;
+        } catch (e) {
+          all404 = false;
+          logger.w(
+            'Fallback gateway ${gw.settings.fqdn} failed for tx $txId: $e',
+          );
+          tried++;
+          continue;
+        }
+      }
+    } catch (e) {
+      all404 = false;
+      logger.w('GAR list unavailable for fallback: $e');
+    }
+
+    // 3. Last resort: arweave.net
+    logger.w('Trying last resort gateway $_lastResortGateway for tx $txId');
+    try {
+      final lastResortClient = _getOrCreateClient('arweave.net');
+      final response = await _tryGateway(lastResortClient, txId);
+      logger.i('Last resort gateway succeeded for tx $txId');
+      return response;
+    } on _ErrorFromStatus catch (e) {
+      if (e.statusCode != 404) all404 = false;
+    } catch (e) {
+      all404 = false;
+    }
+
+    // All gateways failed
+    if (all404) {
+      throw TransactionNotFound(txId);
+    }
+    throw Exception('All gateways failed for tx $txId');
+  }
+
+  Future<Response> _tryGateway(Arweave client, String txId) async {
+    Exception? lastError;
+
+    for (var attempt = 0; attempt < _retryPerGateway; attempt++) {
+      try {
+        final response = await client.api.getSandboxedTx(txId);
+
+        if (response.statusCode >= 200 && response.statusCode <= 208) {
+          return response;
+        }
+
+        if (!_isRetryableStatus(response.statusCode)) {
+          throw _ErrorFromStatus(response.statusCode, txId, retryable: false);
+        }
+
+        throw _ErrorFromStatus(response.statusCode, txId);
+      } catch (e) {
+        lastError = e is Exception ? e : Exception(e.toString());
+        if (attempt < _retryPerGateway - 1) {
+          await Future.delayed(
+            Duration(milliseconds: 500 * (attempt + 1)),
+          );
+        }
+      }
+    }
+
+    throw lastError!;
+  }
+
+  bool _isRetryableStatus(int statusCode) =>
+      statusCode == 404 ||
+      statusCode == 429 ||
+      (statusCode >= 500 && statusCode < 600);
+
+  Arweave _getOrCreateClient(String fqdn) {
+    return _clientCache.putIfAbsent(
+      fqdn,
+      () => Arweave(
+        api: ArweaveApi(gatewayUrl: Uri.parse('https://$fqdn')),
+      ),
+    );
+  }
+}
+
+class _ErrorFromStatus implements Exception {
+  final int statusCode;
+  final String txId;
+  final bool retryable;
+
+  _ErrorFromStatus(this.statusCode, this.txId, {this.retryable = true});
+
+  @override
+  String toString() => 'Gateway returned $statusCode for tx $txId';
+}


### PR DESCRIPTION
## Summary
When the primary data gateway (turbo-gateway.com) fails, automatically try fallback gateways instead of retrying the same failing gateway 8 times.

## Fallback chain
1. **Primary gateway** (turbo-gateway.com) — 2 attempts
2. **Up to 3 GAR gateways** (AR.IO registry, sorted by total stake, cached) — 2 attempts each
3. **arweave.net** — last resort, 2 attempts

**Rotates on:** 404 (data not indexed), 429 (rate limit), 5xx (server error), timeout
**Fallback is per-request** — primary gateway is always tried first on the next request

## Changes
- **New:** `lib/services/arweave/data_gateway_fallback.dart` — `DataGatewayFallback` class with the fallback chain logic, client caching, and logging
- **Modified:** `lib/services/arweave/arweave_service.dart` — replaced 7 direct `client.api.getSandboxedTx()` / `httpRetry.processRequest()` calls with `_gatewayFallback.fetchData()`

## Methods covered (7)
| Method | Purpose |
|--------|---------|
| `getEntityDataFromNetwork()` | Sync / entity loading |
| `getDriveSignatureForDrive()` | Drive key derivation |
| `getUniqueUserDriveEntities()` | Batch entity loading on login |
| `getLatestDriveEntityWithId()` | Drive entity loading |
| `getLatestFileEntityWithId()` | File entity loading |
| `getAllFileEntitiesWithId()` | All file version history |
| `dataFromTxId()` | Raw data fetch |

## Not covered (by design)
- **URL construction sites** (30+ call sites) — preview URLs, Image.network, download links. Can't retry browser-rendered URLs. User can switch gateway via settings.
- **GraphQL** — already has 429 rotation, only ardrive.net serves GraphQL reliably
- **Streaming downloads** — uses arweave SDK streaming API, more complex to add fallback

## Test plan
- [x] `flutter analyze` — no issues
- [x] 84 relevant tests pass (arweave service, GAR, user, sync)
- [ ] Manual: set primary gateway to broken URL in Shift+H → verify data still loads via fallback
- [ ] Manual: verify normal operation unchanged (primary succeeds, no fallback log messages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a multi-gateway fallback mechanism for transaction data retrieval to improve availability and reduce single-gateway dependence.

* **Bug Fixes**
  * Batch fetching now tolerates individual item failures so successful items still load.
  * Improved retry and error handling to avoid premature failures for missing or temporarily unreachable transactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->