### PR TITLE
PE-9132: Read Turbo free-item cap from /v1/info (fix 105 KiB free cap)

### DIFF
--- a/lib/turbo/services/upload_service.dart
+++ b/lib/turbo/services/upload_service.dart
@@ -149,12 +149,22 @@ class TurboUploadService {
       // code only checked top-level `maxItemBytes`, which the current service
       // does not return, so it silently fell back to the config value.
       final freeTier = data is Map ? data['freeTier'] : null;
-      final value = (freeTier is Map ? freeTier['maxItemBytes'] : null) ??
-          (data is Map
-              ? (data['freeUploadLimitBytes'] ?? data['maxItemBytes'])
-              : null);
-      if (value is num && value > 0) {
-        _serverMaxItemBytes = value.toInt();
+
+      // Each candidate is validated *before* the priority order is applied,
+      // not after. `??` picks the first non-null, so a present-but-unusable
+      // `freeTier.maxItemBytes` - a string, a negative, a zero - used to mask
+      // a perfectly good `freeUploadLimitBytes` sitting beside it and drop the
+      // service back to the stale config value this fix exists to stop using.
+      final value = [
+        freeTier is Map ? freeTier['maxItemBytes'] : null,
+        data is Map ? data['freeUploadLimitBytes'] : null,
+        data is Map ? data['maxItemBytes'] : null,
+      ]
+          .map(_wholePositiveBytes)
+          .firstWhere((bytes) => bytes != null, orElse: () => null);
+
+      if (value != null) {
+        _serverMaxItemBytes = value;
         logger.d('Turbo free item size limit from /v1/info: '
             '$_serverMaxItemBytes bytes');
       }
@@ -163,6 +173,27 @@ class TurboUploadService {
           .w('Could not fetch turbo /v1/info; using configured item size: $e');
     }
   }
+}
+
+/// A `/v1/info` cap candidate as a byte count, or `null` when it is not one.
+///
+/// Whole and positive, both deliberately:
+///
+/// * A fractional value is rejected rather than truncated. `0.5` truncates to
+///   `0`, and a zero cap is not the same as no cap - `maxFreeItemSizeBytes`
+///   would return it in preference to the configured fallback, and *nothing*
+///   would qualify for a free upload.
+/// * Infinity and NaN are rejected before `toInt()`, which throws on them.
+int? _wholePositiveBytes(Object? candidate) {
+  if (candidate is! num || !candidate.isFinite || candidate <= 0) {
+    return null;
+  }
+
+  if (candidate is double && candidate.truncateToDouble() != candidate) {
+    return null;
+  }
+
+  return candidate.toInt();
 }
 
 /// True when [error] indicates the upload service rejected an operation for

--- a/lib/turbo/services/upload_service.dart
+++ b/lib/turbo/services/upload_service.dart
@@ -142,14 +142,25 @@ class TurboUploadService {
       final response = await httpClient.get(url: '$turboUploadUri/v1/info');
       final raw = response.data;
       final data = raw is String ? json.decode(raw) : raw;
-      final value = data is Map ? data['maxItemBytes'] : null;
-      if (value is int && value > 0) {
-        _serverMaxItemBytes = value;
-        logger.d('Turbo free item size limit from /v1/info: $value bytes');
+
+      // The per-item free cap lives at `freeTier.maxItemBytes`; some/older
+      // deployments surface it as top-level `freeUploadLimitBytes` (or
+      // `maxItemBytes`). Read whichever is present, in that order — the old
+      // code only checked top-level `maxItemBytes`, which the current service
+      // does not return, so it silently fell back to the config value.
+      final freeTier = data is Map ? data['freeTier'] : null;
+      final value = (freeTier is Map ? freeTier['maxItemBytes'] : null) ??
+          (data is Map
+              ? (data['freeUploadLimitBytes'] ?? data['maxItemBytes'])
+              : null);
+      if (value is num && value > 0) {
+        _serverMaxItemBytes = value.toInt();
+        logger.d('Turbo free item size limit from /v1/info: '
+            '$_serverMaxItemBytes bytes');
       }
     } catch (e) {
-      logger.w(
-          'Could not fetch turbo /v1/info; using configured item size: $e');
+      logger
+          .w('Could not fetch turbo /v1/info; using configured item size: $e');
     }
   }
 }

