### PR TITLE
PE-9130: Point GraphQL at turbo-gateway.com directly with Goldsky fallback

### DIFF
--- a/assets/config/dev.json
+++ b/assets/config/dev.json
@@ -1,6 +1,6 @@
 {
-  "configVersion": 2,
-  "defaultArweaveGatewayUrl": "https://ardrive.net",
+  "configVersion": 3,
+  "defaultArweaveGatewayUrl": "https://turbo-gateway.com",
   "defaultArweaveGatewayForDataRequest": {
     "label": "Turbo Gateway",
     "url": "https://turbo-gateway.com"

--- a/assets/config/prod.json
+++ b/assets/config/prod.json
@@ -1,6 +1,6 @@
 {
-  "configVersion": 2,
-  "defaultArweaveGatewayUrl": "https://ardrive.net",
+  "configVersion": 3,
+  "defaultArweaveGatewayUrl": "https://turbo-gateway.com",
   "defaultArweaveGatewayForDataRequest": {
     "label": "Turbo Gateway",
     "url": "https://turbo-gateway.com"

--- a/assets/config/staging.json
+++ b/assets/config/staging.json
@@ -1,6 +1,6 @@
 {
-  "configVersion": 2,
-  "defaultArweaveGatewayUrl": "https://ardrive.net",
+  "configVersion": 3,
+  "defaultArweaveGatewayUrl": "https://turbo-gateway.com",
   "defaultArweaveGatewayForDataRequest": {
     "label": "Turbo Gateway",
     "url": "https://turbo-gateway.com"

--- a/lib/utils/graphql_retry.dart
+++ b/lib/utils/graphql_retry.dart
@@ -9,15 +9,20 @@ import 'package:retry/retry.dart';
 
 /// Retry every GraphQL query for `ArtemisClient`
 ///
-/// On 429 or 5xx errors, falls back to arweave.net/graphql (Goldsky proxy)
-/// since most AR.IO gateways don't index ArDrive L2 data.
+/// On 429 or 5xx errors, falls back to the Goldsky search index directly
+/// (arweave.net/graphql proxies to it but rate-limits aggressively) since
+/// most AR.IO gateways don't index ArDrive L2 data.
+///
+/// Note: Goldsky caps page size at 100 and, when asked for more, silently
+/// clamps to 100 while reporting hasNextPage: false — so queries sent through
+/// this fallback must never request more than 100 items per page.
 class GraphQLRetry {
   GraphQLRetry(this._client,
       {required InternetChecker internetChecker,
       String? fallbackGraphqlUrl})
       : _internetChecker = internetChecker,
         _fallbackGraphqlUrl =
-            fallbackGraphqlUrl ?? 'https://arweave.net/graphql';
+            fallbackGraphqlUrl ?? 'https://arweave-search.goldsky.com/graphql';
 
   final ArtemisClient _client;
   final InternetChecker _internetChecker;

--- a/packages/ardrive_ui/pubspec.yaml
+++ b/packages/ardrive_ui/pubspec.yaml
@@ -23,7 +23,10 @@ dependencies:
   percent_indicator: ^4.2.2
   flutter_svg_image:
   provider: ^6.0.5
-  equatable: ^2.0.5
+  # pinned below 2.1.0: equatable 2.1.0 deprecates EquatableMixin (used by
+  # data_table.dart) and the main app's lockfile resolves 2.0.7; this package
+  # has no committed lockfile, so CI floats to the newest allowed version
+  equatable: '>=2.0.5 <2.1.0'
   ardrive_utils:
     path: ../ardrive_utils
 


### PR DESCRIPTION
## Summary

Cuts the ardrive.net proxy hop out of the GraphQL path and hardens the fallback:

- **Primary GQL endpoint: `https://turbo-gateway.com`** (was `https://ardrive.net`, which proxies to turbo-gateway anyway). During the 2026-07-08 incident the ardrive.net proxy pool returned 503s while turbo-gateway itself recovered independently — the proxy was a single point of failure adding no value on this path. Data requests already go to turbo-gateway directly.
- **`configVersion` 2 → 3** in all three flavors so existing users' locally-stored configs are replaced on next app load (stored configs only refresh on version bump).
- **Fallback endpoint: `https://arweave-search.goldsky.com/graphql`** (was `https://arweave.net/graphql`, which proxies to Goldsky but rate-limits aggressively — probes got 429'd within a few requests).
- Documents Goldsky's page-size hazard discovered during endpoint testing: `first > 100` is silently clamped to 100 **with `hasNextPage` falsely reporting `false`** — a paginating client would silently truncate results. Fallback queries must stay ≤ 100/page (all current queries do; this matters for the planned page-size increase).

## Verification
- turbo-gateway.com/graphql serves the real sync query shape (owner + Drive-Id + block range, HEIGHT_ASC): 100 edges, correct `hasNextPage`.
- arweave-search.goldsky.com/graphql: healthy, correct pagination at `first: 100`.
- No test pins either endpoint URL; config JSONs validated.

## Rollout note
Merging to dev → staging.ardrive.io picks this up via the staging config; production users get it at the next release. Users with stored configs migrate automatically via the version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172nfTRDj7wgnhs44Lg6mxC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default gateway and fallback GraphQL endpoint used by the app, improving request handling when the primary service is unavailable.
  * Bumped configuration versions across environments to keep settings aligned.

* **Chores**
  * Tightened a UI package dependency version range to improve compatibility and reduce upgrade-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->