### PR TITLE
chore: migrate from permaweb-deploy to @ar.io/deploy

### DIFF
--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -55,12 +55,14 @@ jobs:
           channelId: live
 
       # Deploy to Arweave
-      - run: |
-          scr deploy-to-arweave
-        env:
-          ARNS_NAME: ${{ secrets.ARNS_NAME }}
-          DEPLOY_ANT_UNDERNAME: ${{ secrets.DEPLOY_ANT_UNDERNAME }}
-          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+      - name: Deploy to Arweave
+        uses: ar-io/ar-io-deploy@v1
+        with:
+          deploy-key: ${{ secrets.DEPLOY_KEY }}
+          arns-key: ${{ secrets.ARNS_KEY }}
+          arns-name: ${{ secrets.ARNS_NAME }}
+          undername: ${{ secrets.DEPLOY_ANT_UNDERNAME }}
+          deploy-folder: ./build/web
 
 
   build-ios:

--- a/deploy/package.json
+++ b/deploy/package.json
@@ -1,16 +1,13 @@
 {
   "name": "deploy",
   "version": "1.0.0",
-  "description": "Deployer app for deploying ArDrive to arweave using permaweb-deploy",
+  "description": "Deployer app for deploying ArDrive to arweave using @ar.io/deploy",
   "main": "index.js",
   "license": "AGPL-3.0-only",
   "scripts": {
-    "deploy": "rm -f ../build/web-* && permaweb-deploy --arns-name ${ARNS_NAME} --deploy-folder=../build/web --undername=${DEPLOY_ANT_UNDERNAME}"
+    "deploy": "rm -f ../build/web-* && ario-deploy deploy --arns-name ${ARNS_NAME} --deploy-folder=../build/web --undername=${DEPLOY_ANT_UNDERNAME}"
   },
   "dependencies": {
-    "permaweb-deploy": "^2.1.0"
-  },
-  "resolutions": {
-    "@permaweb/aoconnect": "0.0.57"
+    "@ar.io/deploy": "^1.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- Replaces `scr deploy-to-arweave` (which ran `permaweb-deploy` via `deploy/package.json`) with `ar-io/ar-io-deploy@v1` GitHub Action in the production workflow
- Updates `deploy/package.json` to use `@ar.io/deploy` for local deploys
- Uses the two-key model: `DEPLOY_KEY` (Arweave) for uploads, `ARNS_KEY` (Solana) for ArNS updates

## Setup required
- Add `ARNS_KEY` secret (base58 Solana key with ArNS authority)

## Test plan
- [ ] Verify `ARNS_KEY` secret is set
- [ ] Test production deployment after merge to master

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated production deployment workflow to use modernized deployment tools and GitHub Actions integration
* Migrated deployment dependencies and scripts to updated package management for improved consistency and maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->