### PR TITLE
PE-9103: Add total timeout on data fetch fallback chain

### DIFF
--- a/lib/services/arweave/data_gateway_fallback.dart
+++ b/lib/services/arweave/data_gateway_fallback.dart
@@ -20,6 +20,9 @@ class DataGatewayFallback {
   static const _retryPerGateway = 1;
   static const _garListTimeout = Duration(seconds: 5);
   static const _requestTimeout = Duration(seconds: 5);
+  /// Total time allowed for the entire fallback chain per tx.
+  /// Prevents a single missing/broken tx from blocking sync for minutes.
+  static const _totalFetchTimeout = Duration(seconds: 15);
 
   List<Gateway>? _cachedGateways;
 
@@ -34,6 +37,15 @@ class DataGatewayFallback {
   /// If ALL gateways return 404, throws [TransactionNotFound] to preserve
   /// upstream error handling (e.g. private drive detection during login).
   Future<Response> fetchData(String txId, Arweave primaryClient) async {
+    return _fetchDataWithTimeout(txId, primaryClient)
+        .timeout(_totalFetchTimeout, onTimeout: () {
+      logger.w('Total fetch timeout exceeded for tx $txId');
+      throw Exception('Total fetch timeout exceeded for tx $txId');
+    });
+  }
+
+  Future<Response> _fetchDataWithTimeout(
+      String txId, Arweave primaryClient) async {
     var all404 = true;
 
     // 1. Try primary gateway


### PR DESCRIPTION
## Summary

A single missing/broken transaction could block sync for minutes as the data fetch fallback chain tried every gateway — each potentially timing out with CORS errors or 504s.

Added a **15-second total timeout** wrapping the entire fallback chain (primary → GAR gateways → arweave.net). This caps the worst-case time for any single entity metadata fetch.

## How it works

```
fetchData(txId) {
    return _fetchDataWithTimeout(txId)
        .timeout(15s);  // Hard cap on entire chain
}
```

Combined with the existing 5s per-request timeout:
- Each individual gateway attempt: max 5s
- Entire fallback chain: max 15s
- Before: unlimited (CORS errors + 504s could hang for minutes per tx)

## Why the sync appeared "stuck"

The sync state was `SyncInProgress` while metadata fetches hung. The periodic sync (every 5 min) checked `if (state is SyncInProgress) return;` and skipped. The sync wasn't actually stuck — it was waiting for the fallback chain to exhaust all gateways. With the total timeout, it now fails fast and the next periodic sync can proceed.

## Test plan
- [x] `flutter analyze` — no issues
- [ ] Manual: sync with a drive that has missing/broken tx metadata
- [ ] Verify sync completes within ~15s even for unfetchable txs
- [ ] Verify periodic sync resumes after failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)