### PR TITLE
PE-9103: Sync modal UX improvements

### DIFF
--- a/lib/app_shell.dart
+++ b/lib/app_shell.dart
@@ -338,6 +338,22 @@ class AppShellState extends State<AppShell> {
                                                     appLocalizationsOf(context)
                                                         .close,
                                               ),
+                                              ModalAction(
+                                                action: () {
+                                                  final failedIds = syncState
+                                                      .failedDriveIds;
+                                                  context
+                                                      .read<SyncCubit>()
+                                                      .clearErrorState();
+                                                  context
+                                                      .read<SyncCubit>()
+                                                      .retryFailedDrives(
+                                                          failedIds);
+                                                },
+                                                title:
+                                                    appLocalizationsOf(context)
+                                                        .retryFailedDrives,
+                                              ),
                                             ],
                                           ),
                                         ),
@@ -387,6 +403,47 @@ class AppShellState extends State<AppShell> {
                                                           ArFontWeight.bold,
                                                     ),
                                                   ),
+                                                // Elapsed time — only shown
+                                                // after 5s to avoid clutter
+                                                // on fast syncs
+                                                StreamBuilder<int>(
+                                                  stream: Stream.periodic(
+                                                    const Duration(seconds: 1),
+                                                    (i) => i,
+                                                  ),
+                                                  builder: (context, _) {
+                                                    final elapsed = DateTime
+                                                            .now()
+                                                        .difference(context
+                                                            .read<SyncCubit>()
+                                                            .syncStartTime);
+                                                    if (elapsed.inSeconds < 5) {
+                                                      return const SizedBox
+                                                          .shrink();
+                                                    }
+                                                    return Padding(
+                                                      padding:
+                                                          const EdgeInsets.only(
+                                                              top: 4),
+                                                      child: Text(
+                                                        appLocalizationsOf(
+                                                                context)
+                                                            .syncElapsedTime(
+                                                          elapsed.inSeconds
+                                                              .toString(),
+                                                        ),
+                                                        style: typography
+                                                            .paragraphSmall(
+                                                          color: ArDriveTheme.of(
+                                                                  context)
+                                                              .themeData
+                                                              .colorTokens
+                                                              .textMid,
+                                                        ),
+                                                      ),
+                                                    );
+                                                  },
+                                                ),
                                               ],
                                             ),
                                           ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2262,6 +2262,24 @@
       }
     }
   },
