### PR TITLE
PE-9128: Bump arweave-dart to v4.0.2 to fix file download crash

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -149,11 +149,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "v4.0.1"
-      resolved-ref: "0a55ea0358fb82f14abafc9182a121686735ba2b"
+      ref: "v4.0.2"
+      resolved-ref: "7bee19d601065b451de0aa2e72027ee30c7f934b"
       url: "https://github.com/ardriveapp/arweave-dart.git"
     source: git
-    version: "4.0.1"
+    version: "4.0.2"
   async:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,7 +53,7 @@ dependencies:
   arweave:
     git:
       url: https://github.com/ardriveapp/arweave-dart.git
-      ref: v4.0.1
+      ref: v4.0.2
   ario_sdk:
     path: ./packages/ario_sdk
   cryptography: ^2.0.5
@@ -166,7 +166,7 @@ dependency_overrides:
   arweave:
     git:
       url: https://github.com/ardriveapp/arweave-dart.git
-      ref: v4.0.1
+      ref: v4.0.2
 
   ardrive_io:
     path: ./packages/ardrive_io


### PR DESCRIPTION
## Summary

Bumps the `arweave-dart` dependency from `v4.0.1` to `v4.0.2` to pull in the `TransactionData` null-field fix.

## Background

File downloads crash on web with:

```
type 'JSNull' is not a subtype of type 'String'
```

when the configured gateway's GraphQL response returns `null` for optional transaction fields. `TransactionData.parseData` (in arweave-dart) assigned `anchor`, `recipient` and `signature` directly into non-nullable `late String` fields. On web (dart2js) assigning a `JSNull` to a `String` throws, aborting the entire `download()` call before any bytes are fetched.

Observed against `turbo-gateway.com`, which returns `anchor: null` for bundled data items. The data itself is served correctly (HTTP 200, valid CORS) — only the parse step failed.

The upstream fix ([arweave-dart#74](https://github.com/ardriveapp/arweave-dart/pull/74), tagged `v4.0.2`) coalesces those optional fields to safe defaults. For `target`/`anchor`, empty string is the protocol-canonical encoding of an absent field (it deep-hashes to the same empty bytes), so verification is unaffected; for `signature` the change is fail-safe.

## Changes

- `pubspec.yaml`: `arweave` `ref: v4.0.1` → `v4.0.2` (both the dependency and the override)
- `pubspec.lock`: `resolved-ref` updated to the `v4.0.2` tag commit `7bee19d`

## Notes

This does **not** address the separate `ardrive.net` 504/hang on data serving (which surfaces confusingly as a CORS error) — that needs a download-side gateway-fallback change and is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)