### PR TITLE
PE-9131: Minimize Solana RPC usage in sync and gateway registry

### DIFF
--- a/lib/gar/domain/repositories/gar_repository.dart
+++ b/lib/gar/domain/repositories/gar_repository.dart
@@ -8,6 +8,7 @@ import 'package:collection/collection.dart';
 
 abstract class GarRepository {
   Future<List<Gateway>> getGateways();
+  Future<List<Gateway>> refreshGateways();
   List<Gateway> searchGateways(String query);
   Future<Gateway> getSelectedGateway();
   Future<void> updateGateway(Gateway gateway);
@@ -35,10 +36,21 @@ class GarRepositoryImpl implements GarRepository {
 
   final List<Gateway> _gateways = [];
 
+  /// Serves the persisted/session gateway list; the network is hit at most
+  /// once ever (on the very first use). Use [refreshGateways] for an
+  /// explicit, user-initiated re-fetch.
   @override
   Future<List<Gateway>> getGateways() async {
     _gateways.clear();
-    _gateways.addAll(await arioSDK.getGateways());
+    _gateways.addAll(await arweave.gatewayFallback.getGatewaysCached());
+
+    return _gateways;
+  }
+
+  @override
+  Future<List<Gateway>> refreshGateways() async {
+    _gateways.clear();
+    _gateways.addAll(await arweave.gatewayFallback.refreshGateways());
 
     return _gateways;
   }

--- a/lib/gar/presentation/bloc/gar_bloc.dart
+++ b/lib/gar/presentation/bloc/gar_bloc.dart
@@ -33,6 +33,25 @@ class GarBloc extends Bloc<GarEvent, GarState> {
       }
     });
 
