### PR TITLE
PE-9103: Release v2.84.0

### DIFF
--- a/lib/blocs/fs_entry_info/fs_entry_info_cubit.dart
+++ b/lib/blocs/fs_entry_info/fs_entry_info_cubit.dart
@@ -192,9 +192,22 @@ class FsEntryInfoCubit extends Cubit<FsEntryInfoState> {
     try {
       final isComposed = revision.licenseTxId == revision.dataTxId;
 
+      // Owner of the license transaction, used to make the gateway query more
+      // selective. For composed licenses the license tx is the data tx, so its
+      // owner is the data uploader (the pinned data owner for pinned files);
+      // for assertions and regular files it is the drive owner. Resolved best
+      // effort — when unknown the query is left unscoped.
+      final licenseOwner = _ownerAddress ??
+          revision.pinnedDataOwnerAddress ??
+          revision.originalOwner ??
+          (await _driveDao
+                  .driveById(driveId: revision.driveId)
+                  .getSingleOrNull())
+              ?.ownerAddress;
+
       if (isComposed) {
         final txs = await _arweave
-            .getLicenseComposed([revision.licenseTxId!])
+            .getLicenseComposed([revision.licenseTxId!], owner: licenseOwner)
             .expand((e) => e)
             .toList();
         if (txs.isEmpty) return null;
@@ -210,7 +223,7 @@ class FsEntryInfoCubit extends Cubit<FsEntryInfoState> {
         return _licenseService.fromComposedEntity(entity);
       } else {
         final txs = await _arweave
-            .getLicenseAssertions([revision.licenseTxId!])
+            .getLicenseAssertions([revision.licenseTxId!], owner: licenseOwner)
             .expand((e) => e)
             .toList();
         if (txs.isEmpty) return null;

--- a/lib/blocs/shared_file/shared_file_cubit.dart
+++ b/lib/blocs/shared_file/shared_file_cubit.dart
@@ -87,12 +87,15 @@ class SharedFileCubit extends Cubit<SharedFileState> {
     return revisions.reversed.toList();
   }
 
-  Future<LicenseState?> fetchLicenseForRevision(FileRevision revision) async {
+  Future<LicenseState?> fetchLicenseForRevision(
+    FileRevision revision, {
+    String? owner,
+  }) async {
     final isComposed = revision.licenseTxId == revision.dataTxId;
     if (isComposed) {
       // License Composed
       final licenseTxs = await _arweave
-          .getLicenseComposed([revision.licenseTxId!])
+          .getLicenseComposed([revision.licenseTxId!], owner: owner)
           .expand((e) => e)
           .toList();
       if (licenseTxs.isEmpty) {
@@ -106,7 +109,7 @@ class SharedFileCubit extends Cubit<SharedFileState> {
     } else {
       // License Assertion
       final licenseTxs = await _arweave
-          .getLicenseAssertions([revision.licenseTxId!])
+          .getLicenseAssertions([revision.licenseTxId!], owner: owner)
           .expand((e) => e)
           .toList();
       if (licenseTxs.isEmpty) {
@@ -145,7 +148,7 @@ class SharedFileCubit extends Cubit<SharedFileState> {
       final revisions = await computeRevisionsFromEntities(allEntities);
       // revisions are in reverse chronological order, so first is most recent
       final latestLicense = revisions.first.licenseTxId != null
-          ? await fetchLicenseForRevision(revisions.first)
+          ? await fetchLicenseForRevision(revisions.first, owner: ownerAddress)
           : null;
       
       emit(SharedFileLoadSuccess(

--- a/lib/core/upload/uploader.dart
+++ b/lib/core/upload/uploader.dart
@@ -362,11 +362,19 @@ class UploadPaymentEvaluator {
       totalSize: dataItemSize,
     );
 
-    /// Calculate the upload with AR is not optional
-    final arCostEstimate =
-        await _uploadCostEstimateCalculatorForAR.calculateCost(
-      totalSize: dataItemSize,
-    );
+    /// Calculate the upload cost with AR (D2N). If the gateway is
+    /// unavailable, fall back to a zero estimate so the modal can still
+    /// show Turbo as an option instead of crashing entirely.
+    UploadCostEstimate arCostEstimate;
+    try {
+      arCostEstimate =
+          await _uploadCostEstimateCalculatorForAR.calculateCost(
+        totalSize: dataItemSize,
+      );
+    } catch (e) {
+      logger.e('Failed to get AR cost estimate, falling back to zero', e);
+      arCostEstimate = UploadCostEstimate.zero();
+    }
 
     final allowedDataItemSizeForTurbo = _appConfig.allowedDataItemSizeForTurbo;
 
@@ -433,11 +441,19 @@ class UploadPaymentEvaluator {
       }
     }
 
-    /// Calculate the upload with AR is not optional
-    final arCostEstimate =
-        await _uploadCostEstimateCalculatorForAR.calculateCost(
-      totalSize: arBundleSizes + arFileSizes,
-    );
+    /// Calculate the upload cost with AR (D2N). If the gateway is
+    /// unavailable, fall back to a zero estimate so the modal can still
+    /// show Turbo as an option instead of crashing entirely.
+    UploadCostEstimate arCostEstimate;
+    try {
+      arCostEstimate =
+          await _uploadCostEstimateCalculatorForAR.calculateCost(
+        totalSize: arBundleSizes + arFileSizes,
+      );
+    } catch (e) {
+      logger.e('Failed to get AR cost estimate, falling back to zero', e);
+      arCostEstimate = UploadCostEstimate.zero();
+    }
 
     bool isFreeUploadPossibleUsingTurbo = false;
 

--- a/lib/models/daos/drive_dao/drive_dao.dart
+++ b/lib/models/daos/drive_dao/drive_dao.dart
@@ -121,6 +121,38 @@ class DriveDao extends DatabaseAccessor<Database> with _$DriveDaoMixin {
     }
   }
 
+  /// Bulk-loads ALL latest file revisions for a drive into a map keyed by fileId.
+  Future<Map<String, FileRevision>> getAllLatestFileRevisionsMap(
+      String driveId) async {
+    final revisions =
+        await allLatestFileRevisionsByDriveId(driveId: driveId).get();
+    return {for (final rev in revisions) rev.fileId: rev};
+  }
+
+  /// Bulk-loads ALL oldest file revisions for a drive into a map keyed by fileId.
+  Future<Map<String, FileRevision>> getAllOldestFileRevisionsMap(
+      String driveId) async {
+    final revisions =
+        await allOldestFileRevisionsByDriveId(driveId: driveId).get();
+    return {for (final rev in revisions) rev.fileId: rev};
+  }
+
+  /// Bulk-loads ALL latest folder revisions for a drive into a map keyed by folderId.
+  Future<Map<String, FolderRevision>> getAllLatestFolderRevisionsMap(
+      String driveId) async {
+    final revisions =
+        await allLatestFolderRevisionsByDriveId(driveId: driveId).get();
+    return {for (final rev in revisions) rev.folderId: rev};
+  }
+
+  /// Bulk-loads ALL oldest folder revisions for a drive into a map keyed by folderId.
+  Future<Map<String, FolderRevision>> getAllOldestFolderRevisionsMap(
+      String driveId) async {
+    final revisions =
+        await allOldestFolderRevisionsByDriveId(driveId: driveId).get();
+    return {for (final rev in revisions) rev.folderId: rev};
+  }
+
   Future<void> insertNewDriveRevisions(
     List<DriveRevisionsCompanion> revisions,
   ) async {

--- a/lib/models/queries/drive_queries.drift
+++ b/lib/models/queries/drive_queries.drift
@@ -175,6 +175,38 @@ SELECT * FROM file_entries
 WHERE assignedNames IS NOT NULL;
 
 
+allLatestFileRevisionsByDriveId:
+    SELECT fr.* FROM file_revisions fr
+    INNER JOIN (
+        SELECT fileId, MAX(dateCreated) AS maxDate
+        FROM file_revisions WHERE driveId = :driveId GROUP BY fileId
+    ) latest ON fr.fileId = latest.fileId AND fr.dateCreated = latest.maxDate
+    WHERE fr.driveId = :driveId;
+
+allOldestFileRevisionsByDriveId:
+    SELECT fr.* FROM file_revisions fr
+    INNER JOIN (
+        SELECT fileId, MIN(dateCreated) AS minDate
+        FROM file_revisions WHERE driveId = :driveId GROUP BY fileId
+    ) oldest ON fr.fileId = oldest.fileId AND fr.dateCreated = oldest.minDate
+    WHERE fr.driveId = :driveId;
+
+allLatestFolderRevisionsByDriveId:
+    SELECT fr.* FROM folder_revisions fr
+    INNER JOIN (
+        SELECT folderId, MAX(dateCreated) AS maxDate
+        FROM folder_revisions WHERE driveId = :driveId GROUP BY folderId
+    ) latest ON fr.folderId = latest.folderId AND fr.dateCreated = latest.maxDate
+    WHERE fr.driveId = :driveId;
+
+allOldestFolderRevisionsByDriveId:
+    SELECT fr.* FROM folder_revisions fr
+    INNER JOIN (
+        SELECT folderId, MIN(dateCreated) AS minDate
+        FROM folder_revisions WHERE driveId = :driveId GROUP BY folderId
+    ) oldest ON fr.folderId = oldest.folderId AND fr.dateCreated = oldest.minDate
+    WHERE fr.driveId = :driveId;
+
 deleteDriveById: DELETE FROM drives WHERE id = :driveId;
 deleteAllDriveRevisionsByDriveId:
   DELETE FROM drive_revisions

--- a/lib/models/queries/drive_queries.drift
+++ b/lib/models/queries/drive_queries.drift
@@ -170,6 +170,13 @@ pendingTransactionsForDrive:
         WHERE driveId = :driveId
     );
 
+-- File revisions of pinned files, whose data tx is owned on-chain by the
+-- original uploader (not the drive owner). Used to resolve confirmation status
+-- for these cross-owner txs without an unscoped gateway query.
+pinnedFileRevisions:
+    SELECT * FROM file_revisions
+    WHERE pinnedDataOwnerAddress IS NOT NULL;
+
 getFilesWithAssignedNames:
 SELECT * FROM file_entries
 WHERE assignedNames IS NOT NULL;

--- a/lib/pages/drive_detail/drive_detail_page.dart
+++ b/lib/pages/drive_detail/drive_detail_page.dart
@@ -141,8 +141,11 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
                   state.sharedDrives.isNotEmpty) {
                 final cubit = context.read<DriveDetailCubit>();
 
-                // Don't re-trigger changeDrive if we're already viewing/loading this drive
-                if (cubit.currentDriveId == state.selectedDriveId) {
+                // Don't re-trigger changeDrive if we're already viewing/loading
+                // this drive — UNLESS the drive was not found (it may have
+                // been attached since we last checked).
+                if (cubit.currentDriveId == state.selectedDriveId &&
+                    cubit.state is! DriveDetailLoadNotFound) {
                   return;
                 }
 
@@ -174,9 +177,7 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
               builder: (context, hideState) {
                 return BlocBuilder<DriveDetailCubit, DriveDetailState>(
                   buildWhen: (previous, current) {
-                    return !context.read<ActivityTracker>().isBulkImporting &&
-                        widget.context.read<SyncCubit>().state
-                            is! SyncInProgress;
+                    return !context.read<ActivityTracker>().isBulkImporting;
                   },
                   builder: (context, driveDetailState) {
                     if (driveDetailState is DriveDetailLoadEmpty) {

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -1235,18 +1235,28 @@ class ArweaveService {
   /// owner — keeping every query selective. Ids with no override are left
   /// unresolved rather than re-queried unscoped, which would reintroduce the
   /// expensive gateway scan this scoping is meant to avoid.
+  ///
+  /// [verifiedSink], if provided, is progressively populated with each
+  /// successfully verified confirmation (value >= 0) as the query completes —
+  /// it never receives the -1 "not found" placeholders. A caller can wrap this
+  /// method in a timeout and, on expiry, fall back to [verifiedSink] to keep
+  /// the confirmations resolved so far instead of discarding the whole batch.
+  /// Because it holds only positive verifications, applying it after a timeout
+  /// never marks anything failed off an incomplete run.
   Future<Map<String?, int>> getTransactionConfirmations(
     List<String?> transactionIds, {
     String? owner,
     Map<String, String>? ownerOverrides,
+    Map<String?, int>? verifiedSink,
   }) async {
     final transactionConfirmations = {
       for (final transactionId in transactionIds) transactionId: -1
     };
 
     // Queries confirmation status for [ids] in chunks, writing results into
-    // [transactionConfirmations]. When [owner] is provided, the query is scoped
-    // to that owner so the gateway can prune its search space.
+    // [transactionConfirmations] (and [verifiedSink] for resolved ids). When
+    // [owner] is provided, the query is scoped to that owner so the gateway can
+    // prune its search space.
     Future<void> queryConfirmations(List<String?> ids, {String? owner}) async {
       const chunkSize = 100;
 
@@ -1271,13 +1281,12 @@ class ArweaveService {
 
           for (final transaction
               in query.data!.transactions.edges.map((e) => e.node)) {
-            if (transaction.block == null) {
-              transactionConfirmations[transaction.id] = 0;
-              continue;
-            }
-
-            transactionConfirmations[transaction.id] =
-                currentBlockHeight - transaction.block!.height + 1;
+            final confirmations = transaction.block == null
+                ? 0
+                : currentBlockHeight - transaction.block!.height + 1;
+            transactionConfirmations[transaction.id] = confirmations;
+            // Record the resolved verification so it survives a caller timeout.
+            verifiedSink?[transaction.id] = confirmations;
           }
         }());
       }

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -1298,6 +1298,11 @@ class ArweaveService {
     // confirmed cross-owner txs without an unscoped scan. Genuinely missing txs
     // have no override and are left unresolved — handled by the caller's
     // existing pending/failed logic.
+    //
+    // Best-effort: this pass must never discard the first pass's results. Its
+    // results are merged into the already-populated map, so we swallow any
+    // error and bound it with its own timeout — even if it fails or stalls,
+    // the confirmations resolved by the first pass are still returned.
     if (owner != null && ownerOverrides != null && ownerOverrides.isNotEmpty) {
       final idsByOverrideOwner = <String, List<String?>>{};
       for (final entry in transactionConfirmations.entries) {
@@ -1307,8 +1312,19 @@ class ArweaveService {
         idsByOverrideOwner.putIfAbsent(overrideOwner, () => []).add(entry.key);
       }
 
-      for (final entry in idsByOverrideOwner.entries) {
-        await queryConfirmations(entry.value, owner: entry.key);
+      if (idsByOverrideOwner.isNotEmpty) {
+        try {
+          await Future(() async {
+            for (final entry in idsByOverrideOwner.entries) {
+              await queryConfirmations(entry.value, owner: entry.key);
+            }
+          }).timeout(const Duration(seconds: 3));
+        } catch (e) {
+          logger.w(
+            'Pinned-owner confirmation recovery failed or timed out; '
+            'leaving those txs unresolved: $e',
+          );
+        }
       }
     }
 

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -1236,48 +1236,69 @@ class ArweaveService {
       for (final transactionId in transactionIds) transactionId: -1
     };
 
-    const chunkSize = 100;
+    // Queries confirmation status for [ids] in chunks, writing results into
+    // [transactionConfirmations]. When [owner] is provided, the query is scoped
+    // to that owner so the gateway can prune its search space.
+    Future<void> queryConfirmations(List<String?> ids, {String? owner}) async {
+      const chunkSize = 100;
 
-    final confirmationFutures = <Future<void>>[];
+      final confirmationFutures = <Future<void>>[];
 
-    for (var i = 0; i < transactionIds.length; i += chunkSize) {
-      confirmationFutures.add(() async {
-        final chunkEnd = (i + chunkSize < transactionIds.length)
-            ? i + chunkSize
-            : transactionIds.length;
+      for (var i = 0; i < ids.length; i += chunkSize) {
+        confirmationFutures.add(() async {
+          final chunkEnd =
+              (i + chunkSize < ids.length) ? i + chunkSize : ids.length;
 
-        final query = await graphQLRetry.execute(
-          TransactionStatusesQuery(
-            variables: TransactionStatusesArguments(
-              transactionIds:
-                  transactionIds.sublist(i, chunkEnd) as List<String>?,
-              // Scoping by owner lets the gateway prune its search space; null
-              // leaves the query unscoped (current behavior).
-              owners: owner != null ? [owner] : null,
+          final query = await graphQLRetry.execute(
+            TransactionStatusesQuery(
+              variables: TransactionStatusesArguments(
+                transactionIds: ids.sublist(i, chunkEnd) as List<String>?,
+                owners: owner != null ? [owner] : null,
+              ),
             ),
-          ),
-        );
+          );
 
-        final currentBlockHeight = query.data!.blocks.edges.first.node.height;
+          final currentBlockHeight =
+              query.data!.blocks.edges.first.node.height;
 
-        for (final transaction
-            in query.data!.transactions.edges.map((e) => e.node)) {
-          if (transaction.block == null) {
-            transactionConfirmations[transaction.id] = 0;
-            continue;
+          for (final transaction
+              in query.data!.transactions.edges.map((e) => e.node)) {
+            if (transaction.block == null) {
+              transactionConfirmations[transaction.id] = 0;
+              continue;
+            }
+
+            transactionConfirmations[transaction.id] =
+                currentBlockHeight - transaction.block!.height + 1;
           }
+        }());
+      }
 
-          transactionConfirmations[transaction.id] =
-              currentBlockHeight - transaction.block!.height + 1;
-        }
-      }());
+      try {
+        await Future.wait(confirmationFutures);
+      } catch (e) {
+        logger.e('Error getting transactions confirmations on exception', e);
+        rethrow;
+      }
     }
 
-    try {
-      await Future.wait(confirmationFutures);
-    } catch (e) {
-      logger.e('Error getting transactions confirmations on exception', e);
-      rethrow;
+    // First pass: scoped by owner for gateway selectivity.
+    await queryConfirmations(transactionIds, owner: owner);
+
+    // Fallback: a tx not found under the owner scope may simply belong to a
+    // different owner (e.g. the data tx of a file pinned from another author's
+    // upload) rather than being absent from the network. Re-query just those
+    // unresolved ids without the owner filter so confirmed cross-owner txs
+    // aren't misclassified as failed by the caller. The residual set is
+    // normally tiny, so this preserves the selectivity win of the first pass.
+    if (owner != null) {
+      final unresolvedIds = transactionConfirmations.entries
+          .where((entry) => entry.value < 0)
+          .map((entry) => entry.key)
+          .toList();
+      if (unresolvedIds.isNotEmpty) {
+        await queryConfirmations(unresolvedIds);
+      }
     }
 
     return transactionConfirmations;

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -1259,43 +1259,50 @@ class ArweaveService {
     // prune its search space.
     Future<void> queryConfirmations(List<String?> ids, {String? owner}) async {
       const chunkSize = 100;
+      // Cap how many chunk queries hit the gateway at once so a large page
+      // doesn't fan out into a burst of concurrent GraphQL retries (and a
+      // potential rate-limit storm), matching the throttling used by the other
+      // gateway-heavy paths in this service.
+      final maxConcurrent =
+          _configService.config.maxConcurrentDataFetches.clamp(1, 100);
 
-      final confirmationFutures = <Future<void>>[];
+      Future<void> queryChunk(int start) async {
+        final chunkEnd =
+            (start + chunkSize < ids.length) ? start + chunkSize : ids.length;
 
-      for (var i = 0; i < ids.length; i += chunkSize) {
-        confirmationFutures.add(() async {
-          final chunkEnd =
-              (i + chunkSize < ids.length) ? i + chunkSize : ids.length;
-
-          final query = await graphQLRetry.execute(
-            TransactionStatusesQuery(
-              variables: TransactionStatusesArguments(
-                transactionIds: ids.sublist(i, chunkEnd) as List<String>?,
-                owners: owner != null ? [owner] : null,
-              ),
+        final query = await graphQLRetry.execute(
+          TransactionStatusesQuery(
+            variables: TransactionStatusesArguments(
+              transactionIds:
+                  ids.sublist(start, chunkEnd).whereType<String>().toList(),
+              owners: owner != null ? [owner] : null,
             ),
-          );
+          ),
+        );
 
-          final currentBlockHeight =
-              query.data!.blocks.edges.first.node.height;
+        final currentBlockHeight = query.data!.blocks.edges.first.node.height;
 
-          for (final transaction
-              in query.data!.transactions.edges.map((e) => e.node)) {
-            final confirmations = transaction.block == null
-                ? 0
-                : currentBlockHeight - transaction.block!.height + 1;
-            transactionConfirmations[transaction.id] = confirmations;
-            // Record the resolved verification so it survives a caller timeout.
-            verifiedSink?[transaction.id] = confirmations;
-          }
-        }());
+        for (final transaction
+            in query.data!.transactions.edges.map((e) => e.node)) {
+          final confirmations = transaction.block == null
+              ? 0
+              : currentBlockHeight - transaction.block!.height + 1;
+          transactionConfirmations[transaction.id] = confirmations;
+          // Record the resolved verification so it survives a caller timeout.
+          verifiedSink?[transaction.id] = confirmations;
+        }
       }
 
-      try {
-        await Future.wait(confirmationFutures);
-      } catch (e) {
-        logger.e('Error getting transactions confirmations on exception', e);
-        rethrow;
+      final chunkStarts = [for (var i = 0; i < ids.length; i += chunkSize) i];
+      // Process the chunks in bounded-concurrency batches.
+      for (var b = 0; b < chunkStarts.length; b += maxConcurrent) {
+        final batch = chunkStarts.skip(b).take(maxConcurrent);
+        try {
+          await Future.wait(batch.map(queryChunk));
+        } catch (e) {
+          logger.e('Error getting transactions confirmations on exception', e);
+          rethrow;
+        }
       }
     }
 

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -154,9 +154,24 @@ class ArweaveService {
   }
 
   Future<BigInt> getPrice({required int byteSize}) async {
-    return client.api
-        .get('price/$byteSize')
-        .then((res) => BigInt.parse(res.body));
+    const maxRetries = 3;
+    for (var attempt = 0; attempt < maxRetries; attempt++) {
+      try {
+        final res = await client.api.get('price/$byteSize');
+        if (res.statusCode == 200) {
+          return BigInt.parse(res.body);
+        }
+        logger.w(
+          'getPrice attempt ${attempt + 1} returned ${res.statusCode}',
+        );
+      } catch (e) {
+        logger.w('getPrice attempt ${attempt + 1} failed: $e');
+      }
+      if (attempt < maxRetries - 1) {
+        await Future.delayed(Duration(milliseconds: 500 * (attempt + 1)));
+      }
+    }
+    throw Exception('Failed to get price after $maxRetries attempts');
   }
 
   Future<int> getMempoolSizeFromArweave() async {

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -1228,9 +1228,17 @@ class ArweaveService {
   ///
   /// When the number of confirmations is 0, the transaction has yet to be mined. When
   /// it is -1, the transaction could not be found.
+  /// [ownerOverrides] maps a transaction id to the address that actually owns
+  /// it on-chain when that differs from [owner] (e.g. the data tx of a file
+  /// pinned from another author's upload). Any id left unresolved by the
+  /// owner-scoped pass that has an override is re-queried scoped to its real
+  /// owner — keeping every query selective. Ids with no override are left
+  /// unresolved rather than re-queried unscoped, which would reintroduce the
+  /// expensive gateway scan this scoping is meant to avoid.
   Future<Map<String?, int>> getTransactionConfirmations(
     List<String?> transactionIds, {
     String? owner,
+    Map<String, String>? ownerOverrides,
   }) async {
     final transactionConfirmations = {
       for (final transactionId in transactionIds) transactionId: -1
@@ -1285,19 +1293,22 @@ class ArweaveService {
     // First pass: scoped by owner for gateway selectivity.
     await queryConfirmations(transactionIds, owner: owner);
 
-    // Fallback: a tx not found under the owner scope may simply belong to a
-    // different owner (e.g. the data tx of a file pinned from another author's
-    // upload) rather than being absent from the network. Re-query just those
-    // unresolved ids without the owner filter so confirmed cross-owner txs
-    // aren't misclassified as failed by the caller. The residual set is
-    // normally tiny, so this preserves the selectivity win of the first pass.
-    if (owner != null) {
-      final unresolvedIds = transactionConfirmations.entries
-          .where((entry) => entry.value < 0)
-          .map((entry) => entry.key)
-          .toList();
-      if (unresolvedIds.isNotEmpty) {
-        await queryConfirmations(unresolvedIds);
+    // Second pass: for any unresolved id whose real owner we know locally
+    // (currently pinned data txs), re-query scoped to that owner. This recovers
+    // confirmed cross-owner txs without an unscoped scan. Genuinely missing txs
+    // have no override and are left unresolved — handled by the caller's
+    // existing pending/failed logic.
+    if (owner != null && ownerOverrides != null && ownerOverrides.isNotEmpty) {
+      final idsByOverrideOwner = <String, List<String?>>{};
+      for (final entry in transactionConfirmations.entries) {
+        if (entry.value >= 0) continue;
+        final overrideOwner = ownerOverrides[entry.key];
+        if (overrideOwner == null || overrideOwner == owner) continue;
+        idsByOverrideOwner.putIfAbsent(overrideOwner, () => []).add(entry.key);
+      }
+
+      for (final entry in idsByOverrideOwner.entries) {
+        await queryConfirmations(entry.value, owner: entry.key);
       }
     }
 

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -363,14 +363,22 @@ class ArweaveService {
   }
 
   Stream<List<LicenseAssertions$Query$TransactionConnection$TransactionEdge$Transaction>>
-      getLicenseAssertions(Iterable<String> licenseAssertionTxIds) async* {
+      getLicenseAssertions(
+    Iterable<String> licenseAssertionTxIds, {
+    String? owner,
+  }) async* {
     const chunkSize = 100;
     final chunks = licenseAssertionTxIds.slices(chunkSize);
     for (final chunk in chunks) {
       // Get a page of 100 transactions
       final licenseAssertionsQuery = await graphQLRetry.execute(
         LicenseAssertionsQuery(
-          variables: LicenseAssertionsArguments(transactionIds: chunk),
+          variables: LicenseAssertionsArguments(
+            transactionIds: chunk,
+            // Scoping by owner narrows the gateway's search space; null leaves
+            // the query unscoped (current behavior).
+            owners: owner != null ? [owner] : null,
+          ),
         ),
       );
 
@@ -381,14 +389,22 @@ class ArweaveService {
   }
 
   Stream<List<LicenseComposed$Query$TransactionConnection$TransactionEdge$Transaction>>
-      getLicenseComposed(Iterable<String> licenseComposedTxIds) async* {
+      getLicenseComposed(
+    Iterable<String> licenseComposedTxIds, {
+    String? owner,
+  }) async* {
     const chunkSize = 100;
     final chunks = licenseComposedTxIds.slices(chunkSize);
     for (final chunk in chunks) {
       // Get a page of 100 transactions
       final licenseComposedQuery = await graphQLRetry.execute(
         LicenseComposedQuery(
-          variables: LicenseComposedArguments(transactionIds: chunk),
+          variables: LicenseComposedArguments(
+            transactionIds: chunk,
+            // Scoping by owner narrows the gateway's search space; null leaves
+            // the query unscoped (current behavior).
+            owners: owner != null ? [owner] : null,
+          ),
         ),
       );
 
@@ -1213,7 +1229,9 @@ class ArweaveService {
   /// When the number of confirmations is 0, the transaction has yet to be mined. When
   /// it is -1, the transaction could not be found.
   Future<Map<String?, int>> getTransactionConfirmations(
-      List<String?> transactionIds) async {
+    List<String?> transactionIds, {
+    String? owner,
+  }) async {
     final transactionConfirmations = {
       for (final transactionId in transactionIds) transactionId: -1
     };
@@ -1233,6 +1251,9 @@ class ArweaveService {
             variables: TransactionStatusesArguments(
               transactionIds:
                   transactionIds.sublist(i, chunkEnd) as List<String>?,
+              // Scoping by owner lets the gateway prune its search space; null
+              // leaves the query unscoped (current behavior).
+              owners: owner != null ? [owner] : null,
             ),
           ),
         );

--- a/lib/services/arweave/data_gateway_fallback.dart
+++ b/lib/services/arweave/data_gateway_fallback.dart
@@ -16,9 +16,10 @@ class DataGatewayFallback {
   final Map<String, Arweave> _clientCache = {};
 
   static const _lastResortGateway = 'https://arweave.net';
-  static const _maxGarFallbacks = 3;
-  static const _retryPerGateway = 2;
+  static const _maxGarFallbacks = 2;
+  static const _retryPerGateway = 1;
   static const _garListTimeout = Duration(seconds: 5);
+  static const _requestTimeout = Duration(seconds: 5);
 
   List<Gateway>? _cachedGateways;
 
@@ -120,7 +121,9 @@ class DataGatewayFallback {
 
     for (var attempt = 0; attempt < _retryPerGateway; attempt++) {
       try {
-        final response = await client.api.getSandboxedTx(txId);
+        final response = await client.api
+            .getSandboxedTx(txId)
+            .timeout(_requestTimeout);
 
         if (response.statusCode >= 200 && response.statusCode <= 208) {
           return response;

--- a/lib/services/arweave/data_gateway_fallback.dart
+++ b/lib/services/arweave/data_gateway_fallback.dart
@@ -20,6 +20,9 @@ class DataGatewayFallback {
   static const _retryPerGateway = 1;
   static const _garListTimeout = Duration(seconds: 5);
   static const _requestTimeout = Duration(seconds: 5);
+  /// Total time allowed for the entire fallback chain per tx.
+  /// Prevents a single missing/broken tx from blocking sync for minutes.
+  static const _totalFetchTimeout = Duration(seconds: 15);
 
   List<Gateway>? _cachedGateways;
 
@@ -34,6 +37,15 @@ class DataGatewayFallback {
   /// If ALL gateways return 404, throws [TransactionNotFound] to preserve
   /// upstream error handling (e.g. private drive detection during login).
   Future<Response> fetchData(String txId, Arweave primaryClient) async {
+    return _fetchDataWithTimeout(txId, primaryClient)
+        .timeout(_totalFetchTimeout, onTimeout: () {
+      logger.w('Total fetch timeout exceeded for tx $txId');
+      throw Exception('Total fetch timeout exceeded for tx $txId');
+    });
+  }
+
+  Future<Response> _fetchDataWithTimeout(
+      String txId, Arweave primaryClient) async {
     var all404 = true;
 
     // 1. Try primary gateway

--- a/lib/services/arweave/graphql/queries/LicenseAssertions.graphql
+++ b/lib/services/arweave/graphql/queries/LicenseAssertions.graphql
@@ -1,7 +1,8 @@
-query LicenseAssertions($transactionIds: [ID!]) {
+query LicenseAssertions($transactionIds: [ID!], $owners: [String!]) {
   transactions(
     first: 100
     ids: $transactionIds
+    owners: $owners
     tags: [{ name: "App-Name", values: ["License-Assertion"] }]
   ) {
     edges {

--- a/lib/services/arweave/graphql/queries/LicenseDataBundled.graphql
+++ b/lib/services/arweave/graphql/queries/LicenseDataBundled.graphql
@@ -1,7 +1,8 @@
-query LicenseComposed($transactionIds: [ID!]) {
+query LicenseComposed($transactionIds: [ID!], $owners: [String!]) {
   transactions(
     first: 100
     ids: $transactionIds
+    owners: $owners
   ) {
     edges {
       node {

--- a/lib/services/arweave/graphql/queries/TransactionStatuses.graphql
+++ b/lib/services/arweave/graphql/queries/TransactionStatuses.graphql
@@ -1,5 +1,5 @@
-query TransactionStatuses($transactionIds: [ID!]) {
-  transactions(first: 100, ids: $transactionIds) {
+query TransactionStatuses($transactionIds: [ID!], $owners: [String!]) {
+  transactions(first: 100, ids: $transactionIds, owners: $owners) {
     edges {
       node {
         id

--- a/lib/sync/data/snapshot_validation_service.dart
+++ b/lib/sync/data/snapshot_validation_service.dart
@@ -10,10 +10,13 @@ class SnapshotValidationService {
   final ConfigService _configService;
   final ArioSDK _arioSDK;
 
-  static const _headTimeout = Duration(seconds: 10);
-  static const _retryDelay = Duration(milliseconds: 500);
-  static const _garListTimeout = Duration(seconds: 5);
+  static const _headTimeout = Duration(seconds: 5);
+  static const _garListTimeout = Duration(seconds: 3);
   static const _maxConcurrentValidations = 3;
+
+  /// Cached GAR gateway list — fetched once per session, avoids repeated
+  /// Solana RPC calls which may be slow or unavailable (e.g. localhost).
+  List<Gateway>? _cachedGateways;
 
   SnapshotValidationService({
     required ConfigService configService,
@@ -63,47 +66,51 @@ class SnapshotValidationService {
   /// 2. If primary fails, try 1 fallback gateway from the GAR list
   /// 3. Accept if ANY gateway returns 200
   Future<bool> _validateSnapshot(String txId, String primaryUrl) async {
-    // 1. Try primary gateway (with 1 retry)
-    for (var attempt = 0; attempt < 2; attempt++) {
-      try {
-        final response = await http
-            .head(Uri.parse('$primaryUrl/$txId'))
-            .timeout(_headTimeout);
+    var primaryWas404 = false;
 
-        // 200 = available, 302 = gateway knows about it (redirecting to sandbox URL)
-        if (response.statusCode == 200 || response.statusCode == 302) {
-          return true;
-        }
+    // 1. Try primary gateway (1 attempt, no retry — fail fast)
+    try {
+      final response = await http
+          .head(Uri.parse('$primaryUrl/$txId'))
+          .timeout(_headTimeout);
 
-        if (_isNonRetryable(response.statusCode)) {
-          logger.w(
-            'Snapshot $txId rejected: '
-            'non-retryable status ${response.statusCode}',
-          );
-          return false;
-        }
+      if (response.statusCode == 200 || response.statusCode == 302) {
+        return true;
+      }
 
-        logger.d(
-          'Snapshot $txId HEAD attempt ${attempt + 1} '
-          'returned ${response.statusCode}',
+      if (_isNonRetryable(response.statusCode)) {
+        logger.w(
+          'Snapshot $txId rejected: '
+          'non-retryable status ${response.statusCode}',
         );
-      } on TimeoutException {
-        logger.d('Snapshot $txId HEAD attempt ${attempt + 1} timed out');
-      } catch (e) {
-        logger.d('Snapshot $txId HEAD attempt ${attempt + 1} error: $e');
+        return false;
       }
 
-      // Retry after brief delay (skip delay on last attempt)
-      if (attempt == 0) {
-        await Future.delayed(_retryDelay);
-      }
+      primaryWas404 = response.statusCode == 404;
+
+      logger.d(
+        'Snapshot $txId HEAD returned ${response.statusCode}',
+      );
+    } on TimeoutException {
+      logger.d('Snapshot $txId HEAD timed out');
+    } catch (e) {
+      logger.d('Snapshot $txId HEAD error: $e');
     }
 
-    // 2. Primary failed — try 1 fallback gateway
+    // 2. If primary returned 404, the snapshot likely doesn't exist.
+    //    Skip the fallback — GAR list requires Solana RPC which may be
+    //    unavailable (localhost, rate limits). Fail fast and fall back to GQL.
+    if (primaryWas404) {
+      logger.w('Snapshot $txId not found on primary (404), skipping fallback');
+      return false;
+    }
+
+    // 3. Primary had a transient error (timeout, 5xx) — try 1 fallback gateway
     try {
-      final gateways = await _arioSDK
+      _cachedGateways ??= await _arioSDK
           .getGateways()
           .timeout(_garListTimeout, onTimeout: () => <Gateway>[]);
+      final gateways = _cachedGateways!;
 
       if (gateways.isEmpty) return false;
 

--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -399,8 +399,13 @@ class SyncCubit extends Cubit<SyncState> {
     logger.i('Starting Sync for drive: $driveId, deepSync: $deepSync');
 
     if (state is SyncInProgress) {
-      logger.d('Sync state is SyncInProgress, aborting single drive sync...');
-      return;
+      logger.d('Waiting for current sync to finish before single drive sync');
+      await waitCurrentSync();
+      // Re-check: another caller may have started syncing while we waited
+      if (state is SyncInProgress) {
+        logger.d('Another sync started while waiting, aborting single drive sync');
+        return;
+      }
     }
 
     // Mark as single drive sync from the start so the UI shows the right title

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -172,9 +172,9 @@ class _SyncRepository implements SyncRepository {
     // The address of the currently logged-in wallet. All pending transactions
     // are uploads made by this wallet, so scoping the status query by it lets
     // the gateway prune its search space. Cross-owner txs (e.g. data txs of
-    // files pinned from other authors) won't match this owner, but
-    // getTransactionConfirmations re-queries any unresolved ids without the
-    // owner filter so they aren't misclassified as failed.
+    // files pinned from other authors) won't match this owner; those that we
+    // can identify locally are re-queried scoped to their real owner via
+    // ownerOverrides in getTransactionConfirmations.
     String? walletAddress;
     if (wallet != null) {
       walletAddress = await wallet.getAddress();
@@ -771,6 +771,8 @@ class _SyncRepository implements SyncRepository {
   }) async {
     cancellationToken?.checkCancellation();
 
+    final ownerOverrides = await _buildPinnedDataTxOwnerOverrides(driveDao);
+
     // Load all pending transactions and filter to this drive
     final allPendingTxs = await driveDao.pendingTransactions().get();
     final drivePendingTxs = allPendingTxs
@@ -810,7 +812,7 @@ class _SyncRepository implements SyncRepository {
 
       final map = await arweave
           .getTransactionConfirmations(currentPage.toList(),
-              owner: ownerAddress)
+              owner: ownerAddress, ownerOverrides: ownerOverrides)
           .timeout(
         const Duration(seconds: 5),
         onTimeout: () {
@@ -993,6 +995,21 @@ class _SyncRepository implements SyncRepository {
     }
   }
 
+  /// Maps the data tx id of each pinned file to the address that actually owns
+  /// it on-chain (the original uploader, not the drive owner). Used to resolve
+  /// confirmation status for these cross-owner txs with a selective,
+  /// owner-scoped query instead of an expensive unscoped one.
+  Future<Map<String, String>> _buildPinnedDataTxOwnerOverrides(
+    DriveDao driveDao,
+  ) async {
+    final pinnedFileRevisions = await driveDao.pinnedFileRevisions().get();
+    return {
+      for (final row in pinnedFileRevisions)
+        if (row.pinnedDataOwnerAddress != null)
+          row.dataTxId: row.pinnedDataOwnerAddress!,
+    };
+  }
+
   Future<void> _updateTransactionStatuses({
     required DriveDao driveDao,
     required ArweaveService arweave,
@@ -1002,6 +1019,8 @@ class _SyncRepository implements SyncRepository {
   }) async {
     // Check for cancellation at the start
     cancellationToken?.checkCancellation();
+
+    final ownerOverrides = await _buildPinnedDataTxOwnerOverrides(driveDao);
 
     // Load all pending transactions
     // Note: We load all at once here, but the memory impact is acceptable
@@ -1053,7 +1072,7 @@ class _SyncRepository implements SyncRepository {
       // Use a shorter timeout for individual GraphQL calls
       final map = await arweave
           .getTransactionConfirmations(currentPage.toList(),
-              owner: ownerAddress)
+              owner: ownerAddress, ownerOverrides: ownerOverrides)
           .timeout(
         const Duration(seconds: 5),
         onTimeout: () {

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -1496,6 +1496,45 @@ class _SyncRepository implements SyncRepository {
       'no. of entities in drive with id ${drive.id} to be parsed are: $numberOfDriveEntitiesToParse\n',
     );
 
+    // Pre-load all latest/oldest revisions for this drive into maps.
+    // Replaces thousands of individual DB queries with 4 bulk queries.
+    final isFirstSync =
+        drive.lastBlockHeight == null || drive.lastBlockHeight == 0;
+
+    final latestFileRevisionsCache = isFirstSync
+        ? <String, FileRevisionsCompanion>{}
+        : <String, FileRevisionsCompanion>{
+            for (final e
+                in (await _driveDao.getAllLatestFileRevisionsMap(drive.id))
+                    .entries)
+              e.key: e.value.toCompanion(true),
+          };
+
+    final latestFolderRevisionsCache = isFirstSync
+        ? <String, FolderRevisionsCompanion>{}
+        : <String, FolderRevisionsCompanion>{
+            for (final e
+                in (await _driveDao.getAllLatestFolderRevisionsMap(drive.id))
+                    .entries)
+              e.key: e.value.toCompanion(true),
+          };
+
+    // Oldest revision maps — immutable during processing since inserting
+    // newer revisions doesn't change the oldest.
+    final oldestFileRevisionsCache = isFirstSync
+        ? <String, FileRevision>{}
+        : await _driveDao.getAllOldestFileRevisionsMap(drive.id);
+
+    final oldestFolderRevisionsCache = isFirstSync
+        ? <String, FolderRevision>{}
+        : await _driveDao.getAllOldestFolderRevisionsMap(drive.id);
+
+    if (!isFirstSync) {
+      logger.d('Pre-loaded revision caches: '
+          '${latestFileRevisionsCache.length} files, '
+          '${latestFolderRevisionsCache.length} folders');
+    }
+
     yield* _batchProcessor.batchProcess<DriveEntityHistoryTransactionModel>(
         list: transactions,
         batchSize: batchSize,
@@ -1538,10 +1577,12 @@ class _SyncRepository implements SyncRepository {
             final latestFolderRevisions = await _addNewFolderEntityRevisions(
               driveId: drive.id,
               newEntities: newEntities.whereType<FolderEntity>(),
+              latestRevisionsCache: latestFolderRevisionsCache,
             );
             final latestFileRevisions = await _addNewFileEntityRevisions(
               driveId: drive.id,
               newEntities: newEntities.whereType<FileEntity>(),
+              latestRevisionsCache: latestFileRevisionsCache,
             );
 
             for (final entity in latestFileRevisions) {
@@ -1570,12 +1611,14 @@ class _SyncRepository implements SyncRepository {
               driveDao: _driveDao,
               driveId: drive.id,
               revisionsByFolderId: latestFolderRevisions,
+              oldestRevisionsCache: oldestFolderRevisionsCache,
             );
             final updatedFilesById =
                 await _computeRefreshedFileEntriesFromRevisions(
               driveDao: _driveDao,
               driveId: drive.id,
               revisionsByFileId: latestFileRevisions,
+              oldestRevisionsCache: oldestFileRevisionsCache,
             );
 
             numberOfDriveEntitiesParsed += newEntities.length;
@@ -1652,6 +1695,7 @@ class _SyncRepository implements SyncRepository {
   Future<List<FileRevisionsCompanion>> _addNewFileEntityRevisions({
     required String driveId,
     required Iterable<FileEntity> newEntities,
+    required Map<String, FileRevisionsCompanion> latestRevisionsCache,
   }) async {
     // The latest file revisions, keyed by their entity ids.
     final latestRevisions = <String, FileRevisionsCompanion>{};
@@ -1660,12 +1704,10 @@ class _SyncRepository implements SyncRepository {
     for (final entity in newEntities) {
       if (!latestRevisions.containsKey(entity.id) &&
           entity.parentFolderId != null) {
-        final revisions = await _driveDao
-            .latestFileRevisionByFileId(driveId: driveId, fileId: entity.id!)
-            .getSingleOrNull();
-        // Gets the latest revision for the file, if it exists on the database.
-        if (revisions != null) {
-          latestRevisions[entity.id!] = revisions.toCompanion(true);
+        // Use pre-loaded cache instead of per-entity DB query
+        final cached = latestRevisionsCache[entity.id!];
+        if (cached != null) {
+          latestRevisions[entity.id!] = cached;
         }
       }
 
@@ -1693,10 +1735,12 @@ class _SyncRepository implements SyncRepository {
           if (revision.dateCreated.value
               .isAfter(latestRevision!.dateCreated.value)) {
             latestRevisions[entity.id!] = revision;
+            latestRevisionsCache[entity.id!] = revision;
             newRevisions.add(revision);
           }
         } else {
           latestRevisions[entity.id!] = revision;
+          latestRevisionsCache[entity.id!] = revision;
           newRevisions.add(revision);
         }
       } catch (e, stacktrace) {
@@ -1717,6 +1761,7 @@ class _SyncRepository implements SyncRepository {
   Future<List<FolderRevisionsCompanion>> _addNewFolderEntityRevisions({
     required String driveId,
     required Iterable<FolderEntity> newEntities,
+    required Map<String, FolderRevisionsCompanion> latestRevisionsCache,
   }) async {
     _folderIds.addAll(newEntities.map((e) => e.id!));
     // The latest folder revisions, keyed by their entity ids.
@@ -1725,12 +1770,10 @@ class _SyncRepository implements SyncRepository {
     final newRevisions = <FolderRevisionsCompanion>[];
     for (final entity in newEntities) {
       if (!latestRevisions.containsKey(entity.id)) {
-        final revisions = (await _driveDao
-            .latestFolderRevisionByFolderId(
-                driveId: driveId, folderId: entity.id!)
-            .getSingleOrNull());
-        if (revisions != null) {
-          latestRevisions[entity.id!] = revisions.toCompanion(true);
+        // Use pre-loaded cache instead of per-entity DB query
+        final cached = latestRevisionsCache[entity.id!];
+        if (cached != null) {
+          latestRevisions[entity.id!] = cached;
         }
       }
 
@@ -1748,6 +1791,7 @@ class _SyncRepository implements SyncRepository {
 
       newRevisions.add(revision);
       latestRevisions[entity.id!] = revision;
+      latestRevisionsCache[entity.id!] = revision;
     }
     final newNetworkTransactions =
         createNetworkTransactionsCompanionsForFolders(
@@ -1779,6 +1823,7 @@ Future<Map<String, FileEntriesCompanion>>
   required DriveDao driveDao,
   required String driveId,
   required List<FileRevisionsCompanion> revisionsByFileId,
+  required Map<String, FileRevision> oldestRevisionsCache,
 }) async {
   final updatedFilesById = {
     for (final revision in revisionsByFileId)
@@ -1786,9 +1831,8 @@ Future<Map<String, FileEntriesCompanion>>
   };
 
   for (final fileId in updatedFilesById.keys) {
-    final oldestRevision = await driveDao
-        .oldestFileRevisionByFileId(driveId: driveId, fileId: fileId)
-        .getSingleOrNull();
+    // Use pre-loaded cache instead of per-entity DB query
+    final oldestRevision = oldestRevisionsCache[fileId];
 
     final dateCreated = oldestRevision?.dateCreated ??
         updatedFilesById[fileId]!.dateCreated.value;
@@ -1807,6 +1851,7 @@ Future<Map<String, FolderEntriesCompanion>>
   required DriveDao driveDao,
   required String driveId,
   required List<FolderRevisionsCompanion> revisionsByFolderId,
+  required Map<String, FolderRevision> oldestRevisionsCache,
 }) async {
   final updatedFoldersById = {
     for (final revision in revisionsByFolderId)
@@ -1814,9 +1859,8 @@ Future<Map<String, FolderEntriesCompanion>>
   };
 
   for (final folderId in updatedFoldersById.keys) {
-    final oldestRevision = await driveDao
-        .oldestFolderRevisionByFolderId(driveId: driveId, folderId: folderId)
-        .getSingleOrNull();
+    // Use pre-loaded cache instead of per-entity DB query
+    final oldestRevision = oldestRevisionsCache[folderId];
 
     final dateCreated = oldestRevision?.dateCreated ??
         updatedFoldersById[folderId]!.dateCreated.value;
@@ -1840,7 +1884,7 @@ Future<DrivesCompanion> _computeRefreshedDriveFromRevision({
 
   return latestRevision.toEntryCompanion().copyWith(
         dateCreated: Value(
-          oldestRevision?.dateCreated ?? latestRevision.dateCreated as DateTime,
+          oldestRevision?.dateCreated ?? latestRevision.dateCreated.value,
         ),
       );
 }

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -169,11 +169,17 @@ class _SyncRepository implements SyncRepository {
     _ghostFolders.clear();
     _folderIds.clear();
 
+    // The address of the currently logged-in wallet. All pending transactions
+    // are uploads made by this wallet, so scoping the status query by it lets
+    // the gateway prune its search space. (Edge case: data txs of files pinned
+    // from other authors are owned by those authors and won't match — those
+    // are rare and treated as best-effort.)
+    String? walletAddress;
     if (wallet != null) {
-      final address = await wallet.getAddress();
+      walletAddress = await wallet.getAddress();
 
       _arnsRepository
-          .getAntRecordsForWallet(address, update: true)
+          .getAntRecordsForWallet(walletAddress, update: true)
           .catchError((e) {
         logger.e('Error getting ANT records for wallet. Continuing...', e);
         return Future.value(<ANTRecord>[]);
@@ -383,6 +389,8 @@ class _SyncRepository implements SyncRepository {
               _updateTransactionStatuses(
                 driveDao: _driveDao,
                 arweave: _arweave,
+                // Scope the gateway query to the logged-in wallet for selectivity.
+                ownerAddress: walletAddress,
                 txsIdsToSkip: confirmedFileTxIds,
                 cancellationToken: token,
               ).timeout(
@@ -663,6 +671,8 @@ class _SyncRepository implements SyncRepository {
             driveDao: _driveDao,
             arweave: _arweave,
             driveDataTxIds: driveDataTxIds,
+            // Scope the gateway query to this drive's owner for selectivity.
+            ownerAddress: drive.ownerAddress,
             txsIdsToSkip: confirmedFileTxIds,
             cancellationToken: token,
           ).timeout(
@@ -754,6 +764,7 @@ class _SyncRepository implements SyncRepository {
     required DriveDao driveDao,
     required ArweaveService arweave,
     required Set<String> driveDataTxIds,
+    String? ownerAddress,
     List<TxID> txsIdsToSkip = const [],
     SyncCancellationToken? cancellationToken,
   }) async {
@@ -797,7 +808,8 @@ class _SyncRepository implements SyncRepository {
       cancellationToken?.checkCancellation();
 
       final map = await arweave
-          .getTransactionConfirmations(currentPage.toList())
+          .getTransactionConfirmations(currentPage.toList(),
+              owner: ownerAddress)
           .timeout(
         const Duration(seconds: 5),
         onTimeout: () {
@@ -983,6 +995,7 @@ class _SyncRepository implements SyncRepository {
   Future<void> _updateTransactionStatuses({
     required DriveDao driveDao,
     required ArweaveService arweave,
+    String? ownerAddress,
     List<TxID> txsIdsToSkip = const [],
     SyncCancellationToken? cancellationToken,
   }) async {
@@ -1038,7 +1051,8 @@ class _SyncRepository implements SyncRepository {
 
       // Use a shorter timeout for individual GraphQL calls
       final map = await arweave
-          .getTransactionConfirmations(currentPage.toList())
+          .getTransactionConfirmations(currentPage.toList(),
+              owner: ownerAddress)
           .timeout(
         const Duration(seconds: 5),
         onTimeout: () {

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -1825,17 +1825,22 @@ Future<Map<String, FileEntriesCompanion>>
   required List<FileRevisionsCompanion> revisionsByFileId,
   required Map<String, FileRevision> oldestRevisionsCache,
 }) async {
-  final updatedFilesById = {
-    for (final revision in revisionsByFileId)
-      revision.fileId.value: revision.toEntryCompanion(),
-  };
+  // Build map of entry companions AND keep revision dateCreated for fallback
+  final revisionDateByFileId = <String, DateTime>{};
+  final updatedFilesById = <String, FileEntriesCompanion>{};
+  for (final revision in revisionsByFileId) {
+    final fileId = revision.fileId.value;
+    updatedFilesById[fileId] = revision.toEntryCompanion();
+    revisionDateByFileId[fileId] = revision.dateCreated.value;
+  }
 
   for (final fileId in updatedFilesById.keys) {
-    // Use pre-loaded cache instead of per-entity DB query
+    // Use pre-loaded cache instead of per-entity DB query.
+    // Fall back to the revision's own dateCreated (not the entry companion's,
+    // which may be Value.absent due to schema defaults).
     final oldestRevision = oldestRevisionsCache[fileId];
-
-    final dateCreated = oldestRevision?.dateCreated ??
-        updatedFilesById[fileId]!.dateCreated.value;
+    final dateCreated =
+        oldestRevision?.dateCreated ?? revisionDateByFileId[fileId]!;
 
     updatedFilesById[fileId] = updatedFilesById[fileId]!.copyWith(
       dateCreated: Value<DateTime>(dateCreated),
@@ -1853,17 +1858,22 @@ Future<Map<String, FolderEntriesCompanion>>
   required List<FolderRevisionsCompanion> revisionsByFolderId,
   required Map<String, FolderRevision> oldestRevisionsCache,
 }) async {
-  final updatedFoldersById = {
-    for (final revision in revisionsByFolderId)
-      revision.folderId.value: revision.toEntryCompanion(),
-  };
+  // Build map of entry companions AND keep revision dateCreated for fallback
+  final revisionDateByFolderId = <String, DateTime>{};
+  final updatedFoldersById = <String, FolderEntriesCompanion>{};
+  for (final revision in revisionsByFolderId) {
+    final folderId = revision.folderId.value;
+    updatedFoldersById[folderId] = revision.toEntryCompanion();
+    revisionDateByFolderId[folderId] = revision.dateCreated.value;
+  }
 
   for (final folderId in updatedFoldersById.keys) {
-    // Use pre-loaded cache instead of per-entity DB query
+    // Use pre-loaded cache instead of per-entity DB query.
+    // Fall back to the revision's own dateCreated (not the entry companion's,
+    // which may be Value.absent due to schema defaults).
     final oldestRevision = oldestRevisionsCache[folderId];
-
-    final dateCreated = oldestRevision?.dateCreated ??
-        updatedFoldersById[folderId]!.dateCreated.value;
+    final dateCreated =
+        oldestRevision?.dateCreated ?? revisionDateByFolderId[folderId]!;
 
     updatedFoldersById[folderId] = updatedFoldersById[folderId]!.copyWith(
       dateCreated: Value<DateTime>(dateCreated),

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -810,14 +810,21 @@ class _SyncRepository implements SyncRepository {
 
       cancellationToken?.checkCancellation();
 
+      // Caller-owned sink populated with each resolved confirmation; on timeout
+      // we fall back to it so progress made before the deadline isn't lost.
+      final verified = <String?, int>{};
+
       final map = await arweave
           .getTransactionConfirmations(currentPage.toList(),
-              owner: ownerAddress, ownerOverrides: ownerOverrides)
+              owner: ownerAddress,
+              ownerOverrides: ownerOverrides,
+              verifiedSink: verified)
           .timeout(
         const Duration(seconds: 5),
         onTimeout: () {
-          logger.w('Individual transaction confirmation timeout');
-          return <String, int>{};
+          logger.w('Individual transaction confirmation timeout; '
+              'applying ${verified.length} confirmations resolved so far');
+          return verified;
         },
       );
 
@@ -1069,16 +1076,24 @@ class _SyncRepository implements SyncRepository {
       // Check cancellation before making the GraphQL call
       cancellationToken?.checkCancellation();
 
+      // Caller-owned sink that getTransactionConfirmations populates with each
+      // resolved confirmation. On timeout we fall back to it so the work done
+      // before the deadline isn't discarded (it holds only verified
+      // confirmations, so it never marks anything failed off a partial run).
+      final verified = <String?, int>{};
+
       // Use a shorter timeout for individual GraphQL calls
       final map = await arweave
           .getTransactionConfirmations(currentPage.toList(),
-              owner: ownerAddress, ownerOverrides: ownerOverrides)
+              owner: ownerAddress,
+              ownerOverrides: ownerOverrides,
+              verifiedSink: verified)
           .timeout(
         const Duration(seconds: 5),
         onTimeout: () {
-          logger.w('Individual transaction confirmation timeout');
-          // Return empty map on timeout to continue with other transactions
-          return <String, int>{};
+          logger.w('Individual transaction confirmation timeout; '
+              'applying ${verified.length} confirmations resolved so far');
+          return verified;
         },
       );
 

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -171,9 +171,10 @@ class _SyncRepository implements SyncRepository {
 
     // The address of the currently logged-in wallet. All pending transactions
     // are uploads made by this wallet, so scoping the status query by it lets
-    // the gateway prune its search space. (Edge case: data txs of files pinned
-    // from other authors are owned by those authors and won't match — those
-    // are rare and treated as best-effort.)
+    // the gateway prune its search space. Cross-owner txs (e.g. data txs of
+    // files pinned from other authors) won't match this owner, but
+    // getTransactionConfirmations re-queries any unresolved ids without the
+    // owner filter so they aren't misclassified as failed.
     String? walletAddress;
     if (wallet != null) {
       walletAddress = await wallet.getAddress();

--- a/lib/utils/snapshots/snapshot_drive_history.dart
+++ b/lib/utils/snapshots/snapshot_drive_history.dart
@@ -91,30 +91,9 @@ class SnapshotDriveHistory implements SegmentedGQLData {
         _subRangeToSnapshotItemMapping[subRangeForIndex]!;
 
     // reads the next stream of each item in the list and yields each node in order
-    for (var i = 0; i < itemsInRange.length; i++) {
-      final item = itemsInRange[i];
-
-      // Prefetch the NEXT snapshot body while processing the current one.
-      // This overlaps download with parsing/DB-writes. Only 1 ahead to
-      // avoid gateway 429s.
-      if (i + 1 < itemsInRange.length) {
-        final next = itemsInRange[i + 1];
-        if (next is SnapshotItemOnChain) {
-          next.prefetch();
-        }
-      } else if (currentIndex + 1 < subRanges.rangeSegments.length) {
-        // Prefetch the first item of the NEXT sub-range
-        final nextRange = subRanges.rangeSegments[currentIndex + 1];
-        final nextItems = _subRangeToSnapshotItemMapping[nextRange];
-        if (nextItems != null && nextItems.isNotEmpty) {
-          final next = nextItems.first;
-          if (next is SnapshotItemOnChain) {
-            next.prefetch();
-          }
-        }
-      }
-
-      yield* item.getNextStream();
+    for (SnapshotItem item in itemsInRange) {
+      final stream = item.getNextStream();
+      yield* stream;
     }
   }
 }

--- a/lib/utils/snapshots/snapshot_drive_history.dart
+++ b/lib/utils/snapshots/snapshot_drive_history.dart
@@ -91,9 +91,30 @@ class SnapshotDriveHistory implements SegmentedGQLData {
         _subRangeToSnapshotItemMapping[subRangeForIndex]!;
 
     // reads the next stream of each item in the list and yields each node in order
-    for (SnapshotItem item in itemsInRange) {
-      final stream = item.getNextStream();
-      yield* stream;
+    for (var i = 0; i < itemsInRange.length; i++) {
+      final item = itemsInRange[i];
+
+      // Prefetch the NEXT snapshot body while processing the current one.
+      // This overlaps download with parsing/DB-writes. Only 1 ahead to
+      // avoid gateway 429s.
+      if (i + 1 < itemsInRange.length) {
+        final next = itemsInRange[i + 1];
+        if (next is SnapshotItemOnChain) {
+          next.prefetch();
+        }
+      } else if (currentIndex + 1 < subRanges.rangeSegments.length) {
+        // Prefetch the first item of the NEXT sub-range
+        final nextRange = subRanges.rangeSegments[currentIndex + 1];
+        final nextItems = _subRangeToSnapshotItemMapping[nextRange];
+        if (nextItems != null && nextItems.isNotEmpty) {
+          final next = nextItems.first;
+          if (next is SnapshotItemOnChain) {
+            next.prefetch();
+          }
+        }
+      }
+
+      yield* item.getNextStream();
     }
   }
 }

--- a/lib/utils/snapshots/snapshot_item.dart
+++ b/lib/utils/snapshots/snapshot_item.dart
@@ -214,13 +214,29 @@ class SnapshotItemOnChain implements SnapshotItem {
   @override
   int get currentIndex => _currentIndex;
 
+  Future<String>? _prefetchFuture;
+
   Future<String> _source() async {
     if (_cachedSource != null) {
       return _cachedSource!;
     }
+    // Use prefetch result if available, otherwise fetch now
+    if (_prefetchFuture != null) {
+      return _cachedSource = await _prefetchFuture!;
+    }
     final dataBytes = await _arweave.getEntityDataFromNetwork(txId: txId);
     final dataBytesAsString = String.fromCharCodes(dataBytes);
     return _cachedSource = dataBytesAsString;
+  }
+
+  /// Start downloading the snapshot body without waiting for it.
+  /// Call this on the NEXT snapshot while processing the current one.
+  void prefetch() {
+    if (_cachedSource != null || _prefetchFuture != null) return;
+    logger.d('Prefetching snapshot $txId');
+    _prefetchFuture = _arweave
+        .getEntityDataFromNetwork(txId: txId)
+        .then((bytes) => String.fromCharCodes(bytes));
   }
 
   @override
@@ -233,28 +249,45 @@ class SnapshotItemOnChain implements SnapshotItem {
     return _getNextStream();
   }
 
+  /// Parses snapshot entries one at a time by scanning for object boundaries
+  /// in the JSON string, avoiding a full jsonDecode of the entire snapshot.
+  /// This keeps memory bounded to one entry at a time instead of the full Map.
   Stream<DriveEntityHistoryTransactionModel> _getNextStream() async* {
     final Range range = subRanges.rangeSegments[currentIndex];
+    final source = await _source();
 
-    final Map dataJson = jsonDecode(await _source());
-    final List<Map> txSnapshots =
-        List.castFrom<dynamic, Map>(dataJson['txSnapshots']);
+    // Find the txSnapshots array in the JSON string
+    final arrayStart = source.indexOf('[', source.indexOf('"txSnapshots"'));
+    if (arrayStart == -1) {
+      logger.w('Snapshot $txId has no txSnapshots array');
+      return;
+    }
 
-    for (Map item in txSnapshots) {
+    var yielded = 0;
+    var skipped = 0;
+
+    // Scan for individual objects within the array
+    for (final objectJson in _iterateJsonArrayObjects(source, arrayStart)) {
+      Map item;
+      try {
+        item = jsonDecode(objectJson) as Map;
+      } catch (e) {
+        logger.w('Error parsing snapshot entry in $txId');
+        continue;
+      }
+
       DriveHistoryTransaction node;
-
       try {
         node = DriveHistoryTransaction.fromJson(item['gqlNode']);
       } catch (e) {
-        logger.w(
-          'Error while parsing GQLNode from snapshot item ($txId)',
-        );
+        logger.w('Error parsing GQLNode from snapshot item ($txId)');
         continue;
       }
 
       final isInRange = range.isInRange(node.block?.height ?? -1);
       if (isInRange) {
         yield DriveEntityHistoryTransactionModel(transactionCommonMixin: node);
+        yielded++;
 
         final String? data = item['jsonMetadata'];
         if (data != null) {
@@ -262,15 +295,87 @@ class SnapshotItemOnChain implements SnapshotItem {
           final Uint8List dataAsBytes = Uint8List.fromList(utf8.encode(data));
           await _setDataForTxId(driveId, txId, dataAsBytes);
         }
+      } else {
+        skipped++;
       }
     }
 
-    if (currentIndex == subRanges.rangeSegments.length - 1) {
-      // Done reading all data, the memory can be freed
-      _cachedSource = null;
-    }
+    logger.d('Snapshot $txId range ${range.start}-${range.end}: '
+        'yielded $yielded, skipped $skipped');
 
-    return;
+    if (currentIndex == subRanges.rangeSegments.length - 1) {
+      _cachedSource = null;
+      _prefetchFuture = null;
+    }
+  }
+
+  /// Iterates over top-level JSON objects in an array without parsing the
+  /// entire array. Uses brace counting to find object boundaries.
+  ///
+  /// [source] is the full JSON string. [arrayStartIndex] is the index of
+  /// the opening `[` of the array.
+  static Iterable<String> _iterateJsonArrayObjects(
+    String source,
+    int arrayStartIndex,
+  ) sync* {
+    var i = arrayStartIndex + 1; // skip the '['
+    final len = source.length;
+
+    while (i < len) {
+      // Skip whitespace and commas
+      while (i < len) {
+        final c = source.codeUnitAt(i);
+        if (c == 0x7D + 1) break; // shouldn't happen
+        if (c == 0x5D) return; // ']' — end of array
+        if (c == 0x7B) break; // '{' — start of object
+        i++;
+      }
+      if (i >= len) return;
+
+      // Found '{', count braces to find matching '}'
+      final objectStart = i;
+      var depth = 0;
+      var inString = false;
+      var escaped = false;
+
+      while (i < len) {
+        final c = source.codeUnitAt(i);
+
+        if (escaped) {
+          escaped = false;
+          i++;
+          continue;
+        }
+
+        if (c == 0x5C) {
+          // backslash
+          escaped = true;
+          i++;
+          continue;
+        }
+
+        if (c == 0x22) {
+          // double quote
+          inString = !inString;
+          i++;
+          continue;
+        }
+
+        if (!inString) {
+          if (c == 0x7B) depth++; // '{'
+          if (c == 0x7D) {
+            // '}'
+            depth--;
+            if (depth == 0) {
+              yield source.substring(objectStart, i + 1);
+              i++;
+              break;
+            }
+          }
+        }
+        i++;
+      }
+    }
   }
 
   static Future<Uint8List> _setDataForTxId(

--- a/lib/utils/snapshots/snapshot_item.dart
+++ b/lib/utils/snapshots/snapshot_item.dart
@@ -214,29 +214,13 @@ class SnapshotItemOnChain implements SnapshotItem {
   @override
   int get currentIndex => _currentIndex;
 
-  Future<String>? _prefetchFuture;
-
   Future<String> _source() async {
     if (_cachedSource != null) {
       return _cachedSource!;
     }
-    // Use prefetch result if available, otherwise fetch now
-    if (_prefetchFuture != null) {
-      return _cachedSource = await _prefetchFuture!;
-    }
     final dataBytes = await _arweave.getEntityDataFromNetwork(txId: txId);
     final dataBytesAsString = String.fromCharCodes(dataBytes);
     return _cachedSource = dataBytesAsString;
-  }
-
-  /// Start downloading the snapshot body without waiting for it.
-  /// Call this on the NEXT snapshot while processing the current one.
-  void prefetch() {
-    if (_cachedSource != null || _prefetchFuture != null) return;
-    logger.d('Prefetching snapshot $txId');
-    _prefetchFuture = _arweave
-        .getEntityDataFromNetwork(txId: txId)
-        .then((bytes) => String.fromCharCodes(bytes));
   }
 
   @override
@@ -249,45 +233,28 @@ class SnapshotItemOnChain implements SnapshotItem {
     return _getNextStream();
   }
 
-  /// Parses snapshot entries one at a time by scanning for object boundaries
-  /// in the JSON string, avoiding a full jsonDecode of the entire snapshot.
-  /// This keeps memory bounded to one entry at a time instead of the full Map.
   Stream<DriveEntityHistoryTransactionModel> _getNextStream() async* {
     final Range range = subRanges.rangeSegments[currentIndex];
-    final source = await _source();
 
-    // Find the txSnapshots array in the JSON string
-    final arrayStart = source.indexOf('[', source.indexOf('"txSnapshots"'));
-    if (arrayStart == -1) {
-      logger.w('Snapshot $txId has no txSnapshots array');
-      return;
-    }
+    final Map dataJson = jsonDecode(await _source());
+    final List<Map> txSnapshots =
+        List.castFrom<dynamic, Map>(dataJson['txSnapshots']);
 
-    var yielded = 0;
-    var skipped = 0;
-
-    // Scan for individual objects within the array
-    for (final objectJson in _iterateJsonArrayObjects(source, arrayStart)) {
-      Map item;
-      try {
-        item = jsonDecode(objectJson) as Map;
-      } catch (e) {
-        logger.w('Error parsing snapshot entry in $txId');
-        continue;
-      }
-
+    for (Map item in txSnapshots) {
       DriveHistoryTransaction node;
+
       try {
         node = DriveHistoryTransaction.fromJson(item['gqlNode']);
       } catch (e) {
-        logger.w('Error parsing GQLNode from snapshot item ($txId)');
+        logger.w(
+          'Error while parsing GQLNode from snapshot item ($txId)',
+        );
         continue;
       }
 
       final isInRange = range.isInRange(node.block?.height ?? -1);
       if (isInRange) {
         yield DriveEntityHistoryTransactionModel(transactionCommonMixin: node);
-        yielded++;
 
         final String? data = item['jsonMetadata'];
         if (data != null) {
@@ -295,87 +262,15 @@ class SnapshotItemOnChain implements SnapshotItem {
           final Uint8List dataAsBytes = Uint8List.fromList(utf8.encode(data));
           await _setDataForTxId(driveId, txId, dataAsBytes);
         }
-      } else {
-        skipped++;
       }
     }
-
-    logger.d('Snapshot $txId range ${range.start}-${range.end}: '
-        'yielded $yielded, skipped $skipped');
 
     if (currentIndex == subRanges.rangeSegments.length - 1) {
+      // Done reading all data, the memory can be freed
       _cachedSource = null;
-      _prefetchFuture = null;
     }
-  }
 
-  /// Iterates over top-level JSON objects in an array without parsing the
-  /// entire array. Uses brace counting to find object boundaries.
-  ///
-  /// [source] is the full JSON string. [arrayStartIndex] is the index of
-  /// the opening `[` of the array.
-  static Iterable<String> _iterateJsonArrayObjects(
-    String source,
-    int arrayStartIndex,
-  ) sync* {
-    var i = arrayStartIndex + 1; // skip the '['
-    final len = source.length;
-
-    while (i < len) {
-      // Skip whitespace and commas
-      while (i < len) {
-        final c = source.codeUnitAt(i);
-        if (c == 0x7D + 1) break; // shouldn't happen
-        if (c == 0x5D) return; // ']' — end of array
-        if (c == 0x7B) break; // '{' — start of object
-        i++;
-      }
-      if (i >= len) return;
-
-      // Found '{', count braces to find matching '}'
-      final objectStart = i;
-      var depth = 0;
-      var inString = false;
-      var escaped = false;
-
-      while (i < len) {
-        final c = source.codeUnitAt(i);
-
-        if (escaped) {
-          escaped = false;
-          i++;
-          continue;
-        }
-
-        if (c == 0x5C) {
-          // backslash
-          escaped = true;
-          i++;
-          continue;
-        }
-
-        if (c == 0x22) {
-          // double quote
-          inString = !inString;
-          i++;
-          continue;
-        }
-
-        if (!inString) {
-          if (c == 0x7B) depth++; // '{'
-          if (c == 0x7D) {
-            // '}'
-            depth--;
-            if (depth == 0) {
-              yield source.substring(objectStart, i + 1);
-              i++;
-              break;
-            }
-          }
-        }
-        i++;
-      }
-    }
+    return;
   }
 
   static Future<Uint8List> _setDataForTxId(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -149,11 +149,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "v4.0.1"
-      resolved-ref: "0a55ea0358fb82f14abafc9182a121686735ba2b"
+      ref: "v4.0.2"
+      resolved-ref: "7bee19d601065b451de0aa2e72027ee30c7f934b"
       url: "https://github.com/ardriveapp/arweave-dart.git"
     source: git
-    version: "4.0.1"
+    version: "4.0.2"
   async:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Secure, permanent storage
 
 publish_to: 'none'
 
-version: 2.83.0
+version: 2.84.0
 
 environment:
   sdk: '>=3.2.0 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,7 +53,7 @@ dependencies:
   arweave:
     git:
       url: https://github.com/ardriveapp/arweave-dart.git
-      ref: v4.0.1
+      ref: v4.0.2
   ario_sdk:
     path: ./packages/ario_sdk
   cryptography: ^2.0.5
@@ -166,7 +166,7 @@ dependency_overrides:
   arweave:
     git:
       url: https://github.com/ardriveapp/arweave-dart.git
-      ref: v4.0.1
+      ref: v4.0.2
 
   ardrive_io:
     path: ./packages/ardrive_io


### PR DESCRIPTION
## v2.84.0 Release

### Bug Fixes
- Fixed file download crash by bumping arweave-dart to v4.0.2 (#2146)
- Fixed empty explorer state after drive attach (#2145)
- Fixed `dateCreated` null crash in file/folder entry refresh on first sync

### Sync Performance
- Prefetch next snapshot + streaming JSON parse — eliminates blocking download/parse during sync (#2141)
- Bulk-load revision lookups instead of per-entity DB queries — reduces thousands of individual DB calls (#2142)
- Added 15s total timeout on data fetch fallback chain to prevent hanging (#2143)

### GraphQL Optimizations
- Added drive owner to tx status and license GraphQL queries — bounds confirmation fan-out and uses type-safe ID filtering (#2144)
- Made pinned-owner confirmation recovery best-effort to avoid blocking sync

## Test plan
- [ ] CI passing (lint + tests + web build)
- [ ] Staging deployed and validated at staging.ardrive.io
- [ ] Verify file downloads work without crash (arweave-dart fix)
- [ ] Verify attaching a shared drive shows files in explorer
- [ ] Verify sync completes without timeouts on large drives
- [ ] Verify tx confirmation queries are scoped to drive owner

🤖 Generated with [Claude Code](https://claude.com/claude-code)