### PR TITLE
PE-9103: Add retry + fallback to snapshot validation

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -493,6 +493,7 @@ class AppState extends State<App> {
             batchProcessor: BatchProcessor(),
             snapshotValidationService: SnapshotValidationService(
               configService: configService,
+              arioSDK: ArioSDKFactory().create(),
             ),
             arnsRepository: _.read<ARNSRepository>(),
             userPreferencesRepository: _.read<UserPreferencesRepository>(),

--- a/lib/sync/data/snapshot_validation_service.dart
+++ b/lib/sync/data/snapshot_validation_service.dart
@@ -1,63 +1,132 @@
+import 'dart:async';
+
 import 'package:ardrive/services/config/config_service.dart';
 import 'package:ardrive/utils/logger.dart';
 import 'package:ardrive/utils/snapshots/snapshot_item.dart';
+import 'package:ario_sdk/ario_sdk.dart';
 import 'package:http/http.dart' as http;
 
 class SnapshotValidationService {
   final ConfigService _configService;
+  final ArioSDK _arioSDK;
+
+  static const _headTimeout = Duration(seconds: 10);
+  static const _retryDelay = Duration(milliseconds: 500);
+  static const _garListTimeout = Duration(seconds: 5);
 
   SnapshotValidationService({
     required ConfigService configService,
-  }) : _configService = configService;
+    required ArioSDK arioSDK,
+  })  : _configService = configService,
+        _arioSDK = arioSDK;
 
   Future<List<SnapshotItem>> validateSnapshotItems(
     List<SnapshotItem> snapshotItems,
   ) async {
-    List<SnapshotItem> snapshotsVerified = [];
+    final List<SnapshotItem> snapshotsVerified = [];
+    final primaryUrl = _configService.config.arweaveGatewayForDataRequest.url;
 
     final futures = snapshotItems.map((snapshotItem) async {
-      final appConfig = _configService.config;
-
       try {
-        const validationTimeout = Duration(seconds: 10);
+        final isValid = await _validateSnapshot(snapshotItem.txId, primaryUrl);
 
-        final snapshotValidation = await http
-            .head(
-          Uri.parse(
-              '${appConfig.arweaveGatewayForDataRequest.url}/${snapshotItem.txId}'),
-        )
-            .timeout(
-          validationTimeout,
-          onTimeout: () {
-            logger.w('HEAD request timeout for snapshot ${snapshotItem.txId}');
-            return http.Response('', 408); // Request Timeout
-          },
-        );
-
-        logger.d(
-            'HEAD request for snapshot ${snapshotItem.txId}: ${snapshotValidation.statusCode}');
-
-        // Accept snapshot if HEAD request succeeds
-        if (snapshotValidation.statusCode == 200) {
+        if (isValid) {
           logger.d('Snapshot ${snapshotItem.txId} is valid');
           snapshotsVerified.add(snapshotItem);
         } else {
-          logger.w(
-              'Snapshot ${snapshotItem.txId} failed validation: ${snapshotValidation.statusCode}');
+          logger.w('Snapshot ${snapshotItem.txId} failed validation');
         }
       } catch (e, stackTrace) {
         logger.e(
-            'Error while validating snapshot ${snapshotItem.txId}',
-            e,
-            stackTrace);
+          'Error while validating snapshot ${snapshotItem.txId}',
+          e,
+          stackTrace,
+        );
       }
     });
 
     await Future.wait(futures);
 
-    snapshotItems.clear();
-    snapshotItems = snapshotsVerified;
-
-    return snapshotItems;
+    return snapshotsVerified;
   }
