### PR TITLE
chore(version): bump version to 2.86.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Secure, permanent storage
 
 publish_to: 'none'
 
-version: 2.85.0
+version: 2.86.0
 
 environment:
   sdk: '>=3.2.0 <4.0.0'


### PR DESCRIPTION
Bumps `pubspec.yaml` version `2.85.0` → `2.86.0` in preparation for the next production release.

`v2.85.0` is already released (tag exists; it's the current `master` tip), so the pubspec version was stale. `2.86.0` is a minor bump — the release carries real new features (Turbo free-tier suite) plus fixes, no breaking changes.

Follows the established `chore(version)` pattern (e.g. #2156). Release PR (dev → master) and the `v2.86.0` tag are separate follow-up steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsV2WFHZMGD9DUfX65cxuW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app version from 2.85.0 to 2.86.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->