+    on<RefreshGateways>((event, emit) async {
+      try {
+        emit(LoadingGateways());
+
+        final gateways = await garRepository.refreshGateways();
+        final currentGateway = await garRepository.getSelectedGateway();
+
+        emit(
+          GatewaysLoaded(
+            gateways: gateways,
+            currentGateway: currentGateway,
+          ),
+        );
+      } catch (e) {
+        logger.e('Failed to refresh gateways from AR.IO', e);
+        emit(const GatewaysError());
+      }
+    });
+
     on<SelectGateway>((event, emit) async {
       emit(VerifyingGateway());
 

--- a/lib/gar/presentation/bloc/gar_event.dart
+++ b/lib/gar/presentation/bloc/gar_event.dart
@@ -9,6 +9,9 @@ abstract class GarEvent extends Equatable {
 
 final class GetGateways extends GarEvent {}
 
+/// User-initiated refresh of the gateway list from the network.
+final class RefreshGateways extends GarEvent {}
+
 final class SelectGateway extends GarEvent {
   final Gateway gateway;
 

--- a/lib/gar/presentation/widgets/gar_modal.dart
+++ b/lib/gar/presentation/widgets/gar_modal.dart
@@ -141,6 +141,12 @@ class _ArIOGatewaySelectorModalContentState extends State<_ArIOGatewaySelectorMo
             actions: [
               ModalAction(
                 action: () {
+                  garBloc.add(RefreshGateways());
+                },
+                title: 'Refresh list',
+              ),
+              ModalAction(
+                action: () {
                   Navigator.of(context).pop();
                 },
                 title: 'Cancel',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -494,7 +494,6 @@ class AppState extends State<App> {
               configService: configService,
               arioSDK: ArioSDKFactory().create(),
             ),
-            arnsRepository: _.read<ARNSRepository>(),
             userPreferencesRepository: _.read<UserPreferencesRepository>(),
           ),
         ),

--- a/lib/services/arweave/data_gateway_fallback.dart
+++ b/lib/services/arweave/data_gateway_fallback.dart
@@ -1,7 +1,10 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:ardrive/download/download_exceptions.dart';
 import 'package:ardrive/services/arweave/arweave_service.dart';
+import 'package:ardrive/utils/key_value_store.dart';
+import 'package:ardrive/utils/local_key_value_store.dart';
 import 'package:ardrive/utils/logger.dart';
 import 'package:ardrive_http/ardrive_http.dart';
 import 'package:ario_sdk/ario_sdk.dart';
@@ -33,9 +36,92 @@ class DataGatewayFallback {
   /// SnapshotValidationService) to avoid duplicate Solana RPC calls.
   List<Gateway>? cachedGateways;
 
+  static const _garCacheKey = 'gar_gateways_cache_v1';
+
+  KeyValueStore? _store;
+
   DataGatewayFallback({
     required ArioSDK arioSDK,
-  }) : _arioSDK = arioSDK;
+    KeyValueStore? store,
+  })  : _arioSDK = arioSDK,
+        _store = store;
+
+  Future<KeyValueStore?> _getStore() async {
+    if (_store != null) return _store;
+    try {
+      _store = await LocalKeyValueStore.getInstance();
+    } catch (e) {
+      logger.w('GAR cache store unavailable: $e');
+    }
+    return _store;
+  }
+
+  /// Returns the gateway list while fetching from the network at most once
+  /// ever: memory cache → persisted cache → single SDK fetch (persisted on
+  /// success). The gateway registry rarely changes, so we avoid hitting the
+  /// Solana RPC on every session; explicit refreshes go through
+  /// [refreshGateways] (e.g. from the gateway settings screen).
+  Future<List<Gateway>> getGatewaysCached() async {
+    if (cachedGateways != null) return cachedGateways!;
+
+    final persisted = await _loadPersistedGateways();
+    if (persisted != null) {
+      cachedGateways = persisted;
+      return persisted;
+    }
+
+    try {
+      final fetched = await _arioSDK
+          .getGateways()
+          .timeout(_garListTimeout, onTimeout: () => <Gateway>[]);
+      cachedGateways = fetched;
+      if (fetched.isNotEmpty) {
+        await _persistGateways(fetched);
+      }
+    } catch (e) {
+      // RPC failed — cache empty list in memory so we don't retry every call
+      logger.w('GAR list unavailable, will not retry this session: $e');
+      cachedGateways = [];
+    }
+    return cachedGateways!;
+  }
+
+  /// Force-refreshes the gateway list from the network and persists the
+  /// result. User-initiated only (refresh action in gateway settings).
+  Future<List<Gateway>> refreshGateways() async {
+    final fetched = await _arioSDK.getGateways();
+    cachedGateways = fetched;
+    if (fetched.isNotEmpty) {
+      await _persistGateways(fetched);
+    }
+    return fetched;
+  }
+
+  Future<List<Gateway>?> _loadPersistedGateways() async {
+    try {
+      final store = await _getStore();
+      final raw = await store?.getString(_garCacheKey);
+      if (raw == null) return null;
+      return (json.decode(raw) as List)
+          .map((e) => Gateway.fromJson(e as Map<String, dynamic>))
+          .toList();
+    } catch (e) {
+      logger.w('Failed to load persisted GAR list, refetching: $e');
+      return null;
+    }
+  }
+
+  Future<void> _persistGateways(List<Gateway> gateways) async {
+    try {
+      final store = await _getStore();
+      await store?.putString(
+        _garCacheKey,
+        json.encode(gateways.map((g) => g.toJson()).toList()),
+      );
+    } catch (e) {
+      logger.w('Failed to persist GAR list: $e');
+    }
+  }
 
   /// Fetch transaction data with serial gateway fallback.
   ///
@@ -193,20 +279,10 @@ class DataGatewayFallback {
     final primaryHost = primaryClient.api.gatewayUrl.host;
 
     try {
-      if (cachedGateways == null) {
-        try {
-          cachedGateways = await _arioSDK
-              .getGateways()
-              .timeout(_garListTimeout, onTimeout: () => <Gateway>[]);
-        } catch (e) {
-          // Solana RPC failed — cache empty list so we don't retry every call
-          logger.w('GAR list unavailable for fallback, will not retry: $e');
-          cachedGateways = [];
-        }
-      }
+      final gateways = await getGatewaysCached();
 
       var added = 0;
-      for (final gw in cachedGateways!) {
+      for (final gw in gateways) {
         if (added >= _maxGarFallbacks) break;
         if (gw.settings.fqdn == primaryHost) continue;
         clients.add(_getOrCreateClient(gw.settings.fqdn));

--- a/lib/sync/data/snapshot_validation_service.dart
+++ b/lib/sync/data/snapshot_validation_service.dart
@@ -20,6 +20,10 @@ class SnapshotValidationService {
   /// services share one cache and avoid duplicate Solana RPC calls.
   DataGatewayFallback? gatewayFallback;
 
+  /// Session-local gateway cache used only when no shared
+  /// [gatewayFallback] is wired up.
+  List<Gateway>? _localGateways;
+
   SnapshotValidationService({
     required ConfigService configService,
     required ArioSDK arioSDK,
@@ -108,29 +112,22 @@ class SnapshotValidationService {
     }
 
     // 3. Primary had a transient error (timeout, 5xx) — try 1 fallback gateway.
-    //    Read the shared gateway cache from DataGatewayFallback. If unavailable,
-    //    fetch from Solana RPC once and cache the result (empty on failure).
+    //    Read the shared gateway cache from DataGatewayFallback (which loads
+    //    a persisted list and fetches from Solana RPC at most once ever). If
+    //    no shared cache is wired up, fetch once and keep it in memory.
     try {
       List<Gateway> gateways;
-      if (gatewayFallback != null &&
-          gatewayFallback!.cachedGateways != null) {
-        gateways = gatewayFallback!.cachedGateways!;
+      if (gatewayFallback != null) {
+        gateways = await gatewayFallback!.getGatewaysCached();
       } else {
         try {
-          gateways = await _arioSDK
+          gateways = _localGateways ??= await _arioSDK
               .getGateways()
               .timeout(_garListTimeout, onTimeout: () => <Gateway>[]);
-          // Store in shared cache if available
-          if (gatewayFallback != null) {
-            gatewayFallback!.cachedGateways = gateways;
-          }
         } catch (e) {
           // Solana RPC failed — cache empty list so we don't retry every call
           logger.w('GAR gateway list unavailable, will not retry: $e');
-          if (gatewayFallback != null) {
-            gatewayFallback!.cachedGateways = [];
-          }
-          gateways = [];
+          gateways = _localGateways = [];
         }
       }
 

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:math';
 
-import 'package:ardrive/arns/domain/arns_repository.dart';
 import 'package:ardrive/blocs/constants.dart';
 import 'package:ardrive/core/crypto/crypto.dart';
 import 'package:ardrive/entities/constants.dart';
@@ -36,7 +35,6 @@ import 'package:ardrive/utils/snapshots/range.dart';
 import 'package:ardrive/utils/snapshots/snapshot_drive_history.dart';
 import 'package:ardrive/utils/snapshots/snapshot_item.dart';
 import 'package:ardrive_utils/ardrive_utils.dart';
-import 'package:ario_sdk/ario_sdk.dart';
 import 'package:arweave/arweave.dart';
 import 'package:cryptography/cryptography.dart';
 import 'package:drift/drift.dart';
@@ -125,7 +123,6 @@ abstract class SyncRepository {
     required ConfigService configService,
     required BatchProcessor batchProcessor,
     required SnapshotValidationService snapshotValidationService,
-    required ARNSRepository arnsRepository,
     required UserPreferencesRepository userPreferencesRepository,
   }) {
     return _SyncRepository(
@@ -134,7 +131,6 @@ abstract class SyncRepository {
       configService: configService,
       batchProcessor: batchProcessor,
       snapshotValidationService: snapshotValidationService,
-      arnsRepository: arnsRepository,
       userPreferencesRepository: userPreferencesRepository,
     );
   }
@@ -146,7 +142,6 @@ class _SyncRepository implements SyncRepository {
   final ConfigService _configService;
   final BatchProcessor _batchProcessor;
   final SnapshotValidationService _snapshotValidationService;
-  final ARNSRepository _arnsRepository;
   final UserPreferencesRepository _userPreferencesRepository;
 
   final Map<String, GhostFolder> _ghostFolders = {};
@@ -171,15 +166,13 @@ class _SyncRepository implements SyncRepository {
     required ConfigService configService,
     required BatchProcessor batchProcessor,
     required SnapshotValidationService snapshotValidationService,
-    required ARNSRepository arnsRepository,
     required UserPreferencesRepository userPreferencesRepository,
   })  : _arweave = arweave,
         _driveDao = driveDao,
         _configService = configService,
         _snapshotValidationService = snapshotValidationService,
         _batchProcessor = batchProcessor,
-        _userPreferencesRepository = userPreferencesRepository,
-        _arnsRepository = arnsRepository;
+        _userPreferencesRepository = userPreferencesRepository;
 
   @override
   Stream<SyncProgress> syncAllDrives({
@@ -206,13 +199,6 @@ class _SyncRepository implements SyncRepository {
     String? walletAddress;
     if (wallet != null) {
       walletAddress = await wallet.getAddress();
-
-      _arnsRepository
-          .getAntRecordsForWallet(walletAddress, update: true)
-          .catchError((e) {
-        logger.e('Error getting ANT records for wallet. Continuing...', e);
-        return Future.value(<ANTRecord>[]);
-      });
     }
 
     // Sync the contents of each drive attached in the app.
@@ -586,9 +572,6 @@ class _SyncRepository implements SyncRepository {
         }
         // Clear cached transaction IDs now that we've used them
         SnapshotItemOnChain.clearAllCachedTransactionIds();
-        _arnsRepository
-            .waitForARNSRecordsToUpdate()
-            .then((value) => _arnsRepository.saveAllFilesWithAssignedNames());
         final hasHiddenItems = await _driveDao.hasHiddenItems().getSingle();
         await _userPreferencesRepository.saveUserHasHiddenItem(hasHiddenItems);
         await _userPreferencesRepository.load();

--- a/packages/ardrive_ui/pubspec.yaml
+++ b/packages/ardrive_ui/pubspec.yaml
@@ -23,7 +23,10 @@ dependencies:
   percent_indicator: ^4.2.2
   flutter_svg_image:
   provider: ^6.0.5
-  equatable: ^2.0.5
+  # pinned below 2.1.0: equatable 2.1.0 deprecates EquatableMixin (used by
+  # data_table.dart) and the main app's lockfile resolves 2.0.7; this package
+  # has no committed lockfile, so CI floats to the newest allowed version
+  equatable: '>=2.0.5 <2.1.0'
   ardrive_utils:
     path: ../ardrive_utils
 

--- a/test/gar/domain/repository/gar_repository_test.dart
+++ b/test/gar/domain/repository/gar_repository_test.dart
@@ -1,4 +1,5 @@
 import 'package:ardrive/gar/domain/repositories/gar_repository.dart';
+import 'package:ardrive/services/arweave/data_gateway_fallback.dart';
 import 'package:ardrive/services/arweave/arweave_service.dart';
 import 'package:ardrive/services/config/app_config.dart';
 import 'package:ardrive/services/config/config_service.dart';
@@ -14,6 +15,8 @@ class MockConfigService extends Mock implements ConfigService {}
 
 class MockArweaveService extends Mock implements ArweaveService {}
 
+class MockDataGatewayFallback extends Mock implements DataGatewayFallback {}
+
 class MockGateway extends Mock implements Gateway {}
 
 class MockConfig extends Mock implements AppConfig {}
@@ -27,12 +30,15 @@ void main() {
   late MockArioSDK arioSDK;
   late MockConfigService configService;
   late MockArweaveService arweaveService;
+  late MockDataGatewayFallback gatewayFallback;
   late MockArDriveHTTP http;
 
   setUp(() {
     arioSDK = MockArioSDK();
     configService = MockConfigService();
     arweaveService = MockArweaveService();
+    gatewayFallback = MockDataGatewayFallback();
+    when(() => arweaveService.gatewayFallback).thenReturn(gatewayFallback);
     http = MockArDriveHTTP();
     repository = GarRepositoryImpl(
       arioSDK: arioSDK,
@@ -56,14 +62,30 @@ void main() {
 
   group('GarRepositoryImpl', () {
     group('getGateways', () {
-      test('fetches and returns gateways', () async {
+      test('serves gateways from the shared cache without hitting the SDK',
+          () async {
         final gateways = [MockGateway()];
-        when(() => arioSDK.getGateways()).thenAnswer((_) async => gateways);
+        when(() => gatewayFallback.getGatewaysCached())
+            .thenAnswer((_) async => gateways);
 
         final result = await repository.getGateways();
 
         expect(result, equals(gateways));
-        verify(() => arioSDK.getGateways()).called(1);
+        verify(() => gatewayFallback.getGatewaysCached()).called(1);
+        verifyNever(() => arioSDK.getGateways());
+      });
+    });
+
+    group('refreshGateways', () {
+      test('forces a network refresh through the shared cache', () async {
+        final gateways = [MockGateway()];
+        when(() => gatewayFallback.refreshGateways())
+            .thenAnswer((_) async => gateways);
+
+        final result = await repository.refreshGateways();
+
+        expect(result, equals(gateways));
+        verify(() => gatewayFallback.refreshGateways()).called(1);
       });
     });
 
@@ -137,7 +159,8 @@ void main() {
               url: 'https://ardrive.net',
             ),
           ));
-          when(() => arioSDK.getGateways()).thenAnswer((_) async => gateways);
+          when(() => gatewayFallback.getGatewaysCached())
+              .thenAnswer((_) async => gateways);
           when(() => gateway.settings).thenReturn(settings);
           when(() => settings.label).thenReturn('New Gateway');
 
@@ -171,7 +194,8 @@ void main() {
               url: 'https://not.in.list.com',
             ),
           ));
-          when(() => arioSDK.getGateways()).thenAnswer((_) async => gateways);
+          when(() => gatewayFallback.getGatewaysCached())
+              .thenAnswer((_) async => gateways);
           when(() => gateway1.settings).thenReturn(settings);
           when(() => gateway2.settings).thenReturn(settings);
           when(() => gateway3.settings).thenReturn(settings);
@@ -244,7 +268,8 @@ void main() {
             when(() => settings2.label).thenReturn('second gateway');
             when(() => settings3.label).thenReturn('first');
 
-            when(() => arioSDK.getGateways()).thenAnswer((_) async => gateways);
+            when(() => gatewayFallback.getGatewaysCached())
+              .thenAnswer((_) async => gateways);
 
             // Manually populate the _gateways list
             await repository.getGateways();
@@ -286,7 +311,8 @@ void main() {
             when(() => settings2.label).thenReturn('Beta Gateway');
             when(() => settings3.label).thenReturn('Gamma Gateway');
 
-            when(() => arioSDK.getGateways()).thenAnswer((_) async => gateways);
+            when(() => gatewayFallback.getGatewaysCached())
+              .thenAnswer((_) async => gateways);
 
             // Manually populate the _gateways list
             await repository.getGateways();

--- a/test/services/arweave/data_gateway_fallback_test.dart
+++ b/test/services/arweave/data_gateway_fallback_test.dart
@@ -1,0 +1,194 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:ardrive/services/arweave/data_gateway_fallback.dart';
+import 'package:ardrive/utils/key_value_store.dart';
+import 'package:ario_sdk/ario_sdk.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockArioSDK extends Mock implements ArioSDK {}
+
+class FakeKeyValueStore implements KeyValueStore {
+  final Map<String, Object> _values = {};
+
+  @override
+  FutureOr<bool?> getBool(String key) => _values[key] as bool?;
+
+  @override
+  FutureOr<String?> getString(String key) => _values[key] as String?;
+
+  @override
+  FutureOr<Set<String>> getKeys() => _values.keys.toSet();
+
+  @override
+  Future<bool> putBool(String key, bool value) async {
+    _values[key] = value;
+    return true;
+  }
+
+  @override
+  Future<bool> putString(String key, String value) async {
+    _values[key] = value;
+    return true;
+  }
+
+  @override
+  Future<bool> remove(String key) async {
+    _values.remove(key);
+    return true;
+  }
+}
+
+Gateway _makeGateway(String fqdn) {
+  return Gateway(
+    operatorStake: 1000,
+    gatewayAddress: 'gateway-address-$fqdn',
+    observerAddress: 'observer-address-$fqdn',
+    settings: Settings(
+      port: 443,
+      protocol: 'https',
+      allowDelegatedStaking: true,
+      fqdn: fqdn,
+      delegateRewardShareRatio: 10,
+      properties: '',
+      note: '',
+      minDelegatedStake: 100,
+      label: 'Gateway $fqdn',
+      autoStake: true,
+    ),
+    startTimestamp: 0,
+    totalDelegatedStake: 0,
+    stats: Stats(
+      failedConsecutiveEpochs: 0,
+      observedEpochCount: 1,
+      passedConsecutiveEpochs: 1,
+      totalEpochCount: 1,
+      prescribedEpochCount: 1,
+      passedEpochCount: 1,
+      failedEpochCount: 0,
+    ),
+    status: 'joined',
+  );
+}
+
+void main() {
+  const cacheKey = 'gar_gateways_cache_v1';
+
+  late MockArioSDK sdk;
+  late FakeKeyValueStore store;
+  late DataGatewayFallback fallback;
+
+  setUp(() {
+    sdk = MockArioSDK();
+    store = FakeKeyValueStore();
+    fallback = DataGatewayFallback(arioSDK: sdk, store: store);
+  });
+
+  group('DataGatewayFallback.getGatewaysCached', () {
+    test('serves the persisted list without calling the SDK', () async {
+      final persisted = [_makeGateway('persisted.gateway.com')];
+      await store.putString(
+        cacheKey,
+        json.encode(persisted.map((g) => g.toJson()).toList()),
+      );
+
+      final result = await fallback.getGatewaysCached();
+
+      expect(result, hasLength(1));
+      expect(result.first.settings.fqdn, 'persisted.gateway.com');
+      verifyNever(() => sdk.getGateways());
+    });
+
+    test('fetches from the SDK once and persists when nothing is stored',
+        () async {
+      final fetched = [_makeGateway('fetched.gateway.com')];
+      when(() => sdk.getGateways()).thenAnswer((_) async => fetched);
+
+      final first = await fallback.getGatewaysCached();
+      final second = await fallback.getGatewaysCached();
+
+      expect(first, equals(fetched));
+      expect(second, equals(fetched));
+      verify(() => sdk.getGateways()).called(1);
+
+      final raw = store.getString(cacheKey);
+      expect(raw, isNotNull, reason: 'fetched list must be persisted');
+      final roundTripped = (json.decode(raw!) as List)
+          .map((e) => Gateway.fromJson(e as Map<String, dynamic>))
+          .toList();
+      expect(roundTripped.single.settings.fqdn, 'fetched.gateway.com');
+    });
+
+    test('a fresh instance reads the persisted list instead of refetching',
+        () async {
+      final fetched = [_makeGateway('fetched.gateway.com')];
+      when(() => sdk.getGateways()).thenAnswer((_) async => fetched);
+      await fallback.getGatewaysCached();
+
+      // Simulate a new app session sharing the same storage.
+      final newSdk = MockArioSDK();
+      final newSession = DataGatewayFallback(arioSDK: newSdk, store: store);
+
+      final result = await newSession.getGatewaysCached();
+
+      expect(result.single.settings.fqdn, 'fetched.gateway.com');
+      verifyNever(() => newSdk.getGateways());
+    });
+
+    test('caches an empty list on SDK failure and does not retry or persist',
+        () async {
+      when(() => sdk.getGateways()).thenThrow(Exception('rpc down'));
+
+      final first = await fallback.getGatewaysCached();
+      final second = await fallback.getGatewaysCached();
+
+      expect(first, isEmpty);
+      expect(second, isEmpty);
+      verify(() => sdk.getGateways()).called(1);
+      expect(store.getString(cacheKey), isNull,
+          reason: 'failures must not be persisted');
+    });
+
+    test('recovers from a corrupt persisted entry by refetching', () async {
+      await store.putString(cacheKey, 'not-json');
+      final fetched = [_makeGateway('fetched.gateway.com')];
+      when(() => sdk.getGateways()).thenAnswer((_) async => fetched);
+
+      final result = await fallback.getGatewaysCached();
+
+      expect(result.single.settings.fqdn, 'fetched.gateway.com');
+      verify(() => sdk.getGateways()).called(1);
+    });
+  });
+
+  group('DataGatewayFallback.refreshGateways', () {
+    test('always hits the SDK and replaces the persisted list', () async {
+      final original = [_makeGateway('old.gateway.com')];
+      await store.putString(
+        cacheKey,
+        json.encode(original.map((g) => g.toJson()).toList()),
+      );
+      await fallback.getGatewaysCached();
+
+      final refreshed = [_makeGateway('new.gateway.com')];
+      when(() => sdk.getGateways()).thenAnswer((_) async => refreshed);
+
+      final result = await fallback.refreshGateways();
+
+      expect(result.single.settings.fqdn, 'new.gateway.com');
+      verify(() => sdk.getGateways()).called(1);
+
+      final raw = store.getString(cacheKey);
+      final roundTripped = (json.decode(raw!) as List)
+          .map((e) => Gateway.fromJson(e as Map<String, dynamic>))
+          .toList();
+      expect(roundTripped.single.settings.fqdn, 'new.gateway.com');
+
+      // Subsequent cached reads serve the refreshed list.
+      final cached = await fallback.getGatewaysCached();
+      expect(cached.single.settings.fqdn, 'new.gateway.com');
+      verifyNoMoreInteractions(sdk);
+    });
+  });
+}

--- a/test/services/arweave/data_gateway_fallback_test.dart
+++ b/test/services/arweave/data_gateway_fallback_test.dart
@@ -112,7 +112,7 @@ void main() {
       expect(second, equals(fetched));
       verify(() => sdk.getGateways()).called(1);
 
-      final raw = store.getString(cacheKey);
+      final raw = await store.getString(cacheKey);
       expect(raw, isNotNull, reason: 'fetched list must be persisted');
       final roundTripped = (json.decode(raw!) as List)
           .map((e) => Gateway.fromJson(e as Map<String, dynamic>))
@@ -179,7 +179,7 @@ void main() {
       expect(result.single.settings.fqdn, 'new.gateway.com');
       verify(() => sdk.getGateways()).called(1);
 
-      final raw = store.getString(cacheKey);
+      final raw = await store.getString(cacheKey);
       final roundTripped = (json.decode(raw!) as List)
           .map((e) => Gateway.fromJson(e as Map<String, dynamic>))
           .toList();

--- a/test/sync/domain/sync_repository_optimization_test.dart
+++ b/test/sync/domain/sync_repository_optimization_test.dart
@@ -1,4 +1,3 @@
-import 'package:ardrive/arns/domain/arns_repository.dart';
 import 'package:ardrive/models/database/database.dart';
 import 'package:ardrive/services/arweave/data_gateway_fallback.dart';
 import 'package:ardrive/services/config/app_config.dart';
@@ -9,7 +8,6 @@ import 'package:ardrive/user/repositories/user_preferences_repository.dart';
 import 'package:ardrive/utils/snapshots/gql_drive_history.dart';
 import 'package:ardrive/utils/snapshots/height_range.dart';
 import 'package:ardrive/utils/snapshots/range.dart';
-import 'package:ario_sdk/ario_sdk.dart';
 import 'package:arweave/arweave.dart';
 import 'package:cryptography/cryptography.dart';
 import 'package:drift/drift.dart';
@@ -23,8 +21,6 @@ class MockBatchProcessor extends Mock implements BatchProcessor {}
 
 class MockSnapshotValidationService extends Mock
     implements SnapshotValidationService {}
-
-class _MockARNSRepository extends Mock implements ARNSRepository {}
 
 class MockUserPreferencesRepository extends Mock
     implements UserPreferencesRepository {}
@@ -81,7 +77,6 @@ void main() {
   late MockConfigService mockConfigService;
   late MockBatchProcessor mockBatchProcessor;
   late MockSnapshotValidationService mockSnapshotValidation;
-  late _MockARNSRepository mockArnsRepository;
   late MockUserPreferencesRepository mockUserPrefsRepo;
   late SyncRepository syncRepository;
   late _MockWallet mockWallet;
@@ -94,7 +89,6 @@ void main() {
     mockConfigService = MockConfigService();
     mockBatchProcessor = MockBatchProcessor();
     mockSnapshotValidation = MockSnapshotValidationService();
-    mockArnsRepository = _MockARNSRepository();
     mockUserPrefsRepo = MockUserPreferencesRepository();
     mockWallet = _MockWallet();
 
@@ -111,12 +105,8 @@ void main() {
     final mockGatewayFallback = _MockDataGatewayFallback();
     when(() => mockArweave.gatewayFallback).thenReturn(mockGatewayFallback);
     when(() => mockGatewayFallback.cachedGateways).thenReturn([]);
-
-    // Mock ARNS repository
-    when(() => mockArnsRepository.getAntRecordsForWallet(any(),
-        update: any(named: 'update'))).thenAnswer(
-      (_) async => <ANTRecord>[],
-    );
+    when(() => mockGatewayFallback.getGatewaysCached())
+        .thenAnswer((_) async => []);
 
     syncRepository = SyncRepository(
       arweave: mockArweave,
@@ -124,7 +114,6 @@ void main() {
       configService: mockConfigService,
       batchProcessor: mockBatchProcessor,
       snapshotValidationService: mockSnapshotValidation,
-      arnsRepository: mockArnsRepository,
       userPreferencesRepository: mockUserPrefsRepo,
     );
   });


### PR DESCRIPTION
## Summary

Investigation of heavy traffic to ArDrive's QuikNode Solana RPC found two structural sources; this PR eliminates both.

### 1. Sync no longer sweeps ArNS on every run
Every sync (auto-sync ~5 min, tab-focus restarts, manual) called `getAntRecordsForWallet(update: true)` — deliberately bypassing the repository's 15-minute cache — walking every owned ArNS name on Solana (several RPC calls per name), plus a post-sync `saveAllFilesWithAssignedNames` pass. ArDrive currently has **no ArNS integration**, so this was pure RPC cost with no user-facing effect. Both call sites and the `ARNSRepository` dependency are removed from `SyncRepository`. On-demand ArNS lookups elsewhere (upload flows, profile name) are untouched; sync-time integration can return later with the feature.

### 2. GAR gateway list: fetch at most once ever, refresh only on demand
The AR.IO gateway list was re-fetched from Solana RPC every app session (data-fetch fallback, snapshot validation) and on every open of the gateway settings modal. It's now persisted in local storage:
- `DataGatewayFallback`: memory → persisted cache → single SDK fetch (persisted on success). Across sessions the network is hit at most once, ever.
- Gateway settings serve the cached list; a new **"Refresh list"** button (new `RefreshGateways` bloc event) force-fetches and persists — the only path that re-hits the RPC.
- `SnapshotValidationService` reads through the same shared cache.
- Corrupt/missing persisted entries fall back to a normal fetch; fetch failures are cached in memory only (never persisted) so the next session retries.

## Expected impact
Steady-state Solana RPC volume drops to ~zero for a signed-in user who isn't using crypto top-ups or explicitly refreshing the gateway list.

## Tests
- New `DataGatewayFallback` persistence suite (store-hit/no-RPC, fetch-once-persist, cross-session reuse, failure non-persistence, corrupt-entry recovery, forced refresh)
- `gar_repository_test` rewired to the shared cache (asserts no SDK call on plain `getGateways`)
- Sync optimization tests updated for the removed dependency
- Includes the shared equatable CI pin (identical commit as PRs #2162/#2164; merges cleanly in any order)

Note: local test execution was unavailable for this branch (WSL→Windows interop broke mid-session); CI is the validation gate for this PR — please wait for green before review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172nfTRDj7wgnhs44Lg6mxC