+
+  /// Validates a snapshot is available on at least one gateway.
+  ///
+  /// 1. Try primary gateway with 1 retry on transient errors
+  /// 2. If primary fails, try 1 fallback gateway from the GAR list
+  /// 3. Accept if ANY gateway returns 200
+  Future<bool> _validateSnapshot(String txId, String primaryUrl) async {
+    // 1. Try primary gateway (with 1 retry)
+    for (var attempt = 0; attempt < 2; attempt++) {
+      try {
+        final response = await http
+            .head(Uri.parse('$primaryUrl/$txId'))
+            .timeout(_headTimeout);
+
+        if (response.statusCode == 200) return true;
+
+        if (_isNonRetryable(response.statusCode)) {
+          logger.w(
+            'Snapshot $txId rejected: '
+            'non-retryable status ${response.statusCode}',
+          );
+          return false;
+        }
+
+        logger.d(
+          'Snapshot $txId HEAD attempt ${attempt + 1} '
+          'returned ${response.statusCode}',
+        );
+      } on TimeoutException {
+        logger.d('Snapshot $txId HEAD attempt ${attempt + 1} timed out');
+      } catch (e) {
+        logger.d('Snapshot $txId HEAD attempt ${attempt + 1} error: $e');
+      }
+
+      // Retry after brief delay (skip delay on last attempt)
+      if (attempt == 0) {
+        await Future.delayed(_retryDelay);
+      }
+    }
+
+    // 2. Primary failed — try 1 fallback gateway
+    try {
+      final gateways = await _arioSDK
+          .getGateways()
+          .timeout(_garListTimeout, onTimeout: () => <Gateway>[]);
+
+      if (gateways.isEmpty) return false;
+
+      final primaryHost = Uri.parse(primaryUrl).host;
+      final fallback = gateways.firstWhere(
+        (gw) => gw.settings.fqdn != primaryHost,
+        orElse: () => gateways.first,
+      );
+
+      final response = await http
+          .head(Uri.parse('https://${fallback.settings.fqdn}/$txId'))
+          .timeout(_headTimeout);
+
+      if (response.statusCode == 200) {
+        logger.i(
+          'Snapshot $txId validated via fallback '
+          'gateway ${fallback.settings.fqdn}',
+        );
+        return true;
+      }
+
+      logger.w(
+        'Snapshot $txId fallback gateway ${fallback.settings.fqdn} '
+        'returned ${response.statusCode}',
+      );
+    } catch (e) {
+      logger.w('Snapshot $txId fallback validation failed: $e');
+    }
+
+    return false;
+  }
+
+  /// Status codes that should not be retried or fallback-rotated.
+  bool _isNonRetryable(int statusCode) =>
+      statusCode == 400 || statusCode == 401 || statusCode == 403;
 }


### PR DESCRIPTION
## Summary
Snapshot HEAD validation now retries on transient errors and tries a fallback gateway, aligning with the `DataGatewayFallback` download layer (PR #2130).

## Problem
A single HEAD failure (timeout, gateway blip, 404 due to indexing lag) permanently rejected a snapshot, forcing full GraphQL sync for that block range — much slower. Meanwhile, the download layer could have fetched the snapshot from a fallback gateway.

## Solution
| Condition | Behavior |
|-----------|----------|
| 200 | Accept immediately |
| 400/401/403 | Reject immediately (non-retryable) |
| 404/429/5xx/timeout/error | Retry once on primary (500ms delay), then try 1 GAR fallback |
| All fail | Reject — sync falls back to GraphQL (safe, existing behavior) |

## Changes
- **`lib/sync/data/snapshot_validation_service.dart`**: Rewrite with `_validateSnapshot()` helper — retry + fallback logic, error classification, logging at each step
- **`lib/main.dart`**: Pass `ArioSDK` to `SnapshotValidationService` constructor (for GAR fallback)

## Test plan
- [x] `flutter analyze` — no issues
- [x] 21 sync tests pass
- [ ] Manual: verify snapshots validate normally (primary 200, no retry/fallback in logs)
- [ ] Manual: set gateway to broken URL → verify snapshots validate via fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced snapshot validation with improved resilience through retry mechanisms and configurable fallback gateway support, ensuring better handling of validation failures and network interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->