### PR TITLE
PE-9150: Keep modal actions reachable on mobile (congestion popup)

### DIFF
--- a/lib/pages/congestion_warning_wrapper.dart
+++ b/lib/pages/congestion_warning_wrapper.dart
@@ -27,7 +27,14 @@ Future<void> showCongestionDependentModalDialog(
       bool shouldShowDialog = false;
       await showArDriveDialog(
         context,
+        // Dismissing (tap outside) is treated the same as "Try Later" below,
+        // so the user is never trapped if the layout is tight on mobile.
+        barrierDismissible: true,
         content: ArDriveStandardModalNew(
+          // The warning text wraps to several lines on narrow screens; without
+          // this the modal grew taller than the viewport and pushed the action
+          // buttons off the bottom on mobile.
+          scrollableContent: true,
           title: appLocalizationsOf(context).warningEmphasized,
           content: SizedBox(
             width: kMediumDialogWidth,
@@ -74,7 +81,6 @@ Future<void> showCongestionDependentModalDialog(
             ),
           ],
         ),
-        barrierDismissible: false,
       );
       if (shouldShowDialog) {
         return showAppDialog();

--- a/packages/ardrive_ui/lib/src/components/modal.dart
+++ b/packages/ardrive_ui/lib/src/components/modal.dart
@@ -693,6 +693,7 @@ class ArDriveStandardModalNew extends StatelessWidget {
     this.width,
     this.hasCloseButton = false,
     this.close,
+    this.scrollableContent = false,
   });
 
   final String? title;
@@ -707,6 +708,15 @@ class ArDriveStandardModalNew extends StatelessWidget {
   final bool hasCloseButton;
   final Function()? close;
 
+  /// When true, the modal body (including its actions) is bounded to the
+  /// viewport height and scrolls if it would exceed it, so the actions can
+  /// never be pushed off-screen on short/mobile layouts.
+  ///
+  /// Opt-in: leaving it false preserves the previous unbounded layout, which
+  /// some callers rely on for content that manages its own height (e.g. an
+  /// [Expanded] or a [ListView]) and would break under a scroll view.
+  final bool scrollableContent;
+
   @override
   Widget build(BuildContext context) {
     late double maxWidth;
@@ -720,6 +730,77 @@ class ArDriveStandardModalNew extends StatelessWidget {
       maxWidth = modalStandardMaxWidthSize;
     }
 
+    final body = Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (title != null || titleWidget != null) ...[
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Flexible(
+                  child: titleWidget ??
+                      Text(
+                        title!,
+                        style: typography.heading3(
+                          fontWeight: ArFontWeight.bold,
+                        ),
+                      ),
+                ),
+                if (hasCloseButton)
+                  ArDriveClickArea(
+                    child: GestureDetector(
+                      onTap: () {
+                        if (close != null) {
+                          close?.call();
+                        } else {
+                          Navigator.pop(context);
+                        }
+                      },
+                      child: const Align(
+                        alignment: Alignment.centerRight,
+                        child: ArDriveIcon(
+                          icon: ArDriveIconsData.x,
+                          size: 24,
+                        ),
+                      ),
+                    ),
+                  )
+              ],
+            ),
+            const SizedBox(
+              height: 24,
+            ),
+          ],
+          if (content != null) ...[
+            content!,
+            const SizedBox(
+              height: 24,
+            ),
+          ],
+          if (content == null) ...[
+            if (description != null) ...[
+              Text(
+                description!,
+                style: ArDriveTypography.body.smallRegular(),
+                textAlign: TextAlign.left,
+              ),
+            ],
+          ],
+          if (actions != null) ...[
+            const SizedBox(
+              height: 24,
+            ),
+            Align(
+              alignment: Alignment.bottomRight,
+              child: _buildActions(
+                actions!,
+                context,
+              ),
+            )
+          ]
+        ]);
+
     return ArDriveModalNew(
       constraints: BoxConstraints(
         minHeight: 100,
@@ -727,76 +808,17 @@ class ArDriveStandardModalNew extends StatelessWidget {
         minWidth: 250,
       ),
       contentPadding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
-      content: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            if (title != null || titleWidget != null) ...[
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Flexible(
-                    child: titleWidget ??
-                        Text(
-                          title!,
-                          style: typography.heading3(
-                            fontWeight: ArFontWeight.bold,
-                          ),
-                        ),
-                  ),
-                  if (hasCloseButton)
-                    ArDriveClickArea(
-                      child: GestureDetector(
-                        onTap: () {
-                          if (close != null) {
-                            close?.call();
-                          } else {
-                            Navigator.pop(context);
-                          }
-                        },
-                        child: const Align(
-                          alignment: Alignment.centerRight,
-                          child: ArDriveIcon(
-                            icon: ArDriveIconsData.x,
-                            size: 24,
-                          ),
-                        ),
-                      ),
-                    )
-                ],
+      content: scrollableContent
+          ? ConstrainedBox(
+              // Bound the body to most of the viewport and let it scroll, so a
+              // tall modal on a short screen never pushes its actions off the
+              // bottom — they scroll into reach instead of being clipped.
+              constraints: BoxConstraints(
+                maxHeight: MediaQuery.of(context).size.height * 0.8,
               ),
-              const SizedBox(
-                height: 24,
-              ),
-            ],
-            if (content != null) ...[
-              content!,
-              const SizedBox(
-                height: 24,
-              ),
-            ],
-            if (content == null) ...[
-              if (description != null) ...[
-                Text(
-                  description!,
-                  style: ArDriveTypography.body.smallRegular(),
-                  textAlign: TextAlign.left,
-                ),
-              ],
-            ],
-            if (actions != null) ...[
-              const SizedBox(
-                height: 24,
-              ),
-              Align(
-                alignment: Alignment.bottomRight,
-                child: _buildActions(
-                  actions!,
-                  context,
-                ),
-              )
-            ]
-          ]),
+              child: SingleChildScrollView(child: body),
+            )
+          : body,
     );
   }
 