--- a/test/turbo/services/upload_service_test.dart
+++ b/test/turbo/services/upload_service_test.dart
@@ -1,0 +1,93 @@
+import 'package:ardrive/turbo/services/upload_service.dart';
+import 'package:ardrive_http/ardrive_http.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockArDriveHTTP extends Mock implements ArDriveHTTP {}
+
+void main() {
+  const configFallback = 100000; // stale config value (97.66 KiB)
+
+  late _MockArDriveHTTP httpClient;
+
+  setUp(() {
+    httpClient = _MockArDriveHTTP();
+  });
+
+  TurboUploadService makeService() => TurboUploadService(
+        turboUploadUri: Uri.parse('https://turbo.example'),
+        allowedDataItemSize: configFallback,
+        httpClient: httpClient,
+      );
+
+  void stubInfo(dynamic body) {
+    when(() => httpClient.get(url: any(named: 'url'))).thenAnswer(
+      (_) async =>
+          ArDriveHTTPResponse(data: body, statusCode: 200, retryAttempts: 0),
+    );
+  }
+
+  group('refreshMaxItemBytes', () {
+    test(
+        'reads the real /v1/info shape (freeTier.maxItemBytes) — the bug fix: '
+        '105 KiB, not the stale 100000 config fallback', () async {
+      // The actual production/staging /v1/info payload: no top-level
+      // maxItemBytes; the per-item cap is nested under freeTier.
+      stubInfo(
+        '{"version":"0.2.0","freeUploadLimitBytes":107520,'
+        '"freeTier":{"lifetimeBytes":10485760,"ipBytes":10485760,'
+        '"maxItemBytes":107520}}',
+      );
+      final service = makeService();
+      await service.refreshMaxItemBytes();
+      expect(service.maxFreeItemSizeBytes, 107520);
+    });
+
+    test('falls back to top-level freeUploadLimitBytes when freeTier is absent',
+        () async {
+      stubInfo('{"freeUploadLimitBytes":107520}');
+      final service = makeService();
+      await service.refreshMaxItemBytes();
+      expect(service.maxFreeItemSizeBytes, 107520);
+    });
+
+    test('still honours a top-level maxItemBytes if a deployment returns one',
+        () async {
+      stubInfo('{"maxItemBytes":123456}');
+      final service = makeService();
+      await service.refreshMaxItemBytes();
+      expect(service.maxFreeItemSizeBytes, 123456);
+    });
+
+    test('accepts an already-decoded Map (not just a JSON string)', () async {
+      stubInfo({
+        'freeTier': {'maxItemBytes': 107520}
+      });
+      final service = makeService();
+      await service.refreshMaxItemBytes();
+      expect(service.maxFreeItemSizeBytes, 107520);
+    });
+
+    test('keeps the config fallback when the payload has no cap', () async {
+      stubInfo('{"version":"0.2.0"}');
+      final service = makeService();
+      await service.refreshMaxItemBytes();
+      expect(service.maxFreeItemSizeBytes, configFallback);
+    });
+
+    test('keeps the config fallback on a fetch error (fails safe)', () async {
+      when(() => httpClient.get(url: any(named: 'url')))
+          .thenThrow(Exception('network down'));
+      final service = makeService();
+      await service.refreshMaxItemBytes();
+      expect(service.maxFreeItemSizeBytes, configFallback);
+    });
+
+    test('ignores a non-positive cap', () async {
+      stubInfo('{"freeTier":{"maxItemBytes":0}}');
+      final service = makeService();
+      await service.refreshMaxItemBytes();
+      expect(service.maxFreeItemSizeBytes, configFallback);
+    });
+  });
+}

--- a/test/turbo/services/upload_service_test.dart
+++ b/test/turbo/services/upload_service_test.dart
@@ -89,5 +89,81 @@ void main() {
       await service.refreshMaxItemBytes();
       expect(service.maxFreeItemSizeBytes, configFallback);
     });
