### PR TITLE
PE-9126: Scope tx-status query per-tx by drive owner (fix attached-drive sync)

### DIFF
--- a/lib/models/queries/drive_queries.drift
+++ b/lib/models/queries/drive_queries.drift
@@ -177,6 +177,16 @@ pinnedFileRevisions:
     SELECT * FROM file_revisions
     WHERE pinnedDataOwnerAddress IS NOT NULL;
 
+-- File revisions whose data tx is still pending confirmation. Used to map each
+-- pending data tx to the owner of the drive it belongs to, so the confirmation
+-- query can be scoped per-tx by the actual drive owner rather than assuming the
+-- logged-in wallet owns every pending tx (which breaks for attached drives).
+pendingDataFileRevisions:
+    SELECT * FROM file_revisions
+    WHERE dataTxId IN (
+        SELECT id FROM network_transactions WHERE status = 'pending'
+    );
+
 getFilesWithAssignedNames:
 SELECT * FROM file_entries
 WHERE assignedNames IS NOT NULL;

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -1236,6 +1236,13 @@ class ArweaveService {
   /// unresolved rather than re-queried unscoped, which would reintroduce the
   /// expensive gateway scan this scoping is meant to avoid.
   ///
+  /// [ownersByTxId] maps a transaction id to the owner it should be scoped by
+  /// (the owner of the drive the tx belongs to). It takes precedence over
+  /// [owner] per tx, letting a batch spanning multiple drives — e.g. the user's
+  /// own drives plus attached drives owned by others — be scoped correctly
+  /// instead of assuming a single owner. A tx present in neither [ownersByTxId]
+  /// nor [owner] is left unresolved rather than queried unscoped.
+  ///
   /// [verifiedSink], if provided, is progressively populated with each
   /// successfully verified confirmation (value >= 0) as the query completes —
   /// it never receives the -1 "not found" placeholders. A caller can wrap this
@@ -1246,6 +1253,7 @@ class ArweaveService {
   Future<Map<String?, int>> getTransactionConfirmations(
     List<String?> transactionIds, {
     String? owner,
+    Map<String, String>? ownersByTxId,
     Map<String, String>? ownerOverrides,
     Map<String?, int>? verifiedSink,
   }) async {
@@ -1306,8 +1314,29 @@ class ArweaveService {
       }
     }
 
-    // First pass: scoped by owner for gateway selectivity.
-    await queryConfirmations(transactionIds, owner: owner);
+    // The owner a tx should be scoped by: its per-tx owner if known, else the
+    // single [owner]. Returns null when neither is available (unscopable).
+    String? primaryOwnerFor(String? id) {
+      if (id != null && ownersByTxId != null) {
+        final mapped = ownersByTxId[id];
+        if (mapped != null) return mapped;
+      }
+      return owner;
+    }
+
+    // First pass: scope each tx by its resolved owner and query each owner
+    // once. This keeps every query selective even when the batch spans drives
+    // with different owners. A tx with no resolvable owner is left unresolved
+    // rather than queried unscoped, which would reintroduce the expensive scan.
+    final idsByPrimaryOwner = <String, List<String?>>{};
+    for (final id in transactionIds) {
+      final resolvedOwner = primaryOwnerFor(id);
+      if (resolvedOwner == null) continue;
+      idsByPrimaryOwner.putIfAbsent(resolvedOwner, () => []).add(id);
+    }
+    for (final entry in idsByPrimaryOwner.entries) {
+      await queryConfirmations(entry.value, owner: entry.key);
+    }
 
     // Second pass: for any unresolved id whose real owner we know locally
     // (currently pinned data txs), re-query scoped to that owner. This recovers
@@ -1319,13 +1348,16 @@ class ArweaveService {
     // results are merged into the already-populated map, so we swallow any
     // error and bound it with its own timeout — even if it fails or stalls,
     // the confirmations resolved by the first pass are still returned.
-    if (owner != null && ownerOverrides != null && ownerOverrides.isNotEmpty) {
+    if (ownerOverrides != null && ownerOverrides.isNotEmpty) {
       final idsByOverrideOwner = <String, List<String?>>{};
       for (final entry in transactionConfirmations.entries) {
         if (entry.value >= 0) continue;
-        final overrideOwner = ownerOverrides[entry.key];
-        if (overrideOwner == null || overrideOwner == owner) continue;
-        idsByOverrideOwner.putIfAbsent(overrideOwner, () => []).add(entry.key);
+        final txId = entry.key;
+        final overrideOwner = ownerOverrides[txId];
+        if (overrideOwner == null) continue;
+        // Skip if the tx's first-pass owner already matched its override owner.
+        if (overrideOwner == primaryOwnerFor(txId)) continue;
+        idsByOverrideOwner.putIfAbsent(overrideOwner, () => []).add(txId);
       }
 
       if (idsByOverrideOwner.isNotEmpty) {

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -1331,7 +1331,15 @@ class ArweaveService {
     final idsByPrimaryOwner = <String, List<String?>>{};
     for (final id in transactionIds) {
       final resolvedOwner = primaryOwnerFor(id);
-      if (resolvedOwner == null) continue;
+      if (resolvedOwner == null) {
+        // No owner to scope by, so this tx is never queried. Drop it from the
+        // result rather than leaving the pre-seeded -1, which the caller would
+        // read as a real "not found" and could age an old pending tx into
+        // failed. Absent => the caller skips it; it stays pending until its
+        // drive/owner is known and it can be scoped on a later sync.
+        transactionConfirmations.remove(id);
+        continue;
+      }
       idsByPrimaryOwner.putIfAbsent(resolvedOwner, () => []).add(id);
     }
     for (final entry in idsByPrimaryOwner.entries) {

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -1017,6 +1017,27 @@ class _SyncRepository implements SyncRepository {
     };
   }
 
+  /// Maps each pending data tx id to the owner of the drive it belongs to, so
+  /// the confirmation query can be scoped per-tx by the actual drive owner.
+  /// This is needed because a single sync can span the user's own drives and
+  /// attached drives owned by other wallets — assuming the logged-in wallet
+  /// owns every pending tx would send an unscoped (or wrongly-scoped) query for
+  /// the attached ones.
+  Future<Map<String, String>> _buildPendingTxDriveOwners(
+    DriveDao driveDao,
+  ) async {
+    final pendingRevisions = await driveDao.pendingDataFileRevisions().get();
+    final ownerByDriveId = {
+      for (final drive in await driveDao.allDrives().get())
+        drive.id: drive.ownerAddress,
+    };
+    return {
+      for (final revision in pendingRevisions)
+        if ((ownerByDriveId[revision.driveId] ?? '').isNotEmpty)
+          revision.dataTxId: ownerByDriveId[revision.driveId]!,
+    };
+  }
+
   Future<void> _updateTransactionStatuses({
     required DriveDao driveDao,
     required ArweaveService arweave,
@@ -1028,6 +1049,10 @@ class _SyncRepository implements SyncRepository {
     cancellationToken?.checkCancellation();
 
     final ownerOverrides = await _buildPinnedDataTxOwnerOverrides(driveDao);
+    // Scope each pending tx by the owner of its own drive rather than assuming
+    // the logged-in wallet owns everything (which is wrong for attached drives
+    // owned by other wallets, and null when browsing without a wallet).
+    final ownersByTxId = await _buildPendingTxDriveOwners(driveDao);
 
     // Load all pending transactions
     // Note: We load all at once here, but the memory impact is acceptable
@@ -1086,6 +1111,7 @@ class _SyncRepository implements SyncRepository {
       final map = await arweave
           .getTransactionConfirmations(currentPage.toList(),
               owner: ownerAddress,
+              ownersByTxId: ownersByTxId,
               ownerOverrides: ownerOverrides,
               verifiedSink: verified)
           .timeout(


### PR DESCRIPTION
## Summary

Follow-up to #2144. That PR added owner scoping to the tx-status query but derived the owner from the **logged-in wallet** in the global sync path. This breaks for **attached drives owned by other wallets**: their pending data txs get scoped by the wrong owner, and when there's **no wallet at all** (browsing a public/attached drive) the owner is `null`, so `TransactionStatuses` goes out **unscoped** — hitting the gateway's expensive full-scan path and timing out.

This PR resolves each pending tx's owner from **the drive that tx actually belongs to**, so a single sync spanning the user's own drives and attached drives is scoped correctly per-tx.

## Changes

- **`pendingDataFileRevisions`** (drift, read-only): file revisions whose data tx is still pending.
- **`_buildPendingTxDriveOwners`**: joins those to `allDrives()` → `Map<dataTxId, drive.ownerAddress>`.
- **`getTransactionConfirmations`**: new optional `ownersByTxId` param. The first pass groups txs by their resolved per-tx owner (the map wins, else the single `owner` fallback) and queries each owner **once**, so a multi-drive batch stays selective. A tx with no resolvable owner is left unresolved rather than queried unscoped.
- **Global `_updateTransactionStatuses`** passes the per-tx owner map; `walletAddress` remains only as a fallback for unmapped txs.

## How this fixes the report

- **Attached drive owned by another wallet:** its pending data txs now scope to the *drive's* owner, not the logged-in wallet.
- **No wallet (public/attached browsing):** `walletAddress` is null, but the attached drive's txs are still mapped to the drive owner → scoped correctly instead of the unscoped, timing-out query. Only genuinely unmapped txs fall back, and with no wallet they're skipped rather than sent unscoped.

## Preserved behavior

- **Per-drive path unchanged** (single drive → single owner; already correct).
- **Pinned-owner recovery intact:** pins map to their drive owner in pass 1 (miss), then pass 2 recovers them under `pinnedDataOwnerAddress`; the skip check now compares against the per-tx primary owner.
- **Own drives:** their owner equals the wallet, so those txs collapse into one group — same efficiency as before.

## Not a schema change

Only a read-only query is added under `lib/models/queries/` — no table/column changes, no migration, `schemaVersion` untouched (and outside the `lib/models/tables` pre-push hook scope).

## Testing

- `flutter analyze` clean on the edited files; drift codegen regenerated.
- Not exercised end-to-end against a live attached drive — reproduction with the reported wallet would be the real confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved transaction confirmation handling during sync by checking pending data transactions against the correct drive owner.
  * Added support for resolving confirmations on a per-transaction basis when multiple drives are involved.

* **Bug Fixes**
  * Prevented confirmation lookups from using the wrong owner in mixed-drive scenarios.
  * Unresolved transactions are now left untouched instead of being queried without ownership context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->