--- a/packages/ardrive_ui/test/src/components/modal_test.dart
+++ b/packages/ardrive_ui/test/src/components/modal_test.dart
@@ -197,8 +197,15 @@ void main() {
       ArDriveApp(builder: (context) => MaterialApp(home: modal)),
     );
 
-    // The body scrolls...
-    expect(find.byType(SingleChildScrollView), findsWidgets);
+    // The modal's own body scrolls (scoped to the modal so an unrelated
+    // ancestor scroll view can't make this pass)...
+    expect(
+      find.descendant(
+        of: find.byType(ArDriveStandardModalNew),
+        matching: find.byType(SingleChildScrollView),
+      ),
+      findsOneWidget,
+    );
 
     // ...and the action, though below the fold, can be scrolled to and tapped.
     await tester.ensureVisible(find.text('Proceed'));
@@ -225,6 +232,14 @@ void main() {
 
     expect(find.byWidget(testWidget), findsOneWidget);
     expect(find.text('Ok'), findsOneWidget);
+    // Default path adds no scroll view around the body — the branch is distinct.
+    expect(
+      find.descendant(
+        of: find.byType(ArDriveStandardModalNew),
+        matching: find.byType(SingleChildScrollView),
+      ),
+      findsNothing,
+    );
   });
 }
 

--- a/packages/ardrive_ui/test/src/components/modal_test.dart
+++ b/packages/ardrive_ui/test/src/components/modal_test.dart
@@ -164,6 +164,68 @@ void main() {
     expect(find.byWidget(testWidget), findsNothing);
     expect(find.text('Description'), findsOneWidget);
   });
+  testWidgets(
+      'ArDriveStandardModalNew with scrollableContent keeps its action '
+      'reachable on a short screen', (tester) async {
+    // A short, mobile-height viewport where a tall modal would otherwise push
+    // its actions off the bottom.
+    tester.view.physicalSize = const Size(360, 480);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    var tapped = false;
+
+    final modal = ArDriveStandardModalNew(
+      scrollableContent: true,
+      title: 'Network congestion',
+      content: SizedBox(
+        width: 320,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: List.generate(
+            40,
+            (i) => Text('Congestion warning line $i'),
+          ),
+        ),
+      ),
+      actions: [
+        ModalAction(action: () => tapped = true, title: 'Proceed'),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ArDriveApp(builder: (context) => MaterialApp(home: modal)),
+    );
+
+    // The body scrolls...
+    expect(find.byType(SingleChildScrollView), findsWidgets);
+
+    // ...and the action, though below the fold, can be scrolled to and tapped.
+    await tester.ensureVisible(find.text('Proceed'));
+    await tester.tap(find.text('Proceed'));
+    expect(tapped, isTrue);
+  });
+
+  testWidgets(
+      'ArDriveStandardModalNew without scrollableContent still renders content '
+      'and actions (default behaviour unchanged)', (tester) async {
+    const testWidget = _TestWidget();
+
+    final modal = ArDriveStandardModalNew(
+      title: 'Title',
+      content: testWidget,
+      actions: [
+        ModalAction(action: () {}, title: 'Ok'),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ArDriveApp(builder: (context) => MaterialApp(home: modal)),
+    );
+
+    expect(find.byWidget(testWidget), findsOneWidget);
+    expect(find.text('Ok'), findsOneWidget);
+  });
 }
 
 class _TestWidget extends StatelessWidget {


### PR DESCRIPTION
## Summary

Fixes the user report that the **Arweave network-congestion popup covers/hides its buttons on mobile**.

**Root cause is vertical, not width.** `ArDriveStandardModalNew` constrains `maxWidth` to the viewport but sets **no `maxHeight`**, and its body doesn't scroll. The congestion warning text wraps to many lines on a narrow screen, so the modal grows taller than the viewport and its action buttons are pushed off the bottom — and `barrierDismissible: false` then leaves the user **trapped** with no reachable button.

## Change (surgical / opt-in)

- Add an **opt-in** `scrollableContent` flag to `ArDriveStandardModalNew`. When set, the body is bounded to 80% of viewport height and scrolls, so actions can never be clipped off-screen.
  - **Default is `false`** — the ~40 existing modals are unchanged. This matters: several pass content containing an `Expanded`/`ListView`, which would throw under an unconditional scroll view (unbounded height). Opt-in avoids that whole regression class.
- Opt the **congestion warning** into `scrollableContent`, and make it `barrierDismissible: true` (tap-outside is treated the same as "Try Later", so it's never a trap).

## Tests

New widget tests: the action is reachable (`ensureVisible` + tap) on a 360×480 screen with tall content, and default (non-scrollable) behaviour is unchanged. `ardrive_ui` suite (52) and app suite (733) both pass — zero regressions.

## Note
Ticket number in the title is a placeholder — please correct to the real PE ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsV2WFHZMGD9DUfX65cxuW


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved warning dialogs on smaller screens with scrollable content.
  * Users can now dismiss the congestion warning by tapping outside the dialog.
  * Dialog actions remain accessible even when screen space is limited.

* **Bug Fixes**
  * Prevented dialog actions from being pushed off-screen on short mobile layouts.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->