### PR TITLE
PE-9126: Add drive owner to tx status and license GraphQL queries

### DIFF
--- a/lib/blocs/fs_entry_info/fs_entry_info_cubit.dart
+++ b/lib/blocs/fs_entry_info/fs_entry_info_cubit.dart
@@ -192,9 +192,22 @@ class FsEntryInfoCubit extends Cubit<FsEntryInfoState> {
     try {
       final isComposed = revision.licenseTxId == revision.dataTxId;
 
+      // Owner of the license transaction, used to make the gateway query more
+      // selective. For composed licenses the license tx is the data tx, so its
+      // owner is the data uploader (the pinned data owner for pinned files);
+      // for assertions and regular files it is the drive owner. Resolved best
+      // effort — when unknown the query is left unscoped.
+      final licenseOwner = _ownerAddress ??
+          revision.pinnedDataOwnerAddress ??
+          revision.originalOwner ??
+          (await _driveDao
+                  .driveById(driveId: revision.driveId)
+                  .getSingleOrNull())
+              ?.ownerAddress;
+
       if (isComposed) {
         final txs = await _arweave
-            .getLicenseComposed([revision.licenseTxId!])
+            .getLicenseComposed([revision.licenseTxId!], owner: licenseOwner)
             .expand((e) => e)
             .toList();
         if (txs.isEmpty) return null;
@@ -210,7 +223,7 @@ class FsEntryInfoCubit extends Cubit<FsEntryInfoState> {
         return _licenseService.fromComposedEntity(entity);
       } else {
         final txs = await _arweave
-            .getLicenseAssertions([revision.licenseTxId!])
+            .getLicenseAssertions([revision.licenseTxId!], owner: licenseOwner)
             .expand((e) => e)
             .toList();
         if (txs.isEmpty) return null;

--- a/lib/blocs/shared_file/shared_file_cubit.dart
+++ b/lib/blocs/shared_file/shared_file_cubit.dart
@@ -87,12 +87,15 @@ class SharedFileCubit extends Cubit<SharedFileState> {
     return revisions.reversed.toList();
   }
 
-  Future<LicenseState?> fetchLicenseForRevision(FileRevision revision) async {
+  Future<LicenseState?> fetchLicenseForRevision(
+    FileRevision revision, {
+    String? owner,
+  }) async {
     final isComposed = revision.licenseTxId == revision.dataTxId;
     if (isComposed) {
       // License Composed
       final licenseTxs = await _arweave
-          .getLicenseComposed([revision.licenseTxId!])
+          .getLicenseComposed([revision.licenseTxId!], owner: owner)
           .expand((e) => e)
           .toList();
       if (licenseTxs.isEmpty) {
@@ -106,7 +109,7 @@ class SharedFileCubit extends Cubit<SharedFileState> {
     } else {
       // License Assertion
       final licenseTxs = await _arweave
-          .getLicenseAssertions([revision.licenseTxId!])
+          .getLicenseAssertions([revision.licenseTxId!], owner: owner)
           .expand((e) => e)
           .toList();
       if (licenseTxs.isEmpty) {
@@ -145,7 +148,7 @@ class SharedFileCubit extends Cubit<SharedFileState> {
       final revisions = await computeRevisionsFromEntities(allEntities);
       // revisions are in reverse chronological order, so first is most recent
       final latestLicense = revisions.first.licenseTxId != null
-          ? await fetchLicenseForRevision(revisions.first)
+          ? await fetchLicenseForRevision(revisions.first, owner: ownerAddress)
           : null;
       
       emit(SharedFileLoadSuccess(

--- a/lib/models/queries/drive_queries.drift
+++ b/lib/models/queries/drive_queries.drift
@@ -170,6 +170,13 @@ pendingTransactionsForDrive:
         WHERE driveId = :driveId
     );
 
+-- File revisions of pinned files, whose data tx is owned on-chain by the
+-- original uploader (not the drive owner). Used to resolve confirmation status
+-- for these cross-owner txs without an unscoped gateway query.
+pinnedFileRevisions:
+    SELECT * FROM file_revisions
+    WHERE pinnedDataOwnerAddress IS NOT NULL;
+
 getFilesWithAssignedNames:
 SELECT * FROM file_entries
 WHERE assignedNames IS NOT NULL;

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -1235,18 +1235,28 @@ class ArweaveService {
   /// owner — keeping every query selective. Ids with no override are left
   /// unresolved rather than re-queried unscoped, which would reintroduce the
   /// expensive gateway scan this scoping is meant to avoid.
+  ///
+  /// [verifiedSink], if provided, is progressively populated with each
+  /// successfully verified confirmation (value >= 0) as the query completes —
+  /// it never receives the -1 "not found" placeholders. A caller can wrap this
+  /// method in a timeout and, on expiry, fall back to [verifiedSink] to keep
+  /// the confirmations resolved so far instead of discarding the whole batch.
+  /// Because it holds only positive verifications, applying it after a timeout
+  /// never marks anything failed off an incomplete run.
   Future<Map<String?, int>> getTransactionConfirmations(
     List<String?> transactionIds, {
     String? owner,
     Map<String, String>? ownerOverrides,
+    Map<String?, int>? verifiedSink,
   }) async {
     final transactionConfirmations = {
       for (final transactionId in transactionIds) transactionId: -1
     };
 
     // Queries confirmation status for [ids] in chunks, writing results into
-    // [transactionConfirmations]. When [owner] is provided, the query is scoped
-    // to that owner so the gateway can prune its search space.
+    // [transactionConfirmations] (and [verifiedSink] for resolved ids). When
+    // [owner] is provided, the query is scoped to that owner so the gateway can
+    // prune its search space.
     Future<void> queryConfirmations(List<String?> ids, {String? owner}) async {
       const chunkSize = 100;
 
@@ -1271,13 +1281,12 @@ class ArweaveService {
 
           for (final transaction
               in query.data!.transactions.edges.map((e) => e.node)) {
-            if (transaction.block == null) {
-              transactionConfirmations[transaction.id] = 0;
-              continue;
-            }
-
-            transactionConfirmations[transaction.id] =
-                currentBlockHeight - transaction.block!.height + 1;
+            final confirmations = transaction.block == null
+                ? 0
+                : currentBlockHeight - transaction.block!.height + 1;
+            transactionConfirmations[transaction.id] = confirmations;
+            // Record the resolved verification so it survives a caller timeout.
+            verifiedSink?[transaction.id] = confirmations;
           }
         }());
       }

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -1298,6 +1298,11 @@ class ArweaveService {
     // confirmed cross-owner txs without an unscoped scan. Genuinely missing txs
     // have no override and are left unresolved — handled by the caller's
     // existing pending/failed logic.
+    //
+    // Best-effort: this pass must never discard the first pass's results. Its
+    // results are merged into the already-populated map, so we swallow any
+    // error and bound it with its own timeout — even if it fails or stalls,
+    // the confirmations resolved by the first pass are still returned.
     if (owner != null && ownerOverrides != null && ownerOverrides.isNotEmpty) {
       final idsByOverrideOwner = <String, List<String?>>{};
       for (final entry in transactionConfirmations.entries) {
@@ -1307,8 +1312,19 @@ class ArweaveService {
         idsByOverrideOwner.putIfAbsent(overrideOwner, () => []).add(entry.key);
       }
 
-      for (final entry in idsByOverrideOwner.entries) {
-        await queryConfirmations(entry.value, owner: entry.key);
+      if (idsByOverrideOwner.isNotEmpty) {
+        try {
+          await Future(() async {
+            for (final entry in idsByOverrideOwner.entries) {
+              await queryConfirmations(entry.value, owner: entry.key);
+            }
+          }).timeout(const Duration(seconds: 3));
+        } catch (e) {
+          logger.w(
+            'Pinned-owner confirmation recovery failed or timed out; '
+            'leaving those txs unresolved: $e',
+          );
+        }
       }
     }
 

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -1236,48 +1236,69 @@ class ArweaveService {
       for (final transactionId in transactionIds) transactionId: -1
     };
 
-    const chunkSize = 100;
+    // Queries confirmation status for [ids] in chunks, writing results into
+    // [transactionConfirmations]. When [owner] is provided, the query is scoped
+    // to that owner so the gateway can prune its search space.
+    Future<void> queryConfirmations(List<String?> ids, {String? owner}) async {
+      const chunkSize = 100;
 
-    final confirmationFutures = <Future<void>>[];
+      final confirmationFutures = <Future<void>>[];
 
-    for (var i = 0; i < transactionIds.length; i += chunkSize) {
-      confirmationFutures.add(() async {
-        final chunkEnd = (i + chunkSize < transactionIds.length)
-            ? i + chunkSize
-            : transactionIds.length;
+      for (var i = 0; i < ids.length; i += chunkSize) {
+        confirmationFutures.add(() async {
+          final chunkEnd =
+              (i + chunkSize < ids.length) ? i + chunkSize : ids.length;
 
-        final query = await graphQLRetry.execute(
-          TransactionStatusesQuery(
-            variables: TransactionStatusesArguments(
-              transactionIds:
-                  transactionIds.sublist(i, chunkEnd) as List<String>?,
-              // Scoping by owner lets the gateway prune its search space; null
-              // leaves the query unscoped (current behavior).
-              owners: owner != null ? [owner] : null,
+          final query = await graphQLRetry.execute(
+            TransactionStatusesQuery(
+              variables: TransactionStatusesArguments(
+                transactionIds: ids.sublist(i, chunkEnd) as List<String>?,
+                owners: owner != null ? [owner] : null,
+              ),
             ),
-          ),
-        );
+          );
 
-        final currentBlockHeight = query.data!.blocks.edges.first.node.height;
+          final currentBlockHeight =
+              query.data!.blocks.edges.first.node.height;
 
-        for (final transaction
-            in query.data!.transactions.edges.map((e) => e.node)) {
-          if (transaction.block == null) {
-            transactionConfirmations[transaction.id] = 0;
-            continue;
+          for (final transaction
+              in query.data!.transactions.edges.map((e) => e.node)) {
+            if (transaction.block == null) {
+              transactionConfirmations[transaction.id] = 0;
+              continue;
+            }
+
+            transactionConfirmations[transaction.id] =
+                currentBlockHeight - transaction.block!.height + 1;
           }
+        }());
+      }
 
-          transactionConfirmations[transaction.id] =
-              currentBlockHeight - transaction.block!.height + 1;
-        }
-      }());
+      try {
+        await Future.wait(confirmationFutures);
+      } catch (e) {
+        logger.e('Error getting transactions confirmations on exception', e);
+        rethrow;
+      }
     }
 
-    try {
-      await Future.wait(confirmationFutures);
-    } catch (e) {
-      logger.e('Error getting transactions confirmations on exception', e);
-      rethrow;
+    // First pass: scoped by owner for gateway selectivity.
+    await queryConfirmations(transactionIds, owner: owner);
+
+    // Fallback: a tx not found under the owner scope may simply belong to a
+    // different owner (e.g. the data tx of a file pinned from another author's
+    // upload) rather than being absent from the network. Re-query just those
+    // unresolved ids without the owner filter so confirmed cross-owner txs
+    // aren't misclassified as failed by the caller. The residual set is
+    // normally tiny, so this preserves the selectivity win of the first pass.
+    if (owner != null) {
+      final unresolvedIds = transactionConfirmations.entries
+          .where((entry) => entry.value < 0)
+          .map((entry) => entry.key)
+          .toList();
+      if (unresolvedIds.isNotEmpty) {
+        await queryConfirmations(unresolvedIds);
+      }
     }
 
     return transactionConfirmations;

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -1259,43 +1259,50 @@ class ArweaveService {
     // prune its search space.
     Future<void> queryConfirmations(List<String?> ids, {String? owner}) async {
       const chunkSize = 100;
+      // Cap how many chunk queries hit the gateway at once so a large page
+      // doesn't fan out into a burst of concurrent GraphQL retries (and a
+      // potential rate-limit storm), matching the throttling used by the other
+      // gateway-heavy paths in this service.
+      final maxConcurrent =
+          _configService.config.maxConcurrentDataFetches.clamp(1, 100);
 
-      final confirmationFutures = <Future<void>>[];
+      Future<void> queryChunk(int start) async {
+        final chunkEnd =
+            (start + chunkSize < ids.length) ? start + chunkSize : ids.length;
 
-      for (var i = 0; i < ids.length; i += chunkSize) {
-        confirmationFutures.add(() async {
-          final chunkEnd =
-              (i + chunkSize < ids.length) ? i + chunkSize : ids.length;
-
-          final query = await graphQLRetry.execute(
-            TransactionStatusesQuery(
-              variables: TransactionStatusesArguments(
-                transactionIds: ids.sublist(i, chunkEnd) as List<String>?,
-                owners: owner != null ? [owner] : null,
-              ),
+        final query = await graphQLRetry.execute(
+          TransactionStatusesQuery(
+            variables: TransactionStatusesArguments(
+              transactionIds:
+                  ids.sublist(start, chunkEnd).whereType<String>().toList(),
+              owners: owner != null ? [owner] : null,
             ),
-          );
+          ),
+        );
 
-          final currentBlockHeight =
-              query.data!.blocks.edges.first.node.height;
+        final currentBlockHeight = query.data!.blocks.edges.first.node.height;
 
-          for (final transaction
-              in query.data!.transactions.edges.map((e) => e.node)) {
-            final confirmations = transaction.block == null
-                ? 0
-                : currentBlockHeight - transaction.block!.height + 1;
-            transactionConfirmations[transaction.id] = confirmations;
-            // Record the resolved verification so it survives a caller timeout.
-            verifiedSink?[transaction.id] = confirmations;
-          }
-        }());
+        for (final transaction
+            in query.data!.transactions.edges.map((e) => e.node)) {
+          final confirmations = transaction.block == null
+              ? 0
+              : currentBlockHeight - transaction.block!.height + 1;
+          transactionConfirmations[transaction.id] = confirmations;
+          // Record the resolved verification so it survives a caller timeout.
+          verifiedSink?[transaction.id] = confirmations;
+        }
       }
 
-      try {
-        await Future.wait(confirmationFutures);
-      } catch (e) {
-        logger.e('Error getting transactions confirmations on exception', e);
-        rethrow;
+      final chunkStarts = [for (var i = 0; i < ids.length; i += chunkSize) i];
+      // Process the chunks in bounded-concurrency batches.
+      for (var b = 0; b < chunkStarts.length; b += maxConcurrent) {
+        final batch = chunkStarts.skip(b).take(maxConcurrent);
+        try {
+          await Future.wait(batch.map(queryChunk));
+        } catch (e) {
+          logger.e('Error getting transactions confirmations on exception', e);
+          rethrow;
+        }
       }
     }
 

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -1228,9 +1228,17 @@ class ArweaveService {
   ///
   /// When the number of confirmations is 0, the transaction has yet to be mined. When
   /// it is -1, the transaction could not be found.
+  /// [ownerOverrides] maps a transaction id to the address that actually owns
+  /// it on-chain when that differs from [owner] (e.g. the data tx of a file
+  /// pinned from another author's upload). Any id left unresolved by the
+  /// owner-scoped pass that has an override is re-queried scoped to its real
+  /// owner — keeping every query selective. Ids with no override are left
+  /// unresolved rather than re-queried unscoped, which would reintroduce the
+  /// expensive gateway scan this scoping is meant to avoid.
   Future<Map<String?, int>> getTransactionConfirmations(
     List<String?> transactionIds, {
     String? owner,
+    Map<String, String>? ownerOverrides,
   }) async {
     final transactionConfirmations = {
       for (final transactionId in transactionIds) transactionId: -1
@@ -1285,19 +1293,22 @@ class ArweaveService {
     // First pass: scoped by owner for gateway selectivity.
     await queryConfirmations(transactionIds, owner: owner);
 
-    // Fallback: a tx not found under the owner scope may simply belong to a
-    // different owner (e.g. the data tx of a file pinned from another author's
-    // upload) rather than being absent from the network. Re-query just those
-    // unresolved ids without the owner filter so confirmed cross-owner txs
-    // aren't misclassified as failed by the caller. The residual set is
-    // normally tiny, so this preserves the selectivity win of the first pass.
-    if (owner != null) {
-      final unresolvedIds = transactionConfirmations.entries
-          .where((entry) => entry.value < 0)
-          .map((entry) => entry.key)
-          .toList();
-      if (unresolvedIds.isNotEmpty) {
-        await queryConfirmations(unresolvedIds);
+    // Second pass: for any unresolved id whose real owner we know locally
+    // (currently pinned data txs), re-query scoped to that owner. This recovers
+    // confirmed cross-owner txs without an unscoped scan. Genuinely missing txs
+    // have no override and are left unresolved — handled by the caller's
+    // existing pending/failed logic.
+    if (owner != null && ownerOverrides != null && ownerOverrides.isNotEmpty) {
+      final idsByOverrideOwner = <String, List<String?>>{};
+      for (final entry in transactionConfirmations.entries) {
+        if (entry.value >= 0) continue;
+        final overrideOwner = ownerOverrides[entry.key];
+        if (overrideOwner == null || overrideOwner == owner) continue;
+        idsByOverrideOwner.putIfAbsent(overrideOwner, () => []).add(entry.key);
+      }
+
+      for (final entry in idsByOverrideOwner.entries) {
+        await queryConfirmations(entry.value, owner: entry.key);
       }
     }
 

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -363,14 +363,22 @@ class ArweaveService {
   }
 
   Stream<List<LicenseAssertions$Query$TransactionConnection$TransactionEdge$Transaction>>
-      getLicenseAssertions(Iterable<String> licenseAssertionTxIds) async* {
+      getLicenseAssertions(
+    Iterable<String> licenseAssertionTxIds, {
+    String? owner,
+  }) async* {
     const chunkSize = 100;
     final chunks = licenseAssertionTxIds.slices(chunkSize);
     for (final chunk in chunks) {
       // Get a page of 100 transactions
       final licenseAssertionsQuery = await graphQLRetry.execute(
         LicenseAssertionsQuery(
-          variables: LicenseAssertionsArguments(transactionIds: chunk),
+          variables: LicenseAssertionsArguments(
+            transactionIds: chunk,
+            // Scoping by owner narrows the gateway's search space; null leaves
+            // the query unscoped (current behavior).
+            owners: owner != null ? [owner] : null,
+          ),
         ),
       );
 
@@ -381,14 +389,22 @@ class ArweaveService {
   }
 
   Stream<List<LicenseComposed$Query$TransactionConnection$TransactionEdge$Transaction>>
-      getLicenseComposed(Iterable<String> licenseComposedTxIds) async* {
+      getLicenseComposed(
+    Iterable<String> licenseComposedTxIds, {
+    String? owner,
+  }) async* {
     const chunkSize = 100;
     final chunks = licenseComposedTxIds.slices(chunkSize);
     for (final chunk in chunks) {
       // Get a page of 100 transactions
       final licenseComposedQuery = await graphQLRetry.execute(
         LicenseComposedQuery(
-          variables: LicenseComposedArguments(transactionIds: chunk),
+          variables: LicenseComposedArguments(
+            transactionIds: chunk,
+            // Scoping by owner narrows the gateway's search space; null leaves
+            // the query unscoped (current behavior).
+            owners: owner != null ? [owner] : null,
+          ),
         ),
       );
 
@@ -1213,7 +1229,9 @@ class ArweaveService {
   /// When the number of confirmations is 0, the transaction has yet to be mined. When
   /// it is -1, the transaction could not be found.
   Future<Map<String?, int>> getTransactionConfirmations(
-      List<String?> transactionIds) async {
+    List<String?> transactionIds, {
+    String? owner,
+  }) async {
     final transactionConfirmations = {
       for (final transactionId in transactionIds) transactionId: -1
     };
@@ -1233,6 +1251,9 @@ class ArweaveService {
             variables: TransactionStatusesArguments(
               transactionIds:
                   transactionIds.sublist(i, chunkEnd) as List<String>?,
+              // Scoping by owner lets the gateway prune its search space; null
+              // leaves the query unscoped (current behavior).
+              owners: owner != null ? [owner] : null,
             ),
           ),
         );

--- a/lib/services/arweave/graphql/queries/LicenseAssertions.graphql
+++ b/lib/services/arweave/graphql/queries/LicenseAssertions.graphql
@@ -1,7 +1,8 @@
-query LicenseAssertions($transactionIds: [ID!]) {
+query LicenseAssertions($transactionIds: [ID!], $owners: [String!]) {
   transactions(
     first: 100
     ids: $transactionIds
+    owners: $owners
     tags: [{ name: "App-Name", values: ["License-Assertion"] }]
   ) {
     edges {

--- a/lib/services/arweave/graphql/queries/LicenseDataBundled.graphql
+++ b/lib/services/arweave/graphql/queries/LicenseDataBundled.graphql
@@ -1,7 +1,8 @@
-query LicenseComposed($transactionIds: [ID!]) {
+query LicenseComposed($transactionIds: [ID!], $owners: [String!]) {
   transactions(
     first: 100
     ids: $transactionIds
+    owners: $owners
   ) {
     edges {
       node {

--- a/lib/services/arweave/graphql/queries/TransactionStatuses.graphql
+++ b/lib/services/arweave/graphql/queries/TransactionStatuses.graphql
@@ -1,5 +1,5 @@
-query TransactionStatuses($transactionIds: [ID!]) {
-  transactions(first: 100, ids: $transactionIds) {
+query TransactionStatuses($transactionIds: [ID!], $owners: [String!]) {
+  transactions(first: 100, ids: $transactionIds, owners: $owners) {
     edges {
       node {
         id

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -172,9 +172,9 @@ class _SyncRepository implements SyncRepository {
     // The address of the currently logged-in wallet. All pending transactions
     // are uploads made by this wallet, so scoping the status query by it lets
     // the gateway prune its search space. Cross-owner txs (e.g. data txs of
-    // files pinned from other authors) won't match this owner, but
-    // getTransactionConfirmations re-queries any unresolved ids without the
-    // owner filter so they aren't misclassified as failed.
+    // files pinned from other authors) won't match this owner; those that we
+    // can identify locally are re-queried scoped to their real owner via
+    // ownerOverrides in getTransactionConfirmations.
     String? walletAddress;
     if (wallet != null) {
       walletAddress = await wallet.getAddress();
@@ -771,6 +771,8 @@ class _SyncRepository implements SyncRepository {
   }) async {
     cancellationToken?.checkCancellation();
 
+    final ownerOverrides = await _buildPinnedDataTxOwnerOverrides(driveDao);
+
     // Load all pending transactions and filter to this drive
     final allPendingTxs = await driveDao.pendingTransactions().get();
     final drivePendingTxs = allPendingTxs
@@ -810,7 +812,7 @@ class _SyncRepository implements SyncRepository {
 
       final map = await arweave
           .getTransactionConfirmations(currentPage.toList(),
-              owner: ownerAddress)
+              owner: ownerAddress, ownerOverrides: ownerOverrides)
           .timeout(
         const Duration(seconds: 5),
         onTimeout: () {
@@ -993,6 +995,21 @@ class _SyncRepository implements SyncRepository {
     }
   }
 
+  /// Maps the data tx id of each pinned file to the address that actually owns
+  /// it on-chain (the original uploader, not the drive owner). Used to resolve
+  /// confirmation status for these cross-owner txs with a selective,
+  /// owner-scoped query instead of an expensive unscoped one.
+  Future<Map<String, String>> _buildPinnedDataTxOwnerOverrides(
+    DriveDao driveDao,
+  ) async {
+    final pinnedFileRevisions = await driveDao.pinnedFileRevisions().get();
+    return {
+      for (final row in pinnedFileRevisions)
+        if (row.pinnedDataOwnerAddress != null)
+          row.dataTxId: row.pinnedDataOwnerAddress!,
+    };
+  }
+
   Future<void> _updateTransactionStatuses({
     required DriveDao driveDao,
     required ArweaveService arweave,
@@ -1002,6 +1019,8 @@ class _SyncRepository implements SyncRepository {
   }) async {
     // Check for cancellation at the start
     cancellationToken?.checkCancellation();
+
+    final ownerOverrides = await _buildPinnedDataTxOwnerOverrides(driveDao);
 
     // Load all pending transactions
     // Note: We load all at once here, but the memory impact is acceptable
@@ -1053,7 +1072,7 @@ class _SyncRepository implements SyncRepository {
       // Use a shorter timeout for individual GraphQL calls
       final map = await arweave
           .getTransactionConfirmations(currentPage.toList(),
-              owner: ownerAddress)
+              owner: ownerAddress, ownerOverrides: ownerOverrides)
           .timeout(
         const Duration(seconds: 5),
         onTimeout: () {

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -169,11 +169,17 @@ class _SyncRepository implements SyncRepository {
     _ghostFolders.clear();
     _folderIds.clear();
 
+    // The address of the currently logged-in wallet. All pending transactions
+    // are uploads made by this wallet, so scoping the status query by it lets
+    // the gateway prune its search space. (Edge case: data txs of files pinned
+    // from other authors are owned by those authors and won't match — those
+    // are rare and treated as best-effort.)
+    String? walletAddress;
     if (wallet != null) {
-      final address = await wallet.getAddress();
+      walletAddress = await wallet.getAddress();
 
       _arnsRepository
-          .getAntRecordsForWallet(address, update: true)
+          .getAntRecordsForWallet(walletAddress, update: true)
           .catchError((e) {
         logger.e('Error getting ANT records for wallet. Continuing...', e);
         return Future.value(<ANTRecord>[]);
@@ -383,6 +389,8 @@ class _SyncRepository implements SyncRepository {
               _updateTransactionStatuses(
                 driveDao: _driveDao,
                 arweave: _arweave,
+                // Scope the gateway query to the logged-in wallet for selectivity.
+                ownerAddress: walletAddress,
                 txsIdsToSkip: confirmedFileTxIds,
                 cancellationToken: token,
               ).timeout(
@@ -663,6 +671,8 @@ class _SyncRepository implements SyncRepository {
             driveDao: _driveDao,
             arweave: _arweave,
             driveDataTxIds: driveDataTxIds,
+            // Scope the gateway query to this drive's owner for selectivity.
+            ownerAddress: drive.ownerAddress,
             txsIdsToSkip: confirmedFileTxIds,
             cancellationToken: token,
           ).timeout(
@@ -754,6 +764,7 @@ class _SyncRepository implements SyncRepository {
     required DriveDao driveDao,
     required ArweaveService arweave,
     required Set<String> driveDataTxIds,
+    String? ownerAddress,
     List<TxID> txsIdsToSkip = const [],
     SyncCancellationToken? cancellationToken,
   }) async {
@@ -797,7 +808,8 @@ class _SyncRepository implements SyncRepository {
       cancellationToken?.checkCancellation();
 
       final map = await arweave
-          .getTransactionConfirmations(currentPage.toList())
+          .getTransactionConfirmations(currentPage.toList(),
+              owner: ownerAddress)
           .timeout(
         const Duration(seconds: 5),
         onTimeout: () {
@@ -983,6 +995,7 @@ class _SyncRepository implements SyncRepository {
   Future<void> _updateTransactionStatuses({
     required DriveDao driveDao,
     required ArweaveService arweave,
+    String? ownerAddress,
     List<TxID> txsIdsToSkip = const [],
     SyncCancellationToken? cancellationToken,
   }) async {
@@ -1038,7 +1051,8 @@ class _SyncRepository implements SyncRepository {
 
       // Use a shorter timeout for individual GraphQL calls
       final map = await arweave
-          .getTransactionConfirmations(currentPage.toList())
+          .getTransactionConfirmations(currentPage.toList(),
+              owner: ownerAddress)
           .timeout(
         const Duration(seconds: 5),
         onTimeout: () {

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -810,14 +810,21 @@ class _SyncRepository implements SyncRepository {
 
       cancellationToken?.checkCancellation();
 
+      // Caller-owned sink populated with each resolved confirmation; on timeout
+      // we fall back to it so progress made before the deadline isn't lost.
+      final verified = <String?, int>{};
+
       final map = await arweave
           .getTransactionConfirmations(currentPage.toList(),
-              owner: ownerAddress, ownerOverrides: ownerOverrides)
+              owner: ownerAddress,
+              ownerOverrides: ownerOverrides,
+              verifiedSink: verified)
           .timeout(
         const Duration(seconds: 5),
         onTimeout: () {
-          logger.w('Individual transaction confirmation timeout');
-          return <String, int>{};
+          logger.w('Individual transaction confirmation timeout; '
+              'applying ${verified.length} confirmations resolved so far');
+          return verified;
         },
       );
 
@@ -1069,16 +1076,24 @@ class _SyncRepository implements SyncRepository {
       // Check cancellation before making the GraphQL call
       cancellationToken?.checkCancellation();
 
+      // Caller-owned sink that getTransactionConfirmations populates with each
+      // resolved confirmation. On timeout we fall back to it so the work done
+      // before the deadline isn't discarded (it holds only verified
+      // confirmations, so it never marks anything failed off a partial run).
+      final verified = <String?, int>{};
+
       // Use a shorter timeout for individual GraphQL calls
       final map = await arweave
           .getTransactionConfirmations(currentPage.toList(),
-              owner: ownerAddress, ownerOverrides: ownerOverrides)
+              owner: ownerAddress,
+              ownerOverrides: ownerOverrides,
+              verifiedSink: verified)
           .timeout(
         const Duration(seconds: 5),
         onTimeout: () {
-          logger.w('Individual transaction confirmation timeout');
-          // Return empty map on timeout to continue with other transactions
-          return <String, int>{};
+          logger.w('Individual transaction confirmation timeout; '
+              'applying ${verified.length} confirmations resolved so far');
+          return verified;
         },
       );
 

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -171,9 +171,10 @@ class _SyncRepository implements SyncRepository {
 
     // The address of the currently logged-in wallet. All pending transactions
     // are uploads made by this wallet, so scoping the status query by it lets
-    // the gateway prune its search space. (Edge case: data txs of files pinned
-    // from other authors are owned by those authors and won't match — those
-    // are rare and treated as best-effort.)
+    // the gateway prune its search space. Cross-owner txs (e.g. data txs of
+    // files pinned from other authors) won't match this owner, but
+    // getTransactionConfirmations re-queries any unresolved ids without the
+    // owner filter so they aren't misclassified as failed.
     String? walletAddress;
     if (wallet != null) {
       walletAddress = await wallet.getAddress();


### PR DESCRIPTION
## Summary

The gateway ArDrive is moving to is sensitive to GraphQL queries that force its ClickHouse backend to scan millions of rows for matching data. The by-ID queries — transaction statuses and licenses — are the worst offenders. Adding the **drive owner** to these queries dramatically increases selectivity, letting the gateway prune its search space.

This PR adds an optional `owners: [String!]` filter to the affected queries and threads the owner address through their Dart call sites. The owner variable is **nullable**, so whenever an owner can't be determined the query behaves exactly as it does today — no behavioral regression, selectivity is purely additive.

## Changes

**Queries** (`lib/services/arweave/graphql/queries/`)
- `TransactionStatuses.graphql` — add `$owners`
- `LicenseDataBundled.graphql` (`LicenseComposed`) — add `$owners`
- `LicenseAssertions.graphql` — add `$owners` (sibling licensing query with the same ID-only selectivity problem, called alongside `LicenseComposed`)

**Owner wiring**
- `ArweaveService.getTransactionConfirmations` / `getLicenseComposed` / `getLicenseAssertions` accept an optional `owner` and pass `owners: [owner]` (or `null`).
- Tx status, per-drive (`_updateTransactionStatusesForDrive`): scoped to `drive.ownerAddress`.
- Tx status, global (`_updateTransactionStatuses` in `syncAllDrives`): scoped to the logged-in wallet's address (all genuinely-pending txs are uploads by the current wallet).
- Licenses (`fs_entry_info_cubit`, `shared_file_cubit`): scoped to the best-known tx owner (revision/file owner, falling back to drive owner).

## Edge case

Data txs of files **pinned from other authors** are owned by those authors and won't match the owner filter. In practice pinned txs reference already-confirmed content and aren't usually pending, and the failed path only marks "failed" after a 45-min threshold — so impact is minimal. Treated as best-effort, as discussed.

## Selectivity review of remaining queries

All other by-owner/by-tag/by-id queries are already adequately selective. The only remaining queries without an owner are **`FirstFileEntityWithIdOwner`** and **`FirstDriveEntityWithIdOwner`** — these are owner *discovery* queries (their purpose is to find the owner), so an owner can't be added. `FirstFileEntityWithIdOwner` is the weakest (single `File-Id` tag, no entity-type); flagging as the next most likely source of gateway load if any remains.

## Testing
- `flutter analyze` clean on all edited files (pre-existing project-wide l10n/uploader-example errors are unrelated).
- GraphQL bindings regenerated via `build_runner` (generated files are gitignored).
- No tests reference the changed methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved license loading accuracy by scoping composed licenses and license assertions to the appropriate owner when available.
  * Enhanced transaction confirmation and sync status updates by using owner-scoped queries and more selective resolution for pinned cross-owner data.
  * Expanded sync coverage to include pinned file revisions owned by a different on-chain data owner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->