### PR TITLE
PE-9103: Eliminate redundant GraphQL calls in sync pipeline

### DIFF
--- a/lib/blocs/drive_attach/drive_attach_cubit.dart
+++ b/lib/blocs/drive_attach/drive_attach_cubit.dart
@@ -277,9 +277,14 @@ class DriveAttachCubit extends Cubit<DriveAttachState> {
     _lookupNotifier.value = true;
 
     try {
-      final drivePrivacy = await _arweave.getDrivePrivacyForId(driveId);
+      final result = await _arweave.getDrivePrivacyForId(driveId);
 
-      switch (drivePrivacy) {
+      if (result == null) {
+        emit(DriveAttachDriveNotFound());
+        return null;
+      }
+
+      switch (result.privacy) {
         case DrivePrivacyTag.private:
           emit(DriveAttachPrivate());
           break;
@@ -287,8 +292,12 @@ class DriveAttachCubit extends Cubit<DriveAttachState> {
           emit(DriveAttachDriveNotFound());
           break;
         default:
-          // Public drive — fetch entity now to get the name
-          final drive = await _arweave.getLatestDriveEntityWithId(driveId);
+          // Public drive — build entity from the already-fetched transaction
+          // (avoids 2 redundant GQL queries)
+          final drive = await _arweave.getLatestDriveEntityWithId(
+            driveId,
+            driveOwner: result.ownerAddress,
+          );
 
           if (drive == null) {
             emit(DriveAttachDriveNotFound());

--- a/lib/blocs/drive_attach/drive_attach_cubit.dart
+++ b/lib/blocs/drive_attach/drive_attach_cubit.dart
@@ -223,12 +223,6 @@ class DriveAttachCubit extends Cubit<DriveAttachState> {
       }
     }
 
-    // Reuse entity if already fetched by drivePrivacyLoader or driveKeyValidator
-    if (cachedDriveEntity != null) {
-      driveNameController.text = cachedDriveEntity!.name!;
-      return true;
-    }
-
     _lookupNotifier.value = true;
 
     try {
@@ -298,8 +292,7 @@ class DriveAttachCubit extends Cubit<DriveAttachState> {
           emit(DriveAttachDriveNotFound());
           break;
         default:
-          // Public drive — build entity from the already-fetched transaction
-          // (avoids 2 redundant GQL queries)
+          // Public drive — fetch and cache entity so driveNameLoader can skip
           final drive = await _arweave.getLatestDriveEntityWithId(
             driveId,
             driveOwner: result.ownerAddress,

--- a/lib/blocs/drive_attach/drive_attach_cubit.dart
+++ b/lib/blocs/drive_attach/drive_attach_cubit.dart
@@ -223,6 +223,12 @@ class DriveAttachCubit extends Cubit<DriveAttachState> {
       }
     }
 
+    // Reuse entity if already fetched by drivePrivacyLoader or driveKeyValidator
+    if (cachedDriveEntity != null) {
+      driveNameController.text = cachedDriveEntity!.name!;
+      return true;
+    }
+
     _lookupNotifier.value = true;
 
     try {

--- a/lib/blocs/file_download/file_download_cubit.dart
+++ b/lib/blocs/file_download/file_download_cubit.dart
@@ -4,6 +4,7 @@ import 'package:ardrive/core/arfs/entities/arfs_entities.dart';
 import 'package:ardrive/core/arfs/repository/arfs_repository.dart';
 import 'package:ardrive/core/crypto/crypto.dart';
 import 'package:ardrive/download/ardrive_downloader.dart';
+import 'package:ardrive/download/download_exceptions.dart';
 import 'package:ardrive/download/limits.dart';
 import 'package:ardrive/entities/constants.dart';
 import 'package:ardrive/models/models.dart';
@@ -28,4 +29,5 @@ abstract class FileDownloadCubit extends Cubit<FileDownloadState> {
   FileDownloadCubit(super.state);
 
   FutureOr<void> abortDownload() {}
+  FutureOr<void> retryDownload() {}
 }

--- a/lib/blocs/file_download/file_download_state.dart
+++ b/lib/blocs/file_download/file_download_state.dart
@@ -83,5 +83,6 @@ enum FileDownloadFailureReason {
   fileAboveLimit,
   browserDoesNotSupportLargeDownloads,
   networkConnectionError,
-  fileNotFound
+  fileNotFound,
+  rateLimited,
 }

--- a/lib/blocs/file_download/personal_file_download_cubit.dart
+++ b/lib/blocs/file_download/personal_file_download_cubit.dart
@@ -142,17 +142,19 @@ class ProfileFileDownloadCubit extends FileDownloadCubit {
     String? cipher;
     String? cipherIvTag;
     SecretKey? fileKey;
+    bool verifyDownload = false;
 
     final isPinFile = _file.pinnedDataOwnerAddress != null;
 
-    final dataTx = await (_arweave.getTransactionDetails(_file.txId));
-
-    if (dataTx == null) {
-      throw StateError(
-          'Failed to download: Data transaction not found for file');
-    }
-
     if (drive.drivePrivacy == DrivePrivacy.private && !isPinFile) {
+      // Private files need cipher/IV tags from the data transaction
+      final dataTx = await (_arweave.getTransactionDetails(_file.txId));
+
+      if (dataTx == null) {
+        throw StateError(
+            'Failed to download: Data transaction not found for file');
+      }
+
       DriveKey? driveKey;
 
       if (cipherKey != null) {
@@ -173,13 +175,14 @@ class ProfileFileDownloadCubit extends FileDownloadCubit {
 
       cipher = dataTx.getTag(EntityTag.cipher);
       cipherIvTag = dataTx.getTag(EntityTag.cipherIv);
+      verifyDownload = dataTx.getTag(EntityTag.appName) == 'ArDrive-CLI';
     }
 
     // log file size
     logger.d('File size: ${_file.size}');
 
     final downloadStream = await _arDriveDownloader.downloadFile(
-      dataTx: dataTx,
+      txId: _file.txId,
       fileName: _file.name,
       fileSize: _file.size,
       lastModifiedDate: _file.lastModifiedDate,
@@ -189,6 +192,7 @@ class ProfileFileDownloadCubit extends FileDownloadCubit {
       cipher: cipher,
       cipherIvString: cipherIvTag,
       fileKey: fileKey,
+      verifyDownload: verifyDownload,
     );
 
     downloadStream.listen(

--- a/lib/blocs/file_download/personal_file_download_cubit.dart
+++ b/lib/blocs/file_download/personal_file_download_cubit.dart
@@ -11,6 +11,7 @@ class FileDownloadProgress extends LinearProgress {
 
 class ProfileFileDownloadCubit extends FileDownloadCubit {
   final ARFSFileEntity _file;
+  SecretKey? _lastCipherKey;
 
   final StreamController<LinearProgress> _downloadProgress =
       StreamController<LinearProgress>.broadcast();
@@ -59,7 +60,14 @@ class ProfileFileDownloadCubit extends FileDownloadCubit {
     download(cipherKey);
   }
 
+  @override
+  FutureOr<void> retryDownload() {
+    emit(FileDownloadStarting());
+    download(_lastCipherKey);
+  }
+
   Future<void> download(SecretKey? cipherKey) async {
+    _lastCipherKey = cipherKey;
     try {
       final drive = await _arfsRepository.getDriveById(_file.driveId);
 
@@ -251,18 +259,30 @@ class ProfileFileDownloadCubit extends FileDownloadCubit {
 
   @override
   void onError(Object error, StackTrace stackTrace) {
-    emit(
-      const FileDownloadFailure(
-        FileDownloadFailureReason.unknownError,
-      ),
-    );
+    final reason = _classifyError(error);
+    emit(FileDownloadFailure(reason));
 
     super.onError(error, stackTrace);
 
     logger.e(
-      'Failed to download file ${_file.id} with txId ${_file.txId} from gateway ${_arweave.client.api.gatewayUrl.origin}',
+      'Failed to download file ${_file.id} with txId ${_file.txId} '
+      '(reason: $reason)',
       error,
       stackTrace,
     );
+  }
+
+  static FileDownloadFailureReason _classifyError(Object error) {
+    if (error is DownloadFileNotFoundException) {
+      return FileDownloadFailureReason.fileNotFound;
+    }
+    if (error is DownloadRateLimitException) {
+      return FileDownloadFailureReason.rateLimited;
+    }
+    if (error is DownloadNetworkException ||
+        error is DownloadStalledException) {
+      return FileDownloadFailureReason.networkConnectionError;
+    }
+    return FileDownloadFailureReason.unknownError;
   }
 }

--- a/lib/blocs/file_download/shared_file_download_cubit.dart
+++ b/lib/blocs/file_download/shared_file_download_cubit.dart
@@ -54,16 +54,10 @@ class SharedFileDownloadCubit extends FileDownloadCubit {
 
     String? cipherTag;
     String? cipherIvTag;
+    bool verifyDownload = false;
     final isPinFile = revision.pinnedDataOwnerAddress != null;
 
     final dataTxId = revision.dataTxId;
-
-    final dataTx = await _arweave.getTransactionDetails(revision.dataTxId!);
-
-    if (dataTx == null) {
-      throw StateError(
-          'Data transaction not found for file ${revision.id} with txId ${revision.dataTxId} from gateway ${_arweave.client.api.gatewayUrl.origin}');
-    }
 
     if (dataTxId == null) {
       throw StateError(
@@ -71,14 +65,23 @@ class SharedFileDownloadCubit extends FileDownloadCubit {
     }
 
     if (fileKey != null && !isPinFile) {
+      // Private/encrypted files need cipher/IV tags from the data transaction
+      final dataTx = await _arweave.getTransactionDetails(dataTxId);
+
+      if (dataTx == null) {
+        throw StateError(
+            'Data transaction not found for file ${revision.id} with txId $dataTxId from gateway ${_arweave.client.api.gatewayUrl.origin}');
+      }
+
       cipherTag = dataTx.getTag(EntityTag.cipher);
       cipherIvTag = dataTx.getTag(EntityTag.cipherIv);
+      verifyDownload = dataTx.getTag(EntityTag.appName) == 'ArDrive-CLI';
     }
 
     logger.d('File size: ${revision.size}');
 
     final downloadStream = await _arDriveDownloader.downloadFile(
-      dataTx: dataTx,
+      txId: dataTxId,
       fileName: revision.name,
       fileSize: revision.size,
       lastModifiedDate: revision.lastModifiedDate,
@@ -88,6 +91,7 @@ class SharedFileDownloadCubit extends FileDownloadCubit {
       cipherIvString: cipherIvTag,
       fileKey: fileKey,
       isManifest: revision.contentType == ContentType.manifest,
+      verifyDownload: verifyDownload,
     );
 
     downloadStream.listen(

--- a/lib/blocs/file_download/shared_file_download_cubit.dart
+++ b/lib/blocs/file_download/shared_file_download_cubit.dart
@@ -130,14 +130,36 @@ class SharedFileDownloadCubit extends FileDownloadCubit {
   }
 
   @override
+  FutureOr<void> retryDownload() {
+    emit(FileDownloadStarting());
+    download();
+  }
+
+  @override
   void onError(Object error, StackTrace stackTrace) {
-    emit(const FileDownloadFailure(FileDownloadFailureReason.unknownError));
+    final reason = _classifyError(error);
+    emit(FileDownloadFailure(reason));
     super.onError(error, stackTrace);
 
     logger.e(
-      'Failed to download shared file ${revision.id} with txId ${revision.dataTxId} from gateway ${_arweave.client.api.gatewayUrl.origin}. File name: ${revision.name}, size: ${revision.size}',
+      'Failed to download shared file ${revision.id} with txId '
+      '${revision.dataTxId} (reason: $reason)',
       error,
       stackTrace,
     );
+  }
+
+  static FileDownloadFailureReason _classifyError(Object error) {
+    if (error is DownloadFileNotFoundException) {
+      return FileDownloadFailureReason.fileNotFound;
+    }
+    if (error is DownloadRateLimitException) {
+      return FileDownloadFailureReason.rateLimited;
+    }
+    if (error is DownloadNetworkException ||
+        error is DownloadStalledException) {
+      return FileDownloadFailureReason.networkConnectionError;
+    }
+    return FileDownloadFailureReason.unknownError;
   }
 }

--- a/lib/components/file_download_dialog.dart
+++ b/lib/components/file_download_dialog.dart
@@ -151,14 +151,45 @@ class FileDownloadDialog extends StatelessWidget {
           } else if (state is FileDownloadInProgress) {
             return _fileDownloadInProgressDialog(context, state);
           } else if (state is FileDownloadFailure) {
-            if (state.reason == FileDownloadFailureReason.unknownError) {
-              return _fileDownloadFailedDialog(context);
-            } else if (state.reason ==
-                FileDownloadFailureReason.browserDoesNotSupportLargeDownloads) {
-              return _fileDownloadFailedDueToAboveBrowserLimit(context);
+            switch (state.reason) {
+              case FileDownloadFailureReason.unknownError:
+                return _retryableFailureDialog(
+                  context,
+                  title: appLocalizationsOf(context).fileFailedToDownload,
+                  description:
+                      appLocalizationsOf(context).tryAgainDownloadingFile,
+                );
+              case FileDownloadFailureReason.networkConnectionError:
+                return _retryableFailureDialog(
+                  context,
+                  title: appLocalizationsOf(context).downloadNetworkError,
+                  description: appLocalizationsOf(context)
+                      .downloadNetworkErrorDescription,
+                );
+              case FileDownloadFailureReason.rateLimited:
+                return _retryableFailureDialog(
+                  context,
+                  title: appLocalizationsOf(context).downloadRateLimited,
+                  description: appLocalizationsOf(context)
+                      .downloadRateLimitedDescription,
+                );
+              case FileDownloadFailureReason.fileNotFound:
+                return _modalWrapper(
+                  title: appLocalizationsOf(context).downloadFileNotFound,
+                  description: appLocalizationsOf(context)
+                      .downloadFileNotFoundDescription,
+                  actions: [
+                    ModalAction(
+                      action: () => Navigator.pop(context),
+                      title: appLocalizationsOf(context).ok,
+                    ),
+                  ],
+                );
+              case FileDownloadFailureReason.fileAboveLimit:
+                return _fileDownloadFailedDueToFileAbovePrivateLimit(context);
+              case FileDownloadFailureReason.browserDoesNotSupportLargeDownloads:
+                return _fileDownloadFailedDueToAboveBrowserLimit(context);
             }
-
-            return _fileDownloadFailedDueToFileAbovePrivateLimit(context);
           } else if (state is FileDownloadWarning) {
             return _warningToWaitDownloadFinishes(context);
           } else if (state is FileDownloadAborted) {
@@ -169,14 +200,23 @@ class FileDownloadDialog extends StatelessWidget {
         },
       );
 
-  ArDriveStandardModalNew _fileDownloadFailedDialog(BuildContext context) {
+  ArDriveStandardModalNew _retryableFailureDialog(
+    BuildContext context, {
+    required String title,
+    required String description,
+  }) {
     return _modalWrapper(
-      title: appLocalizationsOf(context).fileFailedToDownload,
-      description: appLocalizationsOf(context).tryAgainDownloadingFile,
+      title: title,
+      description: description,
       actions: [
         ModalAction(
           action: () => Navigator.pop(context),
-          title: appLocalizationsOf(context).ok,
+          title: appLocalizationsOf(context).cancel,
+        ),
+        ModalAction(
+          action: () =>
+              context.read<FileDownloadCubit>().retryDownload(),
+          title: appLocalizationsOf(context).tryAgain,
         ),
       ],
     );

--- a/lib/download/ardrive_downloader.dart
+++ b/lib/download/ardrive_downloader.dart
@@ -270,13 +270,14 @@ class _ArDriveDownloader implements ArDriveDownloader {
 
   static const _stallTimeout = Duration(seconds: 60);
 
-  /// Wraps a download stream with stall detection. If no chunk arrives
-  /// within [_stallTimeout], emits a [DownloadStalledException].
+  /// Wraps a download stream with stall detection. After the first chunk
+  /// arrives, if no subsequent chunk arrives within [_stallTimeout], emits
+  /// a [DownloadStalledException]. If the stream completes before any chunks
+  /// (empty file), no stall error is raised.
   Stream<List<int>> _withStallDetection(
       Stream<List<int>> source, String txId) {
     final controller = StreamController<List<int>>();
     Timer? stallTimer;
-
     void resetTimer() {
       stallTimer?.cancel();
       stallTimer = Timer(_stallTimeout, () {
@@ -305,7 +306,6 @@ class _ArDriveDownloader implements ArDriveDownloader {
       subscription.cancel();
     };
 
-    resetTimer();
     return controller.stream;
   }
 

--- a/lib/download/ardrive_downloader.dart
+++ b/lib/download/ardrive_downloader.dart
@@ -1,14 +1,13 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import 'package:ardrive/download/download_exceptions.dart';
 import 'package:ardrive/services/arweave/arweave.dart';
 import 'package:ardrive/sync/domain/sync_progress.dart';
 import 'package:ardrive/utils/logger.dart';
 import 'package:ardrive_crypto/ardrive_crypto.dart';
-import 'package:ardrive_http/ardrive_http.dart';
 import 'package:ardrive_io/ardrive_io.dart';
 import 'package:ardrive_utils/ardrive_utils.dart';
-import 'package:arweave/arweave.dart' as arweave;
 import 'package:arweave/utils.dart';
 import 'package:cryptography/cryptography.dart' hide Cipher;
 
@@ -87,9 +86,9 @@ class _ArDriveDownloader implements ArDriveDownloader {
         return _getDartVMGCMDecryptStream(
           cipher,
           cipherIvString,
-          (await arweave.download(
+          (await _arweave.gatewayFallback.downloadWithFallback(
             txId: txId,
-            arweave: _arweave.client,
+            primaryClient: _arweave.client,
             onProgress: (progress, speed) => logger.d(progress.toString()),
           ))
               .$1,
@@ -199,13 +198,13 @@ class _ArDriveDownloader implements ArDriveDownloader {
   }
 
   Future<Stream<Uint8List>> _getManifestStream(String dataTxId) async {
-    final urlString = '${_arweave.client.api.gatewayUrl.origin}/raw/$dataTxId';
+    logger.i('The file is a manifest. Downloading with gateway fallback...');
 
-    logger.i('The file is a manifest. Downloading it from $urlString');
+    final response = await _arweave.gatewayFallback
+        .fetchManifestWithFallback(dataTxId, _arweave.client);
 
-    final dataRes = await ArDriveHTTP().getAsBytes(urlString);
-
-    return Stream.fromIterable([dataRes.data]);
+    return Stream.fromIterable(
+        [Uint8List.fromList(response.bodyBytes)]);
   }
 
   Future<Stream<Uint8List>> _getFileStream({
@@ -223,14 +222,18 @@ class _ArDriveDownloader implements ArDriveDownloader {
 
     logger.d('verifying download: $verifyDownload');
 
-    final streamDownloadResponse = await arweave.download(
+    final streamDownloadResponse =
+        await _arweave.gatewayFallback.downloadWithFallback(
       txId: txId,
-      arweave: _arweave.client,
+      primaryClient: _arweave.client,
       onProgress: (progress, speed) => logger.d(progress.toString()),
       verifyDownload: verifyDownload,
     );
 
-    final streamDownload = streamDownloadResponse.$1;
+    final rawStream = streamDownloadResponse.$1;
+
+    // Wrap with stall detection — throw if no chunk arrives within 60s
+    final streamDownload = _withStallDetection(rawStream, txId);
 
     final isPrivateFile =
         fileKey != null && cipher != null && cipherIvString != null;
@@ -263,6 +266,47 @@ class _ArDriveDownloader implements ArDriveDownloader {
 
     logger.d('No cipher found. Saving file as is...');
     return streamDownload.transform(listIntToUint8ListTransformer);
+  }
+
+  static const _stallTimeout = Duration(seconds: 60);
+
+  /// Wraps a download stream with stall detection. If no chunk arrives
+  /// within [_stallTimeout], emits a [DownloadStalledException].
+  Stream<List<int>> _withStallDetection(
+      Stream<List<int>> source, String txId) {
+    final controller = StreamController<List<int>>();
+    Timer? stallTimer;
+
+    void resetTimer() {
+      stallTimer?.cancel();
+      stallTimer = Timer(_stallTimeout, () {
+        controller.addError(DownloadStalledException(txId, _stallTimeout));
+        controller.close();
+      });
+    }
+
+    final subscription = source.listen(
+      (chunk) {
+        resetTimer();
+        controller.add(chunk);
+      },
+      onError: (Object e, StackTrace s) {
+        stallTimer?.cancel();
+        controller.addError(e, s);
+      },
+      onDone: () {
+        stallTimer?.cancel();
+        controller.close();
+      },
+    );
+
+    controller.onCancel = () {
+      stallTimer?.cancel();
+      subscription.cancel();
+    };
+
+    resetTimer();
+    return controller.stream;
   }
 
   Stream<double> _getDartVMGCMDecryptStream(

--- a/lib/download/ardrive_downloader.dart
+++ b/lib/download/ardrive_downloader.dart
@@ -14,7 +14,7 @@ import 'package:cryptography/cryptography.dart' hide Cipher;
 
 abstract class ArDriveDownloader {
   Future<Stream<double>> downloadFile({
-    required TransactionCommonMixin dataTx,
+    required String txId,
     required int fileSize,
     required String fileName,
     required DateTime lastModifiedDate,
@@ -24,9 +24,10 @@ abstract class ArDriveDownloader {
     SecretKey? fileKey,
     String? cipher,
     String? cipherIvString,
+    bool verifyDownload,
   });
   Future<Uint8List> downloadToMemory({
-    required TransactionCommonMixin dataTx,
+    required String txId,
     required int fileSize,
     required String fileName,
     required DateTime lastModifiedDate,
@@ -36,6 +37,7 @@ abstract class ArDriveDownloader {
     SecretKey? fileKey,
     String? cipher,
     String? cipherIvString,
+    bool verifyDownload,
   });
   Future<void> abortDownload();
 
@@ -65,7 +67,7 @@ class _ArDriveDownloader implements ArDriveDownloader {
 
   @override
   Future<Stream<double>> downloadFile({
-    required TransactionCommonMixin dataTx,
+    required String txId,
     required int fileSize,
     required String fileName,
     required DateTime lastModifiedDate,
@@ -75,6 +77,7 @@ class _ArDriveDownloader implements ArDriveDownloader {
     SecretKey? fileKey,
     String? cipher,
     String? cipherIvString,
+    bool verifyDownload = false,
   }) async {
     if (AppPlatform.isMobile) {
       final isPrivateFile =
@@ -85,7 +88,7 @@ class _ArDriveDownloader implements ArDriveDownloader {
           cipher,
           cipherIvString,
           (await arweave.download(
-            txId: dataTx.id,
+            txId: txId,
             arweave: _arweave.client,
             onProgress: (progress, speed) => logger.d(progress.toString()),
           ))
@@ -102,10 +105,10 @@ class _ArDriveDownloader implements ArDriveDownloader {
     Stream<Uint8List> saveStream;
 
     if (isManifest) {
-      saveStream = await _getManifestStream(dataTx.id);
+      saveStream = await _getManifestStream(txId);
     } else {
       saveStream = await _getFileStream(
-        dataTx: dataTx,
+        txId: txId,
         fileSize: fileSize,
         fileName: fileName,
         lastModifiedDate: lastModifiedDate,
@@ -113,6 +116,7 @@ class _ArDriveDownloader implements ArDriveDownloader {
         fileKey: fileKey,
         cipher: cipher,
         cipherIvString: cipherIvString,
+        verifyDownload: verifyDownload,
       );
     }
 
@@ -205,7 +209,7 @@ class _ArDriveDownloader implements ArDriveDownloader {
   }
 
   Future<Stream<Uint8List>> _getFileStream({
-    required TransactionCommonMixin dataTx,
+    required String txId,
     required int fileSize,
     required String fileName,
     required DateTime lastModifiedDate,
@@ -213,16 +217,14 @@ class _ArDriveDownloader implements ArDriveDownloader {
     SecretKey? fileKey,
     String? cipher,
     String? cipherIvString,
+    bool verifyDownload = false,
   }) async {
     logger.d('The file is not a manifest. Downloading it from Arweave...');
-
-    /// Disables the verification when the file was uploaded by the CLI
-    final verifyDownload = dataTx.getTag(EntityTag.appName) == 'ArDrive-CLI';
 
     logger.d('verifying download: $verifyDownload');
 
     final streamDownloadResponse = await arweave.download(
-      txId: dataTx.id,
+      txId: txId,
       arweave: _arweave.client,
       onProgress: (progress, speed) => logger.d(progress.toString()),
       verifyDownload: verifyDownload,
@@ -299,7 +301,7 @@ class _ArDriveDownloader implements ArDriveDownloader {
 
   @override
   Future<Uint8List> downloadToMemory({
-    required TransactionCommonMixin dataTx,
+    required String txId,
     required int fileSize,
     required String fileName,
     required DateTime lastModifiedDate,
@@ -309,9 +311,10 @@ class _ArDriveDownloader implements ArDriveDownloader {
     SecretKey? fileKey,
     String? cipher,
     String? cipherIvString,
+    bool verifyDownload = false,
   }) async {
     final stream = await _getFileStream(
-      dataTx: dataTx,
+      txId: txId,
       fileSize: fileSize,
       fileName: fileName,
       lastModifiedDate: lastModifiedDate,
@@ -319,6 +322,7 @@ class _ArDriveDownloader implements ArDriveDownloader {
       fileKey: fileKey,
       cipher: cipher,
       cipherIvString: cipherIvString,
+      verifyDownload: verifyDownload,
     );
 
     final data = await stream.toList();

--- a/lib/download/ardrive_downloader.dart
+++ b/lib/download/ardrive_downloader.dart
@@ -83,15 +83,18 @@ class _ArDriveDownloader implements ArDriveDownloader {
           fileKey != null && cipher != null && cipherIvString != null;
 
       if (isPrivateFile && cipher == Cipher.aes256gcm) {
+        final downloadResponse =
+            await _arweave.gatewayFallback.downloadWithFallback(
+          txId: txId,
+          primaryClient: _arweave.client,
+          onProgress: (progress, speed) => logger.d(progress.toString()),
+          verifyDownload: verifyDownload,
+        );
+
         return _getDartVMGCMDecryptStream(
           cipher,
           cipherIvString,
-          (await _arweave.gatewayFallback.downloadWithFallback(
-            txId: txId,
-            primaryClient: _arweave.client,
-            onProgress: (progress, speed) => logger.d(progress.toString()),
-          ))
-              .$1,
+          _withStallDetection(downloadResponse.$1, txId),
           fileSize,
           fileName,
           lastModifiedDate,
@@ -278,26 +281,36 @@ class _ArDriveDownloader implements ArDriveDownloader {
       Stream<List<int>> source, String txId) {
     final controller = StreamController<List<int>>();
     Timer? stallTimer;
+    late final StreamSubscription<List<int>> subscription;
+
     void resetTimer() {
       stallTimer?.cancel();
       stallTimer = Timer(_stallTimeout, () {
-        controller.addError(DownloadStalledException(txId, _stallTimeout));
-        controller.close();
+        subscription.cancel();
+        if (!controller.isClosed) {
+          controller.addError(DownloadStalledException(txId, _stallTimeout));
+          controller.close();
+        }
       });
     }
 
-    final subscription = source.listen(
+    subscription = source.listen(
       (chunk) {
+        if (controller.isClosed) return;
         resetTimer();
         controller.add(chunk);
       },
       onError: (Object e, StackTrace s) {
         stallTimer?.cancel();
-        controller.addError(e, s);
+        if (!controller.isClosed) {
+          controller.addError(e, s);
+        }
       },
       onDone: () {
         stallTimer?.cancel();
-        controller.close();
+        if (!controller.isClosed) {
+          controller.close();
+        }
       },
     );
 

--- a/lib/download/download_exceptions.dart
+++ b/lib/download/download_exceptions.dart
@@ -1,0 +1,39 @@
+/// All gateways returned 404 for this transaction.
+class DownloadFileNotFoundException implements Exception {
+  final String txId;
+  const DownloadFileNotFoundException(this.txId);
+
+  @override
+  String toString() => 'File not found on any gateway: $txId';
+}
+
+/// All gateways failed with network/timeout/5xx errors.
+class DownloadNetworkException implements Exception {
+  final String txId;
+  final String? lastError;
+  const DownloadNetworkException(this.txId, [this.lastError]);
+
+  @override
+  String toString() =>
+      'All gateways failed for download $txId: ${lastError ?? 'unknown'}';
+}
+
+/// Rate-limited by gateway(s) and all fallbacks also failed.
+class DownloadRateLimitException implements Exception {
+  final String txId;
+  const DownloadRateLimitException(this.txId);
+
+  @override
+  String toString() => 'Rate limited on all gateways for download: $txId';
+}
+
+/// Download stream started but no bytes received within timeout.
+class DownloadStalledException implements Exception {
+  final String txId;
+  final Duration timeout;
+  const DownloadStalledException(this.txId, this.timeout);
+
+  @override
+  String toString() =>
+      'Download stalled for $txId: no data for ${timeout.inSeconds}s';
+}

--- a/lib/drive_explorer/thumbnail/repository/thumbnail_repository.dart
+++ b/lib/drive_explorer/thumbnail/repository/thumbnail_repository.dart
@@ -73,9 +73,9 @@ class ThumbnailRepository {
   Future<Uint8List> _getThumbnailData({
     required FileDataTableItem fileDataTableItem,
   }) async {
-    final dataTx = await _arweaveService.getTransactionDetails(
-      fileDataTableItem.thumbnail!.variants.first.txId,
-    );
+    // Thumbnails are always for private files — need cipher/IV from data tx
+    final thumbnailTxId = fileDataTableItem.thumbnail!.variants.first.txId;
+    final dataTx = await _arweaveService.getTransactionDetails(thumbnailTxId);
 
     if (dataTx == null) {
       throw Exception('Data transaction not found');
@@ -85,7 +85,7 @@ class ThumbnailRepository {
         fileDataTableItem.driveId, _arDriveAuth.currentUser.cipherKey);
 
     return await _arDriveDownloader.downloadToMemory(
-      dataTx: dataTx,
+      txId: thumbnailTxId,
       fileSize: fileDataTableItem.thumbnail!.variants.first.size,
       fileName: fileDataTableItem.name,
       lastModifiedDate: fileDataTableItem.lastModifiedDate,
@@ -104,10 +104,9 @@ class ThumbnailRepository {
           ..where((tbl) => tbl.id.equals(fileId)))
         .getSingle();
 
-    final dataTx =
-        await _arweaveService.getTransactionDetails(fileEntry.dataTxId);
-
     SecretKey? fileKey;
+    String? cipher;
+    String? cipherIv;
 
     final drive =
         await _driveDao.driveById(driveId: fileEntry.driveId).getSingle();
@@ -123,20 +122,29 @@ class ThumbnailRepository {
         driveKey!.key,
         fileEntry.id,
       );
+
+      // Private files need cipher/IV tags from the data transaction
+      final dataTx =
+          await _arweaveService.getTransactionDetails(fileEntry.dataTxId);
+      if (dataTx == null) {
+        throw Exception('Data transaction not found for ${fileEntry.dataTxId}');
+      }
+      cipher = dataTx.getTag(EntityTag.cipher);
+      cipherIv = dataTx.getTag(EntityTag.cipherIv);
     }
 
     logger.d('Downloading file to memory');
 
     final bytes = await _arDriveDownloader.downloadToMemory(
-      dataTx: dataTx!,
+      txId: fileEntry.dataTxId,
       fileSize: fileEntry.size,
       fileName: fileEntry.name,
       lastModifiedDate: fileEntry.lastModifiedDate,
       contentType: fileEntry.dataContentType!,
       isManifest: false,
       fileKey: fileKey,
-      cipher: dataTx.getTag(EntityTag.cipher),
-      cipherIvString: dataTx.getTag(EntityTag.cipherIv),
+      cipher: cipher,
+      cipherIvString: cipherIv,
     );
 
     logger.d('Generating thumbnail');

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -866,6 +866,30 @@
   "@fileFailedToDownloadFileAbovePublicLimit": {
     "description": "Download failure message when a file is too big"
   },
+  "downloadNetworkError": "Network Error",
+  "@downloadNetworkError": {
+    "description": "Title for network error during download"
+  },
+  "downloadNetworkErrorDescription": "Could not connect to the download server. Please check your connection and try again.",
+  "@downloadNetworkErrorDescription": {
+    "description": "Description for network error during download"
+  },
+  "downloadFileNotFound": "File Not Found",
+  "@downloadFileNotFound": {
+    "description": "Title when downloaded file is not found on any gateway"
+  },
+  "downloadFileNotFoundDescription": "This file could not be found on the network. It may have been uploaded recently and is still being processed.",
+  "@downloadFileNotFoundDescription": {
+    "description": "Description when downloaded file is not found"
+  },
+  "downloadRateLimited": "Too Many Requests",
+  "@downloadRateLimited": {
+    "description": "Title when download is rate limited"
+  },
+  "downloadRateLimitedDescription": "The download server is busy. Please wait a moment and try again.",
+  "@downloadRateLimitedDescription": {
+    "description": "Description when download is rate limited"
+  },
   "fileHadANewRevision": "A new version of this file was uploaded.",
   "@fileHadANewRevision": {
     "description": "File activity (journal): new revision"

--- a/lib/models/database/database.dart
+++ b/lib/models/database/database.dart
@@ -30,7 +30,7 @@ class Database extends _$Database {
   Database([QueryExecutor? e]) : super(e ?? openConnection());
 
   @override
-  int get schemaVersion => 28;
+  int get schemaVersion => 29;
   @override
   MigrationStrategy get migration => MigrationStrategy(
         onCreate: (Migrator m) {
@@ -188,6 +188,18 @@ class Database extends _$Database {
               logger.d('Migrating schema from v27 to v28');
 
               await m.addColumn(profiles, profiles.sourceWalletAddress);
+            }
+
+            if (from < 29) {
+              logger.d('Migrating schema from v28 to v29');
+              logger.d('Adding sync performance indexes');
+              await customStatement('''
+                CREATE INDEX IF NOT EXISTS idx_file_revisions_data_tx_id ON file_revisions(dataTxId);
+              ''');
+              await customStatement('''
+                CREATE INDEX IF NOT EXISTS idx_network_transactions_status ON network_transactions(status);
+              ''');
+              logger.d('Sync performance indexes created');
             }
           } catch (e, stacktrace) {
             logger.e(

--- a/lib/models/queries/drive_queries.drift
+++ b/lib/models/queries/drive_queries.drift
@@ -81,6 +81,15 @@ fileById:
 fileRevisionByDataTx:
     SELECT * FROM file_revisions
     WHERE dataTxId = :tx;
+fileRevisionDateCreatedByDataTxIds:
+    SELECT dataTxId, dateCreated FROM file_revisions
+    WHERE dataTxId IN :txIds;
+foldersByIds:
+    SELECT * FROM folder_entries
+    WHERE id IN :folderIds;
+fileRevisionDataTxIdsByMetadataTxIds:
+    SELECT dataTxId FROM file_revisions
+    WHERE metadataTxId IN :metadataTxIds;
 licenseByTxId:
     SELECT * FROM licenses
     WHERE licenseTxId = :tx;

--- a/lib/models/tables/file_revisions.drift
+++ b/lib/models/tables/file_revisions.drift
@@ -42,3 +42,5 @@ CREATE TABLE file_revisions (
     FOREIGN KEY (metadataTxId) REFERENCES network_transactions(id),
     FOREIGN KEY (dataTxId) REFERENCES network_transactions(id)
 );
+
+CREATE INDEX idx_file_revisions_data_tx_id ON file_revisions(dataTxId);

--- a/lib/models/tables/network_transactions.drift
+++ b/lib/models/tables/network_transactions.drift
@@ -7,3 +7,5 @@ CREATE TABLE network_transactions (
 
     transactionDateCreated DATETIME
 );
+
+CREATE INDEX idx_network_transactions_status ON network_transactions(status);

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -144,11 +144,20 @@ class ArweaveService {
   String? _cachedUserDriveTxsAddress;
   List<TransactionCommonMixin>? _cachedUserDriveTxs;
 
-  /// Clears the cached result of [getUniqueUserDriveEntityTxs].
+  /// Cache for raw entity data bytes fetched during [getUniqueUserDriveEntities].
+  /// Keyed by transaction ID. Allows [getLatestDriveEntityWithId] to re-parse
+  /// the data with a different key without re-downloading from the gateway.
+  final Map<String, Uint8List> _cachedEntityDataBytes = {};
+
+  /// Cache for drive signatures (immutable on-chain, never change).
+  final Map<String, DriveSignatureEntity?> _cachedDriveSignatures = {};
+
+  /// Clears the cached result of [getUniqueUserDriveEntityTxs] and entity data.
   /// Call after creating/updating a drive or after a full sync completes.
   void clearUserDriveTxsCache() {
     _cachedUserDriveTxsAddress = null;
     _cachedUserDriveTxs = null;
+    _cachedEntityDataBytes.clear();
   }
 
   /// Returns the onchain balance of the specified address.
@@ -790,6 +799,11 @@ class ArweaveService {
     Wallet wallet,
     String driveId,
   ) async {
+    // Drive signatures are immutable on-chain — cache permanently once fetched
+    if (_cachedDriveSignatures.containsKey(driveId)) {
+      return _cachedDriveSignatures[driveId];
+    }
+
     final driveSignatureTx = await getDriveSignatureTxForDrive(wallet, driveId);
 
     final driveSignatureData = driveSignatureTx != null
@@ -801,6 +815,7 @@ class ArweaveService {
             ? DriveSignatureEntity.fromTransaction(
                 driveSignatureTx, driveSignatureData.bodyBytes)
             : null;
+    _cachedDriveSignatures[driveId] = driveSignature;
     return driveSignature;
   }
 
@@ -819,6 +834,14 @@ class ArweaveService {
             .then<Response?>((r) => r)
             .catchError((_) => null)),
       );
+
+      // Cache raw bytes for reuse by getLatestDriveEntityWithId (e.g., during
+      // password validation in _validateUser, which re-parses the same data)
+      for (var i = 0; i < driveTxs.length; i++) {
+        if (driveResponses[i] != null) {
+          _cachedEntityDataBytes[driveTxs[i].id] = driveResponses[i]!.bodyBytes;
+        }
+      }
 
       final drivesById = <String?, DriveEntity>{};
       final drivesWithKey = <DriveEntity, DriveKey?>{};
@@ -947,11 +970,15 @@ class ArweaveService {
       }
 
       final fileTx = filteredEdges.first.node;
-      final fileDataRes = await _gatewayFallback.fetchData(fileTx.id, client);
+
+      // Use cached bytes if available (e.g., from getUniqueUserDriveEntities)
+      final cachedBytes = _cachedEntityDataBytes[fileTx.id];
+      final entityBytes = cachedBytes ??
+          (await _gatewayFallback.fetchData(fileTx.id, client)).bodyBytes;
 
       try {
         return await DriveEntity.fromTransaction(
-            fileTx, _crypto, fileDataRes.bodyBytes, driveKey);
+            fileTx, _crypto, entityBytes, driveKey);
       } on EntityTransactionParseException catch (parseException) {
         logger.e(
           'Failed to parse transaction '

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -223,27 +223,41 @@ class ArweaveService {
     return query.data?.transaction;
   }
 
+  /// Fetch snapshots for a single drive. Delegates to [getAllSnapshotsForDrives].
   Stream<SnapshotEntityTransaction> getAllSnapshotsOfDrive(
     String driveId,
     int? lastBlockHeight, {
+    required String ownerAddress,
+  }) =>
+      getAllSnapshotsForDrives([driveId], lastBlockHeight,
+          ownerAddress: ownerAddress);
+
+  /// Fetch snapshots for multiple drives in a single paginated GQL query.
+  ///
+  /// Use [minBlockHeight] = min of all drives' lastBlockHeights.
+  /// Caller should filter results by Drive-Id tag and pass each drive's
+  /// subset to [SnapshotItem.instantiateAll] with that drive's own
+  /// lastBlockHeight to preserve per-drive state isolation.
+  Stream<SnapshotEntityTransaction> getAllSnapshotsForDrives(
+    List<String> driveIds,
+    int? minBlockHeight, {
     required String ownerAddress,
   }) async* {
     String cursor = '';
 
     while (true) {
       try {
-        // Get a page of 100 transactions
         final snapshotEntityHistoryQuery = await graphQLRetry.execute(
           SnapshotEntityHistoryQuery(
             variables: SnapshotEntityHistoryArguments(
-              driveId: driveId,
-              lastBlockHeight: lastBlockHeight,
+              driveIds: driveIds,
+              lastBlockHeight: minBlockHeight,
               after: cursor,
               ownerAddress: ownerAddress,
             ),
           ),
         );
-        for (SnapshotEntityHistory$Query$TransactionConnection$TransactionEdge edge
+        for (final edge
             in snapshotEntityHistoryQuery.data!.transactions.edges) {
           yield edge.node;
         }
@@ -257,8 +271,8 @@ class ArweaveService {
           break;
         }
       } catch (e) {
-        logger.e('Error fetching snapshots for drive $driveId', e);
-        logger.i('This drive and ones after will fall back to GQL');
+        logger.e('Error fetching snapshots for drives $driveIds', e);
+        logger.i('These drives will fall back to GQL');
         break;
       }
     }

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -51,6 +51,7 @@ class ArweaveService {
   final ConfigService _configService;
   late ArtemisClient _gql;
   late DataGatewayFallback _gatewayFallback;
+  DataGatewayFallback get gatewayFallback => _gatewayFallback;
 
   static String _graphqlUrlFromGateway(String gatewayUrl) {
     final uri = Uri.parse(gatewayUrl);
@@ -927,7 +928,11 @@ class ArweaveService {
   /// by that owner.
   ///
   /// Returns `null` if no valid drive is found.
-  Future<Privacy?> getDrivePrivacyForId(String driveId) async {
+  /// Gets drive privacy and the owner address + latest transaction node.
+  ///
+  /// Returns both so the caller can reuse the owner and transaction node
+  /// without making redundant GraphQL queries.
+  Future<DrivePrivacyResult?> getDrivePrivacyForId(String driveId) async {
     final driveOwner = await getOwnerForDriveEntityWithId(driveId);
     if (driveOwner == null) {
       return null;
@@ -945,7 +950,11 @@ class ArweaveService {
 
     final driveTx = queryEdges.first.node;
 
-    return driveTx.getTag(EntityTag.drivePrivacy);
+    return DrivePrivacyResult(
+      privacy: driveTx.getTag(EntityTag.drivePrivacy),
+      ownerAddress: driveOwner,
+      driveTx: driveTx,
+    );
   }
 
   /// Gets the file privacy of the latest file entity with the provided id.
@@ -1677,6 +1686,20 @@ class UploadTransactions {
   Transaction dataTx;
 
   UploadTransactions(this.entityTx, this.dataTx);
+}
+
+/// Result of [ArweaveService.getDrivePrivacyForId], containing the privacy tag
+/// plus the owner and transaction node to avoid redundant re-queries.
+class DrivePrivacyResult {
+  final String? privacy;
+  final String ownerAddress;
+  final TransactionCommonMixin driveTx;
+
+  DrivePrivacyResult({
+    required this.privacy,
+    required this.ownerAddress,
+    required this.driveTx,
+  });
 }
 
 class TransactionNotFound implements Exception {

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -280,14 +280,17 @@ class ArweaveService {
             ),
           ),
         );
-        for (final edge
-            in snapshotEntityHistoryQuery.data!.transactions.edges) {
+        final edges = snapshotEntityHistoryQuery.data!.transactions.edges;
+        for (final edge in edges) {
           yield edge.node;
         }
 
-        cursor = snapshotEntityHistoryQuery.data!.transactions.edges.isNotEmpty
-            ? snapshotEntityHistoryQuery.data!.transactions.edges.last.cursor
-            : '';
+        // Guard against empty edges with hasNextPage=true causing infinite loop
+        if (edges.isEmpty) {
+          break;
+        }
+
+        cursor = edges.last.cursor;
 
         if (!snapshotEntityHistoryQuery
             .data!.transactions.pageInfo.hasNextPage) {

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -209,7 +209,7 @@ class ArweaveService {
   }
 
   Future<TransactionCommonMixin?> getTransactionDetails(String txId) async {
-    final query = await _gql.execute(TransactionDetailsQuery(
+    final query = await graphQLRetry.execute(TransactionDetailsQuery(
         variables: TransactionDetailsArguments(txId: txId)));
     return query.data?.transaction;
   }
@@ -217,7 +217,7 @@ class ArweaveService {
   Future<InfoOfTransactionToBePinned$Query$Transaction?> getInfoOfTxToBePinned(
     String txId,
   ) async {
-    final query = await _gql.execute(InfoOfTransactionToBePinnedQuery(
+    final query = await graphQLRetry.execute(InfoOfTransactionToBePinnedQuery(
         variables: InfoOfTransactionToBePinnedArguments(txId: txId)));
     return query.data?.transaction;
   }
@@ -261,6 +261,43 @@ class ArweaveService {
         break;
       }
     }
+  }
+
+  /// Probes which drives have any new transactions since [minBlockHeight].
+  /// Returns the set of drive IDs with activity. If the query returns
+  /// hasNextPage=true, the result is incomplete — caller should treat
+  /// un-checked drives as potentially active.
+  Future<({Set<String> activeDriveIds, bool isComplete})> probeActiveDriveIds({
+    required List<String> driveIds,
+    required int minBlockHeight,
+    required String ownerAddress,
+  }) async {
+    final query = await graphQLRetry.execute(
+      DriveActivityProbeQuery(
+        variables: DriveActivityProbeArguments(
+          driveIds: driveIds,
+          minBlockHeight: minBlockHeight,
+          ownerAddress: ownerAddress,
+        ),
+      ),
+    );
+
+    if (query.data == null) {
+      // Treat as incomplete — caller will fall back to syncing all drives
+      return (activeDriveIds: <String>{}, isComplete: false);
+    }
+
+    final activeDriveIds = <String>{};
+    for (final edge in query.data!.transactions.edges) {
+      for (final tag in edge.node.tags) {
+        if (tag.name == 'Drive-Id') {
+          activeDriveIds.add(tag.value);
+        }
+      }
+    }
+
+    final isComplete = !query.data!.transactions.pageInfo.hasNextPage;
+    return (activeDriveIds: activeDriveIds, isComplete: isComplete);
   }
 
   Stream<List<DriveEntityHistoryTransactionModel>>
@@ -928,7 +965,7 @@ class ArweaveService {
     String cursor = '';
 
     while (true) {
-      final latestFileQuery = await _gql.execute(
+      final latestFileQuery = await graphQLRetry.execute(
         LatestFileEntityWithIdQuery(
           variables: LatestFileEntityWithIdArguments(
             fileId: fileId,
@@ -1590,7 +1627,7 @@ class ArweaveService {
       logger.i('Fetching transaction info for batch ${batch.length}');
 
       try {
-        final query = await _gql.execute(
+        final query = await graphQLRetry.execute(
           InfoOfTransactionsToBePinnedQuery(
             variables: InfoOfTransactionsToBePinnedArguments(
               transactionIds: batch,

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -137,6 +137,20 @@ class ArweaveService {
   late GraphQLRetry graphQLRetry;
   late HttpRetry httpRetry;
 
+  /// Cache for [getUniqueUserDriveEntityTxs] to avoid redundant GQL calls.
+  /// Auth flow (isExistingUser, _validateUser) and sync (updateUserDrives)
+  /// all call this for the same wallet. Invalidated explicitly via
+  /// [clearUserDriveTxsCache] when a drive is created/updated or after sync.
+  String? _cachedUserDriveTxsAddress;
+  List<TransactionCommonMixin>? _cachedUserDriveTxs;
+
+  /// Clears the cached result of [getUniqueUserDriveEntityTxs].
+  /// Call after creating/updating a drive or after a full sync completes.
+  void clearUserDriveTxsCache() {
+    _cachedUserDriveTxsAddress = null;
+    _cachedUserDriveTxs = null;
+  }
+
   /// Returns the onchain balance of the specified address.
   Future<BigInt> getWalletBalance(String address) => client.api
       .get('wallet/$address/balance')
@@ -691,6 +705,16 @@ class ArweaveService {
     String userAddress, {
     int maxRetries = defaultMaxRetries,
   }) async {
+    // Return cached result if available for the same address.
+    // Auth flow (isExistingUser, _validateUser) and sync (updateUserDrives)
+    // all call this for the same wallet. Cache is invalidated explicitly
+    // via clearUserDriveTxsCache() after drive creation or sync completion.
+    if (_cachedUserDriveTxs != null &&
+        _cachedUserDriveTxsAddress == userAddress) {
+      logger.d('Using cached UserDriveEntityTxs');
+      return _cachedUserDriveTxs!;
+    }
+
     List<TransactionCommonMixin> drives = [];
     String cursor = '';
 
@@ -737,6 +761,10 @@ class ArweaveService {
         break;
       }
     }
+
+    // Cache the result — cleared by clearUserDriveTxsCache()
+    _cachedUserDriveTxsAddress = userAddress;
+    _cachedUserDriveTxs = drives;
 
     return drives;
   }

--- a/lib/services/arweave/data_gateway_fallback.dart
+++ b/lib/services/arweave/data_gateway_fallback.dart
@@ -9,11 +9,13 @@ import 'package:arweave/arweave.dart';
 import 'package:arweave/arweave.dart' as arweave_pkg;
 import 'package:http/http.dart';
 
-/// Provides data gateway fallback resilience using hedged (staggered) requests.
+/// Provides data gateway fallback resilience.
 ///
-/// Instead of waiting for each gateway to fail before trying the next one,
-/// fires additional requests in parallel after a short delay. The first
-/// successful response wins and the rest are ignored.
+/// Metadata fetches use serial waterfall (primary → GAR → arweave.net) to
+/// avoid unnecessary requests during high-volume sync operations.
+///
+/// File downloads use hedged (staggered parallel) requests since they are
+/// single user-initiated operations where latency matters.
 ///
 /// Fallback order: primary → up to 2 GAR gateways → arweave.net
 class DataGatewayFallback {
@@ -23,9 +25,9 @@ class DataGatewayFallback {
   static const _maxGarFallbacks = 2;
   static const _garListTimeout = Duration(seconds: 5);
   static const _requestTimeout = Duration(seconds: 5);
-  static const _downloadConnectTimeout = Duration(seconds: 10);
-  static const _totalFetchTimeout = Duration(seconds: 15);
+  static const _totalFetchTimeout = Duration(seconds: 25);
   static const _hedgeDelay = Duration(milliseconds: 1500);
+  static const _downloadTimeout = Duration(seconds: 15);
 
   List<Gateway>? _cachedGateways;
 
@@ -33,30 +35,56 @@ class DataGatewayFallback {
     required ArioSDK arioSDK,
   }) : _arioSDK = arioSDK;
 
-  /// Fetch transaction data with hedged gateway fallback.
+  /// Fetch transaction data with serial gateway fallback.
   ///
-  /// Fires primary immediately, then launches additional gateways every
-  /// [_hedgeDelay] if no response yet. First 200 response wins.
+  /// Tries: primary → up to 2 GAR gateways → arweave.net
+  /// Used for metadata fetches during sync (called hundreds of times).
   ///
   /// If ALL gateways return 404, throws [TransactionNotFound].
   Future<Response> fetchData(String txId, Arweave primaryClient) async {
-    final clients = await _buildClientList(primaryClient);
-
-    return _hedgedRequest<Response>(
-      txId: txId,
-      clients: clients,
-      attempt: (client) => _tryGateway(client, txId),
-      totalTimeout: _totalFetchTimeout,
-    );
+    return _serialFetch(txId, primaryClient)
+        .timeout(_totalFetchTimeout, onTimeout: () {
+      logger.w('Total fetch timeout exceeded for tx $txId');
+      throw Exception('Total fetch timeout exceeded for tx $txId');
+    });
   }
 
-  /// Download a file with hedged gateway fallback.
+  Future<Response> _serialFetch(String txId, Arweave primaryClient) async {
+    final clients = await _buildClientList(primaryClient);
+    var all404 = true;
+
+    for (final client in clients) {
+      final gatewayName = client.api.gatewayUrl.host;
+      try {
+        final response = await _tryGateway(client, txId);
+        if (client != primaryClient) {
+          logger.i('Fallback gateway $gatewayName succeeded for tx $txId');
+        }
+        return response;
+      } on _ErrorFromStatus catch (e) {
+        if (e.statusCode != 404) all404 = false;
+        logger.w('Gateway $gatewayName failed for tx $txId: $e');
+      } catch (e) {
+        all404 = false;
+        logger.w('Gateway $gatewayName failed for tx $txId: $e');
+      }
+    }
+
+    if (all404) {
+      throw TransactionNotFound(txId);
+    }
+    throw Exception('All gateways failed for tx $txId');
+  }
+
+  /// Download a file with hedged (staggered parallel) gateway fallback.
   ///
-  /// Same staggered pattern as [fetchData] but initiates a streaming download.
+  /// Fires primary immediately, then launches additional gateways every
+  /// [_hedgeDelay] if no response yet. First successful response wins.
+  /// Used for single user-initiated downloads where latency matters.
+  ///
   /// Only retries pre-stream failures (connection, 404, 500 before stream
   /// starts). Once bytes are streaming, failures propagate to the caller.
   ///
-  /// Returns the download stream tuple from the first successful gateway.
   /// Throws [DownloadFileNotFoundException], [DownloadNetworkException], or
   /// [DownloadRateLimitException] on failure.
   Future<(Stream<List<int>>, void Function())> downloadWithFallback({
@@ -66,43 +94,95 @@ class DataGatewayFallback {
     bool verifyDownload = false,
   }) async {
     final clients = await _buildClientList(primaryClient);
+    var all404 = true;
 
-    try {
-      return await _hedgedRequest<(Stream<List<int>>, void Function())>(
-        txId: txId,
-        clients: clients,
-        attempt: (client) => arweave_pkg.download(
+    // Hedged: fire primary, then stagger fallbacks
+    final completer = Completer<(Stream<List<int>>, void Function())>();
+    var failedCount = 0;
+
+    for (var i = 0; i < clients.length; i++) {
+      if (completer.isCompleted) break;
+
+      // Stagger: wait before launching each subsequent gateway
+      if (i > 0) {
+        await Future.any([
+          Future.delayed(_hedgeDelay),
+          completer.future.then((_) {}),
+        ]);
+        if (completer.isCompleted) break;
+      }
+
+      final client = clients[i];
+      final gatewayName = i == 0 ? 'primary' : client.api.gatewayUrl.host;
+
+      // Fire and don't await — let the completer collect the winner
+      unawaited(
+        arweave_pkg
+            .download(
           txId: txId,
           arweave: client,
           onProgress: onProgress,
           verifyDownload: verifyDownload,
-        ),
-        totalTimeout: _downloadConnectTimeout,
+        )
+            .then((result) {
+          if (!completer.isCompleted) {
+            if (i > 0) {
+              logger.i('Hedged gateway $gatewayName won download for tx $txId');
+            }
+            completer.complete(result);
+          }
+        }).catchError((Object e) {
+          failedCount++;
+          if (e is! _ErrorFromStatus || e.statusCode != 404) {
+            all404 = false;
+          }
+          logger.w('Download gateway $gatewayName failed for tx $txId: $e');
+
+          if (failedCount == clients.length && !completer.isCompleted) {
+            if (all404) {
+              completer.completeError(DownloadFileNotFoundException(txId));
+            } else {
+              completer.completeError(
+                  DownloadNetworkException(txId, e.toString()));
+            }
+          }
+        }),
       );
-    } on TransactionNotFound {
-      throw DownloadFileNotFoundException(txId);
-    } catch (e) {
-      if (e is DownloadFileNotFoundException ||
-          e is DownloadRateLimitException) {
-        rethrow;
-      }
-      throw DownloadNetworkException(txId, e.toString());
     }
+
+    return completer.future.timeout(_downloadTimeout, onTimeout: () {
+      throw DownloadNetworkException(txId, 'Download connection timed out');
+    });
   }
 
-  /// Fetch manifest data with hedged gateway fallback.
-  ///
-  /// Replaces direct [ArDriveHTTP().getAsBytes()] calls that had no fallback.
+  /// Fetch manifest data with serial gateway fallback.
   Future<Response> fetchManifestWithFallback(
       String txId, Arweave primaryClient) async {
     final clients = await _buildClientList(primaryClient);
+    var all404 = true;
 
-    return _hedgedRequest<Response>(
-      txId: txId,
-      clients: clients,
-      attempt: (client) => _tryManifestGateway(client, txId),
-      totalTimeout: _totalFetchTimeout,
-    );
+    for (final client in clients) {
+      final gatewayName = client.api.gatewayUrl.host;
+      try {
+        final response = await _tryManifestGateway(client, txId);
+        if (client != primaryClient) {
+          logger.i(
+              'Fallback gateway $gatewayName succeeded for manifest $txId');
+        }
+        return response;
+      } on _ErrorFromStatus catch (e) {
+        if (e.statusCode != 404) all404 = false;
+        logger.w('Gateway $gatewayName failed for manifest $txId: $e');
+      } catch (e) {
+        all404 = false;
+        logger.w('Gateway $gatewayName failed for manifest $txId: $e');
+      }
+    }
+
+    if (all404) {
+      throw TransactionNotFound(txId);
+    }
+    throw Exception('All gateways failed for manifest $txId');
   }
 
   /// Build the ordered list of clients: primary + GAR gateways + arweave.net.
@@ -132,85 +212,6 @@ class DataGatewayFallback {
     }
 
     return clients;
-  }
-
-  /// Execute a hedged request across multiple gateways.
-  ///
-  /// Fires the first client immediately, then launches additional clients
-  /// every [_hedgeDelay] if no success yet. Returns the first successful
-  /// result. If all fail, throws based on failure pattern (all-404 vs mixed).
-  Future<T> _hedgedRequest<T>({
-    required String txId,
-    required List<Arweave> clients,
-    required Future<T> Function(Arweave client) attempt,
-    required Duration totalTimeout,
-  }) async {
-    if (clients.isEmpty) {
-      throw Exception('No gateways available for tx $txId');
-    }
-
-    final completer = Completer<T>();
-    var completedCount = 0;
-    var all404 = true;
-    var allRateLimited = true;
-    Object? lastError;
-    final futures = <Future>[];
-
-    for (var i = 0; i < clients.length; i++) {
-      if (completer.isCompleted) break;
-
-      // Stagger: wait _hedgeDelay before launching each subsequent gateway
-      if (i > 0) {
-        await Future.any([
-          Future.delayed(_hedgeDelay),
-          completer.future.then((_) {}), // resolve immediately if already done
-        ]);
-        if (completer.isCompleted) break;
-      }
-
-      final client = clients[i];
-      final gatewayName =
-          i == 0 ? 'primary' : client.api.gatewayUrl.host;
-
-      futures.add(
-        attempt(client).then((result) {
-          if (!completer.isCompleted) {
-            if (i > 0) {
-              logger.i('Hedged gateway $gatewayName won for tx $txId');
-            }
-            completer.complete(result);
-          }
-        }).catchError((Object e) {
-          completedCount++;
-          if (e is _ErrorFromStatus) {
-            if (e.statusCode != 404) all404 = false;
-            if (e.statusCode != 429) allRateLimited = false;
-          } else {
-            all404 = false;
-            allRateLimited = false;
-          }
-          lastError = e;
-          logger.w('Gateway $gatewayName failed for tx $txId: $e');
-
-          // If all gateways have failed and none succeeded, complete with error
-          if (completedCount == clients.length && !completer.isCompleted) {
-            if (all404) {
-              completer.completeError(TransactionNotFound(txId));
-            } else if (allRateLimited) {
-              completer.completeError(DownloadRateLimitException(txId));
-            } else {
-              completer.completeError(
-                  lastError ?? Exception('All gateways failed for tx $txId'));
-            }
-          }
-        }),
-      );
-    }
-
-    return completer.future.timeout(totalTimeout, onTimeout: () {
-      logger.w('Total fetch timeout exceeded for tx $txId');
-      throw Exception('Total fetch timeout exceeded for tx $txId');
-    });
   }
 
   Future<Response> _tryGateway(Arweave client, String txId) async {

--- a/lib/services/arweave/data_gateway_fallback.dart
+++ b/lib/services/arweave/data_gateway_fallback.dart
@@ -22,7 +22,7 @@ class DataGatewayFallback {
   static const _requestTimeout = Duration(seconds: 5);
   /// Total time allowed for the entire fallback chain per tx.
   /// Prevents a single missing/broken tx from blocking sync for minutes.
-  static const _totalFetchTimeout = Duration(seconds: 15);
+  static const _totalFetchTimeout = Duration(seconds: 25);
 
   List<Gateway>? _cachedGateways;
 
@@ -32,7 +32,7 @@ class DataGatewayFallback {
 
   /// Fetch transaction data with automatic gateway fallback.
   ///
-  /// Tries: primary → up to 3 GAR gateways → arweave.net
+  /// Tries: primary → up to 2 GAR gateways → arweave.net
   ///
   /// If ALL gateways return 404, throws [TransactionNotFound] to preserve
   /// upstream error handling (e.g. private drive detection during login).

--- a/lib/services/arweave/data_gateway_fallback.dart
+++ b/lib/services/arweave/data_gateway_fallback.dart
@@ -1,28 +1,31 @@
 import 'dart:async';
 
+import 'package:ardrive/download/download_exceptions.dart';
 import 'package:ardrive/services/arweave/arweave_service.dart';
 import 'package:ardrive/utils/logger.dart';
+import 'package:ardrive_http/ardrive_http.dart';
 import 'package:ario_sdk/ario_sdk.dart';
 import 'package:arweave/arweave.dart';
+import 'package:arweave/arweave.dart' as arweave_pkg;
 import 'package:http/http.dart';
 
-/// Provides data gateway fallback resilience.
+/// Provides data gateway fallback resilience using hedged (staggered) requests.
 ///
-/// When the primary gateway fails (404, 429, 5xx, timeout), automatically
-/// tries gateways from the AR.IO GAR list, then arweave.net as last resort.
-/// Fallback is per-request — the primary gateway is always tried first.
+/// Instead of waiting for each gateway to fail before trying the next one,
+/// fires additional requests in parallel after a short delay. The first
+/// successful response wins and the rest are ignored.
+///
+/// Fallback order: primary → up to 2 GAR gateways → arweave.net
 class DataGatewayFallback {
   final ArioSDK _arioSDK;
   final Map<String, Arweave> _clientCache = {};
 
-  static const _lastResortGateway = 'https://arweave.net';
   static const _maxGarFallbacks = 2;
-  static const _retryPerGateway = 1;
   static const _garListTimeout = Duration(seconds: 5);
   static const _requestTimeout = Duration(seconds: 5);
-  /// Total time allowed for the entire fallback chain per tx.
-  /// Prevents a single missing/broken tx from blocking sync for minutes.
-  static const _totalFetchTimeout = Duration(seconds: 25);
+  static const _downloadConnectTimeout = Duration(seconds: 10);
+  static const _totalFetchTimeout = Duration(seconds: 15);
+  static const _hedgeDelay = Duration(milliseconds: 1500);
 
   List<Gateway>? _cachedGateways;
 
@@ -30,139 +33,210 @@ class DataGatewayFallback {
     required ArioSDK arioSDK,
   }) : _arioSDK = arioSDK;
 
-  /// Fetch transaction data with automatic gateway fallback.
+  /// Fetch transaction data with hedged gateway fallback.
   ///
-  /// Tries: primary → up to 2 GAR gateways → arweave.net
+  /// Fires primary immediately, then launches additional gateways every
+  /// [_hedgeDelay] if no response yet. First 200 response wins.
   ///
-  /// If ALL gateways return 404, throws [TransactionNotFound] to preserve
-  /// upstream error handling (e.g. private drive detection during login).
+  /// If ALL gateways return 404, throws [TransactionNotFound].
   Future<Response> fetchData(String txId, Arweave primaryClient) async {
-    return _fetchDataWithTimeout(txId, primaryClient)
-        .timeout(_totalFetchTimeout, onTimeout: () {
+    final clients = await _buildClientList(primaryClient);
+
+    return _hedgedRequest<Response>(
+      txId: txId,
+      clients: clients,
+      attempt: (client) => _tryGateway(client, txId),
+      totalTimeout: _totalFetchTimeout,
+    );
+  }
+
+  /// Download a file with hedged gateway fallback.
+  ///
+  /// Same staggered pattern as [fetchData] but initiates a streaming download.
+  /// Only retries pre-stream failures (connection, 404, 500 before stream
+  /// starts). Once bytes are streaming, failures propagate to the caller.
+  ///
+  /// Returns the download stream tuple from the first successful gateway.
+  /// Throws [DownloadFileNotFoundException], [DownloadNetworkException], or
+  /// [DownloadRateLimitException] on failure.
+  Future<(Stream<List<int>>, void Function())> downloadWithFallback({
+    required String txId,
+    required Arweave primaryClient,
+    Function(double progress, int speed)? onProgress,
+    bool verifyDownload = false,
+  }) async {
+    final clients = await _buildClientList(primaryClient);
+
+    try {
+      return await _hedgedRequest<(Stream<List<int>>, void Function())>(
+        txId: txId,
+        clients: clients,
+        attempt: (client) => arweave_pkg.download(
+          txId: txId,
+          arweave: client,
+          onProgress: onProgress,
+          verifyDownload: verifyDownload,
+        ),
+        totalTimeout: _downloadConnectTimeout,
+      );
+    } on TransactionNotFound {
+      throw DownloadFileNotFoundException(txId);
+    } catch (e) {
+      if (e is DownloadFileNotFoundException ||
+          e is DownloadRateLimitException) {
+        rethrow;
+      }
+      throw DownloadNetworkException(txId, e.toString());
+    }
+  }
+
+  /// Fetch manifest data with hedged gateway fallback.
+  ///
+  /// Replaces direct [ArDriveHTTP().getAsBytes()] calls that had no fallback.
+  Future<Response> fetchManifestWithFallback(
+      String txId, Arweave primaryClient) async {
+    final clients = await _buildClientList(primaryClient);
+
+    return _hedgedRequest<Response>(
+      txId: txId,
+      clients: clients,
+      attempt: (client) => _tryManifestGateway(client, txId),
+      totalTimeout: _totalFetchTimeout,
+    );
+  }
+
+  /// Build the ordered list of clients: primary + GAR gateways + arweave.net.
+  Future<List<Arweave>> _buildClientList(Arweave primaryClient) async {
+    final clients = <Arweave>[primaryClient];
+    final primaryHost = primaryClient.api.gatewayUrl.host;
+
+    try {
+      _cachedGateways ??= await _arioSDK
+          .getGateways()
+          .timeout(_garListTimeout, onTimeout: () => <Gateway>[]);
+
+      var added = 0;
+      for (final gw in _cachedGateways!) {
+        if (added >= _maxGarFallbacks) break;
+        if (gw.settings.fqdn == primaryHost) continue;
+        clients.add(_getOrCreateClient(gw.settings.fqdn));
+        added++;
+      }
+    } catch (e) {
+      logger.w('GAR list unavailable for fallback: $e');
+    }
+
+    // Always include arweave.net as last resort
+    if (primaryHost != 'arweave.net') {
+      clients.add(_getOrCreateClient('arweave.net'));
+    }
+
+    return clients;
+  }
+
+  /// Execute a hedged request across multiple gateways.
+  ///
+  /// Fires the first client immediately, then launches additional clients
+  /// every [_hedgeDelay] if no success yet. Returns the first successful
+  /// result. If all fail, throws based on failure pattern (all-404 vs mixed).
+  Future<T> _hedgedRequest<T>({
+    required String txId,
+    required List<Arweave> clients,
+    required Future<T> Function(Arweave client) attempt,
+    required Duration totalTimeout,
+  }) async {
+    if (clients.isEmpty) {
+      throw Exception('No gateways available for tx $txId');
+    }
+
+    final completer = Completer<T>();
+    var completedCount = 0;
+    var all404 = true;
+    var allRateLimited = true;
+    Object? lastError;
+    final futures = <Future>[];
+
+    for (var i = 0; i < clients.length; i++) {
+      if (completer.isCompleted) break;
+
+      // Stagger: wait _hedgeDelay before launching each subsequent gateway
+      if (i > 0) {
+        await Future.any([
+          Future.delayed(_hedgeDelay),
+          completer.future.then((_) {}), // resolve immediately if already done
+        ]);
+        if (completer.isCompleted) break;
+      }
+
+      final client = clients[i];
+      final gatewayName =
+          i == 0 ? 'primary' : client.api.gatewayUrl.host;
+
+      futures.add(
+        attempt(client).then((result) {
+          if (!completer.isCompleted) {
+            if (i > 0) {
+              logger.i('Hedged gateway $gatewayName won for tx $txId');
+            }
+            completer.complete(result);
+          }
+        }).catchError((Object e) {
+          completedCount++;
+          if (e is _ErrorFromStatus) {
+            if (e.statusCode != 404) all404 = false;
+            if (e.statusCode != 429) allRateLimited = false;
+          } else {
+            all404 = false;
+            allRateLimited = false;
+          }
+          lastError = e;
+          logger.w('Gateway $gatewayName failed for tx $txId: $e');
+
+          // If all gateways have failed and none succeeded, complete with error
+          if (completedCount == clients.length && !completer.isCompleted) {
+            if (all404) {
+              completer.completeError(TransactionNotFound(txId));
+            } else if (allRateLimited) {
+              completer.completeError(DownloadRateLimitException(txId));
+            } else {
+              completer.completeError(
+                  lastError ?? Exception('All gateways failed for tx $txId'));
+            }
+          }
+        }),
+      );
+    }
+
+    return completer.future.timeout(totalTimeout, onTimeout: () {
       logger.w('Total fetch timeout exceeded for tx $txId');
       throw Exception('Total fetch timeout exceeded for tx $txId');
     });
   }
 
-  Future<Response> _fetchDataWithTimeout(
-      String txId, Arweave primaryClient) async {
-    var all404 = true;
-
-    // 1. Try primary gateway
-    try {
-      return await _tryGateway(primaryClient, txId);
-    } on _ErrorFromStatus catch (e) {
-      if (!e.retryable) rethrow;
-      if (e.statusCode != 404) all404 = false;
-      logger.w(
-        'Primary gateway failed for tx $txId '
-        '(${primaryClient.api.gatewayUrl}): $e',
-      );
-    } catch (e) {
-      all404 = false;
-      logger.w(
-        'Primary gateway failed for tx $txId '
-        '(${primaryClient.api.gatewayUrl}): $e',
-      );
-    }
-
-    // 2. Try GAR gateways (cached to avoid repeated Solana RPC calls)
-    try {
-      _cachedGateways ??= await _arioSDK
-          .getGateways()
-          .timeout(_garListTimeout, onTimeout: () => <Gateway>[]);
-      final gateways = _cachedGateways!;
-      final primaryHost = primaryClient.api.gatewayUrl.host;
-
-      var tried = 0;
-      for (final gw in gateways) {
-        if (tried >= _maxGarFallbacks) break;
-        if (gw.settings.fqdn == primaryHost) continue;
-
-        try {
-          final client = _getOrCreateClient(gw.settings.fqdn);
-          final response = await _tryGateway(client, txId);
-          logger.i(
-            'Fallback gateway ${gw.settings.fqdn} succeeded for tx $txId',
-          );
-          return response;
-        } on _ErrorFromStatus catch (e) {
-          if (!e.retryable) rethrow;
-          if (e.statusCode != 404) all404 = false;
-          logger.w(
-            'Fallback gateway ${gw.settings.fqdn} failed for tx $txId: $e',
-          );
-          tried++;
-          continue;
-        } catch (e) {
-          all404 = false;
-          logger.w(
-            'Fallback gateway ${gw.settings.fqdn} failed for tx $txId: $e',
-          );
-          tried++;
-          continue;
-        }
-      }
-    } catch (e) {
-      all404 = false;
-      logger.w('GAR list unavailable for fallback: $e');
-    }
-
-    // 3. Last resort: arweave.net
-    logger.w('Trying last resort gateway $_lastResortGateway for tx $txId');
-    try {
-      final lastResortClient = _getOrCreateClient('arweave.net');
-      final response = await _tryGateway(lastResortClient, txId);
-      logger.i('Last resort gateway succeeded for tx $txId');
-      return response;
-    } on _ErrorFromStatus catch (e) {
-      if (e.statusCode != 404) all404 = false;
-    } catch (e) {
-      all404 = false;
-    }
-
-    // All gateways failed
-    if (all404) {
-      throw TransactionNotFound(txId);
-    }
-    throw Exception('All gateways failed for tx $txId');
-  }
-
   Future<Response> _tryGateway(Arweave client, String txId) async {
-    Exception? lastError;
+    final response = await client.api
+        .getSandboxedTx(txId)
+        .timeout(_requestTimeout);
 
-    for (var attempt = 0; attempt < _retryPerGateway; attempt++) {
-      try {
-        final response = await client.api
-            .getSandboxedTx(txId)
-            .timeout(_requestTimeout);
-
-        if (response.statusCode >= 200 && response.statusCode <= 208) {
-          return response;
-        }
-
-        if (!_isRetryableStatus(response.statusCode)) {
-          throw _ErrorFromStatus(response.statusCode, txId, retryable: false);
-        }
-
-        throw _ErrorFromStatus(response.statusCode, txId);
-      } catch (e) {
-        lastError = e is Exception ? e : Exception(e.toString());
-        if (attempt < _retryPerGateway - 1) {
-          await Future.delayed(
-            Duration(milliseconds: 500 * (attempt + 1)),
-          );
-        }
-      }
+    if (response.statusCode >= 200 && response.statusCode <= 208) {
+      return response;
     }
 
-    throw lastError!;
+    throw _ErrorFromStatus(response.statusCode, txId);
   }
 
-  bool _isRetryableStatus(int statusCode) =>
-      statusCode == 404 ||
-      statusCode == 429 ||
-      (statusCode >= 500 && statusCode < 600);
+  Future<Response> _tryManifestGateway(Arweave client, String txId) async {
+    final url = '${client.api.gatewayUrl.origin}/raw/$txId';
+    final response =
+        await ArDriveHTTP().get(url: url).timeout(_requestTimeout);
+
+    final statusCode = response.statusCode ?? 0;
+    if (statusCode >= 200 && statusCode <= 208) {
+      return Response(response.data, statusCode);
+    }
+
+    throw _ErrorFromStatus(statusCode, txId);
+  }
 
   Arweave _getOrCreateClient(String fqdn) {
     return _clientCache.putIfAbsent(
@@ -177,9 +251,8 @@ class DataGatewayFallback {
 class _ErrorFromStatus implements Exception {
   final int statusCode;
   final String txId;
-  final bool retryable;
 
-  _ErrorFromStatus(this.statusCode, this.txId, {this.retryable = true});
+  _ErrorFromStatus(this.statusCode, this.txId);
 
   @override
   String toString() => 'Gateway returned $statusCode for tx $txId';

--- a/lib/services/arweave/data_gateway_fallback.dart
+++ b/lib/services/arweave/data_gateway_fallback.dart
@@ -29,7 +29,9 @@ class DataGatewayFallback {
   static const _hedgeDelay = Duration(milliseconds: 1500);
   static const _downloadTimeout = Duration(seconds: 15);
 
-  List<Gateway>? _cachedGateways;
+  /// Cached gateway list — shared with other services (e.g.
+  /// SnapshotValidationService) to avoid duplicate Solana RPC calls.
+  List<Gateway>? cachedGateways;
 
   DataGatewayFallback({
     required ArioSDK arioSDK,
@@ -191,12 +193,12 @@ class DataGatewayFallback {
     final primaryHost = primaryClient.api.gatewayUrl.host;
 
     try {
-      _cachedGateways ??= await _arioSDK
+      cachedGateways ??= await _arioSDK
           .getGateways()
           .timeout(_garListTimeout, onTimeout: () => <Gateway>[]);
 
       var added = 0;
-      for (final gw in _cachedGateways!) {
+      for (final gw in cachedGateways!) {
         if (added >= _maxGarFallbacks) break;
         if (gw.settings.fqdn == primaryHost) continue;
         clients.add(_getOrCreateClient(gw.settings.fqdn));

--- a/lib/services/arweave/data_gateway_fallback.dart
+++ b/lib/services/arweave/data_gateway_fallback.dart
@@ -193,9 +193,17 @@ class DataGatewayFallback {
     final primaryHost = primaryClient.api.gatewayUrl.host;
 
     try {
-      cachedGateways ??= await _arioSDK
-          .getGateways()
-          .timeout(_garListTimeout, onTimeout: () => <Gateway>[]);
+      if (cachedGateways == null) {
+        try {
+          cachedGateways = await _arioSDK
+              .getGateways()
+              .timeout(_garListTimeout, onTimeout: () => <Gateway>[]);
+        } catch (e) {
+          // Solana RPC failed — cache empty list so we don't retry every call
+          logger.w('GAR list unavailable for fallback, will not retry: $e');
+          cachedGateways = [];
+        }
+      }
 
       var added = 0;
       for (final gw in cachedGateways!) {

--- a/lib/services/arweave/graphql/queries/DriveActivityProbe.graphql
+++ b/lib/services/arweave/graphql/queries/DriveActivityProbe.graphql
@@ -1,0 +1,27 @@
+query DriveActivityProbe(
+  $driveIds: [String!]!
+  $minBlockHeight: Int
+  $ownerAddress: String!
+) {
+  transactions(
+    owners: [$ownerAddress]
+    first: 100
+    sort: HEIGHT_ASC
+    tags: [
+      { name: "Drive-Id", values: $driveIds }
+    ]
+    block: { min: $minBlockHeight }
+  ) {
+    pageInfo {
+      hasNextPage
+    }
+    edges {
+      node {
+        tags {
+          name
+          value
+        }
+      }
+    }
+  }
+}

--- a/lib/services/arweave/graphql/queries/SnapshotEntityHistory.graphql
+++ b/lib/services/arweave/graphql/queries/SnapshotEntityHistory.graphql
@@ -1,5 +1,5 @@
 query SnapshotEntityHistory(
-  $driveId: String!
+  $driveIds: [String!]!
   $after: String
   $lastBlockHeight: Int
   $ownerAddress: String!
@@ -9,8 +9,8 @@ query SnapshotEntityHistory(
     first: 100
     sort: HEIGHT_DESC
     tags: [
-      { name: "Drive-Id", values: [$driveId] }
-      { name: "Entity-Type", values: "snapshot" }
+      { name: "Drive-Id", values: $driveIds }
+      { name: "Entity-Type", values: ["snapshot"] }
     ]
     after: $after
     block: { min: $lastBlockHeight }

--- a/lib/sync/data/snapshot_validation_service.dart
+++ b/lib/sync/data/snapshot_validation_service.dart
@@ -107,9 +107,17 @@ class SnapshotValidationService {
 
     // 3. Primary had a transient error (timeout, 5xx) — try 1 fallback gateway
     try {
-      cachedGateways ??= await _arioSDK
-          .getGateways()
-          .timeout(_garListTimeout, onTimeout: () => <Gateway>[]);
+      if (cachedGateways == null) {
+        try {
+          cachedGateways = await _arioSDK
+              .getGateways()
+              .timeout(_garListTimeout, onTimeout: () => <Gateway>[]);
+        } catch (e) {
+          // Solana RPC failed — cache empty list so we don't retry every call
+          logger.w('GAR gateway list unavailable, will not retry: $e');
+          cachedGateways = [];
+        }
+      }
       final gateways = cachedGateways!;
 
       if (gateways.isEmpty) return false;

--- a/lib/sync/data/snapshot_validation_service.dart
+++ b/lib/sync/data/snapshot_validation_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:ardrive/services/arweave/data_gateway_fallback.dart';
 import 'package:ardrive/services/config/config_service.dart';
 import 'package:ardrive/utils/logger.dart';
 import 'package:ardrive/utils/snapshots/snapshot_item.dart';
@@ -14,9 +15,10 @@ class SnapshotValidationService {
   static const _garListTimeout = Duration(seconds: 3);
   static const _maxConcurrentValidations = 3;
 
-  /// Cached GAR gateway list — populated from DataGatewayFallback's cache
-  /// when available, otherwise fetched from Solana RPC (once per session).
-  List<Gateway>? cachedGateways;
+  /// Shared reference to [DataGatewayFallback] for reading/writing the
+  /// gateway cache. Set by SyncRepository before validation runs so both
+  /// services share one cache and avoid duplicate Solana RPC calls.
+  DataGatewayFallback? gatewayFallback;
 
   SnapshotValidationService({
     required ConfigService configService,
@@ -105,20 +107,32 @@ class SnapshotValidationService {
       return false;
     }
 
-    // 3. Primary had a transient error (timeout, 5xx) — try 1 fallback gateway
+    // 3. Primary had a transient error (timeout, 5xx) — try 1 fallback gateway.
+    //    Read the shared gateway cache from DataGatewayFallback. If unavailable,
+    //    fetch from Solana RPC once and cache the result (empty on failure).
     try {
-      if (cachedGateways == null) {
+      List<Gateway> gateways;
+      if (gatewayFallback != null &&
+          gatewayFallback!.cachedGateways != null) {
+        gateways = gatewayFallback!.cachedGateways!;
+      } else {
         try {
-          cachedGateways = await _arioSDK
+          gateways = await _arioSDK
               .getGateways()
               .timeout(_garListTimeout, onTimeout: () => <Gateway>[]);
+          // Store in shared cache if available
+          if (gatewayFallback != null) {
+            gatewayFallback!.cachedGateways = gateways;
+          }
         } catch (e) {
           // Solana RPC failed — cache empty list so we don't retry every call
           logger.w('GAR gateway list unavailable, will not retry: $e');
-          cachedGateways = [];
+          if (gatewayFallback != null) {
+            gatewayFallback!.cachedGateways = [];
+          }
+          gateways = [];
         }
       }
-      final gateways = cachedGateways!;
 
       if (gateways.isEmpty) return false;
 

--- a/lib/sync/data/snapshot_validation_service.dart
+++ b/lib/sync/data/snapshot_validation_service.dart
@@ -14,9 +14,9 @@ class SnapshotValidationService {
   static const _garListTimeout = Duration(seconds: 3);
   static const _maxConcurrentValidations = 3;
 
-  /// Cached GAR gateway list — fetched once per session, avoids repeated
-  /// Solana RPC calls which may be slow or unavailable (e.g. localhost).
-  List<Gateway>? _cachedGateways;
+  /// Cached GAR gateway list — populated from DataGatewayFallback's cache
+  /// when available, otherwise fetched from Solana RPC (once per session).
+  List<Gateway>? cachedGateways;
 
   SnapshotValidationService({
     required ConfigService configService,
@@ -107,10 +107,10 @@ class SnapshotValidationService {
 
     // 3. Primary had a transient error (timeout, 5xx) — try 1 fallback gateway
     try {
-      _cachedGateways ??= await _arioSDK
+      cachedGateways ??= await _arioSDK
           .getGateways()
           .timeout(_garListTimeout, onTimeout: () => <Gateway>[]);
-      final gateways = _cachedGateways!;
+      final gateways = cachedGateways!;
 
       if (gateways.isEmpty) return false;
 

--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -333,7 +333,8 @@ class SyncCubit extends Cubit<SyncState> {
         syncProgressController.add(_syncProgress);
       }
 
-      if (profile is ProfileLoggedIn) {
+      // Only refresh balance if drives were actually synced (skip after no-op)
+      if (profile is ProfileLoggedIn && _syncProgress.drivesSynced > 0) {
         _profileCubit.refreshBalance();
       }
 
@@ -482,7 +483,8 @@ class SyncCubit extends Cubit<SyncState> {
         syncProgressController.add(_syncProgress);
       }
 
-      if (profile is ProfileLoggedIn) {
+      // Only refresh balance if drives were actually synced
+      if (profile is ProfileLoggedIn && _syncProgress.drivesSynced > 0) {
         _profileCubit.refreshBalance();
       }
 

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -1205,13 +1205,18 @@ class _SyncRepository implements SyncRepository {
       return _userDrivesUpdateFuture!;
     }
 
-    _userDrivesUpdateFuture = _doUpdateUserDrives(
+    final future = _doUpdateUserDrives(
       wallet: wallet,
       password: password,
       cipherKey: cipherKey,
-    );
+    ).catchError((e) {
+      // Clear the cached future on error so the next caller retries
+      _userDrivesUpdateFuture = null;
+      throw e;
+    });
 
-    return _userDrivesUpdateFuture!;
+    _userDrivesUpdateFuture = future;
+    return future;
   }
 
   Future<void> _doUpdateUserDrives({

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -156,10 +156,11 @@ class _SyncRepository implements SyncRepository {
   /// Smaller values = lower memory usage, more frequent DB commits
   static const kStreamTransactionChunkSize = 1000;
 
-  /// Flag to avoid redundant [updateUserDrives] GQL calls when multiple entry
-  /// points (syncMetadataOnly, startSync, startSyncForDrive) call it.
+  /// In-flight or completed [updateUserDrives] future to avoid redundant GQL
+  /// calls when multiple entry points (syncMetadataOnly, startSync,
+  /// startSyncForDrive) call it concurrently or in quick succession.
   /// Cleared after sync completes or when a drive is created/updated.
-  bool _userDrivesUpToDate = false;
+  Future<void>? _userDrivesUpdateFuture;
 
   DateTime? _lastSync;
 
@@ -233,9 +234,9 @@ class _SyncRepository implements SyncRepository {
       ),
     );
 
-    // Share gateway cache between services to avoid duplicate Solana RPC calls
-    _snapshotValidationService.cachedGateways =
-        _arweave.gatewayFallback.cachedGateways;
+    // Share gateway fallback reference so snapshot validation and data fetching
+    // use the same gateway cache (avoids duplicate Solana RPC calls)
+    _snapshotValidationService.gatewayFallback = _arweave.gatewayFallback;
 
     // Probe for drive activity to skip unchanged drives.
     // Partition drives: never-synced drives always need full sync and would
@@ -279,6 +280,7 @@ class _SyncRepository implements SyncRepository {
           bool allComplete = true;
 
           for (final entry in drivesByOwner.entries) {
+            token.checkCancellation();
             final ownerDrives = entry.value;
             final minBlock = ownerDrives
                 .map((d) =>
@@ -352,10 +354,15 @@ class _SyncRepository implements SyncRepository {
 
         for (final entry in snapshotDrivesByOwner.entries) {
           final ownerDrives = entry.value;
-          final minBlock = ownerDrives
+          // Use only previously-synced drives for minBlock so never-synced
+          // drives (lastBlockHeight=0) don't drag the query back to genesis.
+          final syncedHeights = ownerDrives
+              .where((d) => (d.lastBlockHeight ?? 0) > 0)
               .map((d) =>
-                  _calculateSyncLastBlockHeight(d.lastBlockHeight ?? 0))
-              .reduce(min);
+                  _calculateSyncLastBlockHeight(d.lastBlockHeight ?? 0));
+          final minBlock = syncedHeights.isNotEmpty
+              ? syncedHeights.reduce(min)
+              : 0;
 
           final snapshotsStream = _arweave.getAllSnapshotsForDrives(
             ownerDrives.map((d) => d.id).toList(),
@@ -606,7 +613,7 @@ class _SyncRepository implements SyncRepository {
 
         _lastSync = DateTime.now();
         // Invalidate drive caches so next sync re-fetches fresh data
-        _userDrivesUpToDate = false;
+        _userDrivesUpdateFuture = null;
         _arweave.clearUserDriveTxsCache();
 
         // Update progress to 100% when truly complete
@@ -890,7 +897,7 @@ class _SyncRepository implements SyncRepository {
 
         _lastSync = DateTime.now();
         // Invalidate drive caches so next sync re-fetches fresh data
-        _userDrivesUpToDate = false;
+        _userDrivesUpdateFuture = null;
         _arweave.clearUserDriveTxsCache();
 
         // Update progress to 100% when truly complete
@@ -1190,14 +1197,28 @@ class _SyncRepository implements SyncRepository {
     required SecretKey cipherKey,
     bool forceRefresh = false,
   }) async {
-    // Skip if already up-to-date (unless forced).
-    // Multiple entry points (syncMetadataOnly, startSync, startSyncForDrive)
-    // can call this in quick succession with identical results.
-    if (!forceRefresh && _userDrivesUpToDate) {
-      logger.d('Skipping updateUserDrives: already up-to-date');
-      return;
+    // If an in-flight or completed future exists, await it (unless forced).
+    // This handles both concurrent calls (two callers before the first finishes)
+    // and serial calls (syncMetadataOnly then startSync seconds later).
+    if (!forceRefresh && _userDrivesUpdateFuture != null) {
+      logger.d('Skipping updateUserDrives: reusing in-flight/completed result');
+      return _userDrivesUpdateFuture!;
     }
 
+    _userDrivesUpdateFuture = _doUpdateUserDrives(
+      wallet: wallet,
+      password: password,
+      cipherKey: cipherKey,
+    );
+
+    return _userDrivesUpdateFuture!;
+  }
+
+  Future<void> _doUpdateUserDrives({
+    required Wallet wallet,
+    required String password,
+    required SecretKey cipherKey,
+  }) async {
     // This syncs in the latest info on drives owned by the user and will be overwritten
     // below when the full sync process is ran.
     //
@@ -1209,7 +1230,6 @@ class _SyncRepository implements SyncRepository {
     );
 
     await _driveDao.updateUserDrives(userDriveEntities, cipherKey);
-    _userDrivesUpToDate = true;
   }
 
   @override

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -15,7 +15,8 @@ import 'package:ardrive/models/drive_revision.dart';
 import 'package:ardrive/models/enums.dart';
 import 'package:ardrive/models/file_revision.dart';
 import 'package:ardrive/models/folder_revision.dart';
-import 'package:ardrive/services/arweave/arweave.dart';
+import 'package:ardrive/services/arweave/arweave.dart'
+    hide SnapshotEntityTransaction;
 import 'package:ardrive/services/config/config.dart';
 import 'package:ardrive/sync/constants.dart';
 import 'package:ardrive/sync/data/snapshot_validation_service.dart';
@@ -208,6 +209,10 @@ class _SyncRepository implements SyncRepository {
       ),
     );
 
+    // Share gateway cache between services to avoid duplicate Solana RPC calls
+    _snapshotValidationService.cachedGateways =
+        _arweave.gatewayFallback.cachedGateways;
+
     // Probe for drive activity to skip unchanged drives
     List<Drive> drivesToSync;
     if (syncDeep) {
@@ -266,6 +271,55 @@ class _SyncRepository implements SyncRepository {
     syncProgress = syncProgress.copyWith(drivesCount: numberOfDrivesToSync);
     yield syncProgress;
 
+    // Batch-fetch snapshots for all drives per owner (1 GQL query per owner
+    // instead of 1 per drive). Results are grouped by Drive-Id and passed to
+    // each drive's sync to avoid redundant per-drive snapshot queries.
+    final prefetchedSnapshots = <String, List<SnapshotEntityTransaction>>{};
+    if (_configService.config.enableSyncFromSnapshot && !syncDeep) {
+      try {
+        // Reuse the drivesByOwner grouping from the probe (or rebuild it)
+        final snapshotDrivesByOwner = <String, List<Drive>>{};
+        for (final drive in drivesToSync) {
+          snapshotDrivesByOwner
+              .putIfAbsent(drive.ownerAddress, () => [])
+              .add(drive);
+        }
+
+        for (final entry in snapshotDrivesByOwner.entries) {
+          final ownerDrives = entry.value;
+          final minBlock = ownerDrives
+              .map((d) =>
+                  _calculateSyncLastBlockHeight(d.lastBlockHeight ?? 0))
+              .reduce(min);
+
+          final snapshotsStream = _arweave.getAllSnapshotsForDrives(
+            ownerDrives.map((d) => d.id).toList(),
+            minBlock,
+            ownerAddress: entry.key,
+          );
+
+          await for (final snapshot in snapshotsStream) {
+            final driveIdTag = snapshot.tags
+                .where((t) => t.name == 'Drive-Id')
+                .firstOrNull
+                ?.value;
+            if (driveIdTag != null) {
+              prefetchedSnapshots
+                  .putIfAbsent(driveIdTag, () => [])
+                  .add(snapshot);
+            }
+          }
+        }
+
+        logger.i(
+            'Prefetched ${prefetchedSnapshots.values.expand((v) => v).length} '
+            'snapshots across ${prefetchedSnapshots.length} drives');
+      } catch (e) {
+        logger.w('Snapshot prefetch failed, will fetch per-drive: $e');
+        prefetchedSnapshots.clear();
+      }
+    }
+
     double totalProgress = 0;
 
     final StreamController<SyncProgress> syncProgressController =
@@ -302,6 +356,7 @@ class _SyncRepository implements SyncRepository {
             ownerAddress: drive.ownerAddress,
             txFechedCallback: txFechedCallback,
             cancellationToken: token,
+            prefetchedSnapshots: prefetchedSnapshots[drive.id],
           );
 
           double currentDriveProgress = 0;
@@ -1292,6 +1347,7 @@ class _SyncRepository implements SyncRepository {
     required String ownerAddress,
     Function(String driveId, int txCount)? txFechedCallback,
     SyncCancellationToken? cancellationToken,
+    List<SnapshotEntityTransaction>? prefetchedSnapshots,
   }) async* {
     final token = cancellationToken ?? SyncCancellationToken();
 
@@ -1330,11 +1386,12 @@ class _SyncRepository implements SyncRepository {
       if (_configService.config.enableSyncFromSnapshot) {
         logger.i('Syncing from snapshot: ${drive.id}');
 
-        final snapshotsStream = _arweave.getAllSnapshotsOfDrive(
-          driveId,
-          lastBlockHeight,
-          ownerAddress: ownerAddress,
-        );
+        // Use prefetched snapshots if available (batched query),
+        // otherwise fall back to per-drive query
+        final snapshotsStream = prefetchedSnapshots != null
+            ? Stream.fromIterable(prefetchedSnapshots)
+            : _arweave.getAllSnapshotsOfDrive(
+                driveId, lastBlockHeight, ownerAddress: ownerAddress);
 
         snapshotItems = await SnapshotItem.instantiateAll(
           snapshotsStream,

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -86,6 +86,7 @@ abstract class SyncRepository {
     required Wallet wallet,
     required String password,
     required SecretKey cipherKey,
+    bool forceRefresh = false,
   });
 
   Future<void> createGhosts({
@@ -136,6 +137,11 @@ class _SyncRepository implements SyncRepository {
   /// Larger values = better throughput, higher memory usage
   /// Smaller values = lower memory usage, more frequent DB commits
   static const kStreamTransactionChunkSize = 1000;
+
+  /// Flag to avoid redundant [updateUserDrives] GQL calls when multiple entry
+  /// points (syncMetadataOnly, startSync, startSyncForDrive) call it.
+  /// Cleared after sync completes or when a drive is created/updated.
+  bool _userDrivesUpToDate = false;
 
   DateTime? _lastSync;
 
@@ -213,52 +219,85 @@ class _SyncRepository implements SyncRepository {
     _snapshotValidationService.cachedGateways =
         _arweave.gatewayFallback.cachedGateways;
 
-    // Probe for drive activity to skip unchanged drives
+    // Probe for drive activity to skip unchanged drives.
+    // Partition drives: never-synced drives always need full sync and would
+    // poison the probe's minBlockHeight to 0 (causing it to query from genesis,
+    // overflow the page limit, and fall back to syncing ALL drives).
     List<Drive> drivesToSync;
     if (syncDeep) {
       drivesToSync = drives;
     } else {
       try {
-        // Group drives by owner for efficient probing
-        final drivesByOwner = <String, List<Drive>>{};
+        final neverSyncedDrives = <Drive>[];
+        final previouslySyncedDrives = <Drive>[];
+
         for (final drive in drives) {
-          drivesByOwner
-              .putIfAbsent(drive.ownerAddress, () => [])
-              .add(drive);
-        }
-
-        final activeDriveIds = <String>{};
-        bool allComplete = true;
-
-        for (final entry in drivesByOwner.entries) {
-          final ownerDrives = entry.value;
-          final minBlock = ownerDrives
-              .map((d) =>
-                  _calculateSyncLastBlockHeight(d.lastBlockHeight ?? 0))
-              .reduce(min);
-
-          final result = await _arweave.probeActiveDriveIds(
-            driveIds: ownerDrives.map((d) => d.id).toList(),
-            minBlockHeight: minBlock,
-            ownerAddress: entry.key,
-          );
-
-          activeDriveIds.addAll(result.activeDriveIds);
-          if (!result.isComplete) allComplete = false;
-        }
-
-        if (!allComplete) {
-          // Can't confirm all drives checked — sync any not yet seen
-          for (final drive in drives) {
-            activeDriveIds.add(drive.id);
+          if ((drive.lastBlockHeight ?? 0) == 0) {
+            neverSyncedDrives.add(drive);
+          } else {
+            previouslySyncedDrives.add(drive);
           }
         }
 
-        drivesToSync =
-            drives.where((d) => activeDriveIds.contains(d.id)).toList();
-        final skipped = drives.length - drivesToSync.length;
-        if (skipped > 0) {
-          logger.i('Skipping $skipped unchanged drives');
+        // Never-synced drives always need full sync
+        drivesToSync = [...neverSyncedDrives];
+
+        if (previouslySyncedDrives.isEmpty) {
+          // All drives are never-synced; skip probe entirely
+          if (neverSyncedDrives.isNotEmpty) {
+            logger.i(
+                '${neverSyncedDrives.length} drives need first-time sync');
+          }
+        } else {
+          // Group previously-synced drives by owner for efficient probing
+          final drivesByOwner = <String, List<Drive>>{};
+          for (final drive in previouslySyncedDrives) {
+            drivesByOwner
+                .putIfAbsent(drive.ownerAddress, () => [])
+                .add(drive);
+          }
+
+          final activeDriveIds = <String>{};
+          bool allComplete = true;
+
+          for (final entry in drivesByOwner.entries) {
+            final ownerDrives = entry.value;
+            final minBlock = ownerDrives
+                .map((d) =>
+                    _calculateSyncLastBlockHeight(d.lastBlockHeight ?? 0))
+                .reduce(min);
+
+            final result = await _arweave.probeActiveDriveIds(
+              driveIds: ownerDrives.map((d) => d.id).toList(),
+              minBlockHeight: minBlock,
+              ownerAddress: entry.key,
+            );
+
+            activeDriveIds.addAll(result.activeDriveIds);
+            if (!result.isComplete) allComplete = false;
+          }
+
+          if (!allComplete) {
+            // Can't confirm all drives checked — sync all previously-synced
+            for (final drive in previouslySyncedDrives) {
+              activeDriveIds.add(drive.id);
+            }
+          }
+
+          // Add previously-synced drives that have activity
+          drivesToSync.addAll(
+            previouslySyncedDrives
+                .where((d) => activeDriveIds.contains(d.id)),
+          );
+
+          final skipped = drives.length - drivesToSync.length;
+          if (skipped > 0) {
+            logger.i('Skipping $skipped unchanged drives');
+          }
+          if (neverSyncedDrives.isNotEmpty) {
+            logger.i(
+                '${neverSyncedDrives.length} drives need first-time sync');
+          }
         }
       } catch (e) {
         logger.w('Drive activity probe failed, syncing all drives: $e');
@@ -267,6 +306,14 @@ class _SyncRepository implements SyncRepository {
     }
 
     final numberOfDrivesToSync = drivesToSync.length;
+
+    if (numberOfDrivesToSync == 0) {
+      // Probe found no drives with activity — this is a successful no-op sync
+      logger.i('No drives need syncing');
+      yield SyncProgress.emptySyncCompleted();
+      _lastSync = DateTime.now();
+      return;
+    }
 
     syncProgress = syncProgress.copyWith(drivesCount: numberOfDrivesToSync);
     yield syncProgress;
@@ -357,6 +404,8 @@ class _SyncRepository implements SyncRepository {
             txFechedCallback: txFechedCallback,
             cancellationToken: token,
             prefetchedSnapshots: prefetchedSnapshots[drive.id],
+            skipPendingTxFetch: walletAddress != null &&
+                drive.ownerAddress != walletAddress,
           );
 
           double currentDriveProgress = 0;
@@ -537,6 +586,9 @@ class _SyncRepository implements SyncRepository {
         }
 
         _lastSync = DateTime.now();
+        // Invalidate drive caches so next sync re-fetches fresh data
+        _userDrivesUpToDate = false;
+        _arweave.clearUserDriveTxsCache();
 
         // Update progress to 100% when truly complete
         syncProgress = syncProgress.copyWith(
@@ -678,6 +730,8 @@ class _SyncRepository implements SyncRepository {
         // Check for cancellation before starting
         token.checkCancellation();
 
+        final walletAddress = await wallet?.getAddress();
+
         final driveSyncProgress = _syncDrive(
           drive.id,
           cipherKey: cipherKey,
@@ -689,6 +743,8 @@ class _SyncRepository implements SyncRepository {
           ownerAddress: drive.ownerAddress,
           txFechedCallback: txFechedCallback,
           cancellationToken: token,
+          skipPendingTxFetch: walletAddress != null &&
+              drive.ownerAddress != walletAddress,
         );
 
         await for (var driveProgress in driveSyncProgress) {
@@ -813,6 +869,9 @@ class _SyncRepository implements SyncRepository {
         }
 
         _lastSync = DateTime.now();
+        // Invalidate drive caches so next sync re-fetches fresh data
+        _userDrivesUpToDate = false;
+        _arweave.clearUserDriveTxsCache();
 
         // Update progress to 100% when truly complete
         syncProgress = syncProgress.copyWith(
@@ -1109,7 +1168,16 @@ class _SyncRepository implements SyncRepository {
     required Wallet wallet,
     required String password,
     required SecretKey cipherKey,
+    bool forceRefresh = false,
   }) async {
+    // Skip if already up-to-date (unless forced).
+    // Multiple entry points (syncMetadataOnly, startSync, startSyncForDrive)
+    // can call this in quick succession with identical results.
+    if (!forceRefresh && _userDrivesUpToDate) {
+      logger.d('Skipping updateUserDrives: already up-to-date');
+      return;
+    }
+
     // This syncs in the latest info on drives owned by the user and will be overwritten
     // below when the full sync process is ran.
     //
@@ -1121,6 +1189,7 @@ class _SyncRepository implements SyncRepository {
     );
 
     await _driveDao.updateUserDrives(userDriveEntities, cipherKey);
+    _userDrivesUpToDate = true;
   }
 
   @override
@@ -1348,6 +1417,7 @@ class _SyncRepository implements SyncRepository {
     Function(String driveId, int txCount)? txFechedCallback,
     SyncCancellationToken? cancellationToken,
     List<SnapshotEntityTransaction>? prefetchedSnapshots,
+    bool skipPendingTxFetch = false,
   }) async* {
     final token = cancellationToken ?? SyncCancellationToken();
 
@@ -1550,51 +1620,72 @@ class _SyncRepository implements SyncRepository {
       logger.d(
           'Duration of streaming phase for ${drive.name}: $fetchPhaseTotalTime ms. Processed $totalTransactionsProcessed transactions');
 
-      // Fetch pending (unmined) transactions to show Turbo uploads immediately
-      // This is best-effort: errors here should not fail the drive sync
-      logger.d('Fetching pending transactions for drive ${drive.id}');
+      // Fetch pending (unmined) transactions to show Turbo uploads immediately.
+      // This is best-effort: errors here should not fail the drive sync.
+      // Skip for non-owned drives (can't have this user's pending uploads)
+      // and when no locally-tracked pending transactions exist for this drive.
       int pendingTransactionCount = 0;
 
-      try {
-        await for (final pendingTxBatch
-            in _arweave.getPendingTransactionsForDrive(
-          driveId,
-          ownerAddress: ownerAddress,
-        )) {
-          // Check for cancellation before processing each batch
-          if (token.isCancelled) {
-            logger.d(
-                'Pending transactions fetch cancelled for drive ${drive.id}');
-            break;
+      if (skipPendingTxFetch) {
+        logger.d(
+            'Skipping pending tx fetch for drive ${drive.id} (not owned by user)');
+      } else {
+        // Check local DB first: only query the gateway if we have
+        // locally-tracked pending transactions for this drive
+        final localPending = await _driveDao
+            .pendingTransactionsForDrive(driveId: driveId)
+            .get();
+
+        if (localPending.isEmpty) {
+          logger.d(
+              'No locally pending transactions for drive ${drive.id}, skipping GQL query');
+        } else {
+          logger.d(
+              'Fetching pending transactions for drive ${drive.id} '
+              '(${localPending.length} locally pending)');
+
+          try {
+            await for (final pendingTxBatch
+                in _arweave.getPendingTransactionsForDrive(
+              driveId,
+              ownerAddress: ownerAddress,
+            )) {
+              // Check for cancellation before processing each batch
+              if (token.isCancelled) {
+                logger.d(
+                    'Pending transactions fetch cancelled for drive ${drive.id}');
+                break;
+              }
+
+              if (pendingTxBatch.isNotEmpty) {
+                logger.d(
+                    'Processing ${pendingTxBatch.length} pending transactions');
+
+                await _processTransactionChunk(
+                  transactions: pendingTxBatch,
+                  drive: drive,
+                  driveKey: driveKey?.key,
+                  currentBlockHeight: currentBlockHeight,
+                  lastBlockHeight: lastBlockHeight,
+                  transactionParseBatchSize: transactionParseBatchSize,
+                  snapshotDriveHistory: snapshotDriveHistory,
+                  ownerAddress: ownerAddress,
+                );
+
+                pendingTransactionCount += pendingTxBatch.length;
+              }
+            }
+          } catch (e) {
+            // Log but don't rethrow - pending tx fetch is best-effort
+            logger.w(
+                'Error fetching pending transactions for drive ${drive.id}: $e');
           }
 
-          if (pendingTxBatch.isNotEmpty) {
-            logger
-                .d('Processing ${pendingTxBatch.length} pending transactions');
-
-            await _processTransactionChunk(
-              transactions: pendingTxBatch,
-              drive: drive,
-              driveKey: driveKey?.key,
-              currentBlockHeight: currentBlockHeight,
-              lastBlockHeight: lastBlockHeight,
-              transactionParseBatchSize: transactionParseBatchSize,
-              snapshotDriveHistory: snapshotDriveHistory,
-              ownerAddress: ownerAddress,
-            );
-
-            pendingTransactionCount += pendingTxBatch.length;
+          if (pendingTransactionCount > 0) {
+            logger.i(
+                'Processed $pendingTransactionCount pending transactions for drive ${drive.name}');
           }
         }
-      } catch (e) {
-        // Log but don't rethrow - pending tx fetch is best-effort
-        logger
-            .w('Error fetching pending transactions for drive ${drive.id}: $e');
-      }
-
-      if (pendingTransactionCount > 0) {
-        logger.i(
-            'Processed $pendingTransactionCount pending transactions for drive ${drive.name}');
       }
 
       // Yield final progress before cleanup

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -196,10 +196,8 @@ class _SyncRepository implements SyncRepository {
       return;
     }
 
-    final numberOfDrivesToSync = drives.length;
-
     SyncProgress syncProgress =
-        SyncProgress.initial().copyWith(drivesCount: numberOfDrivesToSync);
+        SyncProgress.initial().copyWith(drivesCount: drives.length);
 
     yield syncProgress;
 
@@ -209,6 +207,70 @@ class _SyncRepository implements SyncRepository {
         'Retrying for get the current block height',
       ),
     );
+
+    // Probe for drive activity to skip unchanged drives
+    List<Drive> drivesToSync;
+    if (syncDeep) {
+      drivesToSync = drives;
+    } else {
+      try {
+        // Group drives by owner for efficient probing
+        final drivesByOwner = <String, List<Drive>>{};
+        for (final drive in drives) {
+          drivesByOwner
+              .putIfAbsent(drive.ownerAddress, () => [])
+              .add(drive);
+        }
+
+        final activeDriveIds = <String>{};
+        bool allComplete = true;
+
+        for (final entry in drivesByOwner.entries) {
+          final ownerDrives = entry.value;
+          final minBlock = ownerDrives
+              .map((d) =>
+                  _calculateSyncLastBlockHeight(d.lastBlockHeight ?? 0))
+              .reduce(min);
+
+          final result = await _arweave.probeActiveDriveIds(
+            driveIds: ownerDrives.map((d) => d.id).toList(),
+            minBlockHeight: minBlock,
+            ownerAddress: entry.key,
+          );
+
+          activeDriveIds.addAll(result.activeDriveIds);
+          if (!result.isComplete) allComplete = false;
+        }
+
+        if (!allComplete) {
+          // Can't confirm all drives checked — sync any not yet seen
+          for (final drive in drives) {
+            activeDriveIds.add(drive.id);
+          }
+        }
+
+        drivesToSync =
+            drives.where((d) => activeDriveIds.contains(d.id)).toList();
+        final skipped = drives.length - drivesToSync.length;
+        if (skipped > 0) {
+          logger.i('Skipping $skipped unchanged drives');
+        }
+      } catch (e) {
+        logger.w('Drive activity probe failed, syncing all drives: $e');
+        drivesToSync = drives;
+      }
+    }
+
+    final numberOfDrivesToSync = drivesToSync.length;
+
+    if (numberOfDrivesToSync == 0) {
+      yield SyncProgress.emptySyncCompleted();
+      _lastSync = DateTime.now();
+      return;
+    }
+
+    syncProgress = syncProgress.copyWith(drivesCount: numberOfDrivesToSync);
+    yield syncProgress;
 
     double totalProgress = 0;
 
@@ -226,7 +288,7 @@ class _SyncRepository implements SyncRepository {
     // Start the async work but don't wait for it yet
     // Using Future.wait with eagerError: false to continue even if some drives fail
     Future.wait(
-      drives.map((drive) async {
+      drivesToSync.map((drive) async {
         try {
           // Check for cancellation before starting each drive
           token.checkCancellation();
@@ -367,14 +429,19 @@ class _SyncRepository implements SyncRepository {
         );
         syncProgressController.add(syncProgress);
 
-        final allFileRevisions = await _getAllFileEntities(driveDao: _driveDao);
         final metadataTxsFromSnapshots =
             await SnapshotItemOnChain.getAllCachedTransactionIds();
-        final confirmedFileTxIds = allFileRevisions
-            .where(
-                (file) => metadataTxsFromSnapshots.contains(file.metadataTxId))
-            .map((file) => file.dataTxId)
-            .toList();
+        final confirmedFileTxIds = <String>[];
+        if (metadataTxsFromSnapshots.isNotEmpty) {
+          for (var i = 0; i < metadataTxsFromSnapshots.length; i += 500) {
+            final chunk = metadataTxsFromSnapshots.sublist(
+                i, min(i + 500, metadataTxsFromSnapshots.length));
+            final rows = await _driveDao
+                .fileRevisionDataTxIdsByMetadataTxIds(metadataTxIds: chunk)
+                .get();
+            confirmedFileTxIds.addAll(rows);
+          }
+        }
         // Clear cached transaction IDs now that we've used them
         SnapshotItemOnChain.clearAllCachedTransactionIds();
         _arnsRepository
@@ -791,6 +858,26 @@ class _SyncRepository implements SyncRepository {
       pendingTxMap.remove(txId);
     }
 
+    // Bulk pre-load dateCreated for pending txs missing it (avoids N+1 queries)
+    final txIdsNeedingDates = pendingTxMap.entries
+        .where((e) => e.value.transactionDateCreated == null)
+        .map((e) => e.key)
+        .toList();
+
+    final dateCreatedCache = <String, DateTime?>{};
+    if (txIdsNeedingDates.isNotEmpty) {
+      for (var i = 0; i < txIdsNeedingDates.length; i += 500) {
+        final chunk = txIdsNeedingDates.sublist(
+            i, min(i + 500, txIdsNeedingDates.length));
+        final rows = await driveDao
+            .fileRevisionDateCreatedByDataTxIds(txIds: chunk)
+            .get();
+        for (final row in rows) {
+          dateCreatedCache[row.dataTxId] = row.dateCreated;
+        }
+      }
+    }
+
     final length = pendingTxMap.length;
     final list = pendingTxMap.keys.toList();
     const page = 5000;
@@ -832,72 +919,69 @@ class _SyncRepository implements SyncRepository {
         confirmations.putIfAbsent(key, () => value);
       });
 
-      await driveDao.transaction(() async {
-        for (final txId in currentPage) {
-          cancellationToken?.checkCancellation();
+      final updates = <NetworkTransactionsCompanion>[];
+      for (final txId in currentPage) {
+        cancellationToken?.checkCancellation();
 
-          // Skip if confirmation data is missing (e.g., timeout or partial response)
-          final confirmationCount = confirmations[txId];
-          if (confirmationCount == null) {
-            continue;
-          }
+        // Skip if confirmation data is missing (e.g., timeout or partial response)
+        final confirmationCount = confirmations[txId];
+        if (confirmationCount == null) {
+          continue;
+        }
 
-          final txConfirmed =
-              confirmationCount >= kRequiredTxConfirmationCount;
-          final txNotFound = confirmationCount < 0;
+        final txConfirmed =
+            confirmationCount >= kRequiredTxConfirmationCount;
+        final txNotFound = confirmationCount < 0;
 
-          String? txStatus;
-          DateTime? transactionDateCreated;
+        String? txStatus;
+        DateTime? transactionDateCreated;
 
-          if (pendingTxMap[txId]!.transactionDateCreated != null) {
-            transactionDateCreated =
-                pendingTxMap[txId]!.transactionDateCreated!;
-          } else {
-            transactionDateCreated = await _getDateCreatedByDataTx(
-              driveDao: driveDao,
-              dataTx: txId,
-            );
-          }
+        if (pendingTxMap[txId]!.transactionDateCreated != null) {
+          transactionDateCreated =
+              pendingTxMap[txId]!.transactionDateCreated!;
+        } else {
+          transactionDateCreated = dateCreatedCache[txId];
+        }
 
-          if (txConfirmed) {
-            txStatus = TransactionStatus.confirmed;
-          } else if (txNotFound) {
-            final abovePendingThreshold = DateTime.now()
-                    .difference(pendingTxMap[txId]!.dateCreated)
-                    .inMinutes >
-                kRequiredTxConfirmationPendingThreshold;
+        if (txConfirmed) {
+          txStatus = TransactionStatus.confirmed;
+        } else if (txNotFound) {
+          final abovePendingThreshold = DateTime.now()
+                  .difference(pendingTxMap[txId]!.dateCreated)
+                  .inMinutes >
+              kRequiredTxConfirmationPendingThreshold;
 
-            if (abovePendingThreshold ||
-                _isOverThePendingTime(transactionDateCreated)) {
-              txStatus = TransactionStatus.failed;
-            }
-          }
-          if (txStatus != null) {
-            await driveDao.writeToTransaction(
-              NetworkTransactionsCompanion(
-                transactionDateCreated: Value(transactionDateCreated),
-                id: Value(txId),
-                status: Value(txStatus),
-              ),
-            );
+          if (abovePendingThreshold ||
+              _isOverThePendingTime(transactionDateCreated)) {
+            txStatus = TransactionStatus.failed;
           }
         }
-      });
-
-      await Future.delayed(const Duration(milliseconds: 200));
+        if (txStatus != null) {
+          updates.add(
+            NetworkTransactionsCompanion(
+              transactionDateCreated: Value(transactionDateCreated),
+              id: Value(txId),
+              status: Value(txStatus),
+            ),
+          );
+        }
+      }
+      if (updates.isNotEmpty) {
+        await driveDao.insertNewNetworkTransactions(updates);
+      }
     }
 
     // Mark skipped transactions as confirmed
-    await driveDao.transaction(() async {
-      for (final txId in txsIdsToSkip) {
-        await driveDao.writeToTransaction(
-          NetworkTransactionsCompanion(
-            id: Value(txId),
-            status: const Value(TransactionStatus.confirmed),
-          ),
-        );
-      }
-    });
+    if (txsIdsToSkip.isNotEmpty) {
+      await driveDao.insertNewNetworkTransactions(
+        txsIdsToSkip
+            .map((txId) => NetworkTransactionsCompanion(
+                  id: Value(txId),
+                  status: const Value(TransactionStatus.confirmed),
+                ))
+            .toList(),
+      );
+    }
   }
 
   @override
@@ -912,20 +996,27 @@ class _SyncRepository implements SyncRepository {
     // Collect all ghost folders to be created
     final ghostFoldersToCreate = <FolderEntry>[];
 
-    //Finalize missing parent list
+    if (ghostFolders.isEmpty) return;
+
+    // Bulk pre-load existing folders and drives to avoid N+1 queries
+    final existingFolderIds = (await driveDao
+            .foldersByIds(folderIds: ghostFolders.keys.toList())
+            .get())
+        .map((f) => f.id)
+        .toSet();
+    final drivesMap = {
+      for (final d in await driveDao.allDrives().get()) d.id: d
+    };
+
     for (final ghostFolder in ghostFolders.values) {
-      final folder = await driveDao
-          .folderById(folderId: ghostFolder.folderId)
-          .getSingleOrNull();
-
-      final folderExists = folder != null;
-
-      if (folderExists) {
+      if (existingFolderIds.contains(ghostFolder.folderId)) {
         continue;
       }
 
-      final drive =
-          await driveDao.driveById(driveId: ghostFolder.driveId).getSingle();
+      final drive = drivesMap[ghostFolder.driveId];
+      if (drive == null) {
+        continue;
+      }
 
       // Don't create ghost folder if the ghost is a missing root folder
       // Or if the drive doesn't belong to the user
@@ -1051,11 +1142,29 @@ class _SyncRepository implements SyncRepository {
       pendingTxMap.remove(txId);
     }
 
+    // Bulk pre-load dateCreated for pending txs missing it (avoids N+1 queries)
+    final txIdsNeedingDates = pendingTxMap.entries
+        .where((e) => e.value.transactionDateCreated == null)
+        .map((e) => e.key)
+        .toList();
+
+    final dateCreatedCache = <String, DateTime?>{};
+    if (txIdsNeedingDates.isNotEmpty) {
+      for (var i = 0; i < txIdsNeedingDates.length; i += 500) {
+        final chunk = txIdsNeedingDates.sublist(
+            i, min(i + 500, txIdsNeedingDates.length));
+        final rows = await driveDao
+            .fileRevisionDateCreatedByDataTxIds(txIds: chunk)
+            .get();
+        for (final row in rows) {
+          dateCreatedCache[row.dataTxId] = row.dateCreated;
+        }
+      }
+    }
+
     final length = pendingTxMap.length;
     final list = pendingTxMap.keys.toList();
 
-    // Thats was discovered by tests at profile mode.
-    // TODO(@thiagocarvalhodev): Revisit
     const page = 5000;
 
     for (var i = 0; i < length / page; i++) {
@@ -1101,97 +1210,75 @@ class _SyncRepository implements SyncRepository {
         confirmations.putIfAbsent(key, () => value);
       });
 
-      await driveDao.transaction(() async {
-        for (final txId in currentPage) {
-          // Check cancellation for each transaction
-          cancellationToken?.checkCancellation();
+      final updates = <NetworkTransactionsCompanion>[];
+      for (final txId in currentPage) {
+        // Check cancellation for each transaction
+        cancellationToken?.checkCancellation();
 
-          // Skip if confirmation data is missing (e.g., timeout or partial response)
-          final confirmationCount = confirmations[txId];
-          if (confirmationCount == null) {
-            continue;
-          }
+        // Skip if confirmation data is missing (e.g., timeout or partial response)
+        final confirmationCount = confirmations[txId];
+        if (confirmationCount == null) {
+          continue;
+        }
 
-          final txConfirmed =
-              confirmationCount >= kRequiredTxConfirmationCount;
-          final txNotFound = confirmationCount < 0;
+        final txConfirmed =
+            confirmationCount >= kRequiredTxConfirmationCount;
+        final txNotFound = confirmationCount < 0;
 
-          String? txStatus;
+        String? txStatus;
 
-          DateTime? transactionDateCreated;
+        DateTime? transactionDateCreated;
 
-          if (pendingTxMap[txId]!.transactionDateCreated != null) {
-            transactionDateCreated =
-                pendingTxMap[txId]!.transactionDateCreated!;
-          } else {
-            transactionDateCreated = await _getDateCreatedByDataTx(
-              driveDao: driveDao,
-              dataTx: txId,
-            );
-          }
+        if (pendingTxMap[txId]!.transactionDateCreated != null) {
+          transactionDateCreated =
+              pendingTxMap[txId]!.transactionDateCreated!;
+        } else {
+          transactionDateCreated = dateCreatedCache[txId];
+        }
 
-          if (txConfirmed) {
-            txStatus = TransactionStatus.confirmed;
-          } else if (txNotFound) {
-            // Only mark transactions as failed if they are unconfirmed for over 45 minutes
-            // as the transaction might not be queryable for right after it was created.
-            final abovePendingThreshold = DateTime.now()
-                    .difference(pendingTxMap[txId]!.dateCreated)
-                    .inMinutes >
-                kRequiredTxConfirmationPendingThreshold;
+        if (txConfirmed) {
+          txStatus = TransactionStatus.confirmed;
+        } else if (txNotFound) {
+          // Only mark transactions as failed if they are unconfirmed for over 45 minutes
+          // as the transaction might not be queryable for right after it was created.
+          final abovePendingThreshold = DateTime.now()
+                  .difference(pendingTxMap[txId]!.dateCreated)
+                  .inMinutes >
+              kRequiredTxConfirmationPendingThreshold;
 
-            // Assume that data tx that weren't mined up to a maximum of
-            // `_pendingWaitTime` was failed.
-            if (abovePendingThreshold ||
-                _isOverThePendingTime(transactionDateCreated)) {
-              txStatus = TransactionStatus.failed;
-            }
-          }
-          if (txStatus != null) {
-            await driveDao.writeToTransaction(
-              NetworkTransactionsCompanion(
-                transactionDateCreated: Value(transactionDateCreated),
-                id: Value(txId),
-                status: Value(txStatus),
-              ),
-            );
+          // Assume that data tx that weren't mined up to a maximum of
+          // `_pendingWaitTime` was failed.
+          if (abovePendingThreshold ||
+              _isOverThePendingTime(transactionDateCreated)) {
+            txStatus = TransactionStatus.failed;
           }
         }
-      });
-
-      await Future.delayed(const Duration(milliseconds: 200));
-    }
-    await driveDao.transaction(() async {
-      for (final txId in txsIdsToSkip) {
-        await driveDao.writeToTransaction(
-          NetworkTransactionsCompanion(
-            id: Value(txId),
-            status: const Value(TransactionStatus.confirmed),
-          ),
-        );
+        if (txStatus != null) {
+          updates.add(
+            NetworkTransactionsCompanion(
+              transactionDateCreated: Value(transactionDateCreated),
+              id: Value(txId),
+              status: Value(txStatus),
+            ),
+          );
+        }
       }
-    });
-  }
-
-  Future<List<FileRevision>> _getAllFileEntities({
-    required DriveDao driveDao,
-  }) async {
-    return await driveDao.db.fileRevisions.select().get();
-  }
-
-  Future<DateTime?> _getDateCreatedByDataTx({
-    required DriveDao driveDao,
-    required String dataTx,
-  }) async {
-    final rev = await driveDao.fileRevisionByDataTx(tx: dataTx).get();
-
-    // no file found
-    if (rev.isEmpty) {
-      return null;
+      if (updates.isNotEmpty) {
+        await driveDao.insertNewNetworkTransactions(updates);
+      }
     }
-
-    return rev.first.dateCreated;
+    if (txsIdsToSkip.isNotEmpty) {
+      await driveDao.insertNewNetworkTransactions(
+        txsIdsToSkip
+            .map((txId) => NetworkTransactionsCompanion(
+                  id: Value(txId),
+                  status: const Value(TransactionStatus.confirmed),
+                ))
+            .toList(),
+      );
+    }
   }
+
 
   bool _isOverThePendingTime(DateTime? transactionCreatedDate) {
     // If don't have the date information we cannot assume that is over the pending time

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -263,12 +263,6 @@ class _SyncRepository implements SyncRepository {
 
     final numberOfDrivesToSync = drivesToSync.length;
 
-    if (numberOfDrivesToSync == 0) {
-      yield SyncProgress.emptySyncCompleted();
-      _lastSync = DateTime.now();
-      return;
-    }
-
     syncProgress = syncProgress.copyWith(drivesCount: numberOfDrivesToSync);
     yield syncProgress;
 

--- a/lib/utils/snapshots/gql_drive_history.dart
+++ b/lib/utils/snapshots/gql_drive_history.dart
@@ -43,6 +43,12 @@ class GQLDriveHistory implements SegmentedGQLData {
   Stream<DriveEntityHistoryTransactionModel> _getNextStream() async* {
     Range subRangeForIndex = subRanges.rangeSegments[currentIndex];
 
+    // Skip the genesis block range — no ArFS transactions exist at block 0.
+    // This gap appears when snapshots start at block 1 and lastBlockHeight is 0.
+    if (subRangeForIndex.start == 0 && subRangeForIndex.end == 0) {
+      return;
+    }
+
     final txsStream = _arweave.getSegmentedTransactionsFromDrive(
       driveId,
       minBlockHeight: subRangeForIndex.start,

--- a/lib/utils/snapshots/gql_drive_history.dart
+++ b/lib/utils/snapshots/gql_drive_history.dart
@@ -1,4 +1,3 @@
-import 'package:ardrive/services/arweave/get_segmented_transaction_from_drive_strategy.dart';
 import 'package:ardrive/sync/domain/models/drive_entity_history.dart';
 import 'package:ardrive/utils/snapshots/height_range.dart';
 import 'package:ardrive/utils/snapshots/range.dart';
@@ -54,9 +53,6 @@ class GQLDriveHistory implements SegmentedGQLData {
       minBlockHeight: subRangeForIndex.start,
       maxBlockHeight: subRangeForIndex.end,
       ownerAddress: ownerAddress,
-      strategy: GetSegmentedTransactionFromDriveFilteringByEntityTypeStrategy(
-        _arweave.graphQLRetry,
-      ),
     );
 
     await for (final multipleEdges in txsStream) {

--- a/test/blocs/drive_attach_cubit_test.dart
+++ b/test/blocs/drive_attach_cubit_test.dart
@@ -16,6 +16,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 import '../test_utils/fakes.dart';
+import '../test_utils/mocks.dart';
 import '../test_utils/utils.dart';
 
 void main() {
@@ -85,10 +86,18 @@ void main() {
 
       when(() => arweave.getLatestDriveEntityWithId(notFoundDriveId))
           .thenAnswer((_) => Future.value(null));
-      when(() => arweave.getDrivePrivacyForId(validDriveId))
-          .thenAnswer((_) => Future.value(DrivePrivacyTag.public));
-      when(() => arweave.getDrivePrivacyForId(validPrivateDriveId))
-          .thenAnswer((_) => Future.value(DrivePrivacyTag.private));
+      when(() => arweave.getDrivePrivacyForId(validDriveId)).thenAnswer(
+          (_) => Future.value(DrivePrivacyResult(
+                privacy: DrivePrivacyTag.public,
+                ownerAddress: 'test-owner',
+                driveTx: MockTransactionCommonMixin(),
+              )));
+      when(() => arweave.getDrivePrivacyForId(validPrivateDriveId)).thenAnswer(
+          (_) => Future.value(DrivePrivacyResult(
+                privacy: DrivePrivacyTag.private,
+                ownerAddress: 'test-owner',
+                driveTx: MockTransactionCommonMixin(),
+              )));
 
       when(() => driveDao.writeDriveEntity(
             name: any(named: 'name'),

--- a/test/sync/domain/sync_repository_optimization_test.dart
+++ b/test/sync/domain/sync_repository_optimization_test.dart
@@ -1,0 +1,442 @@
+import 'package:ardrive/arns/domain/arns_repository.dart';
+import 'package:ardrive/models/database/database.dart';
+import 'package:ardrive/services/arweave/data_gateway_fallback.dart';
+import 'package:ardrive/services/config/app_config.dart';
+import 'package:ardrive/sync/data/snapshot_validation_service.dart';
+import 'package:ardrive/sync/domain/repositories/sync_repository.dart';
+import 'package:ardrive/sync/utils/batch_processor.dart';
+import 'package:ardrive/user/repositories/user_preferences_repository.dart';
+import 'package:ardrive/utils/snapshots/gql_drive_history.dart';
+import 'package:ardrive/utils/snapshots/height_range.dart';
+import 'package:ardrive/utils/snapshots/range.dart';
+import 'package:ario_sdk/ario_sdk.dart';
+import 'package:arweave/arweave.dart';
+import 'package:cryptography/cryptography.dart';
+import 'package:drift/drift.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../test_utils/mocks.dart';
+
+// Mocks not available in shared mocks file
+class MockBatchProcessor extends Mock implements BatchProcessor {}
+
+class MockSnapshotValidationService extends Mock
+    implements SnapshotValidationService {}
+
+class _MockARNSRepository extends Mock implements ARNSRepository {}
+
+class MockUserPreferencesRepository extends Mock
+    implements UserPreferencesRepository {}
+
+class _MockWallet extends Mock implements Wallet {}
+
+class _MockDataGatewayFallback extends Mock implements DataGatewayFallback {}
+
+class _FakeWallet extends Fake implements Wallet {}
+
+class _FakeSecretKey extends Fake implements SecretKey {}
+
+class FakeSelectable<T> extends Fake implements Selectable<T> {
+  final List<T> _data;
+  FakeSelectable(this._data);
+
+  @override
+  Future<List<T>> get() async => _data;
+
+  @override
+  Selectable<N> map<N>(N Function(T) f) {
+    return FakeSelectable(_data.map(f).toList());
+  }
+}
+
+// Helper to create a Drive with specific fields
+Drive _makeDrive({
+  required String id,
+  required String ownerAddress,
+  int? lastBlockHeight,
+  String name = 'Test Drive',
+}) {
+  return Drive(
+    id: id,
+    rootFolderId: 'root-$id',
+    ownerAddress: ownerAddress,
+    name: name,
+    lastBlockHeight: lastBlockHeight,
+    privacy: 'public',
+    isHidden: false,
+    dateCreated: DateTime(2024),
+    lastUpdated: DateTime(2024),
+  );
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeWallet());
+    registerFallbackValue(_FakeSecretKey());
+  });
+
+  late MockArweaveService mockArweave;
+  late MockDriveDao mockDriveDao;
+  late MockConfigService mockConfigService;
+  late MockBatchProcessor mockBatchProcessor;
+  late MockSnapshotValidationService mockSnapshotValidation;
+  late _MockARNSRepository mockArnsRepository;
+  late MockUserPreferencesRepository mockUserPrefsRepo;
+  late SyncRepository syncRepository;
+  late _MockWallet mockWallet;
+
+  const ownerAddress = 'owner-address-123';
+
+  setUp(() {
+    mockArweave = MockArweaveService();
+    mockDriveDao = MockDriveDao();
+    mockConfigService = MockConfigService();
+    mockBatchProcessor = MockBatchProcessor();
+    mockSnapshotValidation = MockSnapshotValidationService();
+    mockArnsRepository = _MockARNSRepository();
+    mockUserPrefsRepo = MockUserPreferencesRepository();
+    mockWallet = _MockWallet();
+
+    when(() => mockWallet.getAddress()).thenAnswer((_) async => ownerAddress);
+
+    when(() => mockConfigService.config).thenReturn(AppConfig(
+      allowedDataItemSizeForTurbo: 0,
+      stripePublishableKey: '',
+      enableSyncFromSnapshot: false,
+      autoSync: true,
+    ));
+
+    // Mock gateway fallback for snapshot validation service cache sharing
+    final mockGatewayFallback = _MockDataGatewayFallback();
+    when(() => mockArweave.gatewayFallback).thenReturn(mockGatewayFallback);
+    when(() => mockGatewayFallback.cachedGateways).thenReturn([]);
+
+    // Mock ARNS repository
+    when(() => mockArnsRepository.getAntRecordsForWallet(any(),
+        update: any(named: 'update'))).thenAnswer(
+      (_) async => <ANTRecord>[],
+    );
+
+    syncRepository = SyncRepository(
+      arweave: mockArweave,
+      driveDao: mockDriveDao,
+      configService: mockConfigService,
+      batchProcessor: mockBatchProcessor,
+      snapshotValidationService: mockSnapshotValidation,
+      arnsRepository: mockArnsRepository,
+      userPreferencesRepository: mockUserPrefsRepo,
+    );
+  });
+
+  group('Fix 1: DriveActivityProbe partitioning', () {
+    test('never-synced drives excluded from probe, probe gets non-zero minBlock',
+        () async {
+      final neverSynced = _makeDrive(
+        id: 'drive-never',
+        ownerAddress: ownerAddress,
+        lastBlockHeight: null,
+      );
+      final synced1 = _makeDrive(
+        id: 'drive-synced-1',
+        ownerAddress: ownerAddress,
+        lastBlockHeight: 50000,
+      );
+      final synced2 = _makeDrive(
+        id: 'drive-synced-2',
+        ownerAddress: ownerAddress,
+        lastBlockHeight: 60000,
+      );
+
+      when(() => mockDriveDao.allDrives())
+          .thenReturn(FakeSelectable([neverSynced, synced1, synced2]));
+
+      when(() => mockArweave.getCurrentBlockHeight())
+          .thenAnswer((_) async => 100000);
+
+      // Probe returns only synced1 as active, isComplete: true
+      when(() => mockArweave.probeActiveDriveIds(
+            driveIds: any(named: 'driveIds'),
+            minBlockHeight: any(named: 'minBlockHeight'),
+            ownerAddress: any(named: 'ownerAddress'),
+          )).thenAnswer((_) async => (
+            activeDriveIds: {'drive-synced-1'},
+            isComplete: true,
+          ));
+
+      // Consume the stream — it will fail in _syncDrive since we haven't
+      // mocked the full pipeline, but the probe logic runs synchronously
+      // before _syncDrive is launched.
+      try {
+        await syncRepository
+            .syncAllDrives(wallet: mockWallet)
+            .toList();
+      } catch (_) {}
+
+      // Allow async tasks spawned by syncAllDrives to settle
+      await Future.delayed(const Duration(milliseconds: 100));
+
+      // Verify probe was called with correct parameters
+      final probeCall = verify(() => mockArweave.probeActiveDriveIds(
+            driveIds: captureAny(named: 'driveIds'),
+            minBlockHeight: captureAny(named: 'minBlockHeight'),
+            ownerAddress: any(named: 'ownerAddress'),
+          ));
+      expect(probeCall.callCount, 1);
+
+      // Probe should only include previously-synced drives
+      final probedDriveIds = probeCall.captured[0] as List<String>;
+      expect(probedDriveIds, containsAll(['drive-synced-1', 'drive-synced-2']));
+      expect(probedDriveIds, isNot(contains('drive-never')));
+
+      // The minBlockHeight should NOT be 0 (the whole point of this fix)
+      final minBlock = probeCall.captured[1] as int;
+      expect(minBlock, greaterThan(0));
+    });
+
+    test('all never-synced drives skip probe entirely', () async {
+      final drives = [
+        _makeDrive(
+            id: 'a', ownerAddress: ownerAddress, lastBlockHeight: null),
+        _makeDrive(id: 'b', ownerAddress: ownerAddress, lastBlockHeight: 0),
+        _makeDrive(
+            id: 'c', ownerAddress: ownerAddress, lastBlockHeight: null),
+      ];
+
+      when(() => mockDriveDao.allDrives())
+          .thenReturn(FakeSelectable(drives));
+      when(() => mockArweave.getCurrentBlockHeight())
+          .thenAnswer((_) async => 100000);
+
+      try {
+        await syncRepository
+            .syncAllDrives(wallet: mockWallet)
+            .toList();
+      } catch (_) {}
+
+      await Future.delayed(const Duration(milliseconds: 100));
+
+      // Probe should never be called since all drives are never-synced
+      verifyNever(() => mockArweave.probeActiveDriveIds(
+            driveIds: any(named: 'driveIds'),
+            minBlockHeight: any(named: 'minBlockHeight'),
+            ownerAddress: any(named: 'ownerAddress'),
+          ));
+    });
+
+    test('incomplete probe falls back to all previously-synced drives',
+        () async {
+      final drives = [
+        _makeDrive(
+            id: 'a', ownerAddress: ownerAddress, lastBlockHeight: 50000),
+        _makeDrive(
+            id: 'b', ownerAddress: ownerAddress, lastBlockHeight: 60000),
+        _makeDrive(
+            id: 'c', ownerAddress: ownerAddress, lastBlockHeight: 70000),
+      ];
+
+      when(() => mockDriveDao.allDrives())
+          .thenReturn(FakeSelectable(drives));
+      when(() => mockArweave.getCurrentBlockHeight())
+          .thenAnswer((_) async => 100000);
+
+      // Probe returns isComplete: false (hasNextPage was true)
+      when(() => mockArweave.probeActiveDriveIds(
+            driveIds: any(named: 'driveIds'),
+            minBlockHeight: any(named: 'minBlockHeight'),
+            ownerAddress: any(named: 'ownerAddress'),
+          )).thenAnswer((_) async => (
+            activeDriveIds: {'a'},
+            isComplete: false,
+          ));
+
+      try {
+        await syncRepository
+            .syncAllDrives(wallet: mockWallet)
+            .toList();
+      } catch (_) {}
+
+      await Future.delayed(const Duration(milliseconds: 100));
+
+      // Probe was called once
+      verify(() => mockArweave.probeActiveDriveIds(
+            driveIds: any(named: 'driveIds'),
+            minBlockHeight: any(named: 'minBlockHeight'),
+            ownerAddress: any(named: 'ownerAddress'),
+          )).called(1);
+    });
+
+    test('probe failure falls back to syncing all drives', () async {
+      final drives = [
+        _makeDrive(
+            id: 'a', ownerAddress: ownerAddress, lastBlockHeight: 50000),
+        _makeDrive(
+            id: 'b', ownerAddress: ownerAddress, lastBlockHeight: null),
+      ];
+
+      when(() => mockDriveDao.allDrives())
+          .thenReturn(FakeSelectable(drives));
+      when(() => mockArweave.getCurrentBlockHeight())
+          .thenAnswer((_) async => 100000);
+
+      when(() => mockArweave.probeActiveDriveIds(
+            driveIds: any(named: 'driveIds'),
+            minBlockHeight: any(named: 'minBlockHeight'),
+            ownerAddress: any(named: 'ownerAddress'),
+          )).thenThrow(Exception('network error'));
+
+      try {
+        await syncRepository
+            .syncAllDrives(wallet: mockWallet)
+            .toList();
+      } catch (_) {}
+
+      await Future.delayed(const Duration(milliseconds: 100));
+
+      // Should have attempted probe for the previously-synced drive only
+      verify(() => mockArweave.probeActiveDriveIds(
+            driveIds: any(named: 'driveIds'),
+            minBlockHeight: any(named: 'minBlockHeight'),
+            ownerAddress: any(named: 'ownerAddress'),
+          )).called(1);
+    });
+
+    test('deep sync bypasses probe entirely', () async {
+      final drives = [
+        _makeDrive(
+            id: 'a', ownerAddress: ownerAddress, lastBlockHeight: 50000),
+      ];
+
+      when(() => mockDriveDao.allDrives())
+          .thenReturn(FakeSelectable(drives));
+      when(() => mockArweave.getCurrentBlockHeight())
+          .thenAnswer((_) async => 100000);
+
+      try {
+        await syncRepository
+            .syncAllDrives(wallet: mockWallet, syncDeep: true)
+            .toList();
+      } catch (_) {}
+
+      await Future.delayed(const Duration(milliseconds: 100));
+
+      verifyNever(() => mockArweave.probeActiveDriveIds(
+            driveIds: any(named: 'driveIds'),
+            minBlockHeight: any(named: 'minBlockHeight'),
+            ownerAddress: any(named: 'ownerAddress'),
+          ));
+    });
+  });
+
+  group('Fix 2: updateUserDrives cache', () {
+    test('skips GQL call on repeat calls until cache is cleared', () async {
+      when(() => mockArweave.getUniqueUserDriveEntities(
+            any(),
+            any(),
+          )).thenAnswer((_) async => {});
+      when(() => mockDriveDao.updateUserDrives(any(), any()))
+          .thenAnswer((_) async {});
+
+      // First call should hit GQL
+      await syncRepository.updateUserDrives(
+        wallet: mockWallet,
+        password: 'pass',
+        cipherKey: SecretKey([1, 2, 3]),
+      );
+
+      // Second call should be cached (up-to-date flag is set)
+      await syncRepository.updateUserDrives(
+        wallet: mockWallet,
+        password: 'pass',
+        cipherKey: SecretKey([1, 2, 3]),
+      );
+
+      verify(() => mockArweave.getUniqueUserDriveEntities(
+            any(),
+            any(),
+          )).called(1);
+    });
+
+    test('forceRefresh bypasses cache', () async {
+      when(() => mockArweave.getUniqueUserDriveEntities(
+            any(),
+            any(),
+          )).thenAnswer((_) async => {});
+      when(() => mockDriveDao.updateUserDrives(any(), any()))
+          .thenAnswer((_) async {});
+
+      // First call
+      await syncRepository.updateUserDrives(
+        wallet: mockWallet,
+        password: 'pass',
+        cipherKey: SecretKey([1, 2, 3]),
+      );
+
+      // Second call with forceRefresh should bypass cache
+      await syncRepository.updateUserDrives(
+        wallet: mockWallet,
+        password: 'pass',
+        cipherKey: SecretKey([1, 2, 3]),
+        forceRefresh: true,
+      );
+
+      verify(() => mockArweave.getUniqueUserDriveEntities(
+            any(),
+            any(),
+          )).called(2);
+    });
+  });
+
+  group('Fix 3: GQLDriveHistory genesis block guard', () {
+    test('skips [0,0] range and does not query gateway', () async {
+      final mockArweaveForGql = MockArweaveService();
+
+      final gqlHistory = GQLDriveHistory(
+        subRanges: HeightRange(rangeSegments: [
+          Range(start: 0, end: 0),
+          Range(start: 100, end: 200),
+        ]),
+        arweave: mockArweaveForGql,
+        driveId: 'test-drive',
+        ownerAddress: 'test-owner',
+      );
+
+      when(() => mockArweaveForGql.getSegmentedTransactionsFromDrive(
+            any(),
+            minBlockHeight: any(named: 'minBlockHeight'),
+            maxBlockHeight: any(named: 'maxBlockHeight'),
+            ownerAddress: any(named: 'ownerAddress'),
+            strategy: any(named: 'strategy'),
+          )).thenAnswer((_) => const Stream.empty());
+
+      when(() => mockArweaveForGql.graphQLRetry)
+          .thenReturn(MockGraphQLRetry());
+
+      // First getNextStream() processes [0,0] — should be skipped silently
+      final stream1 = gqlHistory.getNextStream();
+      final results1 = await stream1.toList();
+      expect(results1, isEmpty);
+
+      // Verify NO gateway call was made for [0,0]
+      verifyNever(() => mockArweaveForGql.getSegmentedTransactionsFromDrive(
+            any(),
+            minBlockHeight: any(named: 'minBlockHeight'),
+            maxBlockHeight: any(named: 'maxBlockHeight'),
+            ownerAddress: any(named: 'ownerAddress'),
+            strategy: any(named: 'strategy'),
+          ));
+
+      // Second getNextStream() processes [100,200] — should query normally
+      final stream2 = gqlHistory.getNextStream();
+      await stream2.toList();
+
+      verify(() => mockArweaveForGql.getSegmentedTransactionsFromDrive(
+            any(),
+            minBlockHeight: 100,
+            maxBlockHeight: 200,
+            ownerAddress: any(named: 'ownerAddress'),
+            strategy: any(named: 'strategy'),
+          )).called(1);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

HAR analysis of a real sync session (16 drives, zero changes) revealed **130 GraphQL calls taking 376 seconds**. This PR reduces incremental no-change syncs to **~3 calls in <1 second**.

### Root causes identified and fixed:

- **DriveActivityProbe defeated by minBlockHeight=0**: Never-synced drives (lastBlockHeight=0) poisoned the min block calculation, causing the probe to query from genesis, overflow the 100-result page limit, and fall back to syncing ALL drives. Fix: partition drives into never-synced (always sync) and previously-synced (probe with real block heights).

- **UserDriveEntities called 3x identically (~24s)**: Auth flow (isExistingUser, _validateUser) and sync (updateUserDrives) all call `getUniqueUserDriveEntityTxs` for the same wallet within seconds. Fix: event-based cache on both ArweaveService and SyncRepository levels, invalidated after sync completion.

- **87 DriveEntityHistory calls returning 0 edges (161s)**: Entity-type strategy issues 3 queries per drive per block range. Phantom [0,0] block ranges from snapshot gaps at genesis doubled the ranges. Fix: skip genesis block range (no ArFS data exists there). Primary fix: the probe now correctly skips unchanged drives.

- **16 PendingDriveEntities calls (124s)**: Unconditional per-drive gateway query fetching 100 mined transactions to find 0 pending. Fix: check local DB first (`pendingTransactionsForDrive`), skip for non-owned drives.

- **Solana RPC retry spam (~30 failed calls, ~9s)**: `DataGatewayFallback` and `SnapshotValidationService` retried Solana RPC on every `fetchData`/validation call when the GAR gateway list was unavailable. Fix: cache empty list on first failure.

- **Zero-drives-to-sync reported as failure**: When probe skips all drives, the code fell through to "all drives failed". Fix: early return with `emptySyncCompleted`.

### Results (from HAR traces):

| Scenario | Before | After |
|----------|--------|-------|
| First sync (16 drives, all new) | 130 calls / 376s | 61 calls / 97s |
| Incremental sync (no changes) | 130 calls / 376s | **3 calls / ~1s** |

## Test plan

- [x] New test file: `test/sync/domain/sync_repository_optimization_test.dart` (8 tests)
  - Probe partitioning: never-synced excluded, all-never-synced skips probe, incomplete probe fallback, probe failure fallback, deep sync bypass
  - updateUserDrives cache: skip on repeat calls, forceRefresh bypass
  - GQLDriveHistory genesis guard: [0,0] range skipped
- [x] All 45 existing sync/arweave/snapshot tests pass
- [x] `flutter analyze` clean on all modified files
- [x] Manual HAR trace verification across 3 sync sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added retryable download flows with “Try again” for network and rate-limited failures.
  * Improved stalled-download detection and more specific download error states (file not found/network/rate limited).

* **Bug Fixes**
  * Corrected drive attachment drive-name/privacy/ownership handling for public/private/missing drives.
  * Sync now refreshes profile balance only when at least one drive was actually synced.

* **Performance & Maintenance**
  * Enhanced sync efficiency via drive activity probing, caching, bulk transaction processing, and snapshot optimizations.
  * Added database indexes/migration improvements and expanded sync/edge-case tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->