### PR TITLE
PE-9133: Point development flavor at ar-io.dev testnet

### DIFF
--- a/assets/config/dev.json
+++ b/assets/config/dev.json
@@ -1,14 +1,14 @@
 {
   "configVersion": 2,
-  "defaultArweaveGatewayUrl": "https://ardrive.net",
+  "defaultArweaveGatewayUrl": "https://ar-io.dev",
   "defaultArweaveGatewayForDataRequest": {
-    "label": "Turbo Gateway",
-    "url": "https://turbo-gateway.com"
+    "label": "AR.IO Testnet",
+    "url": "https://ar-io.dev"
   },
   "useTurboUpload": true,
   "useTurboPayment": true,
-  "defaultTurboUploadUrl": "https://upload.ardrive.dev",
-  "defaultTurboPaymentUrl": "https://payment.ardrive.dev",
+  "defaultTurboUploadUrl": "https://upload.services.ar-io.dev",
+  "defaultTurboPaymentUrl": "https://payment.services.ar-io.dev",
   "allowedDataItemSizeForTurbo": 100000,
   "stripePublishableKey": "pk_test_51JUAtwC8apPOWkDLh2FPZkQkiKZEkTo6wqgLCtQoClL6S4l2jlbbc5MgOdwOUdU9Tn93NNvqAGbu115lkJChMikG00XUfTmo2z",
   "uploadThumbnails": true,


### PR DESCRIPTION
## Summary

Updates the **development** flavor (`assets/config/dev.json`) to the new AR.IO testnet, all four services:

| Service | Before | After |
|---|---|---|
| GraphQL gateway | `ardrive.net` | `ar-io.dev` |
| Data gateway | `turbo-gateway.com` | `ar-io.dev` (label "AR.IO Testnet") |
| Turbo upload | `upload.ardrive.dev` | `upload.services.ar-io.dev` |
| Turbo payment | `payment.ardrive.dev` | `payment.services.ar-io.dev` |

All four verified reachable (HTTP 200; the GraphQL endpoint answers a query).

## Scope
- **development flavor only** — `flutter run --dart-define=environment=development`.
- Staging (`staging.ardrive.io`) and production are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172nfTRDj7wgnhs44Lg6mxC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated development defaults to use the new AR.IO gateway, upload, and payment service endpoints.
  * Retained the existing configuration structure and settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->