### PR TITLE
PE-9103: Release v2.85.0

### DIFF
--- a/lib/app_shell.dart
+++ b/lib/app_shell.dart
@@ -338,6 +338,22 @@ class AppShellState extends State<AppShell> {
                                                     appLocalizationsOf(context)
                                                         .close,
                                               ),
+                                              ModalAction(
+                                                action: () {
+                                                  final failedIds = syncState
+                                                      .failedDriveIds;
+                                                  context
+                                                      .read<SyncCubit>()
+                                                      .clearErrorState();
+                                                  context
+                                                      .read<SyncCubit>()
+                                                      .retryFailedDrives(
+                                                          failedIds);
+                                                },
+                                                title:
+                                                    appLocalizationsOf(context)
+                                                        .retryFailedDrives,
+                                              ),
                                             ],
                                           ),
                                         ),
@@ -387,6 +403,47 @@ class AppShellState extends State<AppShell> {
                                                           ArFontWeight.bold,
                                                     ),
                                                   ),
+                                                // Elapsed time — only shown
+                                                // after 5s to avoid clutter
+                                                // on fast syncs
+                                                StreamBuilder<int>(
+                                                  stream: Stream.periodic(
+                                                    const Duration(seconds: 1),
+                                                    (i) => i,
+                                                  ),
+                                                  builder: (context, _) {
+                                                    final elapsed = DateTime
+                                                            .now()
+                                                        .difference(context
+                                                            .read<SyncCubit>()
+                                                            .syncStartTime);
+                                                    if (elapsed.inSeconds < 5) {
+                                                      return const SizedBox
+                                                          .shrink();
+                                                    }
+                                                    return Padding(
+                                                      padding:
+                                                          const EdgeInsets.only(
+                                                              top: 4),
+                                                      child: Text(
+                                                        appLocalizationsOf(
+                                                                context)
+                                                            .syncElapsedTime(
+                                                          elapsed.inSeconds
+                                                              .toString(),
+                                                        ),
+                                                        style: typography
+                                                            .paragraphSmall(
+                                                          color: ArDriveTheme.of(
+                                                                  context)
+                                                              .themeData
+                                                              .colorTokens
+                                                              .textMid,
+                                                        ),
+                                                      ),
+                                                    );
+                                                  },
+                                                ),
                                               ],
                                             ),
                                           ),