+  "syncCheckingForChanges": "Checking for changes...",
+  "@syncCheckingForChanges": {
+    "description": "Status message shown during drive activity probe"
+  },
+  "retryFailedDrives": "Retry Failed",
+  "@retryFailedDrives": {
+    "description": "Button to retry syncing only the drives that failed"
+  },
+  "syncElapsedTime": "{seconds}s elapsed",
+  "@syncElapsedTime": {
+    "description": "Elapsed time shown during sync after 5 seconds",
+    "placeholders": {
+      "seconds": {
+        "type": "String",
+        "example": "45"
+      }
+    }
+  },
   "syncProgressPercentage": "{percentage}% complete",
   "@syncProgressPercentage": {
     "description": "The sync progress percentage",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1764,6 +1764,9 @@
   "@syncingPleaseWait": {
     "description": "Syncing drives"
   },
+  "syncCheckingForChanges": "Comprobando cambios...",
+  "retryFailedDrives": "Reintentar",
+  "syncElapsedTime": "{seconds}s transcurridos",
   "syncProgressPercentage": "{percentage}% completado",
   "@syncProgressPercentage": {
     "description": "The sync progress percentage",

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -1764,6 +1764,9 @@
   "@syncingPleaseWait": {
     "description": "Syncing drives"
   },
+  "syncCheckingForChanges": "परिवर्तनों की जाँच हो रही है...",
+  "retryFailedDrives": "पुनः प्रयास करें",
+  "syncElapsedTime": "{seconds}s बीत चुके",
   "syncProgressPercentage": "{percentage}% पूरा हुआ",
   "@syncProgressPercentage": {
     "description": "The sync progress percentage",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1764,6 +1764,9 @@
   "@syncingPleaseWait": {
     "description": "Syncing drives"
   },
+  "syncCheckingForChanges": "変更を確認中...",
+  "retryFailedDrives": "再試行",
+  "syncElapsedTime": "{seconds}秒経過",
   "syncProgressPercentage": "{percentage}%完了",
   "@syncProgressPercentage": {
     "description": "The sync progress percentage",

--- a/lib/l10n/app_zh-HK.arb
+++ b/lib/l10n/app_zh-HK.arb
@@ -1764,6 +1764,9 @@
   "@syncingPleaseWait": {
     "description": "Syncing drives"
   },
+  "syncCheckingForChanges": "正在檢查變更...",
+  "retryFailedDrives": "重試失敗",
+  "syncElapsedTime": "已用時{seconds}秒",
   "syncProgressPercentage": "{percentage}% 完成",
   "@syncProgressPercentage": {
     "description": "The sync progress percentage",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1764,6 +1764,9 @@
   "@syncingPleaseWait": {
     "description": "Syncing drives"
   },
+  "syncCheckingForChanges": "正在检查更改...",
+  "retryFailedDrives": "重试失败",
+  "syncElapsedTime": "已用时{seconds}秒",
   "syncProgressPercentage": "{percentage}% 完成度",
   "@syncProgressPercentage": {
     "description": "The sync progress percentage",

--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -46,6 +46,10 @@ class SyncCubit extends Cubit<SyncState> {
       StreamController<SyncProgress>.broadcast();
   DateTime? _lastSync;
   late DateTime _initSync;
+
+  /// Exposed for the sync modal to display elapsed time.
+  DateTime get syncStartTime => _initSync;
+
   SyncProgress _syncProgress = SyncProgress.initial();
   SyncCancellationToken? _currentSyncToken;
 
@@ -581,6 +585,23 @@ class SyncCubit extends Cubit<SyncState> {
     if (state is SyncCompleteWithErrors) {
       emit(SyncIdle());
     }
+  }
+
+  /// Retry syncing only the drives that failed in the previous sync.
+  Future<void> retryFailedDrives(List<String> driveIds) async {
+    if (driveIds.isEmpty) return;
+
+    logger.i('Retrying ${driveIds.length} failed drives');
+
+    // For a single failed drive, use the single-drive sync path
+    if (driveIds.length == 1) {
+      return startSyncForDrive(driveId: driveIds.first);
+    }
+
+    // For multiple failed drives, start a full sync
+    // The drives are already synced, so the probe will only pick up
+    // the ones that actually need re-syncing
+    return startSync(deepSync: true);
   }
 
   /// Get the current sync progress

--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -235,6 +235,7 @@ class SyncCubit extends Cubit<SyncState> {
   Future<void> startSync({
     bool deepSync = false,
     bool skipTabVisibilityCheck = false,
+    List<String>? driveIdsToRetry,
   }) async {
     logger.i('Starting Sync');
 
@@ -323,6 +324,7 @@ class SyncCubit extends Cubit<SyncState> {
           password: password,
           cipherKey: cipherKey,
           syncDeep: deepSync,
+          driveIdsToRetry: driveIdsToRetry,
           cancellationToken: _currentSyncToken,
           txFechedCallback: (driveId, txCount) {
             _promptToSnapshotBloc.add(
@@ -592,10 +594,7 @@ class SyncCubit extends Cubit<SyncState> {
     if (driveIds.isEmpty) return;
 
     logger.i('Retrying ${driveIds.length} failed drives');
-
-    for (final driveId in driveIds) {
-      await startSyncForDrive(driveId: driveId);
-    }
+    return startSync(driveIdsToRetry: driveIds);
   }
 
   /// Get the current sync progress

--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -593,15 +593,9 @@ class SyncCubit extends Cubit<SyncState> {
 
     logger.i('Retrying ${driveIds.length} failed drives');
 
-    // For a single failed drive, use the single-drive sync path
-    if (driveIds.length == 1) {
-      return startSyncForDrive(driveId: driveIds.first);
+    for (final driveId in driveIds) {
+      await startSyncForDrive(driveId: driveId);
     }
-
-    // For multiple failed drives, start a full sync
-    // The drives are already synced, so the probe will only pick up
-    // the ones that actually need re-syncing
-    return startSync(deepSync: true);
   }
 
   /// Get the current sync progress

--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -45,7 +45,7 @@ class SyncCubit extends Cubit<SyncState> {
   final StreamController<SyncProgress> syncProgressController =
       StreamController<SyncProgress>.broadcast();
   DateTime? _lastSync;
-  late DateTime _initSync;
+  DateTime _initSync = DateTime.now();
 
   /// Exposed for the sync modal to display elapsed time.
   DateTime get syncStartTime => _initSync;

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -246,6 +246,10 @@ class _SyncRepository implements SyncRepository {
     if (syncDeep) {
       drivesToSync = drives;
     } else {
+      syncProgress = syncProgress.copyWith(
+        statusMessage: 'Checking for changes...',
+      );
+      yield syncProgress;
       try {
         final neverSyncedDrives = <Drive>[];
         final previouslySyncedDrives = <Drive>[];
@@ -324,6 +328,10 @@ class _SyncRepository implements SyncRepository {
         drivesToSync = drives;
       }
     }
+
+    // Clear the probe status message
+    syncProgress = syncProgress.copyWith(statusMessage: null);
+    yield syncProgress;
 
     final numberOfDrivesToSync = drivesToSync.length;
 
@@ -470,7 +478,8 @@ class _SyncRepository implements SyncRepository {
               List<String>.from(syncProgress.failedDriveIds)..add(drive.id);
           final updatedErrorMessages =
               Map<String, String>.from(syncProgress.errorMessages)
-                ..putIfAbsent(drive.id, () => _extractErrorMessage(e));
+                ..putIfAbsent(
+                    drive.id, () => '${drive.name}: ${_extractErrorMessage(e)}');
 
           // Still increment progress but mark as failed (cap at 90%)
           totalProgress += 1;

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -950,7 +950,8 @@ class _SyncRepository implements SyncRepository {
 
         final updatedErrorMessages =
             Map<String, String>.from(syncProgress.errorMessages)
-              ..putIfAbsent(driveId, () => _extractErrorMessage(e));
+              ..putIfAbsent(
+                  driveId, () => '${drive.name}: ${_extractErrorMessage(e)}');
 
         syncProgress = syncProgress.copyWith(
           drivesSynced: 1,

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -91,6 +91,7 @@ abstract class SyncRepository {
     String? password,
     SecretKey? cipherKey,
     SyncCancellationToken? cancellationToken,
+    List<String>? driveIdsToRetry,
 
     /// This was required because the usage of the `PromptToSnapshotBloc` in the
     /// `SyncCubit` and the `PromptToSnapshotBloc` is not available in the `SyncRepository`
@@ -188,6 +189,7 @@ class _SyncRepository implements SyncRepository {
     SecretKey? cipherKey,
     SyncCancellationToken? cancellationToken,
     Function(String driveId, int txCount)? txFechedCallback,
+    List<String>? driveIdsToRetry,
   }) async* {
     final token = cancellationToken ?? SyncCancellationToken();
 
@@ -214,7 +216,13 @@ class _SyncRepository implements SyncRepository {
     }
 
     // Sync the contents of each drive attached in the app.
-    final drives = await _driveDao.allDrives().map((d) => d).get();
+    var drives = await _driveDao.allDrives().map((d) => d).get();
+
+    // If retrying specific drives, filter to only those
+    if (driveIdsToRetry != null && driveIdsToRetry.isNotEmpty) {
+      final retrySet = driveIdsToRetry.toSet();
+      drives = drives.where((d) => retrySet.contains(d.id)).toList();
+    }
 
     if (drives.isEmpty) {
       yield SyncProgress.emptySyncCompleted();


### PR DESCRIPTION
## Summary

Improves the sync modal UX to match the optimized sync pipeline.

### Changes:

- **Probe status message**: Shows "Checking for changes..." during the drive activity probe phase instead of the misleading "0 of 16 Drives Synced"
- **Drive names in errors**: Error messages now include the drive name (e.g., "My Drive: Gateway timeout (504)") so users know which drive failed
- **Retry Failed button**: Adds a "Retry Failed" action button in the sync error modal so users can retry just the failed drives without re-syncing everything
- **Elapsed time**: Shows "Xs elapsed" after 5 seconds during sync so users have feedback that longer syncs are progressing

### Localization

All new strings added to 6 locales (en, es, hi, ja, zh, zh-HK).

## Test plan

- [x] All 45 sync/arweave tests pass
- [x] `flutter analyze` clean
- [ ] Manual: trigger sync with errors (use debug panel) — verify drive names appear in error messages and "Retry Failed" button works
- [ ] Manual: trigger long sync (first login) — verify elapsed time appears after 5s
- [ ] Manual: trigger incremental sync — verify "Checking for changes..." appears briefly
- [ ] Verify desktop and mobile modal layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “elapsed time” display to the sync progress modal (appears after a short delay).
  * Introduced a “checking for changes” status step during syncing.
  * Added drive-scoped retry for syncing failures.
* **Bug Fixes**
  * Updated the sync completion error modal so the primary action retries failed drives (instead of just closing).
  * Improved per-drive error messages by including the drive name.
* **Localization**
  * Added new strings (multi-language) for “checking for changes,” “retry failed,” and elapsed time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->