### PR TITLE
PE-9132: Fetch Turbo free allowance concurrently during upload prep

### DIFF
--- a/lib/core/upload/uploader.dart
+++ b/lib/core/upload/uploader.dart
@@ -369,6 +369,12 @@ class UploadPaymentEvaluator {
 
     TurboBalanceInterface turboBalance;
 
+    // Only needs the wallet, so start it now and let it run concurrently with
+    // the balance and cost round-trips below — it is awaited where the free
+    // status is computed. getFreeAllowance never throws (see its wrapper), so
+    // an in-flight future here cannot become an unhandled rejection.
+    final freeAllowanceFuture = getFreeAllowance();
+
     turboBalance = await _getTurboBalance(canUseTurbo: _canUseTurbo);
     final turboCostEstimate = await _turboUploadCostCalculator.calculateCost(
       totalSize: dataItemSize,
@@ -392,7 +398,7 @@ class UploadPaymentEvaluator {
     /// An item is free only if it is both small enough to qualify AND the
     /// wallet still has free allowance to cover it. Size alone would promise
     /// "free" to a user whose pool is used up, and then fail with a 402.
-    final freeAllowance = await getFreeAllowance();
+    final freeAllowance = await freeAllowanceFuture;
     final freeStatus = freeUploadStatusFor(
       isSizeEligible: dataItemSize <= allowedDataItemSizeForTurbo,
       byteCount: dataItemSize,
@@ -428,6 +434,13 @@ class UploadPaymentEvaluator {
     int totalSize = 0;
 
     TurboBalanceInterface turboBalance;
+
+    // Only needs the wallet, so start it now and let it run concurrently with
+    // the balance, size and cost round-trips below — it is awaited where the
+    // free status is computed. getFreeAllowance never throws (see its
+    // wrapper), so an in-flight future here cannot become an unhandled
+    // rejection.
+    final freeAllowanceFuture = getFreeAllowance();
 
     /// Check the balance of the user
     /// If we can't get the balance, turbo won't be available
@@ -473,7 +486,7 @@ class UploadPaymentEvaluator {
       arCostEstimate = UploadCostEstimate.zero();
     }
 
-    final freeAllowance = await getFreeAllowance();
+    final freeAllowance = await freeAllowanceFuture;
 
     /// Every item being small enough is not sufficient — the wallet's free
     /// pool has to cover the whole upload too. When it does not, we report the


### PR DESCRIPTION
## Summary

Follow-up to #2166. `getFreeAllowance()` (the `GET /v1/account/free` call added there) was awaited **late** in each upload-preparation method, after the balance and cost round-trips that already run serially. But the allowance call is **independent** — it only needs the wallet address — so it added an extra *sequential* Turbo round-trip to every upload-modal open, and **doubled the worst-case wait** when `payment.ardrive.io` is unavailable (two back-to-back 8s `ArDriveHTTP` timeouts instead of one) before failing open to size-only behavior.

## Change

Start the future up front in both `getUploadPaymentInfoForEntities` and `getUploadPaymentInfoForUploadPlans`, and await it where the free status is computed — so the allowance fetch overlaps the balance, size, and cost work already happening.

```dart
final freeAllowanceFuture = getFreeAllowance();  // starts immediately
turboBalance = await _getTurboBalance(...);       // runs concurrently
// ... sizes, cost estimates ...
final freeAllowance = await freeAllowanceFuture;  // already resolved
```

**Timing only — no value changes.** `getFreeAllowance` is a non-throwing wrapper (falls back to `unknown`), so the in-flight future can't become an unhandled rejection even if an intervening `await` throws.

## Effect
- Normal case: one round-trip's worth of latency shaved off opening the upload modal.
- Turbo-outage case: worst-case modal delay back to ~8s (was ~16s after #2166).

## Tests
Full suite unchanged — 733 pass. No behavioral assertions change (same calls, same values, same call counts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsV2WFHZMGD9DUfX65cxuW


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved upload payment evaluation by retrieving free-upload allowance information concurrently with other calculations.
  * Reduced potential waiting time when determining free upload status and payment details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->