### PR TITLE
PE-9103: Make turbo upload and payment service URLs configurable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ Note: The `ario_sdk` package requires separate code generation - `scr setup` han
 - Main database: `lib/models/database/database.dart`
 - Table definitions: `lib/models/tables/*.drift`
 - DAOs: `DriveDao`, `ProfileDao`, `ARNSDao`
-- After schema changes: bump `schemaVersion` in `database.dart` (currently v27) and run code generation
+- After schema changes: bump `schemaVersion` in `database.dart` and run code generation
 - Pre-push hook validates schema version is incremented when `.drift` files change
 - Pre-commit hook validates the correct Flutter version is installed
 

--- a/lib/components/settings_popover.dart
+++ b/lib/components/settings_popover.dart
@@ -150,8 +150,8 @@ class SettingsSubmenu extends StatelessWidget {
       content: TurboUrlDialog(
         initialUploadUrl: config.defaultTurboUploadUrl ?? '',
         initialPaymentUrl: config.defaultTurboPaymentUrl ?? '',
-        onSave: (uploadUrl, paymentUrl) {
-          configService.updateAppConfig(
+        onSave: (uploadUrl, paymentUrl) async {
+          await configService.updateAppConfig(
             config.copyWith(
               defaultTurboUploadUrl: uploadUrl,
               defaultTurboPaymentUrl: paymentUrl,

--- a/lib/components/settings_popover.dart
+++ b/lib/components/settings_popover.dart
@@ -1,4 +1,5 @@
 import 'package:ardrive/components/graphql_endpoint_dialog.dart';
+import 'package:ardrive/components/turbo_url_dialog.dart';
 import 'package:ardrive/gar/domain/repositories/gar_repository.dart';
 import 'package:ardrive/gar/presentation/widgets/gateway_input_modal.dart';
 import 'package:ardrive/pages/drive_detail/components/dropdown_item.dart';
@@ -11,6 +12,7 @@ import 'package:ardrive/utils/constants.dart';
 import 'package:ardrive/utils/show_general_dialog.dart';
 import 'package:ardrive_http/ardrive_http.dart';
 import 'package:ardrive_ui/ardrive_ui.dart';
+import 'package:ardrive_utils/ardrive_utils.dart';
 import 'package:ario_sdk/ario_sdk.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -57,6 +59,22 @@ class SettingsSubmenu extends StatelessWidget {
                 .backgroundColor,
             child: const ArDriveDropdownItemTile(
               name: 'Set GraphQL Server',
+            ),
+          ),
+        ),
+        ArDriveSubmenuItem(
+          onClick: () {
+            _showTurboUrlDialog(context);
+          },
+          widget: ArDriveHoverWidget(
+            hoverColor:
+                ArDriveTheme.of(context).themeData.dropdownTheme.hoverColor,
+            defaultColor: ArDriveTheme.of(context)
+                .themeData
+                .dropdownTheme
+                .backgroundColor,
+            child: const ArDriveDropdownItemTile(
+              name: 'Set Turbo Services',
             ),
           ),
         ),
@@ -120,6 +138,28 @@ class SettingsSubmenu extends StatelessWidget {
         // Use the repository to update the custom gateway
         await garRepository.updateCustomGateway(newGatewayUrl);
       },
+    );
+  }
+
+  void _showTurboUrlDialog(BuildContext context) {
+    final configService = context.read<ConfigService>();
+    final config = configService.config;
+
+    showArDriveDialog(
+      context,
+      content: TurboUrlDialog(
+        initialUploadUrl: config.defaultTurboUploadUrl ?? '',
+        initialPaymentUrl: config.defaultTurboPaymentUrl ?? '',
+        onSave: (uploadUrl, paymentUrl) {
+          configService.updateAppConfig(
+            config.copyWith(
+              defaultTurboUploadUrl: uploadUrl,
+              defaultTurboPaymentUrl: paymentUrl,
+            ),
+          );
+          triggerHTMLPageReload();
+        },
+      ),
     );
   }
 

--- a/lib/components/turbo_url_dialog.dart
+++ b/lib/components/turbo_url_dialog.dart
@@ -1,0 +1,122 @@
+import 'package:ardrive_ui/ardrive_ui.dart';
+import 'package:flutter/material.dart';
+
+class TurboUrlDialog extends StatefulWidget {
+  final String initialUploadUrl;
+  final String initialPaymentUrl;
+  final void Function(String uploadUrl, String paymentUrl) onSave;
+
+  const TurboUrlDialog({
+    super.key,
+    required this.initialUploadUrl,
+    required this.initialPaymentUrl,
+    required this.onSave,
+  });
+
+  @override
+  State<TurboUrlDialog> createState() => _TurboUrlDialogState();
+}
+
+class _TurboUrlDialogState extends State<TurboUrlDialog> {
+  late final TextEditingController _uploadController;
+  late final TextEditingController _paymentController;
+  bool _isValid = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _uploadController = TextEditingController(text: widget.initialUploadUrl);
+    _paymentController = TextEditingController(text: widget.initialPaymentUrl);
+    _uploadController.addListener(_onChanged);
+    _paymentController.addListener(_onChanged);
+  }
+
+  @override
+  void dispose() {
+    _uploadController.removeListener(_onChanged);
+    _paymentController.removeListener(_onChanged);
+    _uploadController.dispose();
+    _paymentController.dispose();
+    super.dispose();
+  }
+
+  void _onChanged() {
+    setState(() {
+      _isValid = _isValidUrl(_uploadController.text.trim()) &&
+          _isValidUrl(_paymentController.text.trim());
+    });
+  }
+
+  static bool _isValidUrl(String value) {
+    if (value.isEmpty) return false;
+    final uri = Uri.tryParse(value);
+    return uri != null && uri.hasScheme && uri.hasAuthority;
+  }
+
+  static String? _validateUrl(String? value) {
+    if (value == null || value.isEmpty) {
+      return 'Please enter a URL';
+    }
+    if (!_isValidUrl(value)) {
+      return 'Please enter a valid URL (e.g. https://upload.ardrive.io)';
+    }
+    return null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
+    final typography = ArDriveTypographyNew.of(context);
+
+    return ArDriveStandardModalNew(
+      width: 500,
+      title: 'Turbo Service URLs',
+      content: SizedBox(
+        width: 500,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Configure the upload and payment service URLs. '
+              'The page will reload after saving.',
+              style: typography.paragraphNormal(
+                color: colorTokens.textMid,
+              ),
+            ),
+            const SizedBox(height: 16),
+            ArDriveTextFieldNew(
+              controller: _uploadController,
+              hintText: 'https://upload.ardrive.io',
+              label: 'Upload Service URL',
+              validator: _validateUrl,
+            ),
+            const SizedBox(height: 16),
+            ArDriveTextFieldNew(
+              controller: _paymentController,
+              hintText: 'https://payment.ardrive.io',
+              label: 'Payment Service URL',
+              validator: _validateUrl,
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        ModalAction(
+          title: 'Cancel',
+          action: () => Navigator.of(context).pop(),
+        ),
+        ModalAction(
+          title: 'Save & Reload',
+          isEnable: _isValid,
+          action: () {
+            widget.onSave(
+              _uploadController.text.trim(),
+              _paymentController.text.trim(),
+            );
+            Navigator.of(context).pop();
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/lib/turbo/config/crypto_network_config.dart
+++ b/lib/turbo/config/crypto_network_config.dart
@@ -12,10 +12,20 @@ class CryptoNetworkConfig {
   /// Arweave gateway URL from config (e.g. [ConfigService.config.arweaveGatewayUrl]).
   final String _arweaveGatewayUrl;
 
+  /// Turbo upload URL override from config, if provided.
+  final String? _turboUploadUrlOverride;
+
+  /// Turbo payment URL override from config, if provided.
+  final String? _turboPaymentUrlOverride;
+
   CryptoNetworkConfig({
     required this.isTestnet,
     required String arweaveGatewayUrl,
-  }) : _arweaveGatewayUrl = arweaveGatewayUrl;
+    String? turboUploadUrl,
+    String? turboPaymentUrl,
+  })  : _arweaveGatewayUrl = arweaveGatewayUrl,
+        _turboUploadUrlOverride = turboUploadUrl,
+        _turboPaymentUrlOverride = turboPaymentUrl;
 
   /// Factory for creating config based on environment
   ///
@@ -27,11 +37,15 @@ class CryptoNetworkConfig {
   factory CryptoNetworkConfig.fromEnvironment(
     String environment, {
     required String arweaveGatewayUrl,
+    String? turboUploadUrl,
+    String? turboPaymentUrl,
   }) {
     final isTestnet = environment == 'development';
     return CryptoNetworkConfig(
       isTestnet: isTestnet,
       arweaveGatewayUrl: arweaveGatewayUrl,
+      turboUploadUrl: turboUploadUrl,
+      turboPaymentUrl: turboPaymentUrl,
     );
   }
 
@@ -136,13 +150,15 @@ class CryptoNetworkConfig {
   // Turbo Service URLs
   // ============================================
 
-  /// Turbo payment service URL
+  /// Turbo payment service URL (uses config override if set)
   String get turboPaymentUrl =>
-      isTestnet ? 'https://payment.ardrive.dev' : 'https://payment.ardrive.io';
+      _turboPaymentUrlOverride ??
+      (isTestnet ? 'https://payment.ardrive.dev' : 'https://payment.ardrive.io');
 
-  /// Turbo upload service URL
+  /// Turbo upload service URL (uses config override if set)
   String get turboUploadUrl =>
-      isTestnet ? 'https://upload.ardrive.dev' : 'https://upload.ardrive.io';
+      _turboUploadUrlOverride ??
+      (isTestnet ? 'https://upload.ardrive.dev' : 'https://upload.ardrive.io');
 
   // ============================================
   // Helper Methods

--- a/lib/turbo/topup/views/crypto_payment_option.dart
+++ b/lib/turbo/topup/views/crypto_payment_option.dart
@@ -133,6 +133,8 @@ class _CryptoPaymentOptionState extends State<CryptoPaymentOption> {
     final networkConfig = CryptoNetworkConfig.fromEnvironment(
       environment,
       arweaveGatewayUrl: gatewayUrl,
+      turboUploadUrl: configService.config.defaultTurboUploadUrl,
+      turboPaymentUrl: configService.config.defaultTurboPaymentUrl,
     );
 
     // Create the HTTP client
@@ -291,6 +293,8 @@ Future<void> showCryptoTopupModalStandalone(
   final networkConfig = CryptoNetworkConfig.fromEnvironment(
     environment,
     arweaveGatewayUrl: gatewayUrl,
+    turboUploadUrl: configService.config.defaultTurboUploadUrl,
+    turboPaymentUrl: configService.config.defaultTurboPaymentUrl,
   );
 
   // Create the HTTP client

--- a/lib/turbo/topup/views/topup_modal.dart
+++ b/lib/turbo/topup/views/topup_modal.dart
@@ -107,6 +107,8 @@ void showTurboTopupModal(BuildContext context, {Function()? onSuccess}) {
             final networkConfig = CryptoNetworkConfig.fromEnvironment(
               environment,
               arweaveGatewayUrl: gatewayUrl,
+              turboUploadUrl: configService.config.defaultTurboUploadUrl,
+              turboPaymentUrl: configService.config.defaultTurboPaymentUrl,
             );
 
             return UnifiedTopupBloc(

--- a/lib/turbo/topup/views/unified/unified_crypto_flow.dart
+++ b/lib/turbo/topup/views/unified/unified_crypto_flow.dart
@@ -113,6 +113,8 @@ class _UnifiedCryptoFlowState extends State<UnifiedCryptoFlow> {
     final networkConfig = CryptoNetworkConfig.fromEnvironment(
       environment,
       arweaveGatewayUrl: gatewayUrl,
+      turboUploadUrl: configService.config.defaultTurboUploadUrl,
+      turboPaymentUrl: configService.config.defaultTurboPaymentUrl,
     );
 
     // Create services


### PR DESCRIPTION
## Summary
- Adds a **"Set Turbo Services"** option to the Settings submenu (alongside "Set Gateway" and "Set GraphQL Server") that lets users override the upload and payment service URLs
- New `TurboUrlDialog` with URL format validation and save-with-reload behavior
- Plumbs config URLs through `CryptoNetworkConfig` so the crypto topup flow also respects user overrides (previously hardcoded to `payment.ardrive.io` / `upload.ardrive.io`)
- Defaults remain `upload.ardrive.io` / `payment.ardrive.io` (prod) and `upload.ardrive.dev` / `payment.ardrive.dev` (dev)

## Changes
| File | Change |
|------|--------|
| `lib/components/turbo_url_dialog.dart` | New dialog with two URL fields, validation, save & reload |
| `lib/components/settings_popover.dart` | Added "Set Turbo Services" menu item |
| `lib/turbo/config/crypto_network_config.dart` | Accept optional URL overrides instead of hardcoding |
| `lib/turbo/topup/views/topup_modal.dart` | Pass config URLs to CryptoNetworkConfig |
| `lib/turbo/topup/views/unified/unified_crypto_flow.dart` | Pass config URLs to CryptoNetworkConfig |
| `lib/turbo/topup/views/crypto_payment_option.dart` | Pass config URLs to CryptoNetworkConfig (2 call sites) |

## Test plan
- [ ] Open Settings submenu, verify "Set Turbo Services" option appears
- [ ] Click it, verify dialog shows current URLs pre-populated
- [ ] Enter invalid URL → Save button should be disabled
- [ ] Enter valid custom URLs → Save & Reload should persist and reload
- [ ] After reload, re-open dialog → custom URLs should still be shown
- [ ] Verify fiat topup flow uses the custom payment URL
- [ ] Verify crypto topup flow uses the custom payment URL
- [ ] Verify file upload uses the custom upload URL
- [ ] Reset via dev tools → URLs should revert to defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Set Turbo Services" option in Settings, enabling users to customize Turbo upload and payment service URLs. The new dialog includes real-time URL validation and applies changes with automatic page reload.

* **Documentation**
  * Updated database schema versioning instructions to provide generic guidance for the version bumping process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->