+
+    test('an unusable preferred value does not mask a good fallback beside it',
+        () async {
+      // The candidates used to be chosen with `??` and validated afterwards,
+      // so any non-null preferred value won - even a useless one - and the
+      // valid number next to it was never looked at.
+      stubInfo(
+        '{"freeTier":{"maxItemBytes":"oops"},"freeUploadLimitBytes":107520}',
+      );
+      final service = makeService();
+      await service.refreshMaxItemBytes();
+      expect(service.maxFreeItemSizeBytes, 107520);
+    });
+
+    test('a negative preferred value does not mask a good fallback', () async {
+      stubInfo(
+        '{"freeTier":{"maxItemBytes":-1},"freeUploadLimitBytes":107520}',
+      );
+      final service = makeService();
+      await service.refreshMaxItemBytes();
+      expect(service.maxFreeItemSizeBytes, 107520);
+    });
+
+    test('rejects a fractional cap rather than truncating it to zero',
+        () async {
+      // The dangerous shape: 0.5 is `> 0`, so it passed, and `toInt()` made it
+      // 0 - a cap of zero bytes, which is not the fallback. Nothing would have
+      // qualified for a free upload.
+      stubInfo('{"freeTier":{"maxItemBytes":0.5}}');
+      final service = makeService();
+      await service.refreshMaxItemBytes();
+      expect(service.maxFreeItemSizeBytes, configFallback);
+    });
+
+    test('rejects a fractional cap even when it is large', () async {
+      stubInfo('{"freeTier":{"maxItemBytes":107520.5}}');
+      final service = makeService();
+      await service.refreshMaxItemBytes();
+      expect(service.maxFreeItemSizeBytes, configFallback);
+    });
+
+    test('accepts a whole number expressed as a double', () async {
+      // JSON has one number type; a server may well send 107520.0.
+      stubInfo({
+        'freeTier': {'maxItemBytes': 107520.0}
+      });
+      final service = makeService();
+      await service.refreshMaxItemBytes();
+      expect(service.maxFreeItemSizeBytes, 107520);
+    });
+
+    test('keeps the last good cap when a later refresh fails', () async {
+      // Deliberate: reverting to the configured value on a transient failure
+      // would reintroduce the stale cap this fix exists to remove. A cap the
+      // server actually reported is better information than the config, and it
+      // does not go stale between two calls seconds apart.
+      stubInfo('{"freeTier":{"maxItemBytes":107520}}');
+      final service = makeService();
+      await service.refreshMaxItemBytes();
+      expect(service.maxFreeItemSizeBytes, 107520);
+
+      when(() => httpClient.get(url: any(named: 'url')))
+          .thenThrow(Exception('network down'));
+      await service.refreshMaxItemBytes();
+      expect(service.maxFreeItemSizeBytes, 107520);
+    });
+
+    test('keeps the last good cap when a later payload is unusable', () async {
+      stubInfo('{"freeTier":{"maxItemBytes":107520}}');
+      final service = makeService();
+      await service.refreshMaxItemBytes();
+
+      stubInfo('{"version":"0.2.0"}');
+      await service.refreshMaxItemBytes();
+      expect(service.maxFreeItemSizeBytes, 107520);
+    });
   });
 }


### PR DESCRIPTION
## Summary

`TurboUploadService.refreshMaxItemBytes` read a **top-level `maxItemBytes`** key that `/v1/info` doesn't return — the per-item free cap is nested under **`freeTier.maxItemBytes`** (with a top-level `freeUploadLimitBytes` mirror). So the server value was never applied and the app silently fell back to the config value, enforcing a free-item cap of **100000 bytes (97.66 KiB) instead of Turbo's actual 107520 (105 KiB)**.

Effect: files between ~97.7 KiB and 105 KiB were charged when Turbo would have made them free. Surfaced during staging upload testing (100 KiB files hit "insufficient balance").

## Fix
Read `freeTier.maxItemBytes` → top-level `freeUploadLimitBytes` → `maxItemBytes` (defensive), accepting `int`/`num`, staying on the config fallback when absent or on error.

## Tests
7 unit tests: the real payload shape (proves the fix), each fallback, decoded-Map input, no-cap fallback, fail-safe on error, non-positive ignored.

Pre-existing bug (the server-cap fetch never worked), independent of the 2.86.0 release — can ship with it or as a fast-follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsV2WFHZMGD9DUfX65cxuW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated free-upload size limits to use the server’s current limit when available.
  - Added support for multiple server response formats and fallback limit sources.
  - Invalid, missing, zero, negative, fractional, or unavailable limits no longer replace a valid existing limit.
  - Valid positive whole-number limits are now applied consistently.
  - Improved logging when retrieving the server limit.
  - Preserved the last known-good limit when later requests fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->