--- a/lib/blocs/create_snapshot/create_snapshot_cubit.dart
+++ b/lib/blocs/create_snapshot/create_snapshot_cubit.dart
@@ -84,6 +84,9 @@ class CreateSnapshotCubit extends Cubit<CreateSnapshotState> {
 
   SnapshotItemToBeCreated? _itemToBeCreated;
   SnapshotEntity? _snapshotEntity;
+  Uint8List? _cachedSnapshotData;
+  bool _isPrivateDrive = false;
+  MetadataCache? _metadataCache;
 
   CreateSnapshotCubit({
     required ArweaveService arweave,
@@ -111,12 +114,18 @@ class CreateSnapshotCubit extends Cubit<CreateSnapshotState> {
     DriveID driveId, {
     Range? range,
   }) async {
-    try {
-      await _reset(driveId);
-    } catch (e) {
-      emit(ComputeSnapshotDataFailure(errorMessage: e.toString()));
-      logger.e('Error while resetting snapshot creation parameters', e);
-      return;
+    // On retry after upload failure, reuse previously computed data
+    final isRetry = _cachedSnapshotData != null && _driveId == driveId;
+
+    if (!isRetry) {
+      _cachedSnapshotData = null;
+      try {
+        await _reset(driveId);
+      } catch (e) {
+        emit(ComputeSnapshotDataFailure(errorMessage: e.toString()));
+        logger.e('Error while resetting snapshot creation parameters', e);
+        return;
+      }
     }
 
     late Uint8List data;
@@ -124,9 +133,15 @@ class CreateSnapshotCubit extends Cubit<CreateSnapshotState> {
       final profileState = _profileCubit.state as ProfileLoggedIn;
       _ownerAddress = profileState.user.walletAddress;
 
-      _setTrustedRange(range);
-
-      data = await _getSnapshotData();
+      if (isRetry) {
+        data = _cachedSnapshotData!;
+        logger.i('Reusing cached snapshot data for retry '
+            '(${data.length} bytes)');
+      } else {
+        _setTrustedRange(range);
+        data = await _getSnapshotData();
+        _cachedSnapshotData = data;
+      }
 
       if (_wasCancelled()) return;
 
@@ -172,6 +187,7 @@ class CreateSnapshotCubit extends Cubit<CreateSnapshotState> {
   bool _wasCancelled() {
     if (_wasSnapshotDataComputingCanceled) {
       _wasSnapshotDataComputingCanceled = false;
+      _cachedSnapshotData = null; // Don't reuse data from cancelled computation
 
       return true;
     }
@@ -185,6 +201,18 @@ class CreateSnapshotCubit extends Cubit<CreateSnapshotState> {
     _itemToBeCreated = null;
     _snapshotEntity = null;
     _wasSnapshotDataComputingCanceled = false;
+
+    // Cache drive privacy once to avoid N+1 DB queries during metadata fetch
+    final drive =
+        await _driveDao.driveById(driveId: driveId).getSingleOrNull();
+    _isPrivateDrive =
+        drive != null && drive.privacy != DrivePrivacyTag.public;
+
+    // Cache MetadataCache instance to avoid re-creating per transaction.
+    // Always refresh on reset to avoid stale references from prior sessions.
+    _metadataCache = await MetadataCache.fromCacheStore(
+      await newSharedPreferencesCacheStore(),
+    );
   }
 
   void _setTrustedRange(Range? range) {
@@ -228,6 +256,16 @@ class CreateSnapshotCubit extends Cubit<CreateSnapshotState> {
       subRanges: HeightRange(rangeSegments: [_range]),
       source: flatGQLEdgesStream,
       jsonMetadataOfTxId: _jsonMetadataOfTxId,
+      onProgress: (processed, total) {
+        if (!isClosed) {
+          emit(ComputingSnapshotData(
+            driveId: _driveId,
+            range: _range,
+            processedTransactions: processed,
+            totalTransactions: total,
+          ));
+        }
+      },
     );
 
     _itemToBeCreated = snapshotItemToBeCreated;
@@ -550,15 +588,7 @@ class CreateSnapshotCubit extends Cubit<CreateSnapshotState> {
   }
 
   Future<Uint8List> _jsonMetadataOfTxId(String txId) async {
-    final drive =
-        await _driveDao.driveById(driveId: _driveId).getSingleOrNull();
-    final isPrivate = drive != null && drive.privacy != DrivePrivacyTag.public;
-
-    final metadataCache = await MetadataCache.fromCacheStore(
-      await newSharedPreferencesCacheStore(),
-    );
-
-    final Uint8List? cachedMetadata = await metadataCache.get(txId);
+    final Uint8List? cachedMetadata = await _metadataCache?.get(txId);
 
     final Uint8List entityJsonData = cachedMetadata ??
         await _arweave.dataFromTxId(
@@ -567,16 +597,11 @@ class CreateSnapshotCubit extends Cubit<CreateSnapshotState> {
         );
 
     if (cachedMetadata == null) {
-      // Write to the cache the data we just fetched
-      await metadataCache.put(txId, entityJsonData);
+      await _metadataCache?.put(txId, entityJsonData);
     }
 
-    if (isPrivate) {
-      final safeEntityDataFromArweave = Uint8List.fromList(
-        utf8.encode(base64Encode(entityJsonData)),
-      );
-
-      return safeEntityDataFromArweave;
+    if (_isPrivateDrive) {
+      return Uint8List.fromList(utf8.encode(base64Encode(entityJsonData)));
     }
 
     return entityJsonData;
@@ -644,6 +669,7 @@ class CreateSnapshotCubit extends Cubit<CreateSnapshotState> {
         );
       }
 
+      _cachedSnapshotData = null; // Clear cache on success
       emit(SnapshotUploadSuccess());
     } catch (err, stacktrace) {
       logger.e('Error while posting the snapshot transaction', err, stacktrace);

--- a/lib/blocs/create_snapshot/create_snapshot_cubit.dart
+++ b/lib/blocs/create_snapshot/create_snapshot_cubit.dart
@@ -208,11 +208,9 @@ class CreateSnapshotCubit extends Cubit<CreateSnapshotState> {
     _isPrivateDrive =
         drive != null && drive.privacy != DrivePrivacyTag.public;
 
-    // Cache MetadataCache instance to avoid re-creating per transaction.
-    // Always refresh on reset to avoid stale references from prior sessions.
-    _metadataCache = await MetadataCache.fromCacheStore(
-      await newSharedPreferencesCacheStore(),
-    );
+    // Clear MetadataCache so it's refreshed on next use (lazy init in
+    // _jsonMetadataOfTxId avoids shared_preferences plugin in tests)
+    _metadataCache = null;
   }
 
   void _setTrustedRange(Range? range) {
@@ -459,9 +457,15 @@ class CreateSnapshotCubit extends Cubit<CreateSnapshotState> {
     _costEstimateAr = await costCalculatorForAr.calculateCost(
       totalSize: _snapshotEntity!.data!.length,
     );
-    _costEstimateTurbo = await costCalculatorForTurbo.calculateCost(
-      totalSize: _snapshotEntity!.data!.length,
-    );
+    try {
+      _costEstimateTurbo = await costCalculatorForTurbo.calculateCost(
+        totalSize: _snapshotEntity!.data!.length,
+      );
+    } catch (e) {
+      logger.w('Turbo cost estimation failed, AR payment still available: $e');
+      _costEstimateTurbo = UploadCostEstimate.zero();
+      _isTurboUploadPossible = false;
+    }
   }
 
   Future<void> refreshTurboBalance() async {
@@ -588,6 +592,9 @@ class CreateSnapshotCubit extends Cubit<CreateSnapshotState> {
   }
 
   Future<Uint8List> _jsonMetadataOfTxId(String txId) async {
+    _metadataCache ??= await MetadataCache.fromCacheStore(
+      await newSharedPreferencesCacheStore(),
+    );
     final Uint8List? cachedMetadata = await _metadataCache?.get(txId);
 
     final Uint8List entityJsonData = cachedMetadata ??

--- a/lib/blocs/create_snapshot/create_snapshot_state.dart
+++ b/lib/blocs/create_snapshot/create_snapshot_state.dart
@@ -11,14 +11,19 @@ class CreateSnapshotInitial extends CreateSnapshotState {}
 class ComputingSnapshotData extends CreateSnapshotState {
   final DriveID driveId;
   final Range range;
+  final int processedTransactions;
+  final int totalTransactions;
 
   ComputingSnapshotData({
     required this.driveId,
     required this.range,
+    this.processedTransactions = 0,
+    this.totalTransactions = 0,
   });
 
   @override
-  List<Object> get props => [driveId, range];
+  List<Object> get props =>
+      [driveId, range, processedTransactions, totalTransactions];
 }
 
 class PreparingAndSigningTransaction extends CreateSnapshotState {

--- a/lib/blocs/drive_attach/drive_attach_cubit.dart
+++ b/lib/blocs/drive_attach/drive_attach_cubit.dart
@@ -277,9 +277,14 @@ class DriveAttachCubit extends Cubit<DriveAttachState> {
     _lookupNotifier.value = true;
 
     try {
-      final drivePrivacy = await _arweave.getDrivePrivacyForId(driveId);
+      final result = await _arweave.getDrivePrivacyForId(driveId);
 
-      switch (drivePrivacy) {
+      if (result == null) {
+        emit(DriveAttachDriveNotFound());
+        return null;
+      }
+
+      switch (result.privacy) {
         case DrivePrivacyTag.private:
           emit(DriveAttachPrivate());
           break;
@@ -287,8 +292,11 @@ class DriveAttachCubit extends Cubit<DriveAttachState> {
           emit(DriveAttachDriveNotFound());
           break;
         default:
-          // Public drive — fetch entity now to get the name
-          final drive = await _arweave.getLatestDriveEntityWithId(driveId);
+          // Public drive — fetch and cache entity so driveNameLoader can skip
+          final drive = await _arweave.getLatestDriveEntityWithId(
+            driveId,
+            driveOwner: result.ownerAddress,
+          );
 
           if (drive == null) {
             emit(DriveAttachDriveNotFound());

--- a/lib/blocs/file_download/file_download_cubit.dart
+++ b/lib/blocs/file_download/file_download_cubit.dart
@@ -4,6 +4,7 @@ import 'package:ardrive/core/arfs/entities/arfs_entities.dart';
 import 'package:ardrive/core/arfs/repository/arfs_repository.dart';
 import 'package:ardrive/core/crypto/crypto.dart';
 import 'package:ardrive/download/ardrive_downloader.dart';
+import 'package:ardrive/download/download_exceptions.dart';
 import 'package:ardrive/download/limits.dart';
 import 'package:ardrive/entities/constants.dart';
 import 'package:ardrive/models/models.dart';
@@ -28,4 +29,5 @@ abstract class FileDownloadCubit extends Cubit<FileDownloadState> {
   FileDownloadCubit(super.state);
 
   FutureOr<void> abortDownload() {}
+  FutureOr<void> retryDownload() {}
 }

--- a/lib/blocs/file_download/file_download_state.dart
+++ b/lib/blocs/file_download/file_download_state.dart
@@ -83,5 +83,6 @@ enum FileDownloadFailureReason {
   fileAboveLimit,
   browserDoesNotSupportLargeDownloads,
   networkConnectionError,
-  fileNotFound
+  fileNotFound,
+  rateLimited,
 }

--- a/lib/blocs/file_download/personal_file_download_cubit.dart
+++ b/lib/blocs/file_download/personal_file_download_cubit.dart
@@ -11,6 +11,7 @@ class FileDownloadProgress extends LinearProgress {
 
 class ProfileFileDownloadCubit extends FileDownloadCubit {
   final ARFSFileEntity _file;
+  SecretKey? _lastCipherKey;
 
   final StreamController<LinearProgress> _downloadProgress =
       StreamController<LinearProgress>.broadcast();
@@ -59,7 +60,14 @@ class ProfileFileDownloadCubit extends FileDownloadCubit {
     download(cipherKey);
   }
 
+  @override
+  FutureOr<void> retryDownload() {
+    emit(FileDownloadStarting());
+    download(_lastCipherKey);
+  }
+
   Future<void> download(SecretKey? cipherKey) async {
+    _lastCipherKey = cipherKey;
     try {
       final drive = await _arfsRepository.getDriveById(_file.driveId);
 
@@ -142,17 +150,19 @@ class ProfileFileDownloadCubit extends FileDownloadCubit {
     String? cipher;
     String? cipherIvTag;
     SecretKey? fileKey;
+    bool verifyDownload = false;
 
     final isPinFile = _file.pinnedDataOwnerAddress != null;
 
-    final dataTx = await (_arweave.getTransactionDetails(_file.txId));
-
-    if (dataTx == null) {
-      throw StateError(
-          'Failed to download: Data transaction not found for file');
-    }
-
     if (drive.drivePrivacy == DrivePrivacy.private && !isPinFile) {
+      // Private files need cipher/IV tags from the data transaction
+      final dataTx = await (_arweave.getTransactionDetails(_file.txId));
+
+      if (dataTx == null) {
+        throw StateError(
+            'Failed to download: Data transaction not found for file');
+      }
+
       DriveKey? driveKey;
 
       if (cipherKey != null) {
@@ -173,13 +183,14 @@ class ProfileFileDownloadCubit extends FileDownloadCubit {
 
       cipher = dataTx.getTag(EntityTag.cipher);
       cipherIvTag = dataTx.getTag(EntityTag.cipherIv);
+      verifyDownload = dataTx.getTag(EntityTag.appName) == 'ArDrive-CLI';
     }
 
     // log file size
     logger.d('File size: ${_file.size}');
 
     final downloadStream = await _arDriveDownloader.downloadFile(
-      dataTx: dataTx,
+      txId: _file.txId,
       fileName: _file.name,
       fileSize: _file.size,
       lastModifiedDate: _file.lastModifiedDate,
@@ -189,6 +200,7 @@ class ProfileFileDownloadCubit extends FileDownloadCubit {
       cipher: cipher,
       cipherIvString: cipherIvTag,
       fileKey: fileKey,
+      verifyDownload: verifyDownload,
     );
 
     downloadStream.listen(
@@ -247,18 +259,30 @@ class ProfileFileDownloadCubit extends FileDownloadCubit {
 
   @override
   void onError(Object error, StackTrace stackTrace) {
-    emit(
-      const FileDownloadFailure(
-        FileDownloadFailureReason.unknownError,
-      ),
-    );
+    final reason = _classifyError(error);
+    emit(FileDownloadFailure(reason));
 
     super.onError(error, stackTrace);
 
     logger.e(
-      'Failed to download file ${_file.id} with txId ${_file.txId} from gateway ${_arweave.client.api.gatewayUrl.origin}',
+      'Failed to download file ${_file.id} with txId ${_file.txId} '
+      '(reason: $reason)',
       error,
       stackTrace,
     );
+  }
+
+  static FileDownloadFailureReason _classifyError(Object error) {
+    if (error is DownloadFileNotFoundException) {
+      return FileDownloadFailureReason.fileNotFound;
+    }
+    if (error is DownloadRateLimitException) {
+      return FileDownloadFailureReason.rateLimited;
+    }
+    if (error is DownloadNetworkException ||
+        error is DownloadStalledException) {
+      return FileDownloadFailureReason.networkConnectionError;
+    }
+    return FileDownloadFailureReason.unknownError;
   }
 }

--- a/lib/blocs/file_download/shared_file_download_cubit.dart
+++ b/lib/blocs/file_download/shared_file_download_cubit.dart
@@ -54,16 +54,10 @@ class SharedFileDownloadCubit extends FileDownloadCubit {
 
     String? cipherTag;
     String? cipherIvTag;
+    bool verifyDownload = false;
     final isPinFile = revision.pinnedDataOwnerAddress != null;
 
     final dataTxId = revision.dataTxId;
-
-    final dataTx = await _arweave.getTransactionDetails(revision.dataTxId!);
-
-    if (dataTx == null) {
-      throw StateError(
-          'Data transaction not found for file ${revision.id} with txId ${revision.dataTxId} from gateway ${_arweave.client.api.gatewayUrl.origin}');
-    }
 
     if (dataTxId == null) {
       throw StateError(
@@ -71,14 +65,23 @@ class SharedFileDownloadCubit extends FileDownloadCubit {
     }
 
     if (fileKey != null && !isPinFile) {
+      // Private/encrypted files need cipher/IV tags from the data transaction
+      final dataTx = await _arweave.getTransactionDetails(dataTxId);
+
+      if (dataTx == null) {
+        throw StateError(
+            'Data transaction not found for file ${revision.id} with txId $dataTxId from gateway ${_arweave.client.api.gatewayUrl.origin}');
+      }
+
       cipherTag = dataTx.getTag(EntityTag.cipher);
       cipherIvTag = dataTx.getTag(EntityTag.cipherIv);
+      verifyDownload = dataTx.getTag(EntityTag.appName) == 'ArDrive-CLI';
     }
 
     logger.d('File size: ${revision.size}');
 
     final downloadStream = await _arDriveDownloader.downloadFile(
-      dataTx: dataTx,
+      txId: dataTxId,
       fileName: revision.name,
       fileSize: revision.size,
       lastModifiedDate: revision.lastModifiedDate,
@@ -88,6 +91,7 @@ class SharedFileDownloadCubit extends FileDownloadCubit {
       cipherIvString: cipherIvTag,
       fileKey: fileKey,
       isManifest: revision.contentType == ContentType.manifest,
+      verifyDownload: verifyDownload,
     );
 
     downloadStream.listen(
@@ -126,14 +130,36 @@ class SharedFileDownloadCubit extends FileDownloadCubit {
   }
 
   @override
+  FutureOr<void> retryDownload() {
+    emit(FileDownloadStarting());
+    download();
+  }
+
+  @override
   void onError(Object error, StackTrace stackTrace) {
-    emit(const FileDownloadFailure(FileDownloadFailureReason.unknownError));
+    final reason = _classifyError(error);
+    emit(FileDownloadFailure(reason));
     super.onError(error, stackTrace);
 
     logger.e(
-      'Failed to download shared file ${revision.id} with txId ${revision.dataTxId} from gateway ${_arweave.client.api.gatewayUrl.origin}. File name: ${revision.name}, size: ${revision.size}',
+      'Failed to download shared file ${revision.id} with txId '
+      '${revision.dataTxId} (reason: $reason)',
       error,
       stackTrace,
     );
+  }
+
+  static FileDownloadFailureReason _classifyError(Object error) {
+    if (error is DownloadFileNotFoundException) {
+      return FileDownloadFailureReason.fileNotFound;
+    }
+    if (error is DownloadRateLimitException) {
+      return FileDownloadFailureReason.rateLimited;
+    }
+    if (error is DownloadNetworkException ||
+        error is DownloadStalledException) {
+      return FileDownloadFailureReason.networkConnectionError;
+    }
+    return FileDownloadFailureReason.unknownError;
   }
 }

--- a/lib/blocs/fs_entry_info/fs_entry_info_cubit.dart
+++ b/lib/blocs/fs_entry_info/fs_entry_info_cubit.dart
@@ -192,9 +192,22 @@ class FsEntryInfoCubit extends Cubit<FsEntryInfoState> {
     try {
       final isComposed = revision.licenseTxId == revision.dataTxId;
 
+      // Owner of the license transaction, used to make the gateway query more
+      // selective. For composed licenses the license tx is the data tx, so its
+      // owner is the data uploader (the pinned data owner for pinned files);
+      // for assertions and regular files it is the drive owner. Resolved best
+      // effort — when unknown the query is left unscoped.
+      final licenseOwner = _ownerAddress ??
+          revision.pinnedDataOwnerAddress ??
+          revision.originalOwner ??
+          (await _driveDao
+                  .driveById(driveId: revision.driveId)
+                  .getSingleOrNull())
+              ?.ownerAddress;
+
       if (isComposed) {
         final txs = await _arweave
-            .getLicenseComposed([revision.licenseTxId!])
+            .getLicenseComposed([revision.licenseTxId!], owner: licenseOwner)
             .expand((e) => e)
             .toList();
         if (txs.isEmpty) return null;
@@ -210,7 +223,7 @@ class FsEntryInfoCubit extends Cubit<FsEntryInfoState> {
         return _licenseService.fromComposedEntity(entity);
       } else {
         final txs = await _arweave
-            .getLicenseAssertions([revision.licenseTxId!])
+            .getLicenseAssertions([revision.licenseTxId!], owner: licenseOwner)
             .expand((e) => e)
             .toList();
         if (txs.isEmpty) return null;

--- a/lib/blocs/shared_file/shared_file_cubit.dart
+++ b/lib/blocs/shared_file/shared_file_cubit.dart
@@ -87,12 +87,15 @@ class SharedFileCubit extends Cubit<SharedFileState> {
     return revisions.reversed.toList();
   }
 
-  Future<LicenseState?> fetchLicenseForRevision(FileRevision revision) async {
+  Future<LicenseState?> fetchLicenseForRevision(
+    FileRevision revision, {
+    String? owner,
+  }) async {
     final isComposed = revision.licenseTxId == revision.dataTxId;
     if (isComposed) {
       // License Composed
       final licenseTxs = await _arweave
-          .getLicenseComposed([revision.licenseTxId!])
+          .getLicenseComposed([revision.licenseTxId!], owner: owner)
           .expand((e) => e)
           .toList();
       if (licenseTxs.isEmpty) {
@@ -106,7 +109,7 @@ class SharedFileCubit extends Cubit<SharedFileState> {
     } else {
       // License Assertion
       final licenseTxs = await _arweave
-          .getLicenseAssertions([revision.licenseTxId!])
+          .getLicenseAssertions([revision.licenseTxId!], owner: owner)
           .expand((e) => e)
           .toList();
       if (licenseTxs.isEmpty) {
@@ -145,7 +148,7 @@ class SharedFileCubit extends Cubit<SharedFileState> {
       final revisions = await computeRevisionsFromEntities(allEntities);
       // revisions are in reverse chronological order, so first is most recent
       final latestLicense = revisions.first.licenseTxId != null
-          ? await fetchLicenseForRevision(revisions.first)
+          ? await fetchLicenseForRevision(revisions.first, owner: ownerAddress)
           : null;
       
       emit(SharedFileLoadSuccess(

--- a/lib/components/create_snapshot_dialog.dart
+++ b/lib/components/create_snapshot_dialog.dart
@@ -225,6 +225,12 @@ String _loadingDialogDescription(
   bool isArConnectProfile,
 ) {
   if (state is ComputingSnapshotData) {
+    if (state.totalTransactions > 0) {
+      return appLocalizationsOf(context).snapshotProcessingProgress(
+        state.processedTransactions,
+        state.totalTransactions,
+      );
+    }
     return appLocalizationsOf(context).thisMayTakeAWhile;
   } else if (state is PreparingAndSigningTransaction) {
     if (isArConnectProfile) {

--- a/lib/components/file_download_dialog.dart
+++ b/lib/components/file_download_dialog.dart
@@ -151,14 +151,45 @@ class FileDownloadDialog extends StatelessWidget {
           } else if (state is FileDownloadInProgress) {
             return _fileDownloadInProgressDialog(context, state);
           } else if (state is FileDownloadFailure) {
-            if (state.reason == FileDownloadFailureReason.unknownError) {
-              return _fileDownloadFailedDialog(context);
-            } else if (state.reason ==
-                FileDownloadFailureReason.browserDoesNotSupportLargeDownloads) {
-              return _fileDownloadFailedDueToAboveBrowserLimit(context);
+            switch (state.reason) {
+              case FileDownloadFailureReason.unknownError:
+                return _retryableFailureDialog(
+                  context,
+                  title: appLocalizationsOf(context).fileFailedToDownload,
+                  description:
+                      appLocalizationsOf(context).tryAgainDownloadingFile,
+                );
+              case FileDownloadFailureReason.networkConnectionError:
+                return _retryableFailureDialog(
+                  context,
+                  title: appLocalizationsOf(context).downloadNetworkError,
+                  description: appLocalizationsOf(context)
+                      .downloadNetworkErrorDescription,
+                );
+              case FileDownloadFailureReason.rateLimited:
+                return _retryableFailureDialog(
+                  context,
+                  title: appLocalizationsOf(context).downloadRateLimited,
+                  description: appLocalizationsOf(context)
+                      .downloadRateLimitedDescription,
+                );
+              case FileDownloadFailureReason.fileNotFound:
+                return _modalWrapper(
+                  title: appLocalizationsOf(context).downloadFileNotFound,
+                  description: appLocalizationsOf(context)
+                      .downloadFileNotFoundDescription,
+                  actions: [
+                    ModalAction(
+                      action: () => Navigator.pop(context),
+                      title: appLocalizationsOf(context).ok,
+                    ),
+                  ],
+                );
+              case FileDownloadFailureReason.fileAboveLimit:
+                return _fileDownloadFailedDueToFileAbovePrivateLimit(context);
+              case FileDownloadFailureReason.browserDoesNotSupportLargeDownloads:
+                return _fileDownloadFailedDueToAboveBrowserLimit(context);
             }
-
-            return _fileDownloadFailedDueToFileAbovePrivateLimit(context);
           } else if (state is FileDownloadWarning) {
             return _warningToWaitDownloadFinishes(context);
           } else if (state is FileDownloadAborted) {
@@ -169,14 +200,23 @@ class FileDownloadDialog extends StatelessWidget {
         },
       );
 
-  ArDriveStandardModalNew _fileDownloadFailedDialog(BuildContext context) {
+  ArDriveStandardModalNew _retryableFailureDialog(
+    BuildContext context, {
+    required String title,
+    required String description,
+  }) {
     return _modalWrapper(
-      title: appLocalizationsOf(context).fileFailedToDownload,
-      description: appLocalizationsOf(context).tryAgainDownloadingFile,
+      title: title,
+      description: description,
       actions: [
         ModalAction(
           action: () => Navigator.pop(context),
-          title: appLocalizationsOf(context).ok,
+          title: appLocalizationsOf(context).cancel,
+        ),
+        ModalAction(
+          action: () =>
+              context.read<FileDownloadCubit>().retryDownload(),
+          title: appLocalizationsOf(context).tryAgain,
         ),
       ],
     );

--- a/lib/components/file_download_dialog.dart
+++ b/lib/components/file_download_dialog.dart
@@ -337,7 +337,7 @@ class FileDownloadDialog extends StatelessWidget {
       BuildContext context, FileDownloadFinishedWithSuccess state) {
     return _modalWrapper(
       title: appLocalizationsOf(context).downloadFinished,
-      description: appLocalizationsOf(context).downloadFinished,
+      description: state.fileName,
       actions: [
         ModalAction(
           action: () {

--- a/lib/components/file_share_dialog.dart
+++ b/lib/components/file_share_dialog.dart
@@ -40,121 +40,142 @@ class FileShareDialogState extends State<FileShareDialog> {
   final shareLinkController = TextEditingController();
 
   @override
-  Widget build(BuildContext context) =>
-      BlocConsumer<FileShareCubit, FileShareState>(
-        listener: (context, state) {
-          if (state is FileShareLoadSuccess) {
-            shareLinkController.text = state.fileShareLink.toString();
-          }
-        },
-        builder: (context, state) => ArDriveStandardModal(
-          width: kLargeDialogWidth,
-          title: appLocalizationsOf(context).shareFileWithOthers,
-          description: state is FileShareLoadSuccess ? state.fileName : null,
-          content: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              if (state is FileShareLoadInProgress)
-                const Center(child: CircularProgressIndicator())
-              else if (state is FileShareLoadedFailedFile)
-                Text(appLocalizationsOf(context).shareFailedFile)
-              else if (state is FileShareLoadSuccess) ...{
-                if (state.isPending)
-                  Padding(
-                    padding: const EdgeInsets.only(bottom: 8.0),
-                    child: Row(
-                      children: [
-                        ArDriveIcons.triangle(
-                          color: ArDriveTheme.of(context)
-                              .themeData
-                              .colors
-                              .themeWarningEmphasis,
-                        ),
-                        const SizedBox(
-                          width: 8,
-                        ),
-                        Flexible(
-                          child: Text(
-                            'Warning: This file is currently pending and may not be immediately accessible.',
-                            style: ArDriveTypography.body.buttonNormalBold(
-                              color: ArDriveTheme.of(context)
-                                  .themeData
-                                  .colors
-                                  .themeWarningEmphasis,
-                            ),
+  Widget build(BuildContext context) {
+    final typography = ArDriveTypographyNew.of(context);
+    final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
+
+    return BlocConsumer<FileShareCubit, FileShareState>(
+      listener: (context, state) {
+        if (state is FileShareLoadSuccess) {
+          shareLinkController.text = state.fileShareLink.toString();
+        }
+      },
+      builder: (context, state) => ArDriveStandardModalNew(
+        width: kLargeDialogWidth,
+        title: appLocalizationsOf(context).shareFileWithOthers,
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (state is FileShareLoadSuccess)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 16),
+                child: Text(
+                  state.fileName,
+                  style: typography.paragraphNormal(
+                    fontWeight: ArFontWeight.semiBold,
+                    color: colorTokens.textHigh,
+                  ),
+                ),
+              ),
+            if (state is FileShareLoadInProgress)
+              const Center(child: CircularProgressIndicator())
+            else if (state is FileShareLoadedFailedFile)
+              Text(
+                appLocalizationsOf(context).shareFailedFile,
+                style: typography.paragraphNormal(
+                  color: colorTokens.textMid,
+                ),
+              )
+            else if (state is FileShareLoadedPendingFile)
+              Text(
+                appLocalizationsOf(context).sharePendingFile,
+                style: typography.paragraphNormal(
+                  color: colorTokens.textMid,
+                ),
+              )
+            else if (state is FileShareLoadSuccess) ...{
+              if (state.isPending)
+                Container(
+                  padding: const EdgeInsets.all(12),
+                  margin: const EdgeInsets.only(bottom: 16),
+                  decoration: BoxDecoration(
+                    color: colorTokens.containerL1,
+                    borderRadius: BorderRadius.circular(6),
+                  ),
+                  child: Row(
+                    children: [
+                      ArDriveIcons.triangle(
+                        size: 16,
+                        color: colorTokens.strokeRed,
+                      ),
+                      const SizedBox(width: 8),
+                      Flexible(
+                        child: Text(
+                          // TODO(PE-9103): extract to ARB localization files
+                          'Warning: This file is currently pending and may not be immediately accessible.',
+                          style: typography.paragraphSmall(
+                            fontWeight: ArFontWeight.semiBold,
+                            color: colorTokens.strokeRed,
                           ),
                         ),
-                      ],
+                      ),
+                    ],
+                  ),
+                ),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Expanded(
+                    child: ArDriveTextFieldNew(
+                      controller: shareLinkController,
+                      isEnabled: false,
                     ),
                   ),
-                Row(
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [
-                    Expanded(
-                      child: ArDriveTextField(
-                        controller: shareLinkController,
-                        isEnabled: false,
-                      ),
+                  const SizedBox(width: 16),
+                  CopyButton(
+                    positionX: 4,
+                    positionY: 40,
+                    copyMessageColor: colorTokens.containerRed,
+                    showCopyText: true,
+                    text: () {
+                      shareLinkController.selection = TextSelection(
+                        baseOffset: 0,
+                        extentOffset: shareLinkController.text.length,
+                      );
+                      return shareLinkController.text;
+                    }(),
+                    child: Text(
+                      appLocalizationsOf(context).copyLink,
+                      style: typography
+                          .paragraphNormal(
+                            fontWeight: ArFontWeight.semiBold,
+                            color: colorTokens.textMid,
+                          )
+                          .copyWith(
+                            decoration: TextDecoration.underline,
+                          ),
                     ),
-                    const SizedBox(width: 16),
-                    CopyButton(
-                      positionX: 4,
-                      positionY: 40,
-                      copyMessageColor: ArDriveTheme.of(context)
-                          .themeData
-                          .tableTheme
-                          .selectedItemColor,
-                      showCopyText: true,
-                      text: () {
-                        // Select the entire link to give the user some feedback on their action.
-                        shareLinkController.selection = TextSelection(
-                          baseOffset: 0,
-                          extentOffset: shareLinkController.text.length,
-                        );
-
-                        return shareLinkController.text;
-                      }(),
-                      child: Text(
-                        appLocalizationsOf(context).copyLink,
-                        style: ArDriveTypography.body
-                            .buttonLargeRegular(
-                              color: ArDriveTheme.of(context)
-                                  .themeData
-                                  .colors
-                                  .themeFgDefault,
-                            )
-                            .copyWith(
-                              decoration: TextDecoration.underline,
-                            ),
-                      ),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 16),
-                Text(
-                  appLocalizationsOf(context).anyoneCanAccessThisFile,
-                  style: ArDriveTypography.body.buttonNormalBold(),
-                ),
-              }
-            ],
-          ),
-          actions: [
-            if (state is FileShareLoadSuccess)
-              ModalAction(
-                action: () {
-                  Navigator.pop(context);
-                  context.read<FeedbackSurveyCubit>().openRemindMe();
-                },
-                title: appLocalizationsOf(context).doneEmphasized,
+                  ),
+                ],
               ),
-            if (state is FileShareLoadedFailedFile ||
-                state is FileShareLoadedPendingFile)
-              ModalAction(
-                action: () => Navigator.pop(context),
-                title: appLocalizationsOf(context).ok,
-              )
+              const SizedBox(height: 16),
+              Text(
+                appLocalizationsOf(context).anyoneCanAccessThisFile,
+                style: typography.paragraphSmall(
+                  color: colorTokens.textLow,
+                ),
+              ),
+            }
           ],
         ),
-      );
+        actions: [
+          if (state is FileShareLoadSuccess)
+            ModalAction(
+              action: () {
+                Navigator.pop(context);
+                context.read<FeedbackSurveyCubit>().openRemindMe();
+              },
+              title: appLocalizationsOf(context).doneEmphasized,
+            ),
+          if (state is FileShareLoadedFailedFile ||
+              state is FileShareLoadedPendingFile)
+            ModalAction(
+              action: () => Navigator.pop(context),
+              title: appLocalizationsOf(context).ok,
+            )
+        ],
+      ),
+    );
+  }
 }

--- a/lib/core/upload/uploader.dart
+++ b/lib/core/upload/uploader.dart
@@ -362,11 +362,19 @@ class UploadPaymentEvaluator {
       totalSize: dataItemSize,
     );
 
-    /// Calculate the upload with AR is not optional
-    final arCostEstimate =
-        await _uploadCostEstimateCalculatorForAR.calculateCost(
-      totalSize: dataItemSize,
-    );
+    /// Calculate the upload cost with AR (D2N). If the gateway is
+    /// unavailable, fall back to a zero estimate so the modal can still
+    /// show Turbo as an option instead of crashing entirely.
+    UploadCostEstimate arCostEstimate;
+    try {
+      arCostEstimate =
+          await _uploadCostEstimateCalculatorForAR.calculateCost(
+        totalSize: dataItemSize,
+      );
+    } catch (e) {
+      logger.e('Failed to get AR cost estimate, falling back to zero', e);
+      arCostEstimate = UploadCostEstimate.zero();
+    }
 
     final allowedDataItemSizeForTurbo = _appConfig.allowedDataItemSizeForTurbo;
 
@@ -433,11 +441,19 @@ class UploadPaymentEvaluator {
       }
     }
 
-    /// Calculate the upload with AR is not optional
-    final arCostEstimate =
-        await _uploadCostEstimateCalculatorForAR.calculateCost(
-      totalSize: arBundleSizes + arFileSizes,
-    );
+    /// Calculate the upload cost with AR (D2N). If the gateway is
+    /// unavailable, fall back to a zero estimate so the modal can still
+    /// show Turbo as an option instead of crashing entirely.
+    UploadCostEstimate arCostEstimate;
+    try {
+      arCostEstimate =
+          await _uploadCostEstimateCalculatorForAR.calculateCost(
+        totalSize: arBundleSizes + arFileSizes,
+      );
+    } catch (e) {
+      logger.e('Failed to get AR cost estimate, falling back to zero', e);
+      arCostEstimate = UploadCostEstimate.zero();
+    }
 
     bool isFreeUploadPossibleUsingTurbo = false;
 

--- a/lib/download/ardrive_downloader.dart
+++ b/lib/download/ardrive_downloader.dart
@@ -1,20 +1,19 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import 'package:ardrive/download/download_exceptions.dart';
 import 'package:ardrive/services/arweave/arweave.dart';
 import 'package:ardrive/sync/domain/sync_progress.dart';
 import 'package:ardrive/utils/logger.dart';
 import 'package:ardrive_crypto/ardrive_crypto.dart';
-import 'package:ardrive_http/ardrive_http.dart';
 import 'package:ardrive_io/ardrive_io.dart';
 import 'package:ardrive_utils/ardrive_utils.dart';
-import 'package:arweave/arweave.dart' as arweave;
 import 'package:arweave/utils.dart';
 import 'package:cryptography/cryptography.dart' hide Cipher;
 
 abstract class ArDriveDownloader {
   Future<Stream<double>> downloadFile({
-    required TransactionCommonMixin dataTx,
+    required String txId,
     required int fileSize,
     required String fileName,
     required DateTime lastModifiedDate,
@@ -24,9 +23,10 @@ abstract class ArDriveDownloader {
     SecretKey? fileKey,
     String? cipher,
     String? cipherIvString,
+    bool verifyDownload,
   });
   Future<Uint8List> downloadToMemory({
-    required TransactionCommonMixin dataTx,
+    required String txId,
     required int fileSize,
     required String fileName,
     required DateTime lastModifiedDate,
@@ -36,6 +36,7 @@ abstract class ArDriveDownloader {
     SecretKey? fileKey,
     String? cipher,
     String? cipherIvString,
+    bool verifyDownload,
   });
   Future<void> abortDownload();
 
@@ -65,7 +66,7 @@ class _ArDriveDownloader implements ArDriveDownloader {
 
   @override
   Future<Stream<double>> downloadFile({
-    required TransactionCommonMixin dataTx,
+    required String txId,
     required int fileSize,
     required String fileName,
     required DateTime lastModifiedDate,
@@ -75,21 +76,25 @@ class _ArDriveDownloader implements ArDriveDownloader {
     SecretKey? fileKey,
     String? cipher,
     String? cipherIvString,
+    bool verifyDownload = false,
   }) async {
     if (AppPlatform.isMobile) {
       final isPrivateFile =
           fileKey != null && cipher != null && cipherIvString != null;
 
       if (isPrivateFile && cipher == Cipher.aes256gcm) {
+        final downloadResponse =
+            await _arweave.gatewayFallback.downloadWithFallback(
+          txId: txId,
+          primaryClient: _arweave.client,
+          onProgress: (progress, speed) => logger.d(progress.toString()),
+          verifyDownload: verifyDownload,
+        );
+
         return _getDartVMGCMDecryptStream(
           cipher,
           cipherIvString,
-          (await arweave.download(
-            txId: dataTx.id,
-            arweave: _arweave.client,
-            onProgress: (progress, speed) => logger.d(progress.toString()),
-          ))
-              .$1,
+          _withStallDetection(downloadResponse.$1, txId),
           fileSize,
           fileName,
           lastModifiedDate,
@@ -102,10 +107,10 @@ class _ArDriveDownloader implements ArDriveDownloader {
     Stream<Uint8List> saveStream;
 
     if (isManifest) {
-      saveStream = await _getManifestStream(dataTx.id);
+      saveStream = await _getManifestStream(txId);
     } else {
       saveStream = await _getFileStream(
-        dataTx: dataTx,
+        txId: txId,
         fileSize: fileSize,
         fileName: fileName,
         lastModifiedDate: lastModifiedDate,
@@ -113,6 +118,7 @@ class _ArDriveDownloader implements ArDriveDownloader {
         fileKey: fileKey,
         cipher: cipher,
         cipherIvString: cipherIvString,
+        verifyDownload: verifyDownload,
       );
     }
 
@@ -195,17 +201,17 @@ class _ArDriveDownloader implements ArDriveDownloader {
   }
 
   Future<Stream<Uint8List>> _getManifestStream(String dataTxId) async {
-    final urlString = '${_arweave.client.api.gatewayUrl.origin}/raw/$dataTxId';
+    logger.i('The file is a manifest. Downloading with gateway fallback...');
 
-    logger.i('The file is a manifest. Downloading it from $urlString');
+    final response = await _arweave.gatewayFallback
+        .fetchManifestWithFallback(dataTxId, _arweave.client);
 
-    final dataRes = await ArDriveHTTP().getAsBytes(urlString);
-
-    return Stream.fromIterable([dataRes.data]);
+    return Stream.fromIterable(
+        [Uint8List.fromList(response.bodyBytes)]);
   }
 
   Future<Stream<Uint8List>> _getFileStream({
-    required TransactionCommonMixin dataTx,
+    required String txId,
     required int fileSize,
     required String fileName,
     required DateTime lastModifiedDate,
@@ -213,22 +219,24 @@ class _ArDriveDownloader implements ArDriveDownloader {
     SecretKey? fileKey,
     String? cipher,
     String? cipherIvString,
+    bool verifyDownload = false,
   }) async {
     logger.d('The file is not a manifest. Downloading it from Arweave...');
 
-    /// Disables the verification when the file was uploaded by the CLI
-    final verifyDownload = dataTx.getTag(EntityTag.appName) == 'ArDrive-CLI';
-
     logger.d('verifying download: $verifyDownload');
 
-    final streamDownloadResponse = await arweave.download(
-      txId: dataTx.id,
-      arweave: _arweave.client,
+    final streamDownloadResponse =
+        await _arweave.gatewayFallback.downloadWithFallback(
+      txId: txId,
+      primaryClient: _arweave.client,
       onProgress: (progress, speed) => logger.d(progress.toString()),
       verifyDownload: verifyDownload,
     );
 
-    final streamDownload = streamDownloadResponse.$1;
+    final rawStream = streamDownloadResponse.$1;
+
+    // Wrap with stall detection — throw if no chunk arrives within 60s
+    final streamDownload = _withStallDetection(rawStream, txId);
 
     final isPrivateFile =
         fileKey != null && cipher != null && cipherIvString != null;
@@ -261,6 +269,57 @@ class _ArDriveDownloader implements ArDriveDownloader {
 
     logger.d('No cipher found. Saving file as is...');
     return streamDownload.transform(listIntToUint8ListTransformer);
+  }
+
+  static const _stallTimeout = Duration(seconds: 60);
+
+  /// Wraps a download stream with stall detection. After the first chunk
+  /// arrives, if no subsequent chunk arrives within [_stallTimeout], emits
+  /// a [DownloadStalledException]. If the stream completes before any chunks
+  /// (empty file), no stall error is raised.
+  Stream<List<int>> _withStallDetection(
+      Stream<List<int>> source, String txId) {
+    final controller = StreamController<List<int>>();
+    Timer? stallTimer;
+    late final StreamSubscription<List<int>> subscription;
+
+    void resetTimer() {
+      stallTimer?.cancel();
+      stallTimer = Timer(_stallTimeout, () {
+        subscription.cancel();
+        if (!controller.isClosed) {
+          controller.addError(DownloadStalledException(txId, _stallTimeout));
+          controller.close();
+        }
+      });
+    }
+
+    subscription = source.listen(
+      (chunk) {
+        if (controller.isClosed) return;
+        resetTimer();
+        controller.add(chunk);
+      },
+      onError: (Object e, StackTrace s) {
+        stallTimer?.cancel();
+        if (!controller.isClosed) {
+          controller.addError(e, s);
+        }
+      },
+      onDone: () {
+        stallTimer?.cancel();
+        if (!controller.isClosed) {
+          controller.close();
+        }
+      },
+    );
+
+    controller.onCancel = () {
+      stallTimer?.cancel();
+      subscription.cancel();
+    };
+
+    return controller.stream;
   }
 
   Stream<double> _getDartVMGCMDecryptStream(
@@ -299,7 +358,7 @@ class _ArDriveDownloader implements ArDriveDownloader {
 
   @override
   Future<Uint8List> downloadToMemory({
-    required TransactionCommonMixin dataTx,
+    required String txId,
     required int fileSize,
     required String fileName,
     required DateTime lastModifiedDate,
@@ -309,9 +368,10 @@ class _ArDriveDownloader implements ArDriveDownloader {
     SecretKey? fileKey,
     String? cipher,
     String? cipherIvString,
+    bool verifyDownload = false,
   }) async {
     final stream = await _getFileStream(
-      dataTx: dataTx,
+      txId: txId,
       fileSize: fileSize,
       fileName: fileName,
       lastModifiedDate: lastModifiedDate,
@@ -319,6 +379,7 @@ class _ArDriveDownloader implements ArDriveDownloader {
       fileKey: fileKey,
       cipher: cipher,
       cipherIvString: cipherIvString,
+      verifyDownload: verifyDownload,
     );
 
     final data = await stream.toList();

--- a/lib/download/ardrive_downloader.dart
+++ b/lib/download/ardrive_downloader.dart
@@ -160,11 +160,13 @@ class _ArDriveDownloader implements ArDriveDownloader {
     });
 
     subscription.onDone(() async {
-      if (_cancelWithReason.isCompleted) {
+      if (_cancelWithReason.isCompleted || saveResult == false) {
         progressController.addError(const DownloadCancelledException());
       }
 
-      logger.d('File saved with success');
+      if (saveResult != false) {
+        logger.d('File saved with success');
+      }
 
       progressController.close();
       subscription.cancel();

--- a/lib/download/download_exceptions.dart
+++ b/lib/download/download_exceptions.dart
@@ -1,0 +1,39 @@
+/// All gateways returned 404 for this transaction.
+class DownloadFileNotFoundException implements Exception {
+  final String txId;
+  const DownloadFileNotFoundException(this.txId);
+
+  @override
+  String toString() => 'File not found on any gateway: $txId';
+}
+
+/// All gateways failed with network/timeout/5xx errors.
+class DownloadNetworkException implements Exception {
+  final String txId;
+  final String? lastError;
+  const DownloadNetworkException(this.txId, [this.lastError]);
+
+  @override
+  String toString() =>
+      'All gateways failed for download $txId: ${lastError ?? 'unknown'}';
+}
+
+/// Rate-limited by gateway(s) and all fallbacks also failed.
+class DownloadRateLimitException implements Exception {
+  final String txId;
+  const DownloadRateLimitException(this.txId);
+
+  @override
+  String toString() => 'Rate limited on all gateways for download: $txId';
+}
+
+/// Download stream started but no bytes received within timeout.
+class DownloadStalledException implements Exception {
+  final String txId;
+  final Duration timeout;
+  const DownloadStalledException(this.txId, this.timeout);
+
+  @override
+  String toString() =>
+      'Download stalled for $txId: no data for ${timeout.inSeconds}s';
+}

--- a/lib/download/multiple_file_download_modal.dart
+++ b/lib/download/multiple_file_download_modal.dart
@@ -48,7 +48,6 @@ promptToDownloadMultipleFiles(
       )..add(
           StartDownload(
             selectedItems,
-            // folderName: driveDetail.folderInView.folder.name,
             zipName: zipName,
           ),
         ),
@@ -69,8 +68,78 @@ class MultipleFilesDownload extends StatefulWidget {
 class _MultipleFilesDownloadState extends State<MultipleFilesDownload> {
   final _scrollController = ScrollController();
 
+  Widget _buildFileListItem(
+    dynamic file,
+    ArdriveTypographyNew typography,
+    ArDriveColorTokens colorTokens,
+  ) {
+    final isFile = file is MultiDownloadFile;
+    final name = isFile ? file.fileName : (file as MultiDownloadFolder).folderPath;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      margin: const EdgeInsets.only(bottom: 4),
+      decoration: BoxDecoration(
+        color: colorTokens.containerL1,
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            isFile ? Icons.insert_drive_file_outlined : Icons.folder_outlined,
+            size: 16,
+            color: colorTokens.textLow,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              name,
+              style: typography.paragraphSmall(
+                fontWeight: ArFontWeight.semiBold,
+                color: colorTokens.textHigh,
+              ),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          if (isFile)
+            Text(
+              filesize(file.size),
+              style: typography.paragraphSmall(
+                color: colorTokens.textLow,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFileList(
+    List<dynamic> files,
+    ArdriveTypographyNew typography,
+    ArDriveColorTokens colorTokens,
+  ) {
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxHeight: 256),
+      child: ArDriveScrollBar(
+        controller: _scrollController,
+        alwaysVisible: true,
+        child: ListView.builder(
+          padding: EdgeInsets.zero,
+          controller: _scrollController,
+          shrinkWrap: true,
+          itemCount: files.length,
+          itemBuilder: (context, index) =>
+              _buildFileListItem(files[index], typography, colorTokens),
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
+    final typography = ArDriveTypographyNew.of(context);
+    final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
+
     return BlocListener<MultipleDownloadBloc, MultipleDownloadState>(
       listener: (context, state) async {
         if (state is MultipleDownloadFinishedWithSuccess) {
@@ -82,7 +151,6 @@ class _MultipleFilesDownloadState extends State<MultipleFilesDownload> {
             lastModifiedDate: state.lastModified,
           );
 
-          // Close modal when save file
           io.saveFile(file).then((value) {
             if (state.skippedFiles.isEmpty) {
               Navigator.pop(context);
@@ -92,11 +160,8 @@ class _MultipleFilesDownloadState extends State<MultipleFilesDownload> {
       },
       child: BlocBuilder<MultipleDownloadBloc, MultipleDownloadState>(
         builder: (context, state) {
-          late Widget content;
-          List<ModalAction> actions = [];
-
           if (state is MultipleDownloadInProgress) {
-            return ArDriveStandardModal(
+            return ArDriveStandardModalNew(
               width: 408,
               title: appLocalizationsOf(context)
                   .multiDownloadDownloadingFilesProgress(
@@ -105,56 +170,7 @@ class _MultipleFilesDownloadState extends State<MultipleFilesDownload> {
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Align(
-                    alignment: Alignment.topCenter,
-                    child: ConstrainedBox(
-                      constraints: const BoxConstraints(maxHeight: 256),
-                      child: ArDriveScrollBar(
-                          controller: _scrollController,
-                          alwaysVisible: true,
-                          child: ListView.builder(
-                            padding: const EdgeInsets.only(top: 0),
-                            controller: _scrollController,
-                            shrinkWrap: true,
-                            itemCount: state.files.length,
-                            itemBuilder: (BuildContext context, int index) {
-                              final file = state.files[index];
-                              return Row(
-                                children: [
-                                  Flexible(
-                                    child: Text(
-                                      file is MultiDownloadFile
-                                          ? '${file.fileName} '
-                                          : (file as MultiDownloadFolder)
-                                              .folderPath,
-                                      style: ArDriveTypography.body.smallBold(
-                                        color: ArDriveTheme.of(context)
-                                            .themeData
-                                            .colors
-                                            .themeFgSubtle,
-                                      ),
-                                    ),
-                                  ),
-                                  if (file is MultiDownloadFile)
-                                    Padding(
-                                      padding: const EdgeInsets.only(right: 16),
-                                      child: Text(
-                                        filesize(file.size),
-                                        style:
-                                            ArDriveTypography.body.smallRegular(
-                                          color: ArDriveTheme.of(context)
-                                              .themeData
-                                              .colors
-                                              .themeFgMuted,
-                                        ),
-                                      ),
-                                    )
-                                ],
-                              );
-                            },
-                          )),
-                    ),
-                  )
+                  _buildFileList(state.files, typography, colorTokens),
                 ],
               ),
               actions: [
@@ -170,8 +186,7 @@ class _MultipleFilesDownloadState extends State<MultipleFilesDownload> {
               ],
             );
           } else if (state is MultipleDownloadFinishedWithSuccess) {
-            // should only get here if there are skipped files
-            return ArDriveStandardModal(
+            return ArDriveStandardModalNew(
               width: 408,
               title: appLocalizationsOf(context)
                   .multiDownloadCompleteWithSkippedFiles(
@@ -180,53 +195,7 @@ class _MultipleFilesDownloadState extends State<MultipleFilesDownload> {
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Align(
-                    alignment: Alignment.topCenter,
-                    child: ConstrainedBox(
-                      constraints: const BoxConstraints(maxHeight: 256),
-                      child: ArDriveScrollBar(
-                          controller: _scrollController,
-                          alwaysVisible: true,
-                          child: ListView.builder(
-                            padding: const EdgeInsets.only(top: 0),
-                            controller: _scrollController,
-                            shrinkWrap: true,
-                            itemCount: state.skippedFiles.length,
-                            itemBuilder: (BuildContext context, int index) {
-                              final file = state.skippedFiles[index];
-                              return Row(
-                                children: [
-                                  Flexible(
-                                    child: Text(
-                                      file is MultiDownloadFile
-                                          ? '${file.fileName} '
-                                          : (file as MultiDownloadFolder)
-                                              .folderPath,
-                                      style: ArDriveTypography.body.smallBold(
-                                        color: ArDriveTheme.of(context)
-                                            .themeData
-                                            .colors
-                                            .themeFgSubtle,
-                                      ),
-                                    ),
-                                  ),
-                                  if (file is MultiDownloadFile)
-                                    Text(
-                                      filesize(file.size),
-                                      style:
-                                          ArDriveTypography.body.smallRegular(
-                                        color: ArDriveTheme.of(context)
-                                            .themeData
-                                            .colors
-                                            .themeFgMuted,
-                                      ),
-                                    ),
-                                ],
-                              );
-                            },
-                          )),
-                    ),
-                  )
+                  _buildFileList(state.skippedFiles, typography, colorTokens),
                 ],
               ),
               actions: [
@@ -239,67 +208,94 @@ class _MultipleFilesDownloadState extends State<MultipleFilesDownload> {
               ],
             );
           } else if (state is MultipleDownloadFailure) {
+            late Widget content;
             bool showRetryAndSkip = true;
+
             switch (state.reason) {
               case FileDownloadFailureReason.fileAboveLimit:
                 content = Text(
                   appLocalizationsOf(context)
                       .fileFailedToDownloadFileAbovePublicLimit,
+                  style: typography.paragraphNormal(
+                    color: colorTokens.textMid,
+                  ),
                 );
                 showRetryAndSkip = false;
                 break;
               case FileDownloadFailureReason.fileNotFound:
-                content =
-                    Text(appLocalizationsOf(context).tryAgainDownloadingFile);
+                content = Text(
+                  appLocalizationsOf(context).tryAgainDownloadingFile,
+                  style: typography.paragraphNormal(
+                    color: colorTokens.textMid,
+                  ),
+                );
                 break;
               case FileDownloadFailureReason.networkConnectionError:
                 content = Text(
-                    appLocalizationsOf(context).multiDownloadErrorTryAgain);
+                  appLocalizationsOf(context).multiDownloadErrorTryAgain,
+                  style: typography.paragraphNormal(
+                    color: colorTokens.textMid,
+                  ),
+                );
                 break;
               default:
-                content = Text(appLocalizationsOf(context).fileDownloadFailed);
+                content = Text(
+                  appLocalizationsOf(context).fileDownloadFailed,
+                  style: typography.paragraphNormal(
+                    color: colorTokens.textMid,
+                  ),
+                );
             }
 
-            actions = [
-              ModalAction(
-                action: () {
-                  context
-                      .read<MultipleDownloadBloc>()
-                      .add(const CancelDownload());
-                  Navigator.pop(context);
-                },
-                title: appLocalizationsOf(context).cancel,
-              ),
-              if (showRetryAndSkip) ...[
+            return ArDriveStandardModalNew(
+              title: appLocalizationsOf(context).download,
+              content: content,
+              actions: [
                 ModalAction(
                   action: () {
                     context
                         .read<MultipleDownloadBloc>()
-                        .add(const ResumeDownload());
+                        .add(const CancelDownload());
+                    Navigator.pop(context);
                   },
-                  title: appLocalizationsOf(context).tryAgain,
+                  title: appLocalizationsOf(context).cancel,
                 ),
-                ModalAction(
-                  action: () {
-                    context
-                        .read<MultipleDownloadBloc>()
-                        .add(const SkipFileAndResumeDownload());
-                  },
-                  title: appLocalizationsOf(context).skip,
-                ),
-              ]
-            ];
-          } else {
-            content = Text(
-              appLocalizationsOf(context).download,
-              style: ArDriveTypography.body.buttonLargeBold(),
+                if (showRetryAndSkip) ...[
+                  ModalAction(
+                    action: () {
+                      context
+                          .read<MultipleDownloadBloc>()
+                          .add(const ResumeDownload());
+                    },
+                    title: appLocalizationsOf(context).tryAgain,
+                  ),
+                  ModalAction(
+                    action: () {
+                      context
+                          .read<MultipleDownloadBloc>()
+                          .add(const SkipFileAndResumeDownload());
+                    },
+                    title: appLocalizationsOf(context).skip,
+                  ),
+                ]
+              ],
             );
           }
 
-          return ArDriveStandardModal(
+          return ArDriveStandardModalNew(
             title: appLocalizationsOf(context).download,
-            content: content,
-            actions: actions,
+            content: Text(
+              appLocalizationsOf(context).download,
+              style: typography.paragraphNormal(
+                color: colorTokens.textMid,
+              ),
+            ),
+            actions: [
+              ModalAction(
+                action: () => Navigator.pop(context),
+                title: appLocalizationsOf(context).close,
+              ),
+            ],
           );
         },
       ),

--- a/lib/drive_explorer/thumbnail/repository/thumbnail_repository.dart
+++ b/lib/drive_explorer/thumbnail/repository/thumbnail_repository.dart
@@ -73,9 +73,9 @@ class ThumbnailRepository {
   Future<Uint8List> _getThumbnailData({
     required FileDataTableItem fileDataTableItem,
   }) async {
-    final dataTx = await _arweaveService.getTransactionDetails(
-      fileDataTableItem.thumbnail!.variants.first.txId,
-    );
+    // Thumbnails are always for private files — need cipher/IV from data tx
+    final thumbnailTxId = fileDataTableItem.thumbnail!.variants.first.txId;
+    final dataTx = await _arweaveService.getTransactionDetails(thumbnailTxId);
 
     if (dataTx == null) {
       throw Exception('Data transaction not found');
@@ -85,7 +85,7 @@ class ThumbnailRepository {
         fileDataTableItem.driveId, _arDriveAuth.currentUser.cipherKey);
 
     return await _arDriveDownloader.downloadToMemory(
-      dataTx: dataTx,
+      txId: thumbnailTxId,
       fileSize: fileDataTableItem.thumbnail!.variants.first.size,
       fileName: fileDataTableItem.name,
       lastModifiedDate: fileDataTableItem.lastModifiedDate,
@@ -104,10 +104,9 @@ class ThumbnailRepository {
           ..where((tbl) => tbl.id.equals(fileId)))
         .getSingle();
 
-    final dataTx =
-        await _arweaveService.getTransactionDetails(fileEntry.dataTxId);
-
     SecretKey? fileKey;
+    String? cipher;
+    String? cipherIv;
 
     final drive =
         await _driveDao.driveById(driveId: fileEntry.driveId).getSingle();
@@ -123,20 +122,29 @@ class ThumbnailRepository {
         driveKey!.key,
         fileEntry.id,
       );
+
+      // Private files need cipher/IV tags from the data transaction
+      final dataTx =
+          await _arweaveService.getTransactionDetails(fileEntry.dataTxId);
+      if (dataTx == null) {
+        throw Exception('Data transaction not found for ${fileEntry.dataTxId}');
+      }
+      cipher = dataTx.getTag(EntityTag.cipher);
+      cipherIv = dataTx.getTag(EntityTag.cipherIv);
     }
 
     logger.d('Downloading file to memory');
 
     final bytes = await _arDriveDownloader.downloadToMemory(
-      dataTx: dataTx!,
+      txId: fileEntry.dataTxId,
       fileSize: fileEntry.size,
       fileName: fileEntry.name,
       lastModifiedDate: fileEntry.lastModifiedDate,
       contentType: fileEntry.dataContentType!,
       isManifest: false,
       fileKey: fileKey,
-      cipher: dataTx.getTag(EntityTag.cipher),
-      cipherIvString: dataTx.getTag(EntityTag.cipherIv),
+      cipher: cipher,
+      cipherIvString: cipherIv,
     );
 
     logger.d('Generating thumbnail');

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -866,6 +866,30 @@
   "@fileFailedToDownloadFileAbovePublicLimit": {
     "description": "Download failure message when a file is too big"
   },
+  "downloadNetworkError": "Network Error",
+  "@downloadNetworkError": {
+    "description": "Title for network error during download"
+  },
+  "downloadNetworkErrorDescription": "Could not connect to the download server. Please check your connection and try again.",
+  "@downloadNetworkErrorDescription": {
+    "description": "Description for network error during download"
+  },
+  "downloadFileNotFound": "File Not Found",
+  "@downloadFileNotFound": {
+    "description": "Title when downloaded file is not found on any gateway"
+  },
+  "downloadFileNotFoundDescription": "This file could not be found on the network. It may have been uploaded recently and is still being processed.",
+  "@downloadFileNotFoundDescription": {
+    "description": "Description when downloaded file is not found"
+  },
+  "downloadRateLimited": "Too Many Requests",
+  "@downloadRateLimited": {
+    "description": "Title when download is rate limited"
+  },
+  "downloadRateLimitedDescription": "The download server is busy. Please wait a moment and try again.",
+  "@downloadRateLimitedDescription": {
+    "description": "Description when download is rate limited"
+  },
   "fileHadANewRevision": "A new version of this file was uploaded.",
   "@fileHadANewRevision": {
     "description": "File activity (journal): new revision"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2302,6 +2302,18 @@
   "@thisMayTakeAWhile": {
     "description": "Uploading may take a while"
   },
+  "snapshotProcessingProgress": "Processing {processed} of {total} transactions...",
+  "@snapshotProcessingProgress": {
+    "description": "Progress text during snapshot data computation",
+    "placeholders": {
+      "processed": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "tooLargeForUpload": "Too large for upload:",
   "@tooLargeForUpload": {
     "description": "Files too large for upload"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2262,6 +2262,24 @@
       }
     }
   },
+  "syncCheckingForChanges": "Checking for changes...",
+  "@syncCheckingForChanges": {
+    "description": "Status message shown during drive activity probe"
+  },
+  "retryFailedDrives": "Retry Failed",
+  "@retryFailedDrives": {
+    "description": "Button to retry syncing only the drives that failed"
+  },
+  "syncElapsedTime": "{seconds}s elapsed",
+  "@syncElapsedTime": {
+    "description": "Elapsed time shown during sync after 5 seconds",
+    "placeholders": {
+      "seconds": {
+        "type": "String",
+        "example": "45"
+      }
+    }
+  },
   "syncProgressPercentage": "{percentage}% complete",
   "@syncProgressPercentage": {
     "description": "The sync progress percentage",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1764,6 +1764,9 @@
   "@syncingPleaseWait": {
     "description": "Syncing drives"
   },
+  "syncCheckingForChanges": "Comprobando cambios...",
+  "retryFailedDrives": "Reintentar",
+  "syncElapsedTime": "{seconds}s transcurridos",
   "syncProgressPercentage": "{percentage}% completado",
   "@syncProgressPercentage": {
     "description": "The sync progress percentage",

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -1764,6 +1764,9 @@
   "@syncingPleaseWait": {
     "description": "Syncing drives"
   },
+  "syncCheckingForChanges": "परिवर्तनों की जाँच हो रही है...",
+  "retryFailedDrives": "पुनः प्रयास करें",
+  "syncElapsedTime": "{seconds}s बीत चुके",
   "syncProgressPercentage": "{percentage}% पूरा हुआ",
   "@syncProgressPercentage": {
     "description": "The sync progress percentage",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1764,6 +1764,9 @@
   "@syncingPleaseWait": {
     "description": "Syncing drives"
   },
+  "syncCheckingForChanges": "変更を確認中...",
+  "retryFailedDrives": "再試行",
+  "syncElapsedTime": "{seconds}秒経過",
   "syncProgressPercentage": "{percentage}%完了",
   "@syncProgressPercentage": {
     "description": "The sync progress percentage",

--- a/lib/l10n/app_zh-HK.arb
+++ b/lib/l10n/app_zh-HK.arb
@@ -1764,6 +1764,9 @@
   "@syncingPleaseWait": {
     "description": "Syncing drives"
   },
+  "syncCheckingForChanges": "正在檢查變更...",
+  "retryFailedDrives": "重試失敗",
+  "syncElapsedTime": "已用時{seconds}秒",
   "syncProgressPercentage": "{percentage}% 完成",
   "@syncProgressPercentage": {
     "description": "The sync progress percentage",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1764,6 +1764,9 @@
   "@syncingPleaseWait": {
     "description": "Syncing drives"
   },
+  "syncCheckingForChanges": "正在检查更改...",
+  "retryFailedDrives": "重试失败",
+  "syncElapsedTime": "已用时{seconds}秒",
   "syncProgressPercentage": "{percentage}% 完成度",
   "@syncProgressPercentage": {
     "description": "The sync progress percentage",

--- a/lib/models/daos/drive_dao/drive_dao.dart
+++ b/lib/models/daos/drive_dao/drive_dao.dart
@@ -121,6 +121,38 @@ class DriveDao extends DatabaseAccessor<Database> with _$DriveDaoMixin {
     }
   }
 
+  /// Bulk-loads ALL latest file revisions for a drive into a map keyed by fileId.
+  Future<Map<String, FileRevision>> getAllLatestFileRevisionsMap(
+      String driveId) async {
+    final revisions =
+        await allLatestFileRevisionsByDriveId(driveId: driveId).get();
+    return {for (final rev in revisions) rev.fileId: rev};
+  }
+
+  /// Bulk-loads ALL oldest file revisions for a drive into a map keyed by fileId.
+  Future<Map<String, FileRevision>> getAllOldestFileRevisionsMap(
+      String driveId) async {
+    final revisions =
+        await allOldestFileRevisionsByDriveId(driveId: driveId).get();
+    return {for (final rev in revisions) rev.fileId: rev};
+  }
+
+  /// Bulk-loads ALL latest folder revisions for a drive into a map keyed by folderId.
+  Future<Map<String, FolderRevision>> getAllLatestFolderRevisionsMap(
+      String driveId) async {
+    final revisions =
+        await allLatestFolderRevisionsByDriveId(driveId: driveId).get();
+    return {for (final rev in revisions) rev.folderId: rev};
+  }
+
+  /// Bulk-loads ALL oldest folder revisions for a drive into a map keyed by folderId.
+  Future<Map<String, FolderRevision>> getAllOldestFolderRevisionsMap(
+      String driveId) async {
+    final revisions =
+        await allOldestFolderRevisionsByDriveId(driveId: driveId).get();
+    return {for (final rev in revisions) rev.folderId: rev};
+  }
+
   Future<void> insertNewDriveRevisions(
     List<DriveRevisionsCompanion> revisions,
   ) async {

--- a/lib/models/database/database.dart
+++ b/lib/models/database/database.dart
@@ -30,7 +30,7 @@ class Database extends _$Database {
   Database([QueryExecutor? e]) : super(e ?? openConnection());
 
   @override
-  int get schemaVersion => 28;
+  int get schemaVersion => 29;
   @override
   MigrationStrategy get migration => MigrationStrategy(
         onCreate: (Migrator m) {
@@ -188,6 +188,18 @@ class Database extends _$Database {
               logger.d('Migrating schema from v27 to v28');
 
               await m.addColumn(profiles, profiles.sourceWalletAddress);
+            }
+
+            if (from < 29) {
+              logger.d('Migrating schema from v28 to v29');
+              logger.d('Adding sync performance indexes');
+              await customStatement('''
+                CREATE INDEX IF NOT EXISTS idx_file_revisions_data_tx_id ON file_revisions(dataTxId);
+              ''');
+              await customStatement('''
+                CREATE INDEX IF NOT EXISTS idx_network_transactions_status ON network_transactions(status);
+              ''');
+              logger.d('Sync performance indexes created');
             }
           } catch (e, stacktrace) {
             logger.e(

--- a/lib/models/queries/drive_queries.drift
+++ b/lib/models/queries/drive_queries.drift
@@ -81,6 +81,15 @@ fileById:
 fileRevisionByDataTx:
     SELECT * FROM file_revisions
     WHERE dataTxId = :tx;
+fileRevisionDateCreatedByDataTxIds:
+    SELECT dataTxId, dateCreated FROM file_revisions
+    WHERE dataTxId IN :txIds;
+foldersByIds:
+    SELECT * FROM folder_entries
+    WHERE id IN :folderIds;
+fileRevisionDataTxIdsByMetadataTxIds:
+    SELECT dataTxId FROM file_revisions
+    WHERE metadataTxId IN :metadataTxIds;
 licenseByTxId:
     SELECT * FROM licenses
     WHERE licenseTxId = :tx;

--- a/lib/models/queries/drive_queries.drift
+++ b/lib/models/queries/drive_queries.drift
@@ -175,6 +175,38 @@ SELECT * FROM file_entries
 WHERE assignedNames IS NOT NULL;
 
 
+allLatestFileRevisionsByDriveId:
+    SELECT fr.* FROM file_revisions fr
+    INNER JOIN (
+        SELECT fileId, MAX(dateCreated) AS maxDate
+        FROM file_revisions WHERE driveId = :driveId GROUP BY fileId
+    ) latest ON fr.fileId = latest.fileId AND fr.dateCreated = latest.maxDate
+    WHERE fr.driveId = :driveId;
+
+allOldestFileRevisionsByDriveId:
+    SELECT fr.* FROM file_revisions fr
+    INNER JOIN (
+        SELECT fileId, MIN(dateCreated) AS minDate
+        FROM file_revisions WHERE driveId = :driveId GROUP BY fileId
+    ) oldest ON fr.fileId = oldest.fileId AND fr.dateCreated = oldest.minDate
+    WHERE fr.driveId = :driveId;
+
+allLatestFolderRevisionsByDriveId:
+    SELECT fr.* FROM folder_revisions fr
+    INNER JOIN (
+        SELECT folderId, MAX(dateCreated) AS maxDate
+        FROM folder_revisions WHERE driveId = :driveId GROUP BY folderId
+    ) latest ON fr.folderId = latest.folderId AND fr.dateCreated = latest.maxDate
+    WHERE fr.driveId = :driveId;
+
+allOldestFolderRevisionsByDriveId:
+    SELECT fr.* FROM folder_revisions fr
+    INNER JOIN (
+        SELECT folderId, MIN(dateCreated) AS minDate
+        FROM folder_revisions WHERE driveId = :driveId GROUP BY folderId
+    ) oldest ON fr.folderId = oldest.folderId AND fr.dateCreated = oldest.minDate
+    WHERE fr.driveId = :driveId;
+
 deleteDriveById: DELETE FROM drives WHERE id = :driveId;
 deleteAllDriveRevisionsByDriveId:
   DELETE FROM drive_revisions

--- a/lib/models/queries/drive_queries.drift
+++ b/lib/models/queries/drive_queries.drift
@@ -170,6 +170,13 @@ pendingTransactionsForDrive:
         WHERE driveId = :driveId
     );
 
+-- File revisions of pinned files, whose data tx is owned on-chain by the
+-- original uploader (not the drive owner). Used to resolve confirmation status
+-- for these cross-owner txs without an unscoped gateway query.
+pinnedFileRevisions:
+    SELECT * FROM file_revisions
+    WHERE pinnedDataOwnerAddress IS NOT NULL;
+
 getFilesWithAssignedNames:
 SELECT * FROM file_entries
 WHERE assignedNames IS NOT NULL;

--- a/lib/models/queries/drive_queries.drift
+++ b/lib/models/queries/drive_queries.drift
@@ -177,6 +177,16 @@ pinnedFileRevisions:
     SELECT * FROM file_revisions
     WHERE pinnedDataOwnerAddress IS NOT NULL;
 
+-- File revisions whose data tx is still pending confirmation. Used to map each
+-- pending data tx to the owner of the drive it belongs to, so the confirmation
+-- query can be scoped per-tx by the actual drive owner rather than assuming the
+-- logged-in wallet owns every pending tx (which breaks for attached drives).
+pendingDataFileRevisions:
+    SELECT * FROM file_revisions
+    WHERE dataTxId IN (
+        SELECT id FROM network_transactions WHERE status = 'pending'
+    );
+
 getFilesWithAssignedNames:
 SELECT * FROM file_entries
 WHERE assignedNames IS NOT NULL;

--- a/lib/models/tables/file_revisions.drift
+++ b/lib/models/tables/file_revisions.drift
@@ -42,3 +42,5 @@ CREATE TABLE file_revisions (
     FOREIGN KEY (metadataTxId) REFERENCES network_transactions(id),
     FOREIGN KEY (dataTxId) REFERENCES network_transactions(id)
 );
+
+CREATE INDEX idx_file_revisions_data_tx_id ON file_revisions(dataTxId);

--- a/lib/models/tables/network_transactions.drift
+++ b/lib/models/tables/network_transactions.drift
@@ -7,3 +7,5 @@ CREATE TABLE network_transactions (
 
     transactionDateCreated DATETIME
 );
+
+CREATE INDEX idx_network_transactions_status ON network_transactions(status);

--- a/lib/pages/drive_detail/drive_detail_page.dart
+++ b/lib/pages/drive_detail/drive_detail_page.dart
@@ -141,8 +141,11 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
                   state.sharedDrives.isNotEmpty) {
                 final cubit = context.read<DriveDetailCubit>();
 
-                // Don't re-trigger changeDrive if we're already viewing/loading this drive
-                if (cubit.currentDriveId == state.selectedDriveId) {
+                // Don't re-trigger changeDrive if we're already viewing/loading
+                // this drive — UNLESS the drive was not found (it may have
+                // been attached since we last checked).
+                if (cubit.currentDriveId == state.selectedDriveId &&
+                    cubit.state is! DriveDetailLoadNotFound) {
                   return;
                 }
 
@@ -174,9 +177,7 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
               builder: (context, hideState) {
                 return BlocBuilder<DriveDetailCubit, DriveDetailState>(
                   buildWhen: (previous, current) {
-                    return !context.read<ActivityTracker>().isBulkImporting &&
-                        widget.context.read<SyncCubit>().state
-                            is! SyncInProgress;
+                    return !context.read<ActivityTracker>().isBulkImporting;
                   },
                   builder: (context, driveDetailState) {
                     if (driveDetailState is DriveDetailLoadEmpty) {

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -1236,6 +1236,13 @@ class ArweaveService {
   /// unresolved rather than re-queried unscoped, which would reintroduce the
   /// expensive gateway scan this scoping is meant to avoid.
   ///
+  /// [ownersByTxId] maps a transaction id to the owner it should be scoped by
+  /// (the owner of the drive the tx belongs to). It takes precedence over
+  /// [owner] per tx, letting a batch spanning multiple drives — e.g. the user's
+  /// own drives plus attached drives owned by others — be scoped correctly
+  /// instead of assuming a single owner. A tx present in neither [ownersByTxId]
+  /// nor [owner] is left unresolved rather than queried unscoped.
+  ///
   /// [verifiedSink], if provided, is progressively populated with each
   /// successfully verified confirmation (value >= 0) as the query completes —
   /// it never receives the -1 "not found" placeholders. A caller can wrap this
@@ -1246,6 +1253,7 @@ class ArweaveService {
   Future<Map<String?, int>> getTransactionConfirmations(
     List<String?> transactionIds, {
     String? owner,
+    Map<String, String>? ownersByTxId,
     Map<String, String>? ownerOverrides,
     Map<String?, int>? verifiedSink,
   }) async {
@@ -1306,8 +1314,29 @@ class ArweaveService {
       }
     }
 
-    // First pass: scoped by owner for gateway selectivity.
-    await queryConfirmations(transactionIds, owner: owner);
+    // The owner a tx should be scoped by: its per-tx owner if known, else the
+    // single [owner]. Returns null when neither is available (unscopable).
+    String? primaryOwnerFor(String? id) {
+      if (id != null && ownersByTxId != null) {
+        final mapped = ownersByTxId[id];
+        if (mapped != null) return mapped;
+      }
+      return owner;
+    }
+
+    // First pass: scope each tx by its resolved owner and query each owner
+    // once. This keeps every query selective even when the batch spans drives
+    // with different owners. A tx with no resolvable owner is left unresolved
+    // rather than queried unscoped, which would reintroduce the expensive scan.
+    final idsByPrimaryOwner = <String, List<String?>>{};
+    for (final id in transactionIds) {
+      final resolvedOwner = primaryOwnerFor(id);
+      if (resolvedOwner == null) continue;
+      idsByPrimaryOwner.putIfAbsent(resolvedOwner, () => []).add(id);
+    }
+    for (final entry in idsByPrimaryOwner.entries) {
+      await queryConfirmations(entry.value, owner: entry.key);
+    }
 
     // Second pass: for any unresolved id whose real owner we know locally
     // (currently pinned data txs), re-query scoped to that owner. This recovers
@@ -1319,13 +1348,16 @@ class ArweaveService {
     // results are merged into the already-populated map, so we swallow any
     // error and bound it with its own timeout — even if it fails or stalls,
     // the confirmations resolved by the first pass are still returned.
-    if (owner != null && ownerOverrides != null && ownerOverrides.isNotEmpty) {
+    if (ownerOverrides != null && ownerOverrides.isNotEmpty) {
       final idsByOverrideOwner = <String, List<String?>>{};
       for (final entry in transactionConfirmations.entries) {
         if (entry.value >= 0) continue;
-        final overrideOwner = ownerOverrides[entry.key];
-        if (overrideOwner == null || overrideOwner == owner) continue;
-        idsByOverrideOwner.putIfAbsent(overrideOwner, () => []).add(entry.key);
+        final txId = entry.key;
+        final overrideOwner = ownerOverrides[txId];
+        if (overrideOwner == null) continue;
+        // Skip if the tx's first-pass owner already matched its override owner.
+        if (overrideOwner == primaryOwnerFor(txId)) continue;
+        idsByOverrideOwner.putIfAbsent(overrideOwner, () => []).add(txId);
       }
 
       if (idsByOverrideOwner.isNotEmpty) {

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -1235,18 +1235,28 @@ class ArweaveService {
   /// owner — keeping every query selective. Ids with no override are left
   /// unresolved rather than re-queried unscoped, which would reintroduce the
   /// expensive gateway scan this scoping is meant to avoid.
+  ///
+  /// [verifiedSink], if provided, is progressively populated with each
+  /// successfully verified confirmation (value >= 0) as the query completes —
+  /// it never receives the -1 "not found" placeholders. A caller can wrap this
+  /// method in a timeout and, on expiry, fall back to [verifiedSink] to keep
+  /// the confirmations resolved so far instead of discarding the whole batch.
+  /// Because it holds only positive verifications, applying it after a timeout
+  /// never marks anything failed off an incomplete run.
   Future<Map<String?, int>> getTransactionConfirmations(
     List<String?> transactionIds, {
     String? owner,
     Map<String, String>? ownerOverrides,
+    Map<String?, int>? verifiedSink,
   }) async {
     final transactionConfirmations = {
       for (final transactionId in transactionIds) transactionId: -1
     };
 
     // Queries confirmation status for [ids] in chunks, writing results into
-    // [transactionConfirmations]. When [owner] is provided, the query is scoped
-    // to that owner so the gateway can prune its search space.
+    // [transactionConfirmations] (and [verifiedSink] for resolved ids). When
+    // [owner] is provided, the query is scoped to that owner so the gateway can
+    // prune its search space.
     Future<void> queryConfirmations(List<String?> ids, {String? owner}) async {
       const chunkSize = 100;
 
@@ -1271,13 +1281,12 @@ class ArweaveService {
 
           for (final transaction
               in query.data!.transactions.edges.map((e) => e.node)) {
-            if (transaction.block == null) {
-              transactionConfirmations[transaction.id] = 0;
-              continue;
-            }
-
-            transactionConfirmations[transaction.id] =
-                currentBlockHeight - transaction.block!.height + 1;
+            final confirmations = transaction.block == null
+                ? 0
+                : currentBlockHeight - transaction.block!.height + 1;
+            transactionConfirmations[transaction.id] = confirmations;
+            // Record the resolved verification so it survives a caller timeout.
+            verifiedSink?[transaction.id] = confirmations;
           }
         }());
       }

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -1298,6 +1298,11 @@ class ArweaveService {
     // confirmed cross-owner txs without an unscoped scan. Genuinely missing txs
     // have no override and are left unresolved — handled by the caller's
     // existing pending/failed logic.
+    //
+    // Best-effort: this pass must never discard the first pass's results. Its
+    // results are merged into the already-populated map, so we swallow any
+    // error and bound it with its own timeout — even if it fails or stalls,
+    // the confirmations resolved by the first pass are still returned.
     if (owner != null && ownerOverrides != null && ownerOverrides.isNotEmpty) {
       final idsByOverrideOwner = <String, List<String?>>{};
       for (final entry in transactionConfirmations.entries) {
@@ -1307,8 +1312,19 @@ class ArweaveService {
         idsByOverrideOwner.putIfAbsent(overrideOwner, () => []).add(entry.key);
       }
 
-      for (final entry in idsByOverrideOwner.entries) {
-        await queryConfirmations(entry.value, owner: entry.key);
+      if (idsByOverrideOwner.isNotEmpty) {
+        try {
+          await Future(() async {
+            for (final entry in idsByOverrideOwner.entries) {
+              await queryConfirmations(entry.value, owner: entry.key);
+            }
+          }).timeout(const Duration(seconds: 3));
+        } catch (e) {
+          logger.w(
+            'Pinned-owner confirmation recovery failed or timed out; '
+            'leaving those txs unresolved: $e',
+          );
+        }
       }
     }
 

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -1236,48 +1236,69 @@ class ArweaveService {
       for (final transactionId in transactionIds) transactionId: -1
     };
 
-    const chunkSize = 100;
+    // Queries confirmation status for [ids] in chunks, writing results into
+    // [transactionConfirmations]. When [owner] is provided, the query is scoped
+    // to that owner so the gateway can prune its search space.
+    Future<void> queryConfirmations(List<String?> ids, {String? owner}) async {
+      const chunkSize = 100;
 
-    final confirmationFutures = <Future<void>>[];
+      final confirmationFutures = <Future<void>>[];
 
-    for (var i = 0; i < transactionIds.length; i += chunkSize) {
-      confirmationFutures.add(() async {
-        final chunkEnd = (i + chunkSize < transactionIds.length)
-            ? i + chunkSize
-            : transactionIds.length;
+      for (var i = 0; i < ids.length; i += chunkSize) {
+        confirmationFutures.add(() async {
+          final chunkEnd =
+              (i + chunkSize < ids.length) ? i + chunkSize : ids.length;
 
-        final query = await graphQLRetry.execute(
-          TransactionStatusesQuery(
-            variables: TransactionStatusesArguments(
-              transactionIds:
-                  transactionIds.sublist(i, chunkEnd) as List<String>?,
-              // Scoping by owner lets the gateway prune its search space; null
-              // leaves the query unscoped (current behavior).
-              owners: owner != null ? [owner] : null,
+          final query = await graphQLRetry.execute(
+            TransactionStatusesQuery(
+              variables: TransactionStatusesArguments(
+                transactionIds: ids.sublist(i, chunkEnd) as List<String>?,
+                owners: owner != null ? [owner] : null,
+              ),
             ),
-          ),
-        );
+          );
 
-        final currentBlockHeight = query.data!.blocks.edges.first.node.height;
+          final currentBlockHeight =
+              query.data!.blocks.edges.first.node.height;
 
-        for (final transaction
-            in query.data!.transactions.edges.map((e) => e.node)) {
-          if (transaction.block == null) {
-            transactionConfirmations[transaction.id] = 0;
-            continue;
+          for (final transaction
+              in query.data!.transactions.edges.map((e) => e.node)) {
+            if (transaction.block == null) {
+              transactionConfirmations[transaction.id] = 0;
+              continue;
+            }
+
+            transactionConfirmations[transaction.id] =
+                currentBlockHeight - transaction.block!.height + 1;
           }
+        }());
+      }
 
-          transactionConfirmations[transaction.id] =
-              currentBlockHeight - transaction.block!.height + 1;
-        }
-      }());
+      try {
+        await Future.wait(confirmationFutures);
+      } catch (e) {
+        logger.e('Error getting transactions confirmations on exception', e);
+        rethrow;
+      }
     }
 
-    try {
-      await Future.wait(confirmationFutures);
-    } catch (e) {
-      logger.e('Error getting transactions confirmations on exception', e);
-      rethrow;
+    // First pass: scoped by owner for gateway selectivity.
+    await queryConfirmations(transactionIds, owner: owner);
+
+    // Fallback: a tx not found under the owner scope may simply belong to a
+    // different owner (e.g. the data tx of a file pinned from another author's
+    // upload) rather than being absent from the network. Re-query just those
+    // unresolved ids without the owner filter so confirmed cross-owner txs
+    // aren't misclassified as failed by the caller. The residual set is
+    // normally tiny, so this preserves the selectivity win of the first pass.
+    if (owner != null) {
+      final unresolvedIds = transactionConfirmations.entries
+          .where((entry) => entry.value < 0)
+          .map((entry) => entry.key)
+          .toList();
+      if (unresolvedIds.isNotEmpty) {
+        await queryConfirmations(unresolvedIds);
+      }
     }
 
     return transactionConfirmations;

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -1259,43 +1259,50 @@ class ArweaveService {
     // prune its search space.
     Future<void> queryConfirmations(List<String?> ids, {String? owner}) async {
       const chunkSize = 100;
+      // Cap how many chunk queries hit the gateway at once so a large page
+      // doesn't fan out into a burst of concurrent GraphQL retries (and a
+      // potential rate-limit storm), matching the throttling used by the other
+      // gateway-heavy paths in this service.
+      final maxConcurrent =
+          _configService.config.maxConcurrentDataFetches.clamp(1, 100);
 
-      final confirmationFutures = <Future<void>>[];
+      Future<void> queryChunk(int start) async {
+        final chunkEnd =
+            (start + chunkSize < ids.length) ? start + chunkSize : ids.length;
 
-      for (var i = 0; i < ids.length; i += chunkSize) {
-        confirmationFutures.add(() async {
-          final chunkEnd =
-              (i + chunkSize < ids.length) ? i + chunkSize : ids.length;
-
-          final query = await graphQLRetry.execute(
-            TransactionStatusesQuery(
-              variables: TransactionStatusesArguments(
-                transactionIds: ids.sublist(i, chunkEnd) as List<String>?,
-                owners: owner != null ? [owner] : null,
-              ),
+        final query = await graphQLRetry.execute(
+          TransactionStatusesQuery(
+            variables: TransactionStatusesArguments(
+              transactionIds:
+                  ids.sublist(start, chunkEnd).whereType<String>().toList(),
+              owners: owner != null ? [owner] : null,
             ),
-          );
+          ),
+        );
 
-          final currentBlockHeight =
-              query.data!.blocks.edges.first.node.height;
+        final currentBlockHeight = query.data!.blocks.edges.first.node.height;
 
-          for (final transaction
-              in query.data!.transactions.edges.map((e) => e.node)) {
-            final confirmations = transaction.block == null
-                ? 0
-                : currentBlockHeight - transaction.block!.height + 1;
-            transactionConfirmations[transaction.id] = confirmations;
-            // Record the resolved verification so it survives a caller timeout.
-            verifiedSink?[transaction.id] = confirmations;
-          }
-        }());
+        for (final transaction
+            in query.data!.transactions.edges.map((e) => e.node)) {
+          final confirmations = transaction.block == null
+              ? 0
+              : currentBlockHeight - transaction.block!.height + 1;
+          transactionConfirmations[transaction.id] = confirmations;
+          // Record the resolved verification so it survives a caller timeout.
+          verifiedSink?[transaction.id] = confirmations;
+        }
       }
 
-      try {
-        await Future.wait(confirmationFutures);
-      } catch (e) {
-        logger.e('Error getting transactions confirmations on exception', e);
-        rethrow;
+      final chunkStarts = [for (var i = 0; i < ids.length; i += chunkSize) i];
+      // Process the chunks in bounded-concurrency batches.
+      for (var b = 0; b < chunkStarts.length; b += maxConcurrent) {
+        final batch = chunkStarts.skip(b).take(maxConcurrent);
+        try {
+          await Future.wait(batch.map(queryChunk));
+        } catch (e) {
+          logger.e('Error getting transactions confirmations on exception', e);
+          rethrow;
+        }
       }
     }
 

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -1331,7 +1331,15 @@ class ArweaveService {
     final idsByPrimaryOwner = <String, List<String?>>{};
     for (final id in transactionIds) {
       final resolvedOwner = primaryOwnerFor(id);
-      if (resolvedOwner == null) continue;
+      if (resolvedOwner == null) {
+        // No owner to scope by, so this tx is never queried. Drop it from the
+        // result rather than leaving the pre-seeded -1, which the caller would
+        // read as a real "not found" and could age an old pending tx into
+        // failed. Absent => the caller skips it; it stays pending until its
+        // drive/owner is known and it can be scoped on a later sync.
+        transactionConfirmations.remove(id);
+        continue;
+      }
       idsByPrimaryOwner.putIfAbsent(resolvedOwner, () => []).add(id);
     }
     for (final entry in idsByPrimaryOwner.entries) {

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -154,9 +154,24 @@ class ArweaveService {
   }
 
   Future<BigInt> getPrice({required int byteSize}) async {
-    return client.api
-        .get('price/$byteSize')
-        .then((res) => BigInt.parse(res.body));
+    const maxRetries = 3;
+    for (var attempt = 0; attempt < maxRetries; attempt++) {
+      try {
+        final res = await client.api.get('price/$byteSize');
+        if (res.statusCode == 200) {
+          return BigInt.parse(res.body);
+        }
+        logger.w(
+          'getPrice attempt ${attempt + 1} returned ${res.statusCode}',
+        );
+      } catch (e) {
+        logger.w('getPrice attempt ${attempt + 1} failed: $e');
+      }
+      if (attempt < maxRetries - 1) {
+        await Future.delayed(Duration(milliseconds: 500 * (attempt + 1)));
+      }
+    }
+    throw Exception('Failed to get price after $maxRetries attempts');
   }
 
   Future<int> getMempoolSizeFromArweave() async {

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -1228,9 +1228,17 @@ class ArweaveService {
   ///
   /// When the number of confirmations is 0, the transaction has yet to be mined. When
   /// it is -1, the transaction could not be found.
+  /// [ownerOverrides] maps a transaction id to the address that actually owns
+  /// it on-chain when that differs from [owner] (e.g. the data tx of a file
+  /// pinned from another author's upload). Any id left unresolved by the
+  /// owner-scoped pass that has an override is re-queried scoped to its real
+  /// owner — keeping every query selective. Ids with no override are left
+  /// unresolved rather than re-queried unscoped, which would reintroduce the
+  /// expensive gateway scan this scoping is meant to avoid.
   Future<Map<String?, int>> getTransactionConfirmations(
     List<String?> transactionIds, {
     String? owner,
+    Map<String, String>? ownerOverrides,
   }) async {
     final transactionConfirmations = {
       for (final transactionId in transactionIds) transactionId: -1
@@ -1285,19 +1293,22 @@ class ArweaveService {
     // First pass: scoped by owner for gateway selectivity.
     await queryConfirmations(transactionIds, owner: owner);
 
-    // Fallback: a tx not found under the owner scope may simply belong to a
-    // different owner (e.g. the data tx of a file pinned from another author's
-    // upload) rather than being absent from the network. Re-query just those
-    // unresolved ids without the owner filter so confirmed cross-owner txs
-    // aren't misclassified as failed by the caller. The residual set is
-    // normally tiny, so this preserves the selectivity win of the first pass.
-    if (owner != null) {
-      final unresolvedIds = transactionConfirmations.entries
-          .where((entry) => entry.value < 0)
-          .map((entry) => entry.key)
-          .toList();
-      if (unresolvedIds.isNotEmpty) {
-        await queryConfirmations(unresolvedIds);
+    // Second pass: for any unresolved id whose real owner we know locally
+    // (currently pinned data txs), re-query scoped to that owner. This recovers
+    // confirmed cross-owner txs without an unscoped scan. Genuinely missing txs
+    // have no override and are left unresolved — handled by the caller's
+    // existing pending/failed logic.
+    if (owner != null && ownerOverrides != null && ownerOverrides.isNotEmpty) {
+      final idsByOverrideOwner = <String, List<String?>>{};
+      for (final entry in transactionConfirmations.entries) {
+        if (entry.value >= 0) continue;
+        final overrideOwner = ownerOverrides[entry.key];
+        if (overrideOwner == null || overrideOwner == owner) continue;
+        idsByOverrideOwner.putIfAbsent(overrideOwner, () => []).add(entry.key);
+      }
+
+      for (final entry in idsByOverrideOwner.entries) {
+        await queryConfirmations(entry.value, owner: entry.key);
       }
     }
 

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -51,6 +51,7 @@ class ArweaveService {
   final ConfigService _configService;
   late ArtemisClient _gql;
   late DataGatewayFallback _gatewayFallback;
+  DataGatewayFallback get gatewayFallback => _gatewayFallback;
 
   static String _graphqlUrlFromGateway(String gatewayUrl) {
     final uri = Uri.parse(gatewayUrl);
@@ -136,6 +137,29 @@ class ArweaveService {
   late GraphQLRetry graphQLRetry;
   late HttpRetry httpRetry;
 
+  /// Cache for [getUniqueUserDriveEntityTxs] to avoid redundant GQL calls.
+  /// Auth flow (isExistingUser, _validateUser) and sync (updateUserDrives)
+  /// all call this for the same wallet. Invalidated explicitly via
+  /// [clearUserDriveTxsCache] when a drive is created/updated or after sync.
+  String? _cachedUserDriveTxsAddress;
+  List<TransactionCommonMixin>? _cachedUserDriveTxs;
+
+  /// Cache for raw entity data bytes fetched during [getUniqueUserDriveEntities].
+  /// Keyed by transaction ID. Allows [getLatestDriveEntityWithId] to re-parse
+  /// the data with a different key without re-downloading from the gateway.
+  final Map<String, Uint8List> _cachedEntityDataBytes = {};
+
+  /// Cache for drive signatures (immutable on-chain, never change).
+  final Map<String, DriveSignatureEntity?> _cachedDriveSignatures = {};
+
+  /// Clears the cached result of [getUniqueUserDriveEntityTxs] and entity data.
+  /// Call after creating/updating a drive or after a full sync completes.
+  void clearUserDriveTxsCache() {
+    _cachedUserDriveTxsAddress = null;
+    _cachedUserDriveTxs = null;
+    _cachedEntityDataBytes.clear();
+  }
+
   /// Returns the onchain balance of the specified address.
   Future<BigInt> getWalletBalance(String address) => client.api
       .get('wallet/$address/balance')
@@ -209,7 +233,7 @@ class ArweaveService {
   }
 
   Future<TransactionCommonMixin?> getTransactionDetails(String txId) async {
-    final query = await _gql.execute(TransactionDetailsQuery(
+    final query = await graphQLRetry.execute(TransactionDetailsQuery(
         variables: TransactionDetailsArguments(txId: txId)));
     return query.data?.transaction;
   }
@@ -217,50 +241,104 @@ class ArweaveService {
   Future<InfoOfTransactionToBePinned$Query$Transaction?> getInfoOfTxToBePinned(
     String txId,
   ) async {
-    final query = await _gql.execute(InfoOfTransactionToBePinnedQuery(
+    final query = await graphQLRetry.execute(InfoOfTransactionToBePinnedQuery(
         variables: InfoOfTransactionToBePinnedArguments(txId: txId)));
     return query.data?.transaction;
   }
 
+  /// Fetch snapshots for a single drive. Delegates to [getAllSnapshotsForDrives].
   Stream<SnapshotEntityTransaction> getAllSnapshotsOfDrive(
     String driveId,
     int? lastBlockHeight, {
+    required String ownerAddress,
+  }) =>
+      getAllSnapshotsForDrives([driveId], lastBlockHeight,
+          ownerAddress: ownerAddress);
+
+  /// Fetch snapshots for multiple drives in a single paginated GQL query.
+  ///
+  /// Use [minBlockHeight] = min of all drives' lastBlockHeights.
+  /// Caller should filter results by Drive-Id tag and pass each drive's
+  /// subset to [SnapshotItem.instantiateAll] with that drive's own
+  /// lastBlockHeight to preserve per-drive state isolation.
+  Stream<SnapshotEntityTransaction> getAllSnapshotsForDrives(
+    List<String> driveIds,
+    int? minBlockHeight, {
     required String ownerAddress,
   }) async* {
     String cursor = '';
 
     while (true) {
       try {
-        // Get a page of 100 transactions
         final snapshotEntityHistoryQuery = await graphQLRetry.execute(
           SnapshotEntityHistoryQuery(
             variables: SnapshotEntityHistoryArguments(
-              driveId: driveId,
-              lastBlockHeight: lastBlockHeight,
+              driveIds: driveIds,
+              lastBlockHeight: minBlockHeight,
               after: cursor,
               ownerAddress: ownerAddress,
             ),
           ),
         );
-        for (SnapshotEntityHistory$Query$TransactionConnection$TransactionEdge edge
-            in snapshotEntityHistoryQuery.data!.transactions.edges) {
+        final edges = snapshotEntityHistoryQuery.data!.transactions.edges;
+        for (final edge in edges) {
           yield edge.node;
         }
 
-        cursor = snapshotEntityHistoryQuery.data!.transactions.edges.isNotEmpty
-            ? snapshotEntityHistoryQuery.data!.transactions.edges.last.cursor
-            : '';
+        // Guard against empty edges with hasNextPage=true causing infinite loop
+        if (edges.isEmpty) {
+          break;
+        }
+
+        cursor = edges.last.cursor;
 
         if (!snapshotEntityHistoryQuery
             .data!.transactions.pageInfo.hasNextPage) {
           break;
         }
       } catch (e) {
-        logger.e('Error fetching snapshots for drive $driveId', e);
-        logger.i('This drive and ones after will fall back to GQL');
+        logger.e('Error fetching snapshots for drives $driveIds', e);
+        logger.i('These drives will fall back to GQL');
         break;
       }
     }
+  }
+
+  /// Probes which drives have any new transactions since [minBlockHeight].
+  /// Returns the set of drive IDs with activity. If the query returns
+  /// hasNextPage=true, the result is incomplete — caller should treat
+  /// un-checked drives as potentially active.
+  Future<({Set<String> activeDriveIds, bool isComplete})> probeActiveDriveIds({
+    required List<String> driveIds,
+    required int minBlockHeight,
+    required String ownerAddress,
+  }) async {
+    final query = await graphQLRetry.execute(
+      DriveActivityProbeQuery(
+        variables: DriveActivityProbeArguments(
+          driveIds: driveIds,
+          minBlockHeight: minBlockHeight,
+          ownerAddress: ownerAddress,
+        ),
+      ),
+    );
+
+    if (query.data == null) {
+      // Treat as incomplete — caller will fall back to syncing all drives
+      return (activeDriveIds: <String>{}, isComplete: false);
+    }
+
+    final activeDriveIds = <String>{};
+    for (final edge in query.data!.transactions.edges) {
+      for (final tag in edge.node.tags) {
+        if (tag.name == 'Drive-Id') {
+          activeDriveIds.add(tag.value);
+        }
+      }
+    }
+
+    final isComplete = !query.data!.transactions.pageInfo.hasNextPage;
+    return (activeDriveIds: activeDriveIds, isComplete: isComplete);
   }
 
   Stream<List<DriveEntityHistoryTransactionModel>>
@@ -639,6 +717,16 @@ class ArweaveService {
     String userAddress, {
     int maxRetries = defaultMaxRetries,
   }) async {
+    // Return cached result if available for the same address.
+    // Auth flow (isExistingUser, _validateUser) and sync (updateUserDrives)
+    // all call this for the same wallet. Cache is invalidated explicitly
+    // via clearUserDriveTxsCache() after drive creation or sync completion.
+    if (_cachedUserDriveTxs != null &&
+        _cachedUserDriveTxsAddress == userAddress) {
+      logger.d('Using cached UserDriveEntityTxs');
+      return _cachedUserDriveTxs!;
+    }
+
     List<TransactionCommonMixin> drives = [];
     String cursor = '';
 
@@ -686,6 +774,10 @@ class ArweaveService {
       }
     }
 
+    // Cache the result — cleared by clearUserDriveTxsCache()
+    _cachedUserDriveTxsAddress = userAddress;
+    _cachedUserDriveTxs = drives;
+
     return drives;
   }
 
@@ -710,6 +802,11 @@ class ArweaveService {
     Wallet wallet,
     String driveId,
   ) async {
+    // Drive signatures are immutable on-chain — cache permanently once fetched
+    if (_cachedDriveSignatures.containsKey(driveId)) {
+      return _cachedDriveSignatures[driveId];
+    }
+
     final driveSignatureTx = await getDriveSignatureTxForDrive(wallet, driveId);
 
     final driveSignatureData = driveSignatureTx != null
@@ -721,6 +818,7 @@ class ArweaveService {
             ? DriveSignatureEntity.fromTransaction(
                 driveSignatureTx, driveSignatureData.bodyBytes)
             : null;
+    _cachedDriveSignatures[driveId] = driveSignature;
     return driveSignature;
   }
 
@@ -739,6 +837,14 @@ class ArweaveService {
             .then<Response?>((r) => r)
             .catchError((_) => null)),
       );
+
+      // Cache raw bytes for reuse by getLatestDriveEntityWithId (e.g., during
+      // password validation in _validateUser, which re-parses the same data)
+      for (var i = 0; i < driveTxs.length; i++) {
+        if (driveResponses[i] != null) {
+          _cachedEntityDataBytes[driveTxs[i].id] = driveResponses[i]!.bodyBytes;
+        }
+      }
 
       final drivesById = <String?, DriveEntity>{};
       final drivesWithKey = <DriveEntity, DriveKey?>{};
@@ -867,11 +973,15 @@ class ArweaveService {
       }
 
       final fileTx = filteredEdges.first.node;
-      final fileDataRes = await _gatewayFallback.fetchData(fileTx.id, client);
+
+      // Use cached bytes if available (e.g., from getUniqueUserDriveEntities)
+      final cachedBytes = _cachedEntityDataBytes[fileTx.id];
+      final entityBytes = cachedBytes ??
+          (await _gatewayFallback.fetchData(fileTx.id, client)).bodyBytes;
 
       try {
         return await DriveEntity.fromTransaction(
-            fileTx, _crypto, fileDataRes.bodyBytes, driveKey);
+            fileTx, _crypto, entityBytes, driveKey);
       } on EntityTransactionParseException catch (parseException) {
         logger.e(
           'Failed to parse transaction '
@@ -890,7 +1000,11 @@ class ArweaveService {
   /// by that owner.
   ///
   /// Returns `null` if no valid drive is found.
-  Future<Privacy?> getDrivePrivacyForId(String driveId) async {
+  /// Gets drive privacy and the owner address + latest transaction node.
+  ///
+  /// Returns both so the caller can reuse the owner and transaction node
+  /// without making redundant GraphQL queries.
+  Future<DrivePrivacyResult?> getDrivePrivacyForId(String driveId) async {
     final driveOwner = await getOwnerForDriveEntityWithId(driveId);
     if (driveOwner == null) {
       return null;
@@ -908,7 +1022,11 @@ class ArweaveService {
 
     final driveTx = queryEdges.first.node;
 
-    return driveTx.getTag(EntityTag.drivePrivacy);
+    return DrivePrivacyResult(
+      privacy: driveTx.getTag(EntityTag.drivePrivacy),
+      ownerAddress: driveOwner,
+      driveTx: driveTx,
+    );
   }
 
   /// Gets the file privacy of the latest file entity with the provided id.
@@ -928,7 +1046,7 @@ class ArweaveService {
     String cursor = '';
 
     while (true) {
-      final latestFileQuery = await _gql.execute(
+      final latestFileQuery = await graphQLRetry.execute(
         LatestFileEntityWithIdQuery(
           variables: LatestFileEntityWithIdArguments(
             fileId: fileId,
@@ -1630,7 +1748,7 @@ class ArweaveService {
       logger.i('Fetching transaction info for batch ${batch.length}');
 
       try {
-        final query = await _gql.execute(
+        final query = await graphQLRetry.execute(
           InfoOfTransactionsToBePinnedQuery(
             variables: InfoOfTransactionsToBePinnedArguments(
               transactionIds: batch,
@@ -1680,6 +1798,20 @@ class UploadTransactions {
   Transaction dataTx;
 
   UploadTransactions(this.entityTx, this.dataTx);
+}
+
+/// Result of [ArweaveService.getDrivePrivacyForId], containing the privacy tag
+/// plus the owner and transaction node to avoid redundant re-queries.
+class DrivePrivacyResult {
+  final String? privacy;
+  final String ownerAddress;
+  final TransactionCommonMixin driveTx;
+
+  DrivePrivacyResult({
+    required this.privacy,
+    required this.ownerAddress,
+    required this.driveTx,
+  });
 }
 
 class TransactionNotFound implements Exception {

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -363,14 +363,22 @@ class ArweaveService {
   }
 
   Stream<List<LicenseAssertions$Query$TransactionConnection$TransactionEdge$Transaction>>
-      getLicenseAssertions(Iterable<String> licenseAssertionTxIds) async* {
+      getLicenseAssertions(
+    Iterable<String> licenseAssertionTxIds, {
+    String? owner,
+  }) async* {
     const chunkSize = 100;
     final chunks = licenseAssertionTxIds.slices(chunkSize);
     for (final chunk in chunks) {
       // Get a page of 100 transactions
       final licenseAssertionsQuery = await graphQLRetry.execute(
         LicenseAssertionsQuery(
-          variables: LicenseAssertionsArguments(transactionIds: chunk),
+          variables: LicenseAssertionsArguments(
+            transactionIds: chunk,
+            // Scoping by owner narrows the gateway's search space; null leaves
+            // the query unscoped (current behavior).
+            owners: owner != null ? [owner] : null,
+          ),
         ),
       );
 
@@ -381,14 +389,22 @@ class ArweaveService {
   }
 
   Stream<List<LicenseComposed$Query$TransactionConnection$TransactionEdge$Transaction>>
-      getLicenseComposed(Iterable<String> licenseComposedTxIds) async* {
+      getLicenseComposed(
+    Iterable<String> licenseComposedTxIds, {
+    String? owner,
+  }) async* {
     const chunkSize = 100;
     final chunks = licenseComposedTxIds.slices(chunkSize);
     for (final chunk in chunks) {
       // Get a page of 100 transactions
       final licenseComposedQuery = await graphQLRetry.execute(
         LicenseComposedQuery(
-          variables: LicenseComposedArguments(transactionIds: chunk),
+          variables: LicenseComposedArguments(
+            transactionIds: chunk,
+            // Scoping by owner narrows the gateway's search space; null leaves
+            // the query unscoped (current behavior).
+            owners: owner != null ? [owner] : null,
+          ),
         ),
       );
 
@@ -1213,7 +1229,9 @@ class ArweaveService {
   /// When the number of confirmations is 0, the transaction has yet to be mined. When
   /// it is -1, the transaction could not be found.
   Future<Map<String?, int>> getTransactionConfirmations(
-      List<String?> transactionIds) async {
+    List<String?> transactionIds, {
+    String? owner,
+  }) async {
     final transactionConfirmations = {
       for (final transactionId in transactionIds) transactionId: -1
     };
@@ -1233,6 +1251,9 @@ class ArweaveService {
             variables: TransactionStatusesArguments(
               transactionIds:
                   transactionIds.sublist(i, chunkEnd) as List<String>?,
+              // Scoping by owner lets the gateway prune its search space; null
+              // leaves the query unscoped (current behavior).
+              owners: owner != null ? [owner] : null,
             ),
           ),
         );

--- a/lib/services/arweave/data_gateway_fallback.dart
+++ b/lib/services/arweave/data_gateway_fallback.dart
@@ -16,9 +16,10 @@ class DataGatewayFallback {
   final Map<String, Arweave> _clientCache = {};
 
   static const _lastResortGateway = 'https://arweave.net';
-  static const _maxGarFallbacks = 3;
-  static const _retryPerGateway = 2;
+  static const _maxGarFallbacks = 2;
+  static const _retryPerGateway = 1;
   static const _garListTimeout = Duration(seconds: 5);
+  static const _requestTimeout = Duration(seconds: 5);
 
   List<Gateway>? _cachedGateways;
 
@@ -120,7 +121,9 @@ class DataGatewayFallback {
 
     for (var attempt = 0; attempt < _retryPerGateway; attempt++) {
       try {
-        final response = await client.api.getSandboxedTx(txId);
+        final response = await client.api
+            .getSandboxedTx(txId)
+            .timeout(_requestTimeout);
 
         if (response.statusCode >= 200 && response.statusCode <= 208) {
           return response;

--- a/lib/services/arweave/data_gateway_fallback.dart
+++ b/lib/services/arweave/data_gateway_fallback.dart
@@ -20,6 +20,9 @@ class DataGatewayFallback {
   static const _retryPerGateway = 1;
   static const _garListTimeout = Duration(seconds: 5);
   static const _requestTimeout = Duration(seconds: 5);
+  /// Total time allowed for the entire fallback chain per tx.
+  /// Prevents a single missing/broken tx from blocking sync for minutes.
+  static const _totalFetchTimeout = Duration(seconds: 15);
 
   List<Gateway>? _cachedGateways;
 
@@ -34,6 +37,15 @@ class DataGatewayFallback {
   /// If ALL gateways return 404, throws [TransactionNotFound] to preserve
   /// upstream error handling (e.g. private drive detection during login).
   Future<Response> fetchData(String txId, Arweave primaryClient) async {
+    return _fetchDataWithTimeout(txId, primaryClient)
+        .timeout(_totalFetchTimeout, onTimeout: () {
+      logger.w('Total fetch timeout exceeded for tx $txId');
+      throw Exception('Total fetch timeout exceeded for tx $txId');
+    });
+  }
+
+  Future<Response> _fetchDataWithTimeout(
+      String txId, Arweave primaryClient) async {
     var all404 = true;
 
     // 1. Try primary gateway

--- a/lib/services/arweave/data_gateway_fallback.dart
+++ b/lib/services/arweave/data_gateway_fallback.dart
@@ -1,168 +1,253 @@
 import 'dart:async';
 
+import 'package:ardrive/download/download_exceptions.dart';
 import 'package:ardrive/services/arweave/arweave_service.dart';
 import 'package:ardrive/utils/logger.dart';
+import 'package:ardrive_http/ardrive_http.dart';
 import 'package:ario_sdk/ario_sdk.dart';
 import 'package:arweave/arweave.dart';
+import 'package:arweave/arweave.dart' as arweave_pkg;
 import 'package:http/http.dart';
 
 /// Provides data gateway fallback resilience.
 ///
-/// When the primary gateway fails (404, 429, 5xx, timeout), automatically
-/// tries gateways from the AR.IO GAR list, then arweave.net as last resort.
-/// Fallback is per-request — the primary gateway is always tried first.
+/// Metadata fetches use serial waterfall (primary → GAR → arweave.net) to
+/// avoid unnecessary requests during high-volume sync operations.
+///
+/// File downloads use hedged (staggered parallel) requests since they are
+/// single user-initiated operations where latency matters.
+///
+/// Fallback order: primary → up to 2 GAR gateways → arweave.net
 class DataGatewayFallback {
   final ArioSDK _arioSDK;
   final Map<String, Arweave> _clientCache = {};
 
-  static const _lastResortGateway = 'https://arweave.net';
   static const _maxGarFallbacks = 2;
-  static const _retryPerGateway = 1;
   static const _garListTimeout = Duration(seconds: 5);
   static const _requestTimeout = Duration(seconds: 5);
-  /// Total time allowed for the entire fallback chain per tx.
-  /// Prevents a single missing/broken tx from blocking sync for minutes.
-  static const _totalFetchTimeout = Duration(seconds: 15);
+  static const _totalFetchTimeout = Duration(seconds: 25);
+  static const _hedgeDelay = Duration(milliseconds: 1500);
+  static const _downloadTimeout = Duration(seconds: 15);
 
-  List<Gateway>? _cachedGateways;
+  /// Cached gateway list — shared with other services (e.g.
+  /// SnapshotValidationService) to avoid duplicate Solana RPC calls.
+  List<Gateway>? cachedGateways;
 
   DataGatewayFallback({
     required ArioSDK arioSDK,
   }) : _arioSDK = arioSDK;
 
-  /// Fetch transaction data with automatic gateway fallback.
+  /// Fetch transaction data with serial gateway fallback.
   ///
-  /// Tries: primary → up to 3 GAR gateways → arweave.net
+  /// Tries: primary → up to 2 GAR gateways → arweave.net
+  /// Used for metadata fetches during sync (called hundreds of times).
   ///
-  /// If ALL gateways return 404, throws [TransactionNotFound] to preserve
-  /// upstream error handling (e.g. private drive detection during login).
+  /// If ALL gateways return 404, throws [TransactionNotFound].
   Future<Response> fetchData(String txId, Arweave primaryClient) async {
-    return _fetchDataWithTimeout(txId, primaryClient)
+    return _serialFetch(txId, primaryClient)
         .timeout(_totalFetchTimeout, onTimeout: () {
       logger.w('Total fetch timeout exceeded for tx $txId');
       throw Exception('Total fetch timeout exceeded for tx $txId');
     });
   }
 
-  Future<Response> _fetchDataWithTimeout(
-      String txId, Arweave primaryClient) async {
+  Future<Response> _serialFetch(String txId, Arweave primaryClient) async {
+    final clients = await _buildClientList(primaryClient);
     var all404 = true;
 
-    // 1. Try primary gateway
-    try {
-      return await _tryGateway(primaryClient, txId);
-    } on _ErrorFromStatus catch (e) {
-      if (!e.retryable) rethrow;
-      if (e.statusCode != 404) all404 = false;
-      logger.w(
-        'Primary gateway failed for tx $txId '
-        '(${primaryClient.api.gatewayUrl}): $e',
-      );
-    } catch (e) {
-      all404 = false;
-      logger.w(
-        'Primary gateway failed for tx $txId '
-        '(${primaryClient.api.gatewayUrl}): $e',
-      );
-    }
-
-    // 2. Try GAR gateways (cached to avoid repeated Solana RPC calls)
-    try {
-      _cachedGateways ??= await _arioSDK
-          .getGateways()
-          .timeout(_garListTimeout, onTimeout: () => <Gateway>[]);
-      final gateways = _cachedGateways!;
-      final primaryHost = primaryClient.api.gatewayUrl.host;
-
-      var tried = 0;
-      for (final gw in gateways) {
-        if (tried >= _maxGarFallbacks) break;
-        if (gw.settings.fqdn == primaryHost) continue;
-
-        try {
-          final client = _getOrCreateClient(gw.settings.fqdn);
-          final response = await _tryGateway(client, txId);
-          logger.i(
-            'Fallback gateway ${gw.settings.fqdn} succeeded for tx $txId',
-          );
-          return response;
-        } on _ErrorFromStatus catch (e) {
-          if (!e.retryable) rethrow;
-          if (e.statusCode != 404) all404 = false;
-          logger.w(
-            'Fallback gateway ${gw.settings.fqdn} failed for tx $txId: $e',
-          );
-          tried++;
-          continue;
-        } catch (e) {
-          all404 = false;
-          logger.w(
-            'Fallback gateway ${gw.settings.fqdn} failed for tx $txId: $e',
-          );
-          tried++;
-          continue;
+    for (final client in clients) {
+      final gatewayName = client.api.gatewayUrl.host;
+      try {
+        final response = await _tryGateway(client, txId);
+        if (client != primaryClient) {
+          logger.i('Fallback gateway $gatewayName succeeded for tx $txId');
         }
+        return response;
+      } on _ErrorFromStatus catch (e) {
+        if (e.statusCode != 404) all404 = false;
+        logger.w('Gateway $gatewayName failed for tx $txId: $e');
+      } catch (e) {
+        all404 = false;
+        logger.w('Gateway $gatewayName failed for tx $txId: $e');
       }
-    } catch (e) {
-      all404 = false;
-      logger.w('GAR list unavailable for fallback: $e');
     }
 
-    // 3. Last resort: arweave.net
-    logger.w('Trying last resort gateway $_lastResortGateway for tx $txId');
-    try {
-      final lastResortClient = _getOrCreateClient('arweave.net');
-      final response = await _tryGateway(lastResortClient, txId);
-      logger.i('Last resort gateway succeeded for tx $txId');
-      return response;
-    } on _ErrorFromStatus catch (e) {
-      if (e.statusCode != 404) all404 = false;
-    } catch (e) {
-      all404 = false;
-    }
-
-    // All gateways failed
     if (all404) {
       throw TransactionNotFound(txId);
     }
     throw Exception('All gateways failed for tx $txId');
   }
 
-  Future<Response> _tryGateway(Arweave client, String txId) async {
-    Exception? lastError;
+  /// Download a file with hedged (staggered parallel) gateway fallback.
+  ///
+  /// Fires primary immediately, then launches additional gateways every
+  /// [_hedgeDelay] if no response yet. First successful response wins.
+  /// Used for single user-initiated downloads where latency matters.
+  ///
+  /// Only retries pre-stream failures (connection, 404, 500 before stream
+  /// starts). Once bytes are streaming, failures propagate to the caller.
+  ///
+  /// Throws [DownloadFileNotFoundException], [DownloadNetworkException], or
+  /// [DownloadRateLimitException] on failure.
+  Future<(Stream<List<int>>, void Function())> downloadWithFallback({
+    required String txId,
+    required Arweave primaryClient,
+    Function(double progress, int speed)? onProgress,
+    bool verifyDownload = false,
+  }) async {
+    final clients = await _buildClientList(primaryClient);
+    var all404 = true;
 
-    for (var attempt = 0; attempt < _retryPerGateway; attempt++) {
+    // Hedged: fire primary, then stagger fallbacks
+    final completer = Completer<(Stream<List<int>>, void Function())>();
+    var failedCount = 0;
+
+    for (var i = 0; i < clients.length; i++) {
+      if (completer.isCompleted) break;
+
+      // Stagger: wait before launching each subsequent gateway
+      if (i > 0) {
+        await Future.any([
+          Future.delayed(_hedgeDelay),
+          completer.future.then((_) {}),
+        ]);
+        if (completer.isCompleted) break;
+      }
+
+      final client = clients[i];
+      final gatewayName = i == 0 ? 'primary' : client.api.gatewayUrl.host;
+
+      // Fire and don't await — let the completer collect the winner
+      unawaited(
+        arweave_pkg
+            .download(
+          txId: txId,
+          arweave: client,
+          onProgress: onProgress,
+          verifyDownload: verifyDownload,
+        )
+            .then((result) {
+          if (!completer.isCompleted) {
+            if (i > 0) {
+              logger.i('Hedged gateway $gatewayName won download for tx $txId');
+            }
+            completer.complete(result);
+          }
+        }).catchError((Object e) {
+          failedCount++;
+          if (e is! _ErrorFromStatus || e.statusCode != 404) {
+            all404 = false;
+          }
+          logger.w('Download gateway $gatewayName failed for tx $txId: $e');
+
+          if (failedCount == clients.length && !completer.isCompleted) {
+            if (all404) {
+              completer.completeError(DownloadFileNotFoundException(txId));
+            } else {
+              completer.completeError(
+                  DownloadNetworkException(txId, e.toString()));
+            }
+          }
+        }),
+      );
+    }
+
+    return completer.future.timeout(_downloadTimeout, onTimeout: () {
+      throw DownloadNetworkException(txId, 'Download connection timed out');
+    });
+  }
+
+  /// Fetch manifest data with serial gateway fallback.
+  Future<Response> fetchManifestWithFallback(
+      String txId, Arweave primaryClient) async {
+    final clients = await _buildClientList(primaryClient);
+    var all404 = true;
+
+    for (final client in clients) {
+      final gatewayName = client.api.gatewayUrl.host;
       try {
-        final response = await client.api
-            .getSandboxedTx(txId)
-            .timeout(_requestTimeout);
-
-        if (response.statusCode >= 200 && response.statusCode <= 208) {
-          return response;
+        final response = await _tryManifestGateway(client, txId);
+        if (client != primaryClient) {
+          logger.i(
+              'Fallback gateway $gatewayName succeeded for manifest $txId');
         }
-
-        if (!_isRetryableStatus(response.statusCode)) {
-          throw _ErrorFromStatus(response.statusCode, txId, retryable: false);
-        }
-
-        throw _ErrorFromStatus(response.statusCode, txId);
+        return response;
+      } on _ErrorFromStatus catch (e) {
+        if (e.statusCode != 404) all404 = false;
+        logger.w('Gateway $gatewayName failed for manifest $txId: $e');
       } catch (e) {
-        lastError = e is Exception ? e : Exception(e.toString());
-        if (attempt < _retryPerGateway - 1) {
-          await Future.delayed(
-            Duration(milliseconds: 500 * (attempt + 1)),
-          );
-        }
+        all404 = false;
+        logger.w('Gateway $gatewayName failed for manifest $txId: $e');
       }
     }
 
-    throw lastError!;
+    if (all404) {
+      throw TransactionNotFound(txId);
+    }
+    throw Exception('All gateways failed for manifest $txId');
   }
 
-  bool _isRetryableStatus(int statusCode) =>
-      statusCode == 404 ||
-      statusCode == 429 ||
-      (statusCode >= 500 && statusCode < 600);
+  /// Build the ordered list of clients: primary + GAR gateways + arweave.net.
+  Future<List<Arweave>> _buildClientList(Arweave primaryClient) async {
+    final clients = <Arweave>[primaryClient];
+    final primaryHost = primaryClient.api.gatewayUrl.host;
+
+    try {
+      if (cachedGateways == null) {
+        try {
+          cachedGateways = await _arioSDK
+              .getGateways()
+              .timeout(_garListTimeout, onTimeout: () => <Gateway>[]);
+        } catch (e) {
+          // Solana RPC failed — cache empty list so we don't retry every call
+          logger.w('GAR list unavailable for fallback, will not retry: $e');
+          cachedGateways = [];
+        }
+      }
+
+      var added = 0;
+      for (final gw in cachedGateways!) {
+        if (added >= _maxGarFallbacks) break;
+        if (gw.settings.fqdn == primaryHost) continue;
+        clients.add(_getOrCreateClient(gw.settings.fqdn));
+        added++;
+      }
+    } catch (e) {
+      logger.w('GAR list unavailable for fallback: $e');
+    }
+
+    // Always include arweave.net as last resort
+    if (primaryHost != 'arweave.net') {
+      clients.add(_getOrCreateClient('arweave.net'));
+    }
+
+    return clients;
+  }
+
+  Future<Response> _tryGateway(Arweave client, String txId) async {
+    final response = await client.api
+        .getSandboxedTx(txId)
+        .timeout(_requestTimeout);
+
+    if (response.statusCode >= 200 && response.statusCode <= 208) {
+      return response;
+    }
+
+    throw _ErrorFromStatus(response.statusCode, txId);
+  }
+
+  Future<Response> _tryManifestGateway(Arweave client, String txId) async {
+    final url = '${client.api.gatewayUrl.origin}/raw/$txId';
+    final response =
+        await ArDriveHTTP().get(url: url).timeout(_requestTimeout);
+
+    final statusCode = response.statusCode ?? 0;
+    if (statusCode >= 200 && statusCode <= 208) {
+      return Response(response.data, statusCode);
+    }
+
+    throw _ErrorFromStatus(statusCode, txId);
+  }
 
   Arweave _getOrCreateClient(String fqdn) {
     return _clientCache.putIfAbsent(
@@ -177,9 +262,8 @@ class DataGatewayFallback {
 class _ErrorFromStatus implements Exception {
   final int statusCode;
   final String txId;
-  final bool retryable;
 
-  _ErrorFromStatus(this.statusCode, this.txId, {this.retryable = true});
+  _ErrorFromStatus(this.statusCode, this.txId);
 
   @override
   String toString() => 'Gateway returned $statusCode for tx $txId';

--- a/lib/services/arweave/graphql/queries/DriveActivityProbe.graphql
+++ b/lib/services/arweave/graphql/queries/DriveActivityProbe.graphql
@@ -1,27 +1,26 @@
-query SnapshotEntityHistory(
+query DriveActivityProbe(
   $driveIds: [String!]!
-  $after: String
-  $lastBlockHeight: Int
+  $minBlockHeight: Int
   $ownerAddress: String!
 ) {
   transactions(
     owners: [$ownerAddress]
     first: 100
-    sort: HEIGHT_DESC
+    sort: HEIGHT_ASC
     tags: [
       { name: "Drive-Id", values: $driveIds }
-      { name: "Entity-Type", values: ["snapshot"] }
     ]
-    after: $after
-    block: { min: $lastBlockHeight }
+    block: { min: $minBlockHeight }
   ) {
     pageInfo {
       hasNextPage
     }
     edges {
-      cursor
       node {
-        ...TransactionCommon
+        tags {
+          name
+          value
+        }
       }
     }
   }

--- a/lib/services/arweave/graphql/queries/LicenseAssertions.graphql
+++ b/lib/services/arweave/graphql/queries/LicenseAssertions.graphql
@@ -1,7 +1,8 @@
-query LicenseAssertions($transactionIds: [ID!]) {
+query LicenseAssertions($transactionIds: [ID!], $owners: [String!]) {
   transactions(
     first: 100
     ids: $transactionIds
+    owners: $owners
     tags: [{ name: "App-Name", values: ["License-Assertion"] }]
   ) {
     edges {

--- a/lib/services/arweave/graphql/queries/LicenseDataBundled.graphql
+++ b/lib/services/arweave/graphql/queries/LicenseDataBundled.graphql
@@ -1,7 +1,8 @@
-query LicenseComposed($transactionIds: [ID!]) {
+query LicenseComposed($transactionIds: [ID!], $owners: [String!]) {
   transactions(
     first: 100
     ids: $transactionIds
+    owners: $owners
   ) {
     edges {
       node {

--- a/lib/services/arweave/graphql/queries/TransactionStatuses.graphql
+++ b/lib/services/arweave/graphql/queries/TransactionStatuses.graphql
@@ -1,5 +1,5 @@
-query TransactionStatuses($transactionIds: [ID!]) {
-  transactions(first: 100, ids: $transactionIds) {
+query TransactionStatuses($transactionIds: [ID!], $owners: [String!]) {
+  transactions(first: 100, ids: $transactionIds, owners: $owners) {
     edges {
       node {
         id

--- a/lib/sync/data/snapshot_validation_service.dart
+++ b/lib/sync/data/snapshot_validation_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:ardrive/services/arweave/data_gateway_fallback.dart';
 import 'package:ardrive/services/config/config_service.dart';
 import 'package:ardrive/utils/logger.dart';
 import 'package:ardrive/utils/snapshots/snapshot_item.dart';
@@ -14,9 +15,10 @@ class SnapshotValidationService {
   static const _garListTimeout = Duration(seconds: 3);
   static const _maxConcurrentValidations = 3;
 
-  /// Cached GAR gateway list — fetched once per session, avoids repeated
-  /// Solana RPC calls which may be slow or unavailable (e.g. localhost).
-  List<Gateway>? _cachedGateways;
+  /// Shared reference to [DataGatewayFallback] for reading/writing the
+  /// gateway cache. Set by SyncRepository before validation runs so both
+  /// services share one cache and avoid duplicate Solana RPC calls.
+  DataGatewayFallback? gatewayFallback;
 
   SnapshotValidationService({
     required ConfigService configService,
@@ -105,12 +107,32 @@ class SnapshotValidationService {
       return false;
     }
 
-    // 3. Primary had a transient error (timeout, 5xx) — try 1 fallback gateway
+    // 3. Primary had a transient error (timeout, 5xx) — try 1 fallback gateway.
+    //    Read the shared gateway cache from DataGatewayFallback. If unavailable,
+    //    fetch from Solana RPC once and cache the result (empty on failure).
     try {
-      _cachedGateways ??= await _arioSDK
-          .getGateways()
-          .timeout(_garListTimeout, onTimeout: () => <Gateway>[]);
-      final gateways = _cachedGateways!;
+      List<Gateway> gateways;
+      if (gatewayFallback != null &&
+          gatewayFallback!.cachedGateways != null) {
+        gateways = gatewayFallback!.cachedGateways!;
+      } else {
+        try {
+          gateways = await _arioSDK
+              .getGateways()
+              .timeout(_garListTimeout, onTimeout: () => <Gateway>[]);
+          // Store in shared cache if available
+          if (gatewayFallback != null) {
+            gatewayFallback!.cachedGateways = gateways;
+          }
+        } catch (e) {
+          // Solana RPC failed — cache empty list so we don't retry every call
+          logger.w('GAR gateway list unavailable, will not retry: $e');
+          if (gatewayFallback != null) {
+            gatewayFallback!.cachedGateways = [];
+          }
+          gateways = [];
+        }
+      }
 
       if (gateways.isEmpty) return false;
 

--- a/lib/sync/data/snapshot_validation_service.dart
+++ b/lib/sync/data/snapshot_validation_service.dart
@@ -10,10 +10,13 @@ class SnapshotValidationService {
   final ConfigService _configService;
   final ArioSDK _arioSDK;
 
-  static const _headTimeout = Duration(seconds: 10);
-  static const _retryDelay = Duration(milliseconds: 500);
-  static const _garListTimeout = Duration(seconds: 5);
+  static const _headTimeout = Duration(seconds: 5);
+  static const _garListTimeout = Duration(seconds: 3);
   static const _maxConcurrentValidations = 3;
+
+  /// Cached GAR gateway list — fetched once per session, avoids repeated
+  /// Solana RPC calls which may be slow or unavailable (e.g. localhost).
+  List<Gateway>? _cachedGateways;
 
   SnapshotValidationService({
     required ConfigService configService,
@@ -63,47 +66,51 @@ class SnapshotValidationService {
   /// 2. If primary fails, try 1 fallback gateway from the GAR list
   /// 3. Accept if ANY gateway returns 200
   Future<bool> _validateSnapshot(String txId, String primaryUrl) async {
-    // 1. Try primary gateway (with 1 retry)
-    for (var attempt = 0; attempt < 2; attempt++) {
-      try {
-        final response = await http
-            .head(Uri.parse('$primaryUrl/$txId'))
-            .timeout(_headTimeout);
+    var primaryWas404 = false;
 
-        // 200 = available, 302 = gateway knows about it (redirecting to sandbox URL)
-        if (response.statusCode == 200 || response.statusCode == 302) {
-          return true;
-        }
+    // 1. Try primary gateway (1 attempt, no retry — fail fast)
+    try {
+      final response = await http
+          .head(Uri.parse('$primaryUrl/$txId'))
+          .timeout(_headTimeout);
 
-        if (_isNonRetryable(response.statusCode)) {
-          logger.w(
-            'Snapshot $txId rejected: '
-            'non-retryable status ${response.statusCode}',
-          );
-          return false;
-        }
+      if (response.statusCode == 200 || response.statusCode == 302) {
+        return true;
+      }
 
-        logger.d(
-          'Snapshot $txId HEAD attempt ${attempt + 1} '
-          'returned ${response.statusCode}',
+      if (_isNonRetryable(response.statusCode)) {
+        logger.w(
+          'Snapshot $txId rejected: '
+          'non-retryable status ${response.statusCode}',
         );
-      } on TimeoutException {
-        logger.d('Snapshot $txId HEAD attempt ${attempt + 1} timed out');
-      } catch (e) {
-        logger.d('Snapshot $txId HEAD attempt ${attempt + 1} error: $e');
+        return false;
       }
 
-      // Retry after brief delay (skip delay on last attempt)
-      if (attempt == 0) {
-        await Future.delayed(_retryDelay);
-      }
+      primaryWas404 = response.statusCode == 404;
+
+      logger.d(
+        'Snapshot $txId HEAD returned ${response.statusCode}',
+      );
+    } on TimeoutException {
+      logger.d('Snapshot $txId HEAD timed out');
+    } catch (e) {
+      logger.d('Snapshot $txId HEAD error: $e');
     }
 
-    // 2. Primary failed — try 1 fallback gateway
+    // 2. If primary returned 404, the snapshot likely doesn't exist.
+    //    Skip the fallback — GAR list requires Solana RPC which may be
+    //    unavailable (localhost, rate limits). Fail fast and fall back to GQL.
+    if (primaryWas404) {
+      logger.w('Snapshot $txId not found on primary (404), skipping fallback');
+      return false;
+    }
+
+    // 3. Primary had a transient error (timeout, 5xx) — try 1 fallback gateway
     try {
-      final gateways = await _arioSDK
+      _cachedGateways ??= await _arioSDK
           .getGateways()
           .timeout(_garListTimeout, onTimeout: () => <Gateway>[]);
+      final gateways = _cachedGateways!;
 
       if (gateways.isEmpty) return false;
 

--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -333,7 +333,8 @@ class SyncCubit extends Cubit<SyncState> {
         syncProgressController.add(_syncProgress);
       }
 
-      if (profile is ProfileLoggedIn) {
+      // Only refresh balance if drives were actually synced (skip after no-op)
+      if (profile is ProfileLoggedIn && _syncProgress.drivesSynced > 0) {
         _profileCubit.refreshBalance();
       }
 
@@ -482,7 +483,8 @@ class SyncCubit extends Cubit<SyncState> {
         syncProgressController.add(_syncProgress);
       }
 
-      if (profile is ProfileLoggedIn) {
+      // Only refresh balance if drives were actually synced
+      if (profile is ProfileLoggedIn && _syncProgress.drivesSynced > 0) {
         _profileCubit.refreshBalance();
       }
 

--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -399,8 +399,13 @@ class SyncCubit extends Cubit<SyncState> {
     logger.i('Starting Sync for drive: $driveId, deepSync: $deepSync');
 
     if (state is SyncInProgress) {
-      logger.d('Sync state is SyncInProgress, aborting single drive sync...');
-      return;
+      logger.d('Waiting for current sync to finish before single drive sync');
+      await waitCurrentSync();
+      // Re-check: another caller may have started syncing while we waited
+      if (state is SyncInProgress) {
+        logger.d('Another sync started while waiting, aborting single drive sync');
+        return;
+      }
     }
 
     // Mark as single drive sync from the start so the UI shows the right title

--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -45,7 +45,11 @@ class SyncCubit extends Cubit<SyncState> {
   final StreamController<SyncProgress> syncProgressController =
       StreamController<SyncProgress>.broadcast();
   DateTime? _lastSync;
-  late DateTime _initSync;
+  DateTime _initSync = DateTime.now();
+
+  /// Exposed for the sync modal to display elapsed time.
+  DateTime get syncStartTime => _initSync;
+
   SyncProgress _syncProgress = SyncProgress.initial();
   SyncCancellationToken? _currentSyncToken;
 
@@ -231,6 +235,7 @@ class SyncCubit extends Cubit<SyncState> {
   Future<void> startSync({
     bool deepSync = false,
     bool skipTabVisibilityCheck = false,
+    List<String>? driveIdsToRetry,
   }) async {
     logger.i('Starting Sync');
 
@@ -319,6 +324,7 @@ class SyncCubit extends Cubit<SyncState> {
           password: password,
           cipherKey: cipherKey,
           syncDeep: deepSync,
+          driveIdsToRetry: driveIdsToRetry,
           cancellationToken: _currentSyncToken,
           txFechedCallback: (driveId, txCount) {
             _promptToSnapshotBloc.add(
@@ -581,6 +587,14 @@ class SyncCubit extends Cubit<SyncState> {
     if (state is SyncCompleteWithErrors) {
       emit(SyncIdle());
     }
+  }
+
+  /// Retry syncing only the drives that failed in the previous sync.
+  Future<void> retryFailedDrives(List<String> driveIds) async {
+    if (driveIds.isEmpty) return;
+
+    logger.i('Retrying ${driveIds.length} failed drives');
+    return startSync(driveIdsToRetry: driveIds);
   }
 
   /// Get the current sync progress

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -41,6 +41,26 @@ import 'package:cryptography/cryptography.dart';
 import 'package:drift/drift.dart';
 import 'package:retry/retry.dart';
 
+/// Timeout for a single transaction-status confirmation batch
+/// ([ArweaveService.getTransactionConfirmations]).
+///
+/// The gateway's GraphQL layer proxies an upstream index (`indexer-core`) with a
+/// ~9.5s upstream timeout and a circuit breaker. When the breaker is open a
+/// status query can legitimately take ~10s to return valid data (observed:
+/// 9.87s, with `UPSTREAM_CIRCUIT_OPEN` / "timeout of 9500ms exceeded" warnings).
+/// This must sit *above* that ceiling: otherwise the client cancels the batch
+/// before the successful response lands, discarding confirmations and leaving
+/// long-confirmed txs stuck as pending. Typical responses are ~0.5s, so this
+/// only extends waits while the gateway is degraded — exactly when we want to
+/// wait rather than drop the batch. Partial progress is still preserved by the
+/// verified sink regardless.
+const _txConfirmationBatchTimeout = Duration(seconds: 15);
+
+/// Overall timeout for a drive's transaction-status update (across batches).
+/// Sits above [_txConfirmationBatchTimeout] so at least one slow-but-successful
+/// batch can complete; remaining work resumes on the next sync.
+const _txStatusUpdateTimeout = Duration(seconds: 30);
+
 abstract class SyncRepository {
   Stream<double> syncDriveById({
     required String driveId,
@@ -395,12 +415,13 @@ class _SyncRepository implements SyncRepository {
                 txsIdsToSkip: confirmedFileTxIds,
                 cancellationToken: token,
               ).timeout(
-                const Duration(seconds: 10),
+                _txStatusUpdateTimeout,
                 onTimeout: () {
                   // Check if cancelled before timing out
                   token.checkCancellation();
                   logger.w(
-                      'Transaction status update timed out after 10 seconds');
+                      'Transaction status update timed out after '
+                      '${_txStatusUpdateTimeout.inSeconds}s');
                   // Update status message to indicate timeout but don't treat as error
                   syncProgress = syncProgress.copyWith(
                     statusMessage: 'Completing sync...',
@@ -677,11 +698,12 @@ class _SyncRepository implements SyncRepository {
             txsIdsToSkip: confirmedFileTxIds,
             cancellationToken: token,
           ).timeout(
-            const Duration(seconds: 10),
+            _txStatusUpdateTimeout,
             onTimeout: () {
               token.checkCancellation();
               logger.w(
-                  'Transaction status update timed out after 10 seconds for single drive');
+                  'Transaction status update timed out after '
+                  '${_txStatusUpdateTimeout.inSeconds}s for single drive');
               syncProgress = syncProgress.copyWith(
                 statusMessage: 'Completing sync...',
               );
@@ -820,7 +842,7 @@ class _SyncRepository implements SyncRepository {
               ownerOverrides: ownerOverrides,
               verifiedSink: verified)
           .timeout(
-        const Duration(seconds: 5),
+        _txConfirmationBatchTimeout,
         onTimeout: () {
           logger.w('Individual transaction confirmation timeout; '
               'applying ${verified.length} confirmations resolved so far');
@@ -1107,7 +1129,8 @@ class _SyncRepository implements SyncRepository {
       // confirmations, so it never marks anything failed off a partial run).
       final verified = <String?, int>{};
 
-      // Use a shorter timeout for individual GraphQL calls
+      // Bound each batch above the gateway's ~9.5s upstream ceiling so a
+      // slow-but-successful response can land instead of being discarded.
       final map = await arweave
           .getTransactionConfirmations(currentPage.toList(),
               owner: ownerAddress,
@@ -1115,7 +1138,7 @@ class _SyncRepository implements SyncRepository {
               ownerOverrides: ownerOverrides,
               verifiedSink: verified)
           .timeout(
-        const Duration(seconds: 5),
+        _txConfirmationBatchTimeout,
         onTimeout: () {
           logger.w('Individual transaction confirmation timeout; '
               'applying ${verified.length} confirmations resolved so far');

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -172,9 +172,9 @@ class _SyncRepository implements SyncRepository {
     // The address of the currently logged-in wallet. All pending transactions
     // are uploads made by this wallet, so scoping the status query by it lets
     // the gateway prune its search space. Cross-owner txs (e.g. data txs of
-    // files pinned from other authors) won't match this owner, but
-    // getTransactionConfirmations re-queries any unresolved ids without the
-    // owner filter so they aren't misclassified as failed.
+    // files pinned from other authors) won't match this owner; those that we
+    // can identify locally are re-queried scoped to their real owner via
+    // ownerOverrides in getTransactionConfirmations.
     String? walletAddress;
     if (wallet != null) {
       walletAddress = await wallet.getAddress();
@@ -771,6 +771,8 @@ class _SyncRepository implements SyncRepository {
   }) async {
     cancellationToken?.checkCancellation();
 
+    final ownerOverrides = await _buildPinnedDataTxOwnerOverrides(driveDao);
+
     // Load all pending transactions and filter to this drive
     final allPendingTxs = await driveDao.pendingTransactions().get();
     final drivePendingTxs = allPendingTxs
@@ -810,7 +812,7 @@ class _SyncRepository implements SyncRepository {
 
       final map = await arweave
           .getTransactionConfirmations(currentPage.toList(),
-              owner: ownerAddress)
+              owner: ownerAddress, ownerOverrides: ownerOverrides)
           .timeout(
         const Duration(seconds: 5),
         onTimeout: () {
@@ -993,6 +995,21 @@ class _SyncRepository implements SyncRepository {
     }
   }
 
+  /// Maps the data tx id of each pinned file to the address that actually owns
+  /// it on-chain (the original uploader, not the drive owner). Used to resolve
+  /// confirmation status for these cross-owner txs with a selective,
+  /// owner-scoped query instead of an expensive unscoped one.
+  Future<Map<String, String>> _buildPinnedDataTxOwnerOverrides(
+    DriveDao driveDao,
+  ) async {
+    final pinnedFileRevisions = await driveDao.pinnedFileRevisions().get();
+    return {
+      for (final row in pinnedFileRevisions)
+        if (row.pinnedDataOwnerAddress != null)
+          row.dataTxId: row.pinnedDataOwnerAddress!,
+    };
+  }
+
   Future<void> _updateTransactionStatuses({
     required DriveDao driveDao,
     required ArweaveService arweave,
@@ -1002,6 +1019,8 @@ class _SyncRepository implements SyncRepository {
   }) async {
     // Check for cancellation at the start
     cancellationToken?.checkCancellation();
+
+    final ownerOverrides = await _buildPinnedDataTxOwnerOverrides(driveDao);
 
     // Load all pending transactions
     // Note: We load all at once here, but the memory impact is acceptable
@@ -1053,7 +1072,7 @@ class _SyncRepository implements SyncRepository {
       // Use a shorter timeout for individual GraphQL calls
       final map = await arweave
           .getTransactionConfirmations(currentPage.toList(),
-              owner: ownerAddress)
+              owner: ownerAddress, ownerOverrides: ownerOverrides)
           .timeout(
         const Duration(seconds: 5),
         onTimeout: () {

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -1496,6 +1496,45 @@ class _SyncRepository implements SyncRepository {
       'no. of entities in drive with id ${drive.id} to be parsed are: $numberOfDriveEntitiesToParse\n',
     );
 
+    // Pre-load all latest/oldest revisions for this drive into maps.
+    // Replaces thousands of individual DB queries with 4 bulk queries.
+    final isFirstSync =
+        drive.lastBlockHeight == null || drive.lastBlockHeight == 0;
+
+    final latestFileRevisionsCache = isFirstSync
+        ? <String, FileRevisionsCompanion>{}
+        : <String, FileRevisionsCompanion>{
+            for (final e
+                in (await _driveDao.getAllLatestFileRevisionsMap(drive.id))
+                    .entries)
+              e.key: e.value.toCompanion(true),
+          };
+
+    final latestFolderRevisionsCache = isFirstSync
+        ? <String, FolderRevisionsCompanion>{}
+        : <String, FolderRevisionsCompanion>{
+            for (final e
+                in (await _driveDao.getAllLatestFolderRevisionsMap(drive.id))
+                    .entries)
+              e.key: e.value.toCompanion(true),
+          };
+
+    // Oldest revision maps — immutable during processing since inserting
+    // newer revisions doesn't change the oldest.
+    final oldestFileRevisionsCache = isFirstSync
+        ? <String, FileRevision>{}
+        : await _driveDao.getAllOldestFileRevisionsMap(drive.id);
+
+    final oldestFolderRevisionsCache = isFirstSync
+        ? <String, FolderRevision>{}
+        : await _driveDao.getAllOldestFolderRevisionsMap(drive.id);
+
+    if (!isFirstSync) {
+      logger.d('Pre-loaded revision caches: '
+          '${latestFileRevisionsCache.length} files, '
+          '${latestFolderRevisionsCache.length} folders');
+    }
+
     yield* _batchProcessor.batchProcess<DriveEntityHistoryTransactionModel>(
         list: transactions,
         batchSize: batchSize,
@@ -1538,10 +1577,12 @@ class _SyncRepository implements SyncRepository {
             final latestFolderRevisions = await _addNewFolderEntityRevisions(
               driveId: drive.id,
               newEntities: newEntities.whereType<FolderEntity>(),
+              latestRevisionsCache: latestFolderRevisionsCache,
             );
             final latestFileRevisions = await _addNewFileEntityRevisions(
               driveId: drive.id,
               newEntities: newEntities.whereType<FileEntity>(),
+              latestRevisionsCache: latestFileRevisionsCache,
             );
 
             for (final entity in latestFileRevisions) {
@@ -1570,12 +1611,14 @@ class _SyncRepository implements SyncRepository {
               driveDao: _driveDao,
               driveId: drive.id,
               revisionsByFolderId: latestFolderRevisions,
+              oldestRevisionsCache: oldestFolderRevisionsCache,
             );
             final updatedFilesById =
                 await _computeRefreshedFileEntriesFromRevisions(
               driveDao: _driveDao,
               driveId: drive.id,
               revisionsByFileId: latestFileRevisions,
+              oldestRevisionsCache: oldestFileRevisionsCache,
             );
 
             numberOfDriveEntitiesParsed += newEntities.length;
@@ -1652,6 +1695,7 @@ class _SyncRepository implements SyncRepository {
   Future<List<FileRevisionsCompanion>> _addNewFileEntityRevisions({
     required String driveId,
     required Iterable<FileEntity> newEntities,
+    required Map<String, FileRevisionsCompanion> latestRevisionsCache,
   }) async {
     // The latest file revisions, keyed by their entity ids.
     final latestRevisions = <String, FileRevisionsCompanion>{};
@@ -1660,12 +1704,10 @@ class _SyncRepository implements SyncRepository {
     for (final entity in newEntities) {
       if (!latestRevisions.containsKey(entity.id) &&
           entity.parentFolderId != null) {
-        final revisions = await _driveDao
-            .latestFileRevisionByFileId(driveId: driveId, fileId: entity.id!)
-            .getSingleOrNull();
-        // Gets the latest revision for the file, if it exists on the database.
-        if (revisions != null) {
-          latestRevisions[entity.id!] = revisions.toCompanion(true);
+        // Use pre-loaded cache instead of per-entity DB query
+        final cached = latestRevisionsCache[entity.id!];
+        if (cached != null) {
+          latestRevisions[entity.id!] = cached;
         }
       }
 
@@ -1693,10 +1735,12 @@ class _SyncRepository implements SyncRepository {
           if (revision.dateCreated.value
               .isAfter(latestRevision!.dateCreated.value)) {
             latestRevisions[entity.id!] = revision;
+            latestRevisionsCache[entity.id!] = revision;
             newRevisions.add(revision);
           }
         } else {
           latestRevisions[entity.id!] = revision;
+          latestRevisionsCache[entity.id!] = revision;
           newRevisions.add(revision);
         }
       } catch (e, stacktrace) {
@@ -1717,6 +1761,7 @@ class _SyncRepository implements SyncRepository {
   Future<List<FolderRevisionsCompanion>> _addNewFolderEntityRevisions({
     required String driveId,
     required Iterable<FolderEntity> newEntities,
+    required Map<String, FolderRevisionsCompanion> latestRevisionsCache,
   }) async {
     _folderIds.addAll(newEntities.map((e) => e.id!));
     // The latest folder revisions, keyed by their entity ids.
@@ -1725,12 +1770,10 @@ class _SyncRepository implements SyncRepository {
     final newRevisions = <FolderRevisionsCompanion>[];
     for (final entity in newEntities) {
       if (!latestRevisions.containsKey(entity.id)) {
-        final revisions = (await _driveDao
-            .latestFolderRevisionByFolderId(
-                driveId: driveId, folderId: entity.id!)
-            .getSingleOrNull());
-        if (revisions != null) {
-          latestRevisions[entity.id!] = revisions.toCompanion(true);
+        // Use pre-loaded cache instead of per-entity DB query
+        final cached = latestRevisionsCache[entity.id!];
+        if (cached != null) {
+          latestRevisions[entity.id!] = cached;
         }
       }
 
@@ -1748,6 +1791,7 @@ class _SyncRepository implements SyncRepository {
 
       newRevisions.add(revision);
       latestRevisions[entity.id!] = revision;
+      latestRevisionsCache[entity.id!] = revision;
     }
     final newNetworkTransactions =
         createNetworkTransactionsCompanionsForFolders(
@@ -1779,6 +1823,7 @@ Future<Map<String, FileEntriesCompanion>>
   required DriveDao driveDao,
   required String driveId,
   required List<FileRevisionsCompanion> revisionsByFileId,
+  required Map<String, FileRevision> oldestRevisionsCache,
 }) async {
   final updatedFilesById = {
     for (final revision in revisionsByFileId)
@@ -1786,9 +1831,8 @@ Future<Map<String, FileEntriesCompanion>>
   };
 
   for (final fileId in updatedFilesById.keys) {
-    final oldestRevision = await driveDao
-        .oldestFileRevisionByFileId(driveId: driveId, fileId: fileId)
-        .getSingleOrNull();
+    // Use pre-loaded cache instead of per-entity DB query
+    final oldestRevision = oldestRevisionsCache[fileId];
 
     final dateCreated = oldestRevision?.dateCreated ??
         updatedFilesById[fileId]!.dateCreated.value;
@@ -1807,6 +1851,7 @@ Future<Map<String, FolderEntriesCompanion>>
   required DriveDao driveDao,
   required String driveId,
   required List<FolderRevisionsCompanion> revisionsByFolderId,
+  required Map<String, FolderRevision> oldestRevisionsCache,
 }) async {
   final updatedFoldersById = {
     for (final revision in revisionsByFolderId)
@@ -1814,9 +1859,8 @@ Future<Map<String, FolderEntriesCompanion>>
   };
 
   for (final folderId in updatedFoldersById.keys) {
-    final oldestRevision = await driveDao
-        .oldestFolderRevisionByFolderId(driveId: driveId, folderId: folderId)
-        .getSingleOrNull();
+    // Use pre-loaded cache instead of per-entity DB query
+    final oldestRevision = oldestRevisionsCache[folderId];
 
     final dateCreated = oldestRevision?.dateCreated ??
         updatedFoldersById[folderId]!.dateCreated.value;
@@ -1840,7 +1884,7 @@ Future<DrivesCompanion> _computeRefreshedDriveFromRevision({
 
   return latestRevision.toEntryCompanion().copyWith(
         dateCreated: Value(
-          oldestRevision?.dateCreated ?? latestRevision.dateCreated as DateTime,
+          oldestRevision?.dateCreated ?? latestRevision.dateCreated.value,
         ),
       );
 }

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -169,11 +169,17 @@ class _SyncRepository implements SyncRepository {
     _ghostFolders.clear();
     _folderIds.clear();
 
+    // The address of the currently logged-in wallet. All pending transactions
+    // are uploads made by this wallet, so scoping the status query by it lets
+    // the gateway prune its search space. (Edge case: data txs of files pinned
+    // from other authors are owned by those authors and won't match — those
+    // are rare and treated as best-effort.)
+    String? walletAddress;
     if (wallet != null) {
-      final address = await wallet.getAddress();
+      walletAddress = await wallet.getAddress();
 
       _arnsRepository
-          .getAntRecordsForWallet(address, update: true)
+          .getAntRecordsForWallet(walletAddress, update: true)
           .catchError((e) {
         logger.e('Error getting ANT records for wallet. Continuing...', e);
         return Future.value(<ANTRecord>[]);
@@ -383,6 +389,8 @@ class _SyncRepository implements SyncRepository {
               _updateTransactionStatuses(
                 driveDao: _driveDao,
                 arweave: _arweave,
+                // Scope the gateway query to the logged-in wallet for selectivity.
+                ownerAddress: walletAddress,
                 txsIdsToSkip: confirmedFileTxIds,
                 cancellationToken: token,
               ).timeout(
@@ -663,6 +671,8 @@ class _SyncRepository implements SyncRepository {
             driveDao: _driveDao,
             arweave: _arweave,
             driveDataTxIds: driveDataTxIds,
+            // Scope the gateway query to this drive's owner for selectivity.
+            ownerAddress: drive.ownerAddress,
             txsIdsToSkip: confirmedFileTxIds,
             cancellationToken: token,
           ).timeout(
@@ -754,6 +764,7 @@ class _SyncRepository implements SyncRepository {
     required DriveDao driveDao,
     required ArweaveService arweave,
     required Set<String> driveDataTxIds,
+    String? ownerAddress,
     List<TxID> txsIdsToSkip = const [],
     SyncCancellationToken? cancellationToken,
   }) async {
@@ -797,7 +808,8 @@ class _SyncRepository implements SyncRepository {
       cancellationToken?.checkCancellation();
 
       final map = await arweave
-          .getTransactionConfirmations(currentPage.toList())
+          .getTransactionConfirmations(currentPage.toList(),
+              owner: ownerAddress)
           .timeout(
         const Duration(seconds: 5),
         onTimeout: () {
@@ -983,6 +995,7 @@ class _SyncRepository implements SyncRepository {
   Future<void> _updateTransactionStatuses({
     required DriveDao driveDao,
     required ArweaveService arweave,
+    String? ownerAddress,
     List<TxID> txsIdsToSkip = const [],
     SyncCancellationToken? cancellationToken,
   }) async {
@@ -1038,7 +1051,8 @@ class _SyncRepository implements SyncRepository {
 
       // Use a shorter timeout for individual GraphQL calls
       final map = await arweave
-          .getTransactionConfirmations(currentPage.toList())
+          .getTransactionConfirmations(currentPage.toList(),
+              owner: ownerAddress)
           .timeout(
         const Duration(seconds: 5),
         onTimeout: () {

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -1825,17 +1825,22 @@ Future<Map<String, FileEntriesCompanion>>
   required List<FileRevisionsCompanion> revisionsByFileId,
   required Map<String, FileRevision> oldestRevisionsCache,
 }) async {
-  final updatedFilesById = {
-    for (final revision in revisionsByFileId)
-      revision.fileId.value: revision.toEntryCompanion(),
-  };
+  // Build map of entry companions AND keep revision dateCreated for fallback
+  final revisionDateByFileId = <String, DateTime>{};
+  final updatedFilesById = <String, FileEntriesCompanion>{};
+  for (final revision in revisionsByFileId) {
+    final fileId = revision.fileId.value;
+    updatedFilesById[fileId] = revision.toEntryCompanion();
+    revisionDateByFileId[fileId] = revision.dateCreated.value;
+  }
 
   for (final fileId in updatedFilesById.keys) {
-    // Use pre-loaded cache instead of per-entity DB query
+    // Use pre-loaded cache instead of per-entity DB query.
+    // Fall back to the revision's own dateCreated (not the entry companion's,
+    // which may be Value.absent due to schema defaults).
     final oldestRevision = oldestRevisionsCache[fileId];
-
-    final dateCreated = oldestRevision?.dateCreated ??
-        updatedFilesById[fileId]!.dateCreated.value;
+    final dateCreated =
+        oldestRevision?.dateCreated ?? revisionDateByFileId[fileId]!;
 
     updatedFilesById[fileId] = updatedFilesById[fileId]!.copyWith(
       dateCreated: Value<DateTime>(dateCreated),
@@ -1853,17 +1858,22 @@ Future<Map<String, FolderEntriesCompanion>>
   required List<FolderRevisionsCompanion> revisionsByFolderId,
   required Map<String, FolderRevision> oldestRevisionsCache,
 }) async {
-  final updatedFoldersById = {
-    for (final revision in revisionsByFolderId)
-      revision.folderId.value: revision.toEntryCompanion(),
-  };
+  // Build map of entry companions AND keep revision dateCreated for fallback
+  final revisionDateByFolderId = <String, DateTime>{};
+  final updatedFoldersById = <String, FolderEntriesCompanion>{};
+  for (final revision in revisionsByFolderId) {
+    final folderId = revision.folderId.value;
+    updatedFoldersById[folderId] = revision.toEntryCompanion();
+    revisionDateByFolderId[folderId] = revision.dateCreated.value;
+  }
 
   for (final folderId in updatedFoldersById.keys) {
-    // Use pre-loaded cache instead of per-entity DB query
+    // Use pre-loaded cache instead of per-entity DB query.
+    // Fall back to the revision's own dateCreated (not the entry companion's,
+    // which may be Value.absent due to schema defaults).
     final oldestRevision = oldestRevisionsCache[folderId];
-
-    final dateCreated = oldestRevision?.dateCreated ??
-        updatedFoldersById[folderId]!.dateCreated.value;
+    final dateCreated =
+        oldestRevision?.dateCreated ?? revisionDateByFolderId[folderId]!;
 
     updatedFoldersById[folderId] = updatedFoldersById[folderId]!.copyWith(
       dateCreated: Value<DateTime>(dateCreated),

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -15,7 +15,8 @@ import 'package:ardrive/models/drive_revision.dart';
 import 'package:ardrive/models/enums.dart';
 import 'package:ardrive/models/file_revision.dart';
 import 'package:ardrive/models/folder_revision.dart';
-import 'package:ardrive/services/arweave/arweave.dart';
+import 'package:ardrive/services/arweave/arweave.dart'
+    hide SnapshotEntityTransaction;
 import 'package:ardrive/services/config/config.dart';
 import 'package:ardrive/sync/constants.dart';
 import 'package:ardrive/sync/data/snapshot_validation_service.dart';
@@ -103,6 +104,7 @@ abstract class SyncRepository {
     required Wallet wallet,
     required String password,
     required SecretKey cipherKey,
+    bool forceRefresh = false,
   });
 
   Future<void> createGhosts({
@@ -153,6 +155,12 @@ class _SyncRepository implements SyncRepository {
   /// Larger values = better throughput, higher memory usage
   /// Smaller values = lower memory usage, more frequent DB commits
   static const kStreamTransactionChunkSize = 1000;
+
+  /// In-flight or completed [updateUserDrives] future to avoid redundant GQL
+  /// calls when multiple entry points (syncMetadataOnly, startSync,
+  /// startSyncForDrive) call it concurrently or in quick succession.
+  /// Cleared after sync completes or when a drive is created/updated.
+  Future<void>? _userDrivesUpdateFuture;
 
   DateTime? _lastSync;
 
@@ -214,10 +222,8 @@ class _SyncRepository implements SyncRepository {
       return;
     }
 
-    final numberOfDrivesToSync = drives.length;
-
     SyncProgress syncProgress =
-        SyncProgress.initial().copyWith(drivesCount: numberOfDrivesToSync);
+        SyncProgress.initial().copyWith(drivesCount: drives.length);
 
     yield syncProgress;
 
@@ -227,6 +233,164 @@ class _SyncRepository implements SyncRepository {
         'Retrying for get the current block height',
       ),
     );
+
+    // Share gateway fallback reference so snapshot validation and data fetching
+    // use the same gateway cache (avoids duplicate Solana RPC calls)
+    _snapshotValidationService.gatewayFallback = _arweave.gatewayFallback;
+
+    // Probe for drive activity to skip unchanged drives.
+    // Partition drives: never-synced drives always need full sync and would
+    // poison the probe's minBlockHeight to 0 (causing it to query from genesis,
+    // overflow the page limit, and fall back to syncing ALL drives).
+    List<Drive> drivesToSync;
+    if (syncDeep) {
+      drivesToSync = drives;
+    } else {
+      try {
+        final neverSyncedDrives = <Drive>[];
+        final previouslySyncedDrives = <Drive>[];
+
+        for (final drive in drives) {
+          if ((drive.lastBlockHeight ?? 0) == 0) {
+            neverSyncedDrives.add(drive);
+          } else {
+            previouslySyncedDrives.add(drive);
+          }
+        }
+
+        // Never-synced drives always need full sync
+        drivesToSync = [...neverSyncedDrives];
+
+        if (previouslySyncedDrives.isEmpty) {
+          // All drives are never-synced; skip probe entirely
+          if (neverSyncedDrives.isNotEmpty) {
+            logger.i(
+                '${neverSyncedDrives.length} drives need first-time sync');
+          }
+        } else {
+          // Group previously-synced drives by owner for efficient probing
+          final drivesByOwner = <String, List<Drive>>{};
+          for (final drive in previouslySyncedDrives) {
+            drivesByOwner
+                .putIfAbsent(drive.ownerAddress, () => [])
+                .add(drive);
+          }
+
+          final activeDriveIds = <String>{};
+          bool allComplete = true;
+
+          for (final entry in drivesByOwner.entries) {
+            token.checkCancellation();
+            final ownerDrives = entry.value;
+            final minBlock = ownerDrives
+                .map((d) =>
+                    _calculateSyncLastBlockHeight(d.lastBlockHeight ?? 0))
+                .reduce(min);
+
+            final result = await _arweave.probeActiveDriveIds(
+              driveIds: ownerDrives.map((d) => d.id).toList(),
+              minBlockHeight: minBlock,
+              ownerAddress: entry.key,
+            );
+
+            activeDriveIds.addAll(result.activeDriveIds);
+            if (!result.isComplete) allComplete = false;
+          }
+
+          if (!allComplete) {
+            // Can't confirm all drives checked — sync all previously-synced
+            for (final drive in previouslySyncedDrives) {
+              activeDriveIds.add(drive.id);
+            }
+          }
+
+          // Add previously-synced drives that have activity
+          drivesToSync.addAll(
+            previouslySyncedDrives
+                .where((d) => activeDriveIds.contains(d.id)),
+          );
+
+          final skipped = drives.length - drivesToSync.length;
+          if (skipped > 0) {
+            logger.i('Skipping $skipped unchanged drives');
+          }
+          if (neverSyncedDrives.isNotEmpty) {
+            logger.i(
+                '${neverSyncedDrives.length} drives need first-time sync');
+          }
+        }
+      } catch (e) {
+        logger.w('Drive activity probe failed, syncing all drives: $e');
+        drivesToSync = drives;
+      }
+    }
+
+    final numberOfDrivesToSync = drivesToSync.length;
+
+    if (numberOfDrivesToSync == 0) {
+      // Probe found no drives with activity — this is a successful no-op sync
+      logger.i('No drives need syncing');
+      yield SyncProgress.emptySyncCompleted();
+      _lastSync = DateTime.now();
+      return;
+    }
+
+    syncProgress = syncProgress.copyWith(drivesCount: numberOfDrivesToSync);
+    yield syncProgress;
+
+    // Batch-fetch snapshots for all drives per owner (1 GQL query per owner
+    // instead of 1 per drive). Results are grouped by Drive-Id and passed to
+    // each drive's sync to avoid redundant per-drive snapshot queries.
+    final prefetchedSnapshots = <String, List<SnapshotEntityTransaction>>{};
+    if (_configService.config.enableSyncFromSnapshot && !syncDeep) {
+      try {
+        // Reuse the drivesByOwner grouping from the probe (or rebuild it)
+        final snapshotDrivesByOwner = <String, List<Drive>>{};
+        for (final drive in drivesToSync) {
+          snapshotDrivesByOwner
+              .putIfAbsent(drive.ownerAddress, () => [])
+              .add(drive);
+        }
+
+        for (final entry in snapshotDrivesByOwner.entries) {
+          final ownerDrives = entry.value;
+          // Use only previously-synced drives for minBlock so never-synced
+          // drives (lastBlockHeight=0) don't drag the query back to genesis.
+          final syncedHeights = ownerDrives
+              .where((d) => (d.lastBlockHeight ?? 0) > 0)
+              .map((d) =>
+                  _calculateSyncLastBlockHeight(d.lastBlockHeight ?? 0));
+          final minBlock = syncedHeights.isNotEmpty
+              ? syncedHeights.reduce(min)
+              : 0;
+
+          final snapshotsStream = _arweave.getAllSnapshotsForDrives(
+            ownerDrives.map((d) => d.id).toList(),
+            minBlock,
+            ownerAddress: entry.key,
+          );
+
+          await for (final snapshot in snapshotsStream) {
+            final driveIdTag = snapshot.tags
+                .where((t) => t.name == 'Drive-Id')
+                .firstOrNull
+                ?.value;
+            if (driveIdTag != null) {
+              prefetchedSnapshots
+                  .putIfAbsent(driveIdTag, () => [])
+                  .add(snapshot);
+            }
+          }
+        }
+
+        logger.i(
+            'Prefetched ${prefetchedSnapshots.values.expand((v) => v).length} '
+            'snapshots across ${prefetchedSnapshots.length} drives');
+      } catch (e) {
+        logger.w('Snapshot prefetch failed, will fetch per-drive: $e');
+        prefetchedSnapshots.clear();
+      }
+    }
 
     double totalProgress = 0;
 
@@ -244,7 +408,7 @@ class _SyncRepository implements SyncRepository {
     // Start the async work but don't wait for it yet
     // Using Future.wait with eagerError: false to continue even if some drives fail
     Future.wait(
-      drives.map((drive) async {
+      drivesToSync.map((drive) async {
         try {
           // Check for cancellation before starting each drive
           token.checkCancellation();
@@ -264,6 +428,9 @@ class _SyncRepository implements SyncRepository {
             ownerAddress: drive.ownerAddress,
             txFechedCallback: txFechedCallback,
             cancellationToken: token,
+            prefetchedSnapshots: prefetchedSnapshots[drive.id],
+            skipPendingTxFetch: walletAddress != null &&
+                drive.ownerAddress != walletAddress,
           );
 
           double currentDriveProgress = 0;
@@ -385,14 +552,19 @@ class _SyncRepository implements SyncRepository {
         );
         syncProgressController.add(syncProgress);
 
-        final allFileRevisions = await _getAllFileEntities(driveDao: _driveDao);
         final metadataTxsFromSnapshots =
             await SnapshotItemOnChain.getAllCachedTransactionIds();
-        final confirmedFileTxIds = allFileRevisions
-            .where(
-                (file) => metadataTxsFromSnapshots.contains(file.metadataTxId))
-            .map((file) => file.dataTxId)
-            .toList();
+        final confirmedFileTxIds = <String>[];
+        if (metadataTxsFromSnapshots.isNotEmpty) {
+          for (var i = 0; i < metadataTxsFromSnapshots.length; i += 500) {
+            final chunk = metadataTxsFromSnapshots.sublist(
+                i, min(i + 500, metadataTxsFromSnapshots.length));
+            final rows = await _driveDao
+                .fileRevisionDataTxIdsByMetadataTxIds(metadataTxIds: chunk)
+                .get();
+            confirmedFileTxIds.addAll(rows);
+          }
+        }
         // Clear cached transaction IDs now that we've used them
         SnapshotItemOnChain.clearAllCachedTransactionIds();
         _arnsRepository
@@ -440,6 +612,9 @@ class _SyncRepository implements SyncRepository {
         }
 
         _lastSync = DateTime.now();
+        // Invalidate drive caches so next sync re-fetches fresh data
+        _userDrivesUpdateFuture = null;
+        _arweave.clearUserDriveTxsCache();
 
         // Update progress to 100% when truly complete
         syncProgress = syncProgress.copyWith(
@@ -581,6 +756,8 @@ class _SyncRepository implements SyncRepository {
         // Check for cancellation before starting
         token.checkCancellation();
 
+        final walletAddress = await wallet?.getAddress();
+
         final driveSyncProgress = _syncDrive(
           drive.id,
           cipherKey: cipherKey,
@@ -592,6 +769,8 @@ class _SyncRepository implements SyncRepository {
           ownerAddress: drive.ownerAddress,
           txFechedCallback: txFechedCallback,
           cancellationToken: token,
+          skipPendingTxFetch: walletAddress != null &&
+              drive.ownerAddress != walletAddress,
         );
 
         await for (var driveProgress in driveSyncProgress) {
@@ -717,6 +896,9 @@ class _SyncRepository implements SyncRepository {
         }
 
         _lastSync = DateTime.now();
+        // Invalidate drive caches so next sync re-fetches fresh data
+        _userDrivesUpdateFuture = null;
+        _arweave.clearUserDriveTxsCache();
 
         // Update progress to 100% when truly complete
         syncProgress = syncProgress.copyWith(
@@ -811,6 +993,26 @@ class _SyncRepository implements SyncRepository {
       pendingTxMap.remove(txId);
     }
 
+    // Bulk pre-load dateCreated for pending txs missing it (avoids N+1 queries)
+    final txIdsNeedingDates = pendingTxMap.entries
+        .where((e) => e.value.transactionDateCreated == null)
+        .map((e) => e.key)
+        .toList();
+
+    final dateCreatedCache = <String, DateTime?>{};
+    if (txIdsNeedingDates.isNotEmpty) {
+      for (var i = 0; i < txIdsNeedingDates.length; i += 500) {
+        final chunk = txIdsNeedingDates.sublist(
+            i, min(i + 500, txIdsNeedingDates.length));
+        final rows = await driveDao
+            .fileRevisionDateCreatedByDataTxIds(txIds: chunk)
+            .get();
+        for (final row in rows) {
+          dateCreatedCache[row.dataTxId] = row.dateCreated;
+        }
+      }
+    }
+
     final length = pendingTxMap.length;
     final list = pendingTxMap.keys.toList();
     const page = 5000;
@@ -852,72 +1054,69 @@ class _SyncRepository implements SyncRepository {
         confirmations.putIfAbsent(key, () => value);
       });
 
-      await driveDao.transaction(() async {
-        for (final txId in currentPage) {
-          cancellationToken?.checkCancellation();
+      final updates = <NetworkTransactionsCompanion>[];
+      for (final txId in currentPage) {
+        cancellationToken?.checkCancellation();
 
-          // Skip if confirmation data is missing (e.g., timeout or partial response)
-          final confirmationCount = confirmations[txId];
-          if (confirmationCount == null) {
-            continue;
-          }
+        // Skip if confirmation data is missing (e.g., timeout or partial response)
+        final confirmationCount = confirmations[txId];
+        if (confirmationCount == null) {
+          continue;
+        }
 
-          final txConfirmed =
-              confirmationCount >= kRequiredTxConfirmationCount;
-          final txNotFound = confirmationCount < 0;
+        final txConfirmed =
+            confirmationCount >= kRequiredTxConfirmationCount;
+        final txNotFound = confirmationCount < 0;
 
-          String? txStatus;
-          DateTime? transactionDateCreated;
+        String? txStatus;
+        DateTime? transactionDateCreated;
 
-          if (pendingTxMap[txId]!.transactionDateCreated != null) {
-            transactionDateCreated =
-                pendingTxMap[txId]!.transactionDateCreated!;
-          } else {
-            transactionDateCreated = await _getDateCreatedByDataTx(
-              driveDao: driveDao,
-              dataTx: txId,
-            );
-          }
+        if (pendingTxMap[txId]!.transactionDateCreated != null) {
+          transactionDateCreated =
+              pendingTxMap[txId]!.transactionDateCreated!;
+        } else {
+          transactionDateCreated = dateCreatedCache[txId];
+        }
 
-          if (txConfirmed) {
-            txStatus = TransactionStatus.confirmed;
-          } else if (txNotFound) {
-            final abovePendingThreshold = DateTime.now()
-                    .difference(pendingTxMap[txId]!.dateCreated)
-                    .inMinutes >
-                kRequiredTxConfirmationPendingThreshold;
+        if (txConfirmed) {
+          txStatus = TransactionStatus.confirmed;
+        } else if (txNotFound) {
+          final abovePendingThreshold = DateTime.now()
+                  .difference(pendingTxMap[txId]!.dateCreated)
+                  .inMinutes >
+              kRequiredTxConfirmationPendingThreshold;
 
-            if (abovePendingThreshold ||
-                _isOverThePendingTime(transactionDateCreated)) {
-              txStatus = TransactionStatus.failed;
-            }
-          }
-          if (txStatus != null) {
-            await driveDao.writeToTransaction(
-              NetworkTransactionsCompanion(
-                transactionDateCreated: Value(transactionDateCreated),
-                id: Value(txId),
-                status: Value(txStatus),
-              ),
-            );
+          if (abovePendingThreshold ||
+              _isOverThePendingTime(transactionDateCreated)) {
+            txStatus = TransactionStatus.failed;
           }
         }
-      });
-
-      await Future.delayed(const Duration(milliseconds: 200));
+        if (txStatus != null) {
+          updates.add(
+            NetworkTransactionsCompanion(
+              transactionDateCreated: Value(transactionDateCreated),
+              id: Value(txId),
+              status: Value(txStatus),
+            ),
+          );
+        }
+      }
+      if (updates.isNotEmpty) {
+        await driveDao.insertNewNetworkTransactions(updates);
+      }
     }
 
     // Mark skipped transactions as confirmed
-    await driveDao.transaction(() async {
-      for (final txId in txsIdsToSkip) {
-        await driveDao.writeToTransaction(
-          NetworkTransactionsCompanion(
-            id: Value(txId),
-            status: const Value(TransactionStatus.confirmed),
-          ),
-        );
-      }
-    });
+    if (txsIdsToSkip.isNotEmpty) {
+      await driveDao.insertNewNetworkTransactions(
+        txsIdsToSkip
+            .map((txId) => NetworkTransactionsCompanion(
+                  id: Value(txId),
+                  status: const Value(TransactionStatus.confirmed),
+                ))
+            .toList(),
+      );
+    }
   }
 
   @override
@@ -932,20 +1131,27 @@ class _SyncRepository implements SyncRepository {
     // Collect all ghost folders to be created
     final ghostFoldersToCreate = <FolderEntry>[];
 
-    //Finalize missing parent list
+    if (ghostFolders.isEmpty) return;
+
+    // Bulk pre-load existing folders and drives to avoid N+1 queries
+    final existingFolderIds = (await driveDao
+            .foldersByIds(folderIds: ghostFolders.keys.toList())
+            .get())
+        .map((f) => f.id)
+        .toSet();
+    final drivesMap = {
+      for (final d in await driveDao.allDrives().get()) d.id: d
+    };
+
     for (final ghostFolder in ghostFolders.values) {
-      final folder = await driveDao
-          .folderById(folderId: ghostFolder.folderId)
-          .getSingleOrNull();
-
-      final folderExists = folder != null;
-
-      if (folderExists) {
+      if (existingFolderIds.contains(ghostFolder.folderId)) {
         continue;
       }
 
-      final drive =
-          await driveDao.driveById(driveId: ghostFolder.driveId).getSingle();
+      final drive = drivesMap[ghostFolder.driveId];
+      if (drive == null) {
+        continue;
+      }
 
       // Don't create ghost folder if the ghost is a missing root folder
       // Or if the drive doesn't belong to the user
@@ -986,6 +1192,34 @@ class _SyncRepository implements SyncRepository {
 
   @override
   Future<void> updateUserDrives({
+    required Wallet wallet,
+    required String password,
+    required SecretKey cipherKey,
+    bool forceRefresh = false,
+  }) async {
+    // If an in-flight or completed future exists, await it (unless forced).
+    // This handles both concurrent calls (two callers before the first finishes)
+    // and serial calls (syncMetadataOnly then startSync seconds later).
+    if (!forceRefresh && _userDrivesUpdateFuture != null) {
+      logger.d('Skipping updateUserDrives: reusing in-flight/completed result');
+      return _userDrivesUpdateFuture!;
+    }
+
+    final future = _doUpdateUserDrives(
+      wallet: wallet,
+      password: password,
+      cipherKey: cipherKey,
+    ).catchError((e) {
+      // Clear the cached future on error so the next caller retries
+      _userDrivesUpdateFuture = null;
+      throw e;
+    });
+
+    _userDrivesUpdateFuture = future;
+    return future;
+  }
+
+  Future<void> _doUpdateUserDrives({
     required Wallet wallet,
     required String password,
     required SecretKey cipherKey,
@@ -1096,11 +1330,29 @@ class _SyncRepository implements SyncRepository {
       pendingTxMap.remove(txId);
     }
 
+    // Bulk pre-load dateCreated for pending txs missing it (avoids N+1 queries)
+    final txIdsNeedingDates = pendingTxMap.entries
+        .where((e) => e.value.transactionDateCreated == null)
+        .map((e) => e.key)
+        .toList();
+
+    final dateCreatedCache = <String, DateTime?>{};
+    if (txIdsNeedingDates.isNotEmpty) {
+      for (var i = 0; i < txIdsNeedingDates.length; i += 500) {
+        final chunk = txIdsNeedingDates.sublist(
+            i, min(i + 500, txIdsNeedingDates.length));
+        final rows = await driveDao
+            .fileRevisionDateCreatedByDataTxIds(txIds: chunk)
+            .get();
+        for (final row in rows) {
+          dateCreatedCache[row.dataTxId] = row.dateCreated;
+        }
+      }
+    }
+
     final length = pendingTxMap.length;
     final list = pendingTxMap.keys.toList();
 
-    // Thats was discovered by tests at profile mode.
-    // TODO(@thiagocarvalhodev): Revisit
     const page = 5000;
 
     for (var i = 0; i < length / page; i++) {
@@ -1148,97 +1400,75 @@ class _SyncRepository implements SyncRepository {
         confirmations.putIfAbsent(key, () => value);
       });
 
-      await driveDao.transaction(() async {
-        for (final txId in currentPage) {
-          // Check cancellation for each transaction
-          cancellationToken?.checkCancellation();
+      final updates = <NetworkTransactionsCompanion>[];
+      for (final txId in currentPage) {
+        // Check cancellation for each transaction
+        cancellationToken?.checkCancellation();
 
-          // Skip if confirmation data is missing (e.g., timeout or partial response)
-          final confirmationCount = confirmations[txId];
-          if (confirmationCount == null) {
-            continue;
-          }
+        // Skip if confirmation data is missing (e.g., timeout or partial response)
+        final confirmationCount = confirmations[txId];
+        if (confirmationCount == null) {
+          continue;
+        }
 
-          final txConfirmed =
-              confirmationCount >= kRequiredTxConfirmationCount;
-          final txNotFound = confirmationCount < 0;
+        final txConfirmed =
+            confirmationCount >= kRequiredTxConfirmationCount;
+        final txNotFound = confirmationCount < 0;
 
-          String? txStatus;
+        String? txStatus;
 
-          DateTime? transactionDateCreated;
+        DateTime? transactionDateCreated;
 
-          if (pendingTxMap[txId]!.transactionDateCreated != null) {
-            transactionDateCreated =
-                pendingTxMap[txId]!.transactionDateCreated!;
-          } else {
-            transactionDateCreated = await _getDateCreatedByDataTx(
-              driveDao: driveDao,
-              dataTx: txId,
-            );
-          }
+        if (pendingTxMap[txId]!.transactionDateCreated != null) {
+          transactionDateCreated =
+              pendingTxMap[txId]!.transactionDateCreated!;
+        } else {
+          transactionDateCreated = dateCreatedCache[txId];
+        }
 
-          if (txConfirmed) {
-            txStatus = TransactionStatus.confirmed;
-          } else if (txNotFound) {
-            // Only mark transactions as failed if they are unconfirmed for over 45 minutes
-            // as the transaction might not be queryable for right after it was created.
-            final abovePendingThreshold = DateTime.now()
-                    .difference(pendingTxMap[txId]!.dateCreated)
-                    .inMinutes >
-                kRequiredTxConfirmationPendingThreshold;
+        if (txConfirmed) {
+          txStatus = TransactionStatus.confirmed;
+        } else if (txNotFound) {
+          // Only mark transactions as failed if they are unconfirmed for over 45 minutes
+          // as the transaction might not be queryable for right after it was created.
+          final abovePendingThreshold = DateTime.now()
+                  .difference(pendingTxMap[txId]!.dateCreated)
+                  .inMinutes >
+              kRequiredTxConfirmationPendingThreshold;
 
-            // Assume that data tx that weren't mined up to a maximum of
-            // `_pendingWaitTime` was failed.
-            if (abovePendingThreshold ||
-                _isOverThePendingTime(transactionDateCreated)) {
-              txStatus = TransactionStatus.failed;
-            }
-          }
-          if (txStatus != null) {
-            await driveDao.writeToTransaction(
-              NetworkTransactionsCompanion(
-                transactionDateCreated: Value(transactionDateCreated),
-                id: Value(txId),
-                status: Value(txStatus),
-              ),
-            );
+          // Assume that data tx that weren't mined up to a maximum of
+          // `_pendingWaitTime` was failed.
+          if (abovePendingThreshold ||
+              _isOverThePendingTime(transactionDateCreated)) {
+            txStatus = TransactionStatus.failed;
           }
         }
-      });
-
-      await Future.delayed(const Duration(milliseconds: 200));
-    }
-    await driveDao.transaction(() async {
-      for (final txId in txsIdsToSkip) {
-        await driveDao.writeToTransaction(
-          NetworkTransactionsCompanion(
-            id: Value(txId),
-            status: const Value(TransactionStatus.confirmed),
-          ),
-        );
+        if (txStatus != null) {
+          updates.add(
+            NetworkTransactionsCompanion(
+              transactionDateCreated: Value(transactionDateCreated),
+              id: Value(txId),
+              status: Value(txStatus),
+            ),
+          );
+        }
       }
-    });
-  }
-
-  Future<List<FileRevision>> _getAllFileEntities({
-    required DriveDao driveDao,
-  }) async {
-    return await driveDao.db.fileRevisions.select().get();
-  }
-
-  Future<DateTime?> _getDateCreatedByDataTx({
-    required DriveDao driveDao,
-    required String dataTx,
-  }) async {
-    final rev = await driveDao.fileRevisionByDataTx(tx: dataTx).get();
-
-    // no file found
-    if (rev.isEmpty) {
-      return null;
+      if (updates.isNotEmpty) {
+        await driveDao.insertNewNetworkTransactions(updates);
+      }
     }
-
-    return rev.first.dateCreated;
+    if (txsIdsToSkip.isNotEmpty) {
+      await driveDao.insertNewNetworkTransactions(
+        txsIdsToSkip
+            .map((txId) => NetworkTransactionsCompanion(
+                  id: Value(txId),
+                  status: const Value(TransactionStatus.confirmed),
+                ))
+            .toList(),
+      );
+    }
   }
+
 
   bool _isOverThePendingTime(DateTime? transactionCreatedDate) {
     // If don't have the date information we cannot assume that is over the pending time
@@ -1258,6 +1488,8 @@ class _SyncRepository implements SyncRepository {
     required String ownerAddress,
     Function(String driveId, int txCount)? txFechedCallback,
     SyncCancellationToken? cancellationToken,
+    List<SnapshotEntityTransaction>? prefetchedSnapshots,
+    bool skipPendingTxFetch = false,
   }) async* {
     final token = cancellationToken ?? SyncCancellationToken();
 
@@ -1296,11 +1528,12 @@ class _SyncRepository implements SyncRepository {
       if (_configService.config.enableSyncFromSnapshot) {
         logger.i('Syncing from snapshot: ${drive.id}');
 
-        final snapshotsStream = _arweave.getAllSnapshotsOfDrive(
-          driveId,
-          lastBlockHeight,
-          ownerAddress: ownerAddress,
-        );
+        // Use prefetched snapshots if available (batched query),
+        // otherwise fall back to per-drive query
+        final snapshotsStream = prefetchedSnapshots != null
+            ? Stream.fromIterable(prefetchedSnapshots)
+            : _arweave.getAllSnapshotsOfDrive(
+                driveId, lastBlockHeight, ownerAddress: ownerAddress);
 
         snapshotItems = await SnapshotItem.instantiateAll(
           snapshotsStream,
@@ -1459,51 +1692,72 @@ class _SyncRepository implements SyncRepository {
       logger.d(
           'Duration of streaming phase for ${drive.name}: $fetchPhaseTotalTime ms. Processed $totalTransactionsProcessed transactions');
 
-      // Fetch pending (unmined) transactions to show Turbo uploads immediately
-      // This is best-effort: errors here should not fail the drive sync
-      logger.d('Fetching pending transactions for drive ${drive.id}');
+      // Fetch pending (unmined) transactions to show Turbo uploads immediately.
+      // This is best-effort: errors here should not fail the drive sync.
+      // Skip for non-owned drives (can't have this user's pending uploads)
+      // and when no locally-tracked pending transactions exist for this drive.
       int pendingTransactionCount = 0;
 
-      try {
-        await for (final pendingTxBatch
-            in _arweave.getPendingTransactionsForDrive(
-          driveId,
-          ownerAddress: ownerAddress,
-        )) {
-          // Check for cancellation before processing each batch
-          if (token.isCancelled) {
-            logger.d(
-                'Pending transactions fetch cancelled for drive ${drive.id}');
-            break;
+      if (skipPendingTxFetch) {
+        logger.d(
+            'Skipping pending tx fetch for drive ${drive.id} (not owned by user)');
+      } else {
+        // Check local DB first: only query the gateway if we have
+        // locally-tracked pending transactions for this drive
+        final localPending = await _driveDao
+            .pendingTransactionsForDrive(driveId: driveId)
+            .get();
+
+        if (localPending.isEmpty) {
+          logger.d(
+              'No locally pending transactions for drive ${drive.id}, skipping GQL query');
+        } else {
+          logger.d(
+              'Fetching pending transactions for drive ${drive.id} '
+              '(${localPending.length} locally pending)');
+
+          try {
+            await for (final pendingTxBatch
+                in _arweave.getPendingTransactionsForDrive(
+              driveId,
+              ownerAddress: ownerAddress,
+            )) {
+              // Check for cancellation before processing each batch
+              if (token.isCancelled) {
+                logger.d(
+                    'Pending transactions fetch cancelled for drive ${drive.id}');
+                break;
+              }
+
+              if (pendingTxBatch.isNotEmpty) {
+                logger.d(
+                    'Processing ${pendingTxBatch.length} pending transactions');
+
+                await _processTransactionChunk(
+                  transactions: pendingTxBatch,
+                  drive: drive,
+                  driveKey: driveKey?.key,
+                  currentBlockHeight: currentBlockHeight,
+                  lastBlockHeight: lastBlockHeight,
+                  transactionParseBatchSize: transactionParseBatchSize,
+                  snapshotDriveHistory: snapshotDriveHistory,
+                  ownerAddress: ownerAddress,
+                );
+
+                pendingTransactionCount += pendingTxBatch.length;
+              }
+            }
+          } catch (e) {
+            // Log but don't rethrow - pending tx fetch is best-effort
+            logger.w(
+                'Error fetching pending transactions for drive ${drive.id}: $e');
           }
 
-          if (pendingTxBatch.isNotEmpty) {
-            logger
-                .d('Processing ${pendingTxBatch.length} pending transactions');
-
-            await _processTransactionChunk(
-              transactions: pendingTxBatch,
-              drive: drive,
-              driveKey: driveKey?.key,
-              currentBlockHeight: currentBlockHeight,
-              lastBlockHeight: lastBlockHeight,
-              transactionParseBatchSize: transactionParseBatchSize,
-              snapshotDriveHistory: snapshotDriveHistory,
-              ownerAddress: ownerAddress,
-            );
-
-            pendingTransactionCount += pendingTxBatch.length;
+          if (pendingTransactionCount > 0) {
+            logger.i(
+                'Processed $pendingTransactionCount pending transactions for drive ${drive.name}');
           }
         }
-      } catch (e) {
-        // Log but don't rethrow - pending tx fetch is best-effort
-        logger
-            .w('Error fetching pending transactions for drive ${drive.id}: $e');
-      }
-
-      if (pendingTransactionCount > 0) {
-        logger.i(
-            'Processed $pendingTransactionCount pending transactions for drive ${drive.name}');
       }
 
       // Yield final progress before cleanup

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -379,6 +379,8 @@ class _SyncRepository implements SyncRepository {
               prefetchedSnapshots
                   .putIfAbsent(driveIdTag, () => [])
                   .add(snapshot);
+            } else {
+              logger.w('Snapshot ${snapshot.id} has no Drive-Id tag, skipping');
             }
           }
         }

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -810,14 +810,21 @@ class _SyncRepository implements SyncRepository {
 
       cancellationToken?.checkCancellation();
 
+      // Caller-owned sink populated with each resolved confirmation; on timeout
+      // we fall back to it so progress made before the deadline isn't lost.
+      final verified = <String?, int>{};
+
       final map = await arweave
           .getTransactionConfirmations(currentPage.toList(),
-              owner: ownerAddress, ownerOverrides: ownerOverrides)
+              owner: ownerAddress,
+              ownerOverrides: ownerOverrides,
+              verifiedSink: verified)
           .timeout(
         const Duration(seconds: 5),
         onTimeout: () {
-          logger.w('Individual transaction confirmation timeout');
-          return <String, int>{};
+          logger.w('Individual transaction confirmation timeout; '
+              'applying ${verified.length} confirmations resolved so far');
+          return verified;
         },
       );
 
@@ -1069,16 +1076,24 @@ class _SyncRepository implements SyncRepository {
       // Check cancellation before making the GraphQL call
       cancellationToken?.checkCancellation();
 
+      // Caller-owned sink that getTransactionConfirmations populates with each
+      // resolved confirmation. On timeout we fall back to it so the work done
+      // before the deadline isn't discarded (it holds only verified
+      // confirmations, so it never marks anything failed off a partial run).
+      final verified = <String?, int>{};
+
       // Use a shorter timeout for individual GraphQL calls
       final map = await arweave
           .getTransactionConfirmations(currentPage.toList(),
-              owner: ownerAddress, ownerOverrides: ownerOverrides)
+              owner: ownerAddress,
+              ownerOverrides: ownerOverrides,
+              verifiedSink: verified)
           .timeout(
         const Duration(seconds: 5),
         onTimeout: () {
-          logger.w('Individual transaction confirmation timeout');
-          // Return empty map on timeout to continue with other transactions
-          return <String, int>{};
+          logger.w('Individual transaction confirmation timeout; '
+              'applying ${verified.length} confirmations resolved so far');
+          return verified;
         },
       );
 

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -44,15 +44,13 @@ import 'package:retry/retry.dart';
 /// Timeout for a single transaction-status confirmation batch
 /// ([ArweaveService.getTransactionConfirmations]).
 ///
-/// The gateway's GraphQL layer proxies an upstream index (`indexer-core`) with a
-/// ~9.5s upstream timeout and a circuit breaker. When the breaker is open a
-/// status query can legitimately take ~10s to return valid data (observed:
-/// 9.87s, with `UPSTREAM_CIRCUIT_OPEN` / "timeout of 9500ms exceeded" warnings).
-/// This must sit *above* that ceiling: otherwise the client cancels the batch
-/// before the successful response lands, discarding confirmations and leaving
-/// long-confirmed txs stuck as pending. Typical responses are ~0.5s, so this
-/// only extends waits while the gateway is degraded — exactly when we want to
-/// wait rather than drop the batch. Partial progress is still preserved by the
+/// A gateway can be intermittently slow to answer a status query — a request may
+/// take several seconds and still return valid data. This is set well above
+/// typical response times so a slow-but-successful response isn't cancelled:
+/// cancelling early discards the batch's confirmations and leaves
+/// already-confirmed txs stuck showing as pending. Normal responses are fast, so
+/// this only lengthens waits while a gateway is degraded — when we want to wait
+/// rather than drop the batch. Partial progress is still preserved by the
 /// verified sink regardless.
 const _txConfirmationBatchTimeout = Duration(seconds: 15);
 
@@ -1129,8 +1127,8 @@ class _SyncRepository implements SyncRepository {
       // confirmations, so it never marks anything failed off a partial run).
       final verified = <String?, int>{};
 
-      // Bound each batch above the gateway's ~9.5s upstream ceiling so a
-      // slow-but-successful response can land instead of being discarded.
+      // Give each batch a generous timeout so a slow-but-successful response
+      // can land instead of being discarded.
       final map = await arweave
           .getTransactionConfirmations(currentPage.toList(),
               owner: ownerAddress,

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -1017,6 +1017,27 @@ class _SyncRepository implements SyncRepository {
     };
   }
 
+  /// Maps each pending data tx id to the owner of the drive it belongs to, so
+  /// the confirmation query can be scoped per-tx by the actual drive owner.
+  /// This is needed because a single sync can span the user's own drives and
+  /// attached drives owned by other wallets — assuming the logged-in wallet
+  /// owns every pending tx would send an unscoped (or wrongly-scoped) query for
+  /// the attached ones.
+  Future<Map<String, String>> _buildPendingTxDriveOwners(
+    DriveDao driveDao,
+  ) async {
+    final pendingRevisions = await driveDao.pendingDataFileRevisions().get();
+    final ownerByDriveId = {
+      for (final drive in await driveDao.allDrives().get())
+        drive.id: drive.ownerAddress,
+    };
+    return {
+      for (final revision in pendingRevisions)
+        if ((ownerByDriveId[revision.driveId] ?? '').isNotEmpty)
+          revision.dataTxId: ownerByDriveId[revision.driveId]!,
+    };
+  }
+
   Future<void> _updateTransactionStatuses({
     required DriveDao driveDao,
     required ArweaveService arweave,
@@ -1028,6 +1049,10 @@ class _SyncRepository implements SyncRepository {
     cancellationToken?.checkCancellation();
 
     final ownerOverrides = await _buildPinnedDataTxOwnerOverrides(driveDao);
+    // Scope each pending tx by the owner of its own drive rather than assuming
+    // the logged-in wallet owns everything (which is wrong for attached drives
+    // owned by other wallets, and null when browsing without a wallet).
+    final ownersByTxId = await _buildPendingTxDriveOwners(driveDao);
 
     // Load all pending transactions
     // Note: We load all at once here, but the memory impact is acceptable
@@ -1086,6 +1111,7 @@ class _SyncRepository implements SyncRepository {
       final map = await arweave
           .getTransactionConfirmations(currentPage.toList(),
               owner: ownerAddress,
+              ownersByTxId: ownersByTxId,
               ownerOverrides: ownerOverrides,
               verifiedSink: verified)
           .timeout(

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -171,9 +171,10 @@ class _SyncRepository implements SyncRepository {
 
     // The address of the currently logged-in wallet. All pending transactions
     // are uploads made by this wallet, so scoping the status query by it lets
-    // the gateway prune its search space. (Edge case: data txs of files pinned
-    // from other authors are owned by those authors and won't match — those
-    // are rare and treated as best-effort.)
+    // the gateway prune its search space. Cross-owner txs (e.g. data txs of
+    // files pinned from other authors) won't match this owner, but
+    // getTransactionConfirmations re-queries any unresolved ids without the
+    // owner filter so they aren't misclassified as failed.
     String? walletAddress;
     if (wallet != null) {
       walletAddress = await wallet.getAddress();

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -91,6 +91,7 @@ abstract class SyncRepository {
     String? password,
     SecretKey? cipherKey,
     SyncCancellationToken? cancellationToken,
+    List<String>? driveIdsToRetry,
 
     /// This was required because the usage of the `PromptToSnapshotBloc` in the
     /// `SyncCubit` and the `PromptToSnapshotBloc` is not available in the `SyncRepository`
@@ -188,6 +189,7 @@ class _SyncRepository implements SyncRepository {
     SecretKey? cipherKey,
     SyncCancellationToken? cancellationToken,
     Function(String driveId, int txCount)? txFechedCallback,
+    List<String>? driveIdsToRetry,
   }) async* {
     final token = cancellationToken ?? SyncCancellationToken();
 
@@ -214,7 +216,13 @@ class _SyncRepository implements SyncRepository {
     }
 
     // Sync the contents of each drive attached in the app.
-    final drives = await _driveDao.allDrives().map((d) => d).get();
+    var drives = await _driveDao.allDrives().map((d) => d).get();
+
+    // If retrying specific drives, filter to only those
+    if (driveIdsToRetry != null && driveIdsToRetry.isNotEmpty) {
+      final retrySet = driveIdsToRetry.toSet();
+      drives = drives.where((d) => retrySet.contains(d.id)).toList();
+    }
 
     if (drives.isEmpty) {
       yield SyncProgress.emptySyncCompleted();
@@ -246,6 +254,10 @@ class _SyncRepository implements SyncRepository {
     if (syncDeep) {
       drivesToSync = drives;
     } else {
+      syncProgress = syncProgress.copyWith(
+        statusMessage: 'Checking for changes...',
+      );
+      yield syncProgress;
       try {
         final neverSyncedDrives = <Drive>[];
         final previouslySyncedDrives = <Drive>[];
@@ -324,6 +336,10 @@ class _SyncRepository implements SyncRepository {
         drivesToSync = drives;
       }
     }
+
+    // Clear the probe status message
+    syncProgress = syncProgress.copyWith(statusMessage: null);
+    yield syncProgress;
 
     final numberOfDrivesToSync = drivesToSync.length;
 
@@ -472,7 +488,8 @@ class _SyncRepository implements SyncRepository {
               List<String>.from(syncProgress.failedDriveIds)..add(drive.id);
           final updatedErrorMessages =
               Map<String, String>.from(syncProgress.errorMessages)
-                ..putIfAbsent(drive.id, () => _extractErrorMessage(e));
+                ..putIfAbsent(
+                    drive.id, () => '${drive.name}: ${_extractErrorMessage(e)}');
 
           // Still increment progress but mark as failed (cap at 90%)
           totalProgress += 1;
@@ -935,7 +952,8 @@ class _SyncRepository implements SyncRepository {
 
         final updatedErrorMessages =
             Map<String, String>.from(syncProgress.errorMessages)
-              ..putIfAbsent(driveId, () => _extractErrorMessage(e));
+              ..putIfAbsent(
+                  driveId, () => '${drive.name}: ${_extractErrorMessage(e)}');
 
         syncProgress = syncProgress.copyWith(
           drivesSynced: 1,

--- a/lib/utils/snapshots/gql_drive_history.dart
+++ b/lib/utils/snapshots/gql_drive_history.dart
@@ -1,4 +1,3 @@
-import 'package:ardrive/services/arweave/get_segmented_transaction_from_drive_strategy.dart';
 import 'package:ardrive/sync/domain/models/drive_entity_history.dart';
 import 'package:ardrive/utils/snapshots/height_range.dart';
 import 'package:ardrive/utils/snapshots/range.dart';
@@ -43,14 +42,17 @@ class GQLDriveHistory implements SegmentedGQLData {
   Stream<DriveEntityHistoryTransactionModel> _getNextStream() async* {
     Range subRangeForIndex = subRanges.rangeSegments[currentIndex];
 
+    // Skip the genesis block range — no ArFS transactions exist at block 0.
+    // This gap appears when snapshots start at block 1 and lastBlockHeight is 0.
+    if (subRangeForIndex.start == 0 && subRangeForIndex.end == 0) {
+      return;
+    }
+
     final txsStream = _arweave.getSegmentedTransactionsFromDrive(
       driveId,
       minBlockHeight: subRangeForIndex.start,
       maxBlockHeight: subRangeForIndex.end,
       ownerAddress: ownerAddress,
-      strategy: GetSegmentedTransactionFromDriveFilteringByEntityTypeStrategy(
-        _arweave.graphQLRetry,
-      ),
     );
 
     await for (final multipleEdges in txsStream) {

--- a/lib/utils/snapshots/snapshot_drive_history.dart
+++ b/lib/utils/snapshots/snapshot_drive_history.dart
@@ -91,30 +91,9 @@ class SnapshotDriveHistory implements SegmentedGQLData {
         _subRangeToSnapshotItemMapping[subRangeForIndex]!;
 
     // reads the next stream of each item in the list and yields each node in order
-    for (var i = 0; i < itemsInRange.length; i++) {
-      final item = itemsInRange[i];
-
-      // Prefetch the NEXT snapshot body while processing the current one.
-      // This overlaps download with parsing/DB-writes. Only 1 ahead to
-      // avoid gateway 429s.
-      if (i + 1 < itemsInRange.length) {
-        final next = itemsInRange[i + 1];
-        if (next is SnapshotItemOnChain) {
-          next.prefetch();
-        }
-      } else if (currentIndex + 1 < subRanges.rangeSegments.length) {
-        // Prefetch the first item of the NEXT sub-range
-        final nextRange = subRanges.rangeSegments[currentIndex + 1];
-        final nextItems = _subRangeToSnapshotItemMapping[nextRange];
-        if (nextItems != null && nextItems.isNotEmpty) {
-          final next = nextItems.first;
-          if (next is SnapshotItemOnChain) {
-            next.prefetch();
-          }
-        }
-      }
-
-      yield* item.getNextStream();
+    for (SnapshotItem item in itemsInRange) {
+      final stream = item.getNextStream();
+      yield* stream;
     }
   }
 }

--- a/lib/utils/snapshots/snapshot_drive_history.dart
+++ b/lib/utils/snapshots/snapshot_drive_history.dart
@@ -91,9 +91,30 @@ class SnapshotDriveHistory implements SegmentedGQLData {
         _subRangeToSnapshotItemMapping[subRangeForIndex]!;
 
     // reads the next stream of each item in the list and yields each node in order
-    for (SnapshotItem item in itemsInRange) {
-      final stream = item.getNextStream();
-      yield* stream;
+    for (var i = 0; i < itemsInRange.length; i++) {
+      final item = itemsInRange[i];
+
+      // Prefetch the NEXT snapshot body while processing the current one.
+      // This overlaps download with parsing/DB-writes. Only 1 ahead to
+      // avoid gateway 429s.
+      if (i + 1 < itemsInRange.length) {
+        final next = itemsInRange[i + 1];
+        if (next is SnapshotItemOnChain) {
+          next.prefetch();
+        }
+      } else if (currentIndex + 1 < subRanges.rangeSegments.length) {
+        // Prefetch the first item of the NEXT sub-range
+        final nextRange = subRanges.rangeSegments[currentIndex + 1];
+        final nextItems = _subRangeToSnapshotItemMapping[nextRange];
+        if (nextItems != null && nextItems.isNotEmpty) {
+          final next = nextItems.first;
+          if (next is SnapshotItemOnChain) {
+            next.prefetch();
+          }
+        }
+      }
+
+      yield* item.getNextStream();
     }
   }
 }

--- a/lib/utils/snapshots/snapshot_item.dart
+++ b/lib/utils/snapshots/snapshot_item.dart
@@ -214,13 +214,29 @@ class SnapshotItemOnChain implements SnapshotItem {
   @override
   int get currentIndex => _currentIndex;
 
+  Future<String>? _prefetchFuture;
+
   Future<String> _source() async {
     if (_cachedSource != null) {
       return _cachedSource!;
     }
+    // Use prefetch result if available, otherwise fetch now
+    if (_prefetchFuture != null) {
+      return _cachedSource = await _prefetchFuture!;
+    }
     final dataBytes = await _arweave.getEntityDataFromNetwork(txId: txId);
     final dataBytesAsString = String.fromCharCodes(dataBytes);
     return _cachedSource = dataBytesAsString;
+  }
+
+  /// Start downloading the snapshot body without waiting for it.
+  /// Call this on the NEXT snapshot while processing the current one.
+  void prefetch() {
+    if (_cachedSource != null || _prefetchFuture != null) return;
+    logger.d('Prefetching snapshot $txId');
+    _prefetchFuture = _arweave
+        .getEntityDataFromNetwork(txId: txId)
+        .then((bytes) => String.fromCharCodes(bytes));
   }
 
   @override
@@ -233,28 +249,45 @@ class SnapshotItemOnChain implements SnapshotItem {
     return _getNextStream();
   }
 
+  /// Parses snapshot entries one at a time by scanning for object boundaries
+  /// in the JSON string, avoiding a full jsonDecode of the entire snapshot.
+  /// This keeps memory bounded to one entry at a time instead of the full Map.
   Stream<DriveEntityHistoryTransactionModel> _getNextStream() async* {
     final Range range = subRanges.rangeSegments[currentIndex];
+    final source = await _source();
 
-    final Map dataJson = jsonDecode(await _source());
-    final List<Map> txSnapshots =
-        List.castFrom<dynamic, Map>(dataJson['txSnapshots']);
+    // Find the txSnapshots array in the JSON string
+    final arrayStart = source.indexOf('[', source.indexOf('"txSnapshots"'));
+    if (arrayStart == -1) {
+      logger.w('Snapshot $txId has no txSnapshots array');
+      return;
+    }
 
-    for (Map item in txSnapshots) {
+    var yielded = 0;
+    var skipped = 0;
+
+    // Scan for individual objects within the array
+    for (final objectJson in _iterateJsonArrayObjects(source, arrayStart)) {
+      Map item;
+      try {
+        item = jsonDecode(objectJson) as Map;
+      } catch (e) {
+        logger.w('Error parsing snapshot entry in $txId');
+        continue;
+      }
+
       DriveHistoryTransaction node;
-
       try {
         node = DriveHistoryTransaction.fromJson(item['gqlNode']);
       } catch (e) {
-        logger.w(
-          'Error while parsing GQLNode from snapshot item ($txId)',
-        );
+        logger.w('Error parsing GQLNode from snapshot item ($txId)');
         continue;
       }
 
       final isInRange = range.isInRange(node.block?.height ?? -1);
       if (isInRange) {
         yield DriveEntityHistoryTransactionModel(transactionCommonMixin: node);
+        yielded++;
 
         final String? data = item['jsonMetadata'];
         if (data != null) {
@@ -262,15 +295,87 @@ class SnapshotItemOnChain implements SnapshotItem {
           final Uint8List dataAsBytes = Uint8List.fromList(utf8.encode(data));
           await _setDataForTxId(driveId, txId, dataAsBytes);
         }
+      } else {
+        skipped++;
       }
     }
 
-    if (currentIndex == subRanges.rangeSegments.length - 1) {
-      // Done reading all data, the memory can be freed
-      _cachedSource = null;
-    }
+    logger.d('Snapshot $txId range ${range.start}-${range.end}: '
+        'yielded $yielded, skipped $skipped');
 
-    return;
+    if (currentIndex == subRanges.rangeSegments.length - 1) {
+      _cachedSource = null;
+      _prefetchFuture = null;
+    }
+  }
+
+  /// Iterates over top-level JSON objects in an array without parsing the
+  /// entire array. Uses brace counting to find object boundaries.
+  ///
+  /// [source] is the full JSON string. [arrayStartIndex] is the index of
+  /// the opening `[` of the array.
+  static Iterable<String> _iterateJsonArrayObjects(
+    String source,
+    int arrayStartIndex,
+  ) sync* {
+    var i = arrayStartIndex + 1; // skip the '['
+    final len = source.length;
+
+    while (i < len) {
+      // Skip whitespace and commas
+      while (i < len) {
+        final c = source.codeUnitAt(i);
+        if (c == 0x7D + 1) break; // shouldn't happen
+        if (c == 0x5D) return; // ']' — end of array
+        if (c == 0x7B) break; // '{' — start of object
+        i++;
+      }
+      if (i >= len) return;
+
+      // Found '{', count braces to find matching '}'
+      final objectStart = i;
+      var depth = 0;
+      var inString = false;
+      var escaped = false;
+
+      while (i < len) {
+        final c = source.codeUnitAt(i);
+
+        if (escaped) {
+          escaped = false;
+          i++;
+          continue;
+        }
+
+        if (c == 0x5C) {
+          // backslash
+          escaped = true;
+          i++;
+          continue;
+        }
+
+        if (c == 0x22) {
+          // double quote
+          inString = !inString;
+          i++;
+          continue;
+        }
+
+        if (!inString) {
+          if (c == 0x7B) depth++; // '{'
+          if (c == 0x7D) {
+            // '}'
+            depth--;
+            if (depth == 0) {
+              yield source.substring(objectStart, i + 1);
+              i++;
+              break;
+            }
+          }
+        }
+        i++;
+      }
+    }
   }
 
   static Future<Uint8List> _setDataForTxId(

--- a/lib/utils/snapshots/snapshot_item.dart
+++ b/lib/utils/snapshots/snapshot_item.dart
@@ -214,29 +214,13 @@ class SnapshotItemOnChain implements SnapshotItem {
   @override
   int get currentIndex => _currentIndex;
 
-  Future<String>? _prefetchFuture;
-
   Future<String> _source() async {
     if (_cachedSource != null) {
       return _cachedSource!;
     }
-    // Use prefetch result if available, otherwise fetch now
-    if (_prefetchFuture != null) {
-      return _cachedSource = await _prefetchFuture!;
-    }
     final dataBytes = await _arweave.getEntityDataFromNetwork(txId: txId);
     final dataBytesAsString = String.fromCharCodes(dataBytes);
     return _cachedSource = dataBytesAsString;
-  }
-
-  /// Start downloading the snapshot body without waiting for it.
-  /// Call this on the NEXT snapshot while processing the current one.
-  void prefetch() {
-    if (_cachedSource != null || _prefetchFuture != null) return;
-    logger.d('Prefetching snapshot $txId');
-    _prefetchFuture = _arweave
-        .getEntityDataFromNetwork(txId: txId)
-        .then((bytes) => String.fromCharCodes(bytes));
   }
 
   @override
@@ -249,45 +233,28 @@ class SnapshotItemOnChain implements SnapshotItem {
     return _getNextStream();
   }
 
-  /// Parses snapshot entries one at a time by scanning for object boundaries
-  /// in the JSON string, avoiding a full jsonDecode of the entire snapshot.
-  /// This keeps memory bounded to one entry at a time instead of the full Map.
   Stream<DriveEntityHistoryTransactionModel> _getNextStream() async* {
     final Range range = subRanges.rangeSegments[currentIndex];
-    final source = await _source();
 
-    // Find the txSnapshots array in the JSON string
-    final arrayStart = source.indexOf('[', source.indexOf('"txSnapshots"'));
-    if (arrayStart == -1) {
-      logger.w('Snapshot $txId has no txSnapshots array');
-      return;
-    }
+    final Map dataJson = jsonDecode(await _source());
+    final List<Map> txSnapshots =
+        List.castFrom<dynamic, Map>(dataJson['txSnapshots']);
 
-    var yielded = 0;
-    var skipped = 0;
-
-    // Scan for individual objects within the array
-    for (final objectJson in _iterateJsonArrayObjects(source, arrayStart)) {
-      Map item;
-      try {
-        item = jsonDecode(objectJson) as Map;
-      } catch (e) {
-        logger.w('Error parsing snapshot entry in $txId');
-        continue;
-      }
-
+    for (Map item in txSnapshots) {
       DriveHistoryTransaction node;
+
       try {
         node = DriveHistoryTransaction.fromJson(item['gqlNode']);
       } catch (e) {
-        logger.w('Error parsing GQLNode from snapshot item ($txId)');
+        logger.w(
+          'Error while parsing GQLNode from snapshot item ($txId)',
+        );
         continue;
       }
 
       final isInRange = range.isInRange(node.block?.height ?? -1);
       if (isInRange) {
         yield DriveEntityHistoryTransactionModel(transactionCommonMixin: node);
-        yielded++;
 
         final String? data = item['jsonMetadata'];
         if (data != null) {
@@ -295,87 +262,15 @@ class SnapshotItemOnChain implements SnapshotItem {
           final Uint8List dataAsBytes = Uint8List.fromList(utf8.encode(data));
           await _setDataForTxId(driveId, txId, dataAsBytes);
         }
-      } else {
-        skipped++;
       }
     }
-
-    logger.d('Snapshot $txId range ${range.start}-${range.end}: '
-        'yielded $yielded, skipped $skipped');
 
     if (currentIndex == subRanges.rangeSegments.length - 1) {
+      // Done reading all data, the memory can be freed
       _cachedSource = null;
-      _prefetchFuture = null;
     }
-  }
 
-  /// Iterates over top-level JSON objects in an array without parsing the
-  /// entire array. Uses brace counting to find object boundaries.
-  ///
-  /// [source] is the full JSON string. [arrayStartIndex] is the index of
-  /// the opening `[` of the array.
-  static Iterable<String> _iterateJsonArrayObjects(
-    String source,
-    int arrayStartIndex,
-  ) sync* {
-    var i = arrayStartIndex + 1; // skip the '['
-    final len = source.length;
-
-    while (i < len) {
-      // Skip whitespace and commas
-      while (i < len) {
-        final c = source.codeUnitAt(i);
-        if (c == 0x7D + 1) break; // shouldn't happen
-        if (c == 0x5D) return; // ']' — end of array
-        if (c == 0x7B) break; // '{' — start of object
-        i++;
-      }
-      if (i >= len) return;
-
-      // Found '{', count braces to find matching '}'
-      final objectStart = i;
-      var depth = 0;
-      var inString = false;
-      var escaped = false;
-
-      while (i < len) {
-        final c = source.codeUnitAt(i);
-
-        if (escaped) {
-          escaped = false;
-          i++;
-          continue;
-        }
-
-        if (c == 0x5C) {
-          // backslash
-          escaped = true;
-          i++;
-          continue;
-        }
-
-        if (c == 0x22) {
-          // double quote
-          inString = !inString;
-          i++;
-          continue;
-        }
-
-        if (!inString) {
-          if (c == 0x7B) depth++; // '{'
-          if (c == 0x7D) {
-            // '}'
-            depth--;
-            if (depth == 0) {
-              yield source.substring(objectStart, i + 1);
-              i++;
-              break;
-            }
-          }
-        }
-        i++;
-      }
-    }
+    return;
   }
 
   static Future<Uint8List> _setDataForTxId(

--- a/lib/utils/snapshots/snapshot_item_to_be_created.dart
+++ b/lib/utils/snapshots/snapshot_item_to_be_created.dart
@@ -34,6 +34,7 @@ class SnapshotItemToBeCreated {
   int get dataEnd => _dataEnd ?? -1;
 
   final Future<Uint8List> Function(TxID txId) _jsonMetadataOfTxId;
+  final void Function(int processed, int total)? _onProgress;
 
   SnapshotItemToBeCreated({
     required this.blockStart,
@@ -42,11 +43,17 @@ class SnapshotItemToBeCreated {
     required this.subRanges,
     required this.source,
     required Future<Uint8List> Function(TxID txId) jsonMetadataOfTxId,
-  }) : _jsonMetadataOfTxId = jsonMetadataOfTxId;
+    void Function(int processed, int total)? onProgress,
+  })  : _jsonMetadataOfTxId = jsonMetadataOfTxId,
+        _onProgress = onProgress;
 
   Stream<Uint8List> getSnapshotData() async* {
     // Convert the source Stream into a List to get all elements at once
     final nodes = await source.toList();
+    final totalCount = nodes.length;
+    var processedCount = 0;
+
+    _onProgress?.call(0, totalCount);
 
     final processor = BatchProcessor();
     List<TxSnapshot> results = [];
@@ -61,6 +68,8 @@ class SnapshotItemToBeCreated {
         }
 
         results.addAll(await Future.wait(tasks));
+        processedCount += items.length;
+        _onProgress?.call(processedCount, totalCount);
 
         yield 1;
       },

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -149,11 +149,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "v4.0.1"
-      resolved-ref: "0a55ea0358fb82f14abafc9182a121686735ba2b"
+      ref: "v4.0.2"
+      resolved-ref: "7bee19d601065b451de0aa2e72027ee30c7f934b"
       url: "https://github.com/ardriveapp/arweave-dart.git"
     source: git
-    version: "4.0.1"
+    version: "4.0.2"
   async:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Secure, permanent storage
 
 publish_to: 'none'
 
-version: 2.83.0
+version: 2.84.0
 
 environment:
   sdk: '>=3.2.0 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,7 +53,7 @@ dependencies:
   arweave:
     git:
       url: https://github.com/ardriveapp/arweave-dart.git
-      ref: v4.0.1
+      ref: v4.0.2
   ario_sdk:
     path: ./packages/ario_sdk
   cryptography: ^2.0.5
@@ -166,7 +166,7 @@ dependency_overrides:
   arweave:
     git:
       url: https://github.com/ardriveapp/arweave-dart.git
-      ref: v4.0.1
+      ref: v4.0.2
 
   ardrive_io:
     path: ./packages/ardrive_io

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Secure, permanent storage
 
 publish_to: 'none'
 
-version: 2.84.0
+version: 2.85.0
 
 environment:
   sdk: '>=3.2.0 <4.0.0'

--- a/test/blocs/drive_attach_cubit_test.dart
+++ b/test/blocs/drive_attach_cubit_test.dart
@@ -16,6 +16,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 import '../test_utils/fakes.dart';
+import '../test_utils/mocks.dart';
 import '../test_utils/utils.dart';
 
 void main() {
@@ -85,10 +86,18 @@ void main() {
 
       when(() => arweave.getLatestDriveEntityWithId(notFoundDriveId))
           .thenAnswer((_) => Future.value(null));
-      when(() => arweave.getDrivePrivacyForId(validDriveId))
-          .thenAnswer((_) => Future.value(DrivePrivacyTag.public));
-      when(() => arweave.getDrivePrivacyForId(validPrivateDriveId))
-          .thenAnswer((_) => Future.value(DrivePrivacyTag.private));
+      when(() => arweave.getDrivePrivacyForId(validDriveId)).thenAnswer(
+          (_) => Future.value(DrivePrivacyResult(
+                privacy: DrivePrivacyTag.public,
+                ownerAddress: 'test-owner',
+                driveTx: MockTransactionCommonMixin(),
+              )));
+      when(() => arweave.getDrivePrivacyForId(validPrivateDriveId)).thenAnswer(
+          (_) => Future.value(DrivePrivacyResult(
+                privacy: DrivePrivacyTag.private,
+                ownerAddress: 'test-owner',
+                driveTx: MockTransactionCommonMixin(),
+              )));
 
       when(() => driveDao.writeDriveEntity(
             name: any(named: 'name'),

--- a/test/sync/domain/sync_repository_optimization_test.dart
+++ b/test/sync/domain/sync_repository_optimization_test.dart
@@ -1,0 +1,442 @@
+import 'package:ardrive/arns/domain/arns_repository.dart';
+import 'package:ardrive/models/database/database.dart';
+import 'package:ardrive/services/arweave/data_gateway_fallback.dart';
+import 'package:ardrive/services/config/app_config.dart';
+import 'package:ardrive/sync/data/snapshot_validation_service.dart';
+import 'package:ardrive/sync/domain/repositories/sync_repository.dart';
+import 'package:ardrive/sync/utils/batch_processor.dart';
+import 'package:ardrive/user/repositories/user_preferences_repository.dart';
+import 'package:ardrive/utils/snapshots/gql_drive_history.dart';
+import 'package:ardrive/utils/snapshots/height_range.dart';
+import 'package:ardrive/utils/snapshots/range.dart';
+import 'package:ario_sdk/ario_sdk.dart';
+import 'package:arweave/arweave.dart';
+import 'package:cryptography/cryptography.dart';
+import 'package:drift/drift.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../test_utils/mocks.dart';
+
+// Mocks not available in shared mocks file
+class MockBatchProcessor extends Mock implements BatchProcessor {}
+
+class MockSnapshotValidationService extends Mock
+    implements SnapshotValidationService {}
+
+class _MockARNSRepository extends Mock implements ARNSRepository {}
+
+class MockUserPreferencesRepository extends Mock
+    implements UserPreferencesRepository {}
+
+class _MockWallet extends Mock implements Wallet {}
+
+class _MockDataGatewayFallback extends Mock implements DataGatewayFallback {}
+
+class _FakeWallet extends Fake implements Wallet {}
+
+class _FakeSecretKey extends Fake implements SecretKey {}
+
+class FakeSelectable<T> extends Fake implements Selectable<T> {
+  final List<T> _data;
+  FakeSelectable(this._data);
+
+  @override
+  Future<List<T>> get() async => _data;
+
+  @override
+  Selectable<N> map<N>(N Function(T) f) {
+    return FakeSelectable(_data.map(f).toList());
+  }
+}
+
+// Helper to create a Drive with specific fields
+Drive _makeDrive({
+  required String id,
+  required String ownerAddress,
+  int? lastBlockHeight,
+  String name = 'Test Drive',
+}) {
+  return Drive(
+    id: id,
+    rootFolderId: 'root-$id',
+    ownerAddress: ownerAddress,
+    name: name,
+    lastBlockHeight: lastBlockHeight,
+    privacy: 'public',
+    isHidden: false,
+    dateCreated: DateTime(2024),
+    lastUpdated: DateTime(2024),
+  );
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeWallet());
+    registerFallbackValue(_FakeSecretKey());
+  });
+
+  late MockArweaveService mockArweave;
+  late MockDriveDao mockDriveDao;
+  late MockConfigService mockConfigService;
+  late MockBatchProcessor mockBatchProcessor;
+  late MockSnapshotValidationService mockSnapshotValidation;
+  late _MockARNSRepository mockArnsRepository;
+  late MockUserPreferencesRepository mockUserPrefsRepo;
+  late SyncRepository syncRepository;
+  late _MockWallet mockWallet;
+
+  const ownerAddress = 'owner-address-123';
+
+  setUp(() {
+    mockArweave = MockArweaveService();
+    mockDriveDao = MockDriveDao();
+    mockConfigService = MockConfigService();
+    mockBatchProcessor = MockBatchProcessor();
+    mockSnapshotValidation = MockSnapshotValidationService();
+    mockArnsRepository = _MockARNSRepository();
+    mockUserPrefsRepo = MockUserPreferencesRepository();
+    mockWallet = _MockWallet();
+
+    when(() => mockWallet.getAddress()).thenAnswer((_) async => ownerAddress);
+
+    when(() => mockConfigService.config).thenReturn(AppConfig(
+      allowedDataItemSizeForTurbo: 0,
+      stripePublishableKey: '',
+      enableSyncFromSnapshot: false,
+      autoSync: true,
+    ));
+
+    // Mock gateway fallback for snapshot validation service cache sharing
+    final mockGatewayFallback = _MockDataGatewayFallback();
+    when(() => mockArweave.gatewayFallback).thenReturn(mockGatewayFallback);
+    when(() => mockGatewayFallback.cachedGateways).thenReturn([]);
+
+    // Mock ARNS repository
+    when(() => mockArnsRepository.getAntRecordsForWallet(any(),
+        update: any(named: 'update'))).thenAnswer(
+      (_) async => <ANTRecord>[],
+    );
+
+    syncRepository = SyncRepository(
+      arweave: mockArweave,
+      driveDao: mockDriveDao,
+      configService: mockConfigService,
+      batchProcessor: mockBatchProcessor,
+      snapshotValidationService: mockSnapshotValidation,
+      arnsRepository: mockArnsRepository,
+      userPreferencesRepository: mockUserPrefsRepo,
+    );
+  });
+
+  group('Fix 1: DriveActivityProbe partitioning', () {
+    test('never-synced drives excluded from probe, probe gets non-zero minBlock',
+        () async {
+      final neverSynced = _makeDrive(
+        id: 'drive-never',
+        ownerAddress: ownerAddress,
+        lastBlockHeight: null,
+      );
+      final synced1 = _makeDrive(
+        id: 'drive-synced-1',
+        ownerAddress: ownerAddress,
+        lastBlockHeight: 50000,
+      );
+      final synced2 = _makeDrive(
+        id: 'drive-synced-2',
+        ownerAddress: ownerAddress,
+        lastBlockHeight: 60000,
+      );
+
+      when(() => mockDriveDao.allDrives())
+          .thenReturn(FakeSelectable([neverSynced, synced1, synced2]));
+
+      when(() => mockArweave.getCurrentBlockHeight())
+          .thenAnswer((_) async => 100000);
+
+      // Probe returns only synced1 as active, isComplete: true
+      when(() => mockArweave.probeActiveDriveIds(
+            driveIds: any(named: 'driveIds'),
+            minBlockHeight: any(named: 'minBlockHeight'),
+            ownerAddress: any(named: 'ownerAddress'),
+          )).thenAnswer((_) async => (
+            activeDriveIds: {'drive-synced-1'},
+            isComplete: true,
+          ));
+
+      // Consume the stream — it will fail in _syncDrive since we haven't
+      // mocked the full pipeline, but the probe logic runs synchronously
+      // before _syncDrive is launched.
+      try {
+        await syncRepository
+            .syncAllDrives(wallet: mockWallet)
+            .toList();
+      } catch (_) {}
+
+      // Allow async tasks spawned by syncAllDrives to settle
+      await Future.delayed(const Duration(milliseconds: 100));
+
+      // Verify probe was called with correct parameters
+      final probeCall = verify(() => mockArweave.probeActiveDriveIds(
+            driveIds: captureAny(named: 'driveIds'),
+            minBlockHeight: captureAny(named: 'minBlockHeight'),
+            ownerAddress: any(named: 'ownerAddress'),
+          ));
+      expect(probeCall.callCount, 1);
+
+      // Probe should only include previously-synced drives
+      final probedDriveIds = probeCall.captured[0] as List<String>;
+      expect(probedDriveIds, containsAll(['drive-synced-1', 'drive-synced-2']));
+      expect(probedDriveIds, isNot(contains('drive-never')));
+
+      // The minBlockHeight should NOT be 0 (the whole point of this fix)
+      final minBlock = probeCall.captured[1] as int;
+      expect(minBlock, greaterThan(0));
+    });
+
+    test('all never-synced drives skip probe entirely', () async {
+      final drives = [
+        _makeDrive(
+            id: 'a', ownerAddress: ownerAddress, lastBlockHeight: null),
+        _makeDrive(id: 'b', ownerAddress: ownerAddress, lastBlockHeight: 0),
+        _makeDrive(
+            id: 'c', ownerAddress: ownerAddress, lastBlockHeight: null),
+      ];
+
+      when(() => mockDriveDao.allDrives())
+          .thenReturn(FakeSelectable(drives));
+      when(() => mockArweave.getCurrentBlockHeight())
+          .thenAnswer((_) async => 100000);
+
+      try {
+        await syncRepository
+            .syncAllDrives(wallet: mockWallet)
+            .toList();
+      } catch (_) {}
+
+      await Future.delayed(const Duration(milliseconds: 100));
+
+      // Probe should never be called since all drives are never-synced
+      verifyNever(() => mockArweave.probeActiveDriveIds(
+            driveIds: any(named: 'driveIds'),
+            minBlockHeight: any(named: 'minBlockHeight'),
+            ownerAddress: any(named: 'ownerAddress'),
+          ));
+    });
+
+    test('incomplete probe falls back to all previously-synced drives',
+        () async {
+      final drives = [
+        _makeDrive(
+            id: 'a', ownerAddress: ownerAddress, lastBlockHeight: 50000),
+        _makeDrive(
+            id: 'b', ownerAddress: ownerAddress, lastBlockHeight: 60000),
+        _makeDrive(
+            id: 'c', ownerAddress: ownerAddress, lastBlockHeight: 70000),
+      ];
+
+      when(() => mockDriveDao.allDrives())
+          .thenReturn(FakeSelectable(drives));
+      when(() => mockArweave.getCurrentBlockHeight())
+          .thenAnswer((_) async => 100000);
+
+      // Probe returns isComplete: false (hasNextPage was true)
+      when(() => mockArweave.probeActiveDriveIds(
+            driveIds: any(named: 'driveIds'),
+            minBlockHeight: any(named: 'minBlockHeight'),
+            ownerAddress: any(named: 'ownerAddress'),
+          )).thenAnswer((_) async => (
+            activeDriveIds: {'a'},
+            isComplete: false,
+          ));
+
+      try {
+        await syncRepository
+            .syncAllDrives(wallet: mockWallet)
+            .toList();
+      } catch (_) {}
+
+      await Future.delayed(const Duration(milliseconds: 100));
+
+      // Probe was called once
+      verify(() => mockArweave.probeActiveDriveIds(
+            driveIds: any(named: 'driveIds'),
+            minBlockHeight: any(named: 'minBlockHeight'),
+            ownerAddress: any(named: 'ownerAddress'),
+          )).called(1);
+    });
+
+    test('probe failure falls back to syncing all drives', () async {
+      final drives = [
+        _makeDrive(
+            id: 'a', ownerAddress: ownerAddress, lastBlockHeight: 50000),
+        _makeDrive(
+            id: 'b', ownerAddress: ownerAddress, lastBlockHeight: null),
+      ];
+
+      when(() => mockDriveDao.allDrives())
+          .thenReturn(FakeSelectable(drives));
+      when(() => mockArweave.getCurrentBlockHeight())
+          .thenAnswer((_) async => 100000);
+
+      when(() => mockArweave.probeActiveDriveIds(
+            driveIds: any(named: 'driveIds'),
+            minBlockHeight: any(named: 'minBlockHeight'),
+            ownerAddress: any(named: 'ownerAddress'),
+          )).thenThrow(Exception('network error'));
+
+      try {
+        await syncRepository
+            .syncAllDrives(wallet: mockWallet)
+            .toList();
+      } catch (_) {}
+
+      await Future.delayed(const Duration(milliseconds: 100));
+
+      // Should have attempted probe for the previously-synced drive only
+      verify(() => mockArweave.probeActiveDriveIds(
+            driveIds: any(named: 'driveIds'),
+            minBlockHeight: any(named: 'minBlockHeight'),
+            ownerAddress: any(named: 'ownerAddress'),
+          )).called(1);
+    });
+
+    test('deep sync bypasses probe entirely', () async {
+      final drives = [
+        _makeDrive(
+            id: 'a', ownerAddress: ownerAddress, lastBlockHeight: 50000),
+      ];
+
+      when(() => mockDriveDao.allDrives())
+          .thenReturn(FakeSelectable(drives));
+      when(() => mockArweave.getCurrentBlockHeight())
+          .thenAnswer((_) async => 100000);
+
+      try {
+        await syncRepository
+            .syncAllDrives(wallet: mockWallet, syncDeep: true)
+            .toList();
+      } catch (_) {}
+
+      await Future.delayed(const Duration(milliseconds: 100));
+
+      verifyNever(() => mockArweave.probeActiveDriveIds(
+            driveIds: any(named: 'driveIds'),
+            minBlockHeight: any(named: 'minBlockHeight'),
+            ownerAddress: any(named: 'ownerAddress'),
+          ));
+    });
+  });
+
+  group('Fix 2: updateUserDrives cache', () {
+    test('skips GQL call on repeat calls until cache is cleared', () async {
+      when(() => mockArweave.getUniqueUserDriveEntities(
+            any(),
+            any(),
+          )).thenAnswer((_) async => {});
+      when(() => mockDriveDao.updateUserDrives(any(), any()))
+          .thenAnswer((_) async {});
+
+      // First call should hit GQL
+      await syncRepository.updateUserDrives(
+        wallet: mockWallet,
+        password: 'pass',
+        cipherKey: SecretKey([1, 2, 3]),
+      );
+
+      // Second call should be cached (up-to-date flag is set)
+      await syncRepository.updateUserDrives(
+        wallet: mockWallet,
+        password: 'pass',
+        cipherKey: SecretKey([1, 2, 3]),
+      );
+
+      verify(() => mockArweave.getUniqueUserDriveEntities(
+            any(),
+            any(),
+          )).called(1);
+    });
+
+    test('forceRefresh bypasses cache', () async {
+      when(() => mockArweave.getUniqueUserDriveEntities(
+            any(),
+            any(),
+          )).thenAnswer((_) async => {});
+      when(() => mockDriveDao.updateUserDrives(any(), any()))
+          .thenAnswer((_) async {});
+
+      // First call
+      await syncRepository.updateUserDrives(
+        wallet: mockWallet,
+        password: 'pass',
+        cipherKey: SecretKey([1, 2, 3]),
+      );
+
+      // Second call with forceRefresh should bypass cache
+      await syncRepository.updateUserDrives(
+        wallet: mockWallet,
+        password: 'pass',
+        cipherKey: SecretKey([1, 2, 3]),
+        forceRefresh: true,
+      );
+
+      verify(() => mockArweave.getUniqueUserDriveEntities(
+            any(),
+            any(),
+          )).called(2);
+    });
+  });
+
+  group('Fix 3: GQLDriveHistory genesis block guard', () {
+    test('skips [0,0] range and does not query gateway', () async {
+      final mockArweaveForGql = MockArweaveService();
+
+      final gqlHistory = GQLDriveHistory(
+        subRanges: HeightRange(rangeSegments: [
+          Range(start: 0, end: 0),
+          Range(start: 100, end: 200),
+        ]),
+        arweave: mockArweaveForGql,
+        driveId: 'test-drive',
+        ownerAddress: 'test-owner',
+      );
+
+      when(() => mockArweaveForGql.getSegmentedTransactionsFromDrive(
+            any(),
+            minBlockHeight: any(named: 'minBlockHeight'),
+            maxBlockHeight: any(named: 'maxBlockHeight'),
+            ownerAddress: any(named: 'ownerAddress'),
+            strategy: any(named: 'strategy'),
+          )).thenAnswer((_) => const Stream.empty());
+
+      when(() => mockArweaveForGql.graphQLRetry)
+          .thenReturn(MockGraphQLRetry());
+
+      // First getNextStream() processes [0,0] — should be skipped silently
+      final stream1 = gqlHistory.getNextStream();
+      final results1 = await stream1.toList();
+      expect(results1, isEmpty);
+
+      // Verify NO gateway call was made for [0,0]
+      verifyNever(() => mockArweaveForGql.getSegmentedTransactionsFromDrive(
+            any(),
+            minBlockHeight: any(named: 'minBlockHeight'),
+            maxBlockHeight: any(named: 'maxBlockHeight'),
+            ownerAddress: any(named: 'ownerAddress'),
+            strategy: any(named: 'strategy'),
+          ));
+
+      // Second getNextStream() processes [100,200] — should query normally
+      final stream2 = gqlHistory.getNextStream();
+      await stream2.toList();
+
+      verify(() => mockArweaveForGql.getSegmentedTransactionsFromDrive(
+            any(),
+            minBlockHeight: 100,
+            maxBlockHeight: 200,
+            ownerAddress: any(named: 'ownerAddress'),
+            strategy: any(named: 'strategy'),
+          )).called(1);
+    });
+  });
+}


### PR DESCRIPTION
# v2.85.0 Release

## Sync Performance — Major Overhaul

Comprehensive optimization of the sync pipeline. Incremental syncs (no changes) reduced from **130 GraphQL calls / 376 seconds to 3 calls / <1 second**.

### GraphQL Optimization
- **Drive activity probe**: Partitions never-synced vs previously-synced drives to avoid poisoning the probe with minBlockHeight=0, which was causing all drives to resync every time (#2150)
- **Unfiltered GQL strategy**: Switched from 3 queries per drive (drive/folder/file entity types) to 1 query per drive — 48 → 16 calls on first sync
- **UserDriveEntityTxs cache**: Event-based cache prevents redundant calls across auth flow and sync (3 → 1 calls per session)
- **PendingDriveEntities local DB pre-check**: Only queries gateway when locally-tracked pending transactions exist (16 → 0-1 calls)
- **Genesis block [0,0] range guard**: Eliminates phantom GQL queries from snapshot gaps at block 0
- **Entity data bytes cache**: Password validation reuses cached data from drive discovery (9.7s → 0.3s)
- **Drive signature cache**: Immutable on-chain signatures cached permanently

### Solana RPC & Gateway Fixes
- **Stop Solana RPC retry spam**: Cache empty gateway list on first failure instead of retrying 30+ times per sync
- **Shared gateway cache**: SnapshotValidationService and DataGatewayFallback share one cache

### Sync Pipeline Fixes
- **Zero-drives-to-sync**: Early return with success instead of "all drives failed" when probe skips all drives
- **updateUserDrives race condition**: Future-based dedup instead of boolean flag
- **Snapshot prefetch minBlock**: Never-synced drives excluded from min calculation
- **Cancellation check in probe loop**
- **Conditional balance refresh**: Skip PendingTxFees query after no-op sync
- **Infinite loop guard**: Empty-edges guard on snapshot pagination

## Sync Modal UX Improvements (#2154)
- Show "Checking for changes..." during drive activity probe phase
- Include drive names in sync error messages (e.g., "My Drive: Gateway timeout (504)")
- "Retry Failed" button in error modal — retries only failed drives via driveIdsToRetry filter
- Elapsed time display ("45s elapsed") shown after 5 seconds during longer syncs

## Snapshot Creation Improvements (#2153, #2155)
- Snapshot creation progress reporting, caching, and retry
- Download UX fixes for snapshot creation flow

## Transaction Status Fixes (PE-9126)
- Scope tx-status query per-tx by drive owner, not logged-in wallet (#2151)
- Raise tx-status timeouts above gateway upstream ceiling (#2152)
- Drop unscopable txs from confirmations instead of returning -1

## UI Improvements
- Modernized share file and download all modals (#2149)