### PR TITLE
PE-9204: One drive's gateway hiccup killed the whole sync

### DIFF
--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -1025,10 +1025,27 @@ class ArweaveService {
             final sigTypeTag = driveTx.getTag(EntityTag.signatureType) ?? '1';
             final signatureType = DriveSignatureType.fromString(sigTypeTag);
 
-            final driveSignature = signatureType == DriveSignatureType.v1
-                ? await getDriveSignatureForDriveOnSync(
-                    wallet, driveTx.getTag(EntityTag.driveId)!)
-                : null;
+            // Contained deliberately. This was the one unguarded await in the
+            // loop, and a gateway hiccup on a single drive's signature threw
+            // all the way out of drive discovery and killed the entire sync -
+            // before any drive had synced at all. Every other failure here
+            // drops one drive and carries on; this one now does too, and the
+            // drive is picked up on the next pass.
+            DriveSignatureEntity? driveSignature;
+
+            if (signatureType == DriveSignatureType.v1) {
+              try {
+                driveSignature = await getDriveSignatureForDriveOnSync(
+                    wallet, driveTx.getTag(EntityTag.driveId)!);
+              } catch (e) {
+                logger.w(
+                  'Could not read the drive signature for '
+                  '${driveTx.getTag(EntityTag.driveId)}; skipping this drive '
+                  'for this pass: $e',
+                );
+                continue;
+              }
+            }
 
             driveKey = await _crypto.deriveDriveKey(
                 wallet,

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -1005,12 +1005,24 @@ class ArweaveService {
 
       final drivesById = <String?, DriveEntity>{};
       final drivesWithKey = <DriveEntity, DriveKey?>{};
+
+      /// Drives whose newest transaction was reached but could not be used.
+      ///
+      /// `getUniqueUserDriveEntityTxs` dedupes **per page**, so the same
+      /// Drive-Id can appear on more than one page and the list is newest
+      /// first. Skipping the newest without recording it would let an older
+      /// revision take its place and write stale metadata - worse than the
+      /// drive simply being late.
+      final handledDriveIds = <String?>{};
       for (var i = 0; i < driveTxs.length; i++) {
         if (driveResponses[i] == null) continue;
         final driveTx = driveTxs[i];
 
         // Ignore drive entity transactions which we already have newer entities for.
-        if (drivesById.containsKey(driveTx.getTag(EntityTag.driveId))) {
+        final txDriveId = driveTx.getTag(EntityTag.driveId);
+
+        if (drivesById.containsKey(txDriveId) ||
+            handledDriveIds.contains(txDriveId)) {
           continue;
         }
 
@@ -1039,10 +1051,12 @@ class ArweaveService {
                     wallet, driveTx.getTag(EntityTag.driveId)!);
               } catch (e) {
                 logger.w(
-                  'Could not read the drive signature for '
-                  '${driveTx.getTag(EntityTag.driveId)}; skipping this drive '
-                  'for this pass: $e',
+                  'Could not read the drive signature for $txDriveId; '
+                  'skipping this drive for this pass: $e',
                 );
+                // Claim the id so an older transaction for the same drive on
+                // a later page cannot quietly stand in for the newest one.
+                handledDriveIds.add(txDriveId);
                 continue;
               }
             }

--- a/lib/services/arweave/data_gateway_fallback.dart
+++ b/lib/services/arweave/data_gateway_fallback.dart
@@ -86,7 +86,11 @@ class DataGatewayFallback {
   /// each, so a slow or flaky primary turns into minutes of serial timeouts.
   /// Worst case here is [syncMaxAttempts] attempts / ~10.3s.
   ///
-  /// A 404 is not retried — the same host will not change its mind.
+  /// A 404 is retried like any other failure: a gateway that has not
+  /// finished indexing a transaction answers 404 for it and 200 a moment
+  /// later. [TransactionNotFound] is reported only when *every* attempt
+  /// returned 404 — a 500 followed by a 404 is an unwell gateway, not an
+  /// absent transaction.
   ///
   /// Callers must treat a failure as "skip this item", and must record the tx
   /// id so it is not lost. See the note on `ArweaveService._getEntityData` and
@@ -104,6 +108,8 @@ class DataGatewayFallback {
   Future<Response> _syncFetch(String txId, Arweave primaryClient) async {
     final gatewayName = primaryClient.api.gatewayUrl.host;
 
+    var allAttempts404 = true;
+
     for (var attempt = 1; attempt <= syncMaxAttempts; attempt++) {
       try {
         return await _tryGateway(primaryClient, txId);
@@ -117,7 +123,17 @@ class DataGatewayFallback {
         //
         // The last attempt still reports it as not found, so a genuinely
         // absent transaction keeps its typed error.
-        if (e.statusCode == 404 && attempt == syncMaxAttempts) {
+        if (e.statusCode != 404) {
+          allAttempts404 = false;
+        }
+
+        // `TransactionNotFound` is a claim that the transaction is absent, so
+        // only every attempt agreeing earns it. A 500 followed by a 404 says
+        // the gateway was unwell, not that the data is gone, and reporting it
+        // as not-found would state more than we know.
+        if (e.statusCode == 404 &&
+            attempt == syncMaxAttempts &&
+            allAttempts404) {
           logger.w('Gateway $gatewayName returned 404 for sync tx $txId '
               'on every attempt');
           throw TransactionNotFound(txId);
@@ -125,6 +141,8 @@ class DataGatewayFallback {
         logger.w('Gateway $gatewayName failed for sync tx $txId '
             '(attempt $attempt/$syncMaxAttempts): $e');
       } catch (e) {
+        // A timeout or a socket error is not a 404 either.
+        allAttempts404 = false;
         logger.w('Gateway $gatewayName failed for sync tx $txId '
             '(attempt $attempt/$syncMaxAttempts): $e');
       }

--- a/lib/services/arweave/data_gateway_fallback.dart
+++ b/lib/services/arweave/data_gateway_fallback.dart
@@ -108,9 +108,18 @@ class DataGatewayFallback {
       try {
         return await _tryGateway(primaryClient, txId);
       } on _ErrorFromStatus catch (e) {
-        if (e.statusCode == 404) {
-          // Retrying the same host cannot turn a 404 into a 200.
-          logger.w('Gateway $gatewayName returned 404 for sync tx $txId');
+        // A 404 is NOT treated as final here, and the reasoning that said it
+        // was is wrong for this case. A gateway that has not finished indexing
+        // a transaction answers 404 for it, and answers 200 a moment later -
+        // observed in the wild on a drive signature that 404ed once and
+        // resolved on the retry. Spending the second attempt is cheap; losing
+        // a drive because its gateway was a beat behind is not.
+        //
+        // The last attempt still reports it as not found, so a genuinely
+        // absent transaction keeps its typed error.
+        if (e.statusCode == 404 && attempt == syncMaxAttempts) {
+          logger.w('Gateway $gatewayName returned 404 for sync tx $txId '
+              'on every attempt');
           throw TransactionNotFound(txId);
         }
         logger.w('Gateway $gatewayName failed for sync tx $txId '

--- a/test/services/arweave/data_gateway_fallback_test.dart
+++ b/test/services/arweave/data_gateway_fallback_test.dart
@@ -77,7 +77,25 @@ void main() {
       expect(DataGatewayFallback.syncMaxAttempts, 2);
     });
 
-    test('does not retry a 404 — the same host will not change its mind',
+    test('retries a 404, because a gateway mid-index answers one', () async {
+      // Observed in the wild: a drive signature 404ed once and resolved on the
+      // retry. The gateway had the transaction, it just had not indexed it
+      // yet. Treating the first 404 as final cost a whole drive.
+      var calls = 0;
+      when(() => primaryApi.getSandboxedTx(txId)).thenAnswer((_) async {
+        calls++;
+        return calls == 1
+            ? Response('not found', 404)
+            : Response('metadata', 200);
+      });
+
+      final response = await fallback.fetchDataForSync(txId, primaryClient);
+
+      expect(response.statusCode, 200);
+      expect(calls, 2);
+    });
+
+    test('reports a transaction absent from every attempt as not found',
         () async {
       when(() => primaryApi.getSandboxedTx(txId))
           .thenAnswer((_) async => Response('not found', 404));
@@ -87,7 +105,9 @@ void main() {
         throwsA(isA<TransactionNotFound>()),
       );
 
-      verify(() => primaryApi.getSandboxedTx(txId)).called(1);
+      // Bounded: a genuinely missing transaction still costs only the two
+      // attempts every other sync read gets.
+      verify(() => primaryApi.getSandboxedTx(txId)).called(2);
     });
 
     test('never consults the GAR, so no Solana RPC is issued on the sync path',

--- a/test/services/arweave/data_gateway_fallback_test.dart
+++ b/test/services/arweave/data_gateway_fallback_test.dart
@@ -110,6 +110,41 @@ void main() {
       verify(() => primaryApi.getSandboxedTx(txId)).called(2);
     });
 
+    test('a 500 then a 404 is not reported as not found', () async {
+      // Only every attempt agreeing earns `TransactionNotFound`. A gateway
+      // that errored once and 404ed once has not told us the data is absent.
+      var calls = 0;
+      when(() => primaryApi.getSandboxedTx(txId)).thenAnswer((_) async {
+        calls++;
+        return calls == 1
+            ? Response('boom', 500)
+            : Response('not found', 404);
+      });
+
+      await expectLater(
+        fallback.fetchDataForSync(txId, primaryClient),
+        throwsA(allOf(isA<Exception>(), isNot(isA<TransactionNotFound>()))),
+      );
+
+      expect(calls, 2);
+    });
+
+    test('a thrown error then a 404 is not reported as not found', () async {
+      var calls = 0;
+      when(() => primaryApi.getSandboxedTx(txId)).thenAnswer((_) async {
+        calls++;
+        if (calls == 1) throw Exception('socket closed');
+        return Response('not found', 404);
+      });
+
+      await expectLater(
+        fallback.fetchDataForSync(txId, primaryClient),
+        throwsA(allOf(isA<Exception>(), isNot(isA<TransactionNotFound>()))),
+      );
+
+      expect(calls, 2);
+    });
+
     test('never consults the GAR, so no Solana RPC is issued on the sync path',
         () async {
       when(() => primaryApi.getSandboxedTx(txId))


### PR DESCRIPTION
Reported from staging: a drive signature 404ed and **sync stopped dead before any drive had synced**. Retrying by hand found the transaction present — the gateway had it, it just hadn't indexed it yet.

Two causes.

## The failure wasn't contained

Drive discovery already skips a drive whose metadata can't be read (`if (driveResponses[i] == null) continue`). But the drive-signature read a few lines below was **the one unguarded `await` in that loop**. It threw past every handler to the method's outer catch — which rethrows — so `getUniqueUserDriveEntities` failed, `updateUserDrives` failed, and sync died at discovery.

One drive's bad luck took every drive with it, including public ones that would have synced fine. It now drops that drive for the pass, like every other failure there, and picks it up next time.

## A 404 was treated as final, and that was wrong

The 404 fast-path reasoned that *the same host will not turn a 404 into a 200*. That holds for a host that has answered definitively. It does **not** hold for one still indexing — which is precisely what was observed: 404 on the first read, present on the second.

A 404 now spends the second attempt like any other failure and is only reported as `TransactionNotFound` when every attempt agrees. A genuinely missing transaction still costs two attempts, no more.

## Why this got worse recently

Before #2179 this path used the multi-gateway waterfall, so a gateway that was a beat behind was covered by the next one. Single-gateway reads removed that cushion, and the 404 fast-path removed the retry too — so an indexing lag went straight to a hard failure with no second chance.

## Verification

`flutter analyze` clean · 1,320 tests passing.

The test asserting *"does not retry a 404"* encoded the behaviour this reverses; it's replaced by two — one proving a 404-then-200 succeeds, one proving a persistent 404 still raises `TransactionNotFound` in exactly two attempts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UpkQ6gRPTUuy3MCUFxFw2P

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved private-drive discovery so a failed signature request no longer stops the entire discovery process.
  * Added retry handling for temporary 404 responses when fetching data from the configured gateway.
  * Persistent 404 responses still report that the requested transaction could not be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->