### PR TITLE
PE-9205: A drive whose root folder never synced spins forever

### DIFF
--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -47,6 +47,13 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
   StreamSubscription? _syncSubscription;
   bool _initialLoadComplete = false;
   bool _isExplicitSync = false;
+
+  /// Bumped by every [openFolder]. Cancelling `_folderSubscription` does not
+  /// cancel a callback that already began awaiting, so an in-flight load can
+  /// still emit after the user has navigated somewhere else in the same drive
+  /// - where the `_driveId` checks cannot see it, because the drive did not
+  /// change. Callbacks capture this and drop their result if it moved on.
+  int _folderLoadGeneration = 0;
   final _defaultAvailableRowsPerPage = [25, 50, 75, 100];
 
   List<ArDriveDataTableItem> _selectedItems = [];
@@ -140,6 +147,33 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
     });
   }
 
+  /// Whether this drive's root folder metadata has actually been read.
+  ///
+  /// [DriveDetailLoadUnsynced] is entered when the root folder has no
+  /// revision, so every path that leaves it has to test the same thing.
+  /// Gating recovery on `lastBlockHeight` instead lets the two conditions
+  /// disagree, and this is exactly the codebase where they do: a sync that
+  /// writes the root revision and then fails before advancing the watermark
+  /// leaves readable metadata behind a drive pinned on "Drive Not Synced",
+  /// where the sync button only re-emits the same state.
+  ///
+  /// `lastBlockHeight` is still honoured, because a drive synced by an earlier
+  /// build may have advanced its watermark and is by definition synced.
+  Future<bool> _hasRootFolderMetadata(Drive drive) async {
+    if ((drive.lastBlockHeight ?? 0) > 0) {
+      return true;
+    }
+
+    final rootFolderRevision = await _driveDao
+        .latestFolderRevisionByFolderId(
+          driveId: drive.id,
+          folderId: drive.rootFolderId,
+        )
+        .getSingleOrNull();
+
+    return rootFolderRevision != null;
+  }
+
   /// Called when sync completes. Re-checks drive state if we're showing
   /// unsynced or loading state, and loads the drive content if now available.
   Future<void> _onSyncCompleted() async {
@@ -165,7 +199,9 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
         return;
       }
 
-      if (drive.lastBlockHeight != null && drive.lastBlockHeight! > 0) {
+      if (await _hasRootFolderMetadata(drive)) {
+        if (isClosed || state is! DriveDetailLoadUnsynced) return;
+
         openFolder(folderId: drive.rootFolderId, otherDriveId: capturedDriveId);
       }
     }
@@ -231,6 +267,10 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
     DriveOrder contentOrderBy = DriveOrder.name,
     OrderingMode contentOrderingMode = OrderingMode.asc,
   }) async {
+    // Claimed before the first await, so anything already in flight for a
+    // previous folder is stale from here on even when the drive is unchanged.
+    final loadGeneration = ++_folderLoadGeneration;
+
     /// always wait for the current sync to finish before opening a new folder
     await _syncCubit.waitCurrentSync();
 
@@ -355,7 +395,9 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
                 )
                 .getSingleOrNull();
 
-            if (isClosed || driveId != _driveId) {
+            if (isClosed ||
+                driveId != _driveId ||
+                loadGeneration != _folderLoadGeneration) {
               return;
             }
 
@@ -383,6 +425,12 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
             driveId: driveId,
           );
 
+          if (isClosed ||
+              driveId != _driveId ||
+              loadGeneration != _folderLoadGeneration) {
+            return;
+          }
+
           if (state != null) {
             emit(
               state.copyWith(
@@ -403,6 +451,12 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
             );
           } else {
             final columnsVisibility = await getTableColumnVisibility();
+
+            if (isClosed ||
+                driveId != _driveId ||
+                loadGeneration != _folderLoadGeneration) {
+              return;
+            }
 
             emit(
               DriveDetailLoadSuccess(
@@ -748,7 +802,11 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
         return;
       }
 
-      if (drive.lastBlockHeight != null && drive.lastBlockHeight! > 0) {
+      final hasRootFolderMetadata = await _hasRootFolderMetadata(drive);
+
+      if (isClosed || _driveId != driveId) return;
+
+      if (hasRootFolderMetadata) {
         openFolder(folderId: rootFolderId, otherDriveId: driveId);
       } else {
         emit(DriveDetailLoadUnsynced(drive: drive));
@@ -802,8 +860,12 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
         return;
       }
 
-      if (drive.lastBlockHeight == null || drive.lastBlockHeight == 0) {
-        // Sync reported success but drive content wasn't actually synced
+      final hasRootFolderMetadata = await _hasRootFolderMetadata(drive);
+
+      if (isClosed || _driveId != driveId) return;
+
+      if (!hasRootFolderMetadata) {
+        // Sync reported success but the drive's root metadata never arrived
         emit(DriveDetailLoadUnsynced(drive: drive));
         return;
       }

--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -818,7 +818,9 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
   Future<void> _handleFolderNotFound(String driveId) async {
     final drive =
         await _driveDao.driveById(driveId: driveId).getSingleOrNull();
-    if (isClosed) return;
+    // The drive can be switched out from under this query. Emitting after that
+    // would put the previous drive's state on the new drive's screen.
+    if (isClosed || _driveId != driveId) return;
 
     if (drive == null) {
       emit(DriveDetailLoadNotFound());

--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -330,6 +330,41 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
             }
           }
 
+          final driveIsEmpty = folderContents.files.isEmpty &&
+              folderContents.subfolders.isEmpty;
+
+          // A drive that renders with nothing in it is ambiguous: it may be
+          // genuinely empty, or its contents may simply never have synced.
+          // Telling someone their drive is empty when we have not actually
+          // read it reads as "my data is gone", so only claim emptiness we
+          // can back up. Otherwise fall through to DriveDetailLoadUnsynced,
+          // which already says "Drive Not Synced" and offers to sync.
+          //
+          // The root folder's revision is the honest signal for that. A drive
+          // created in this app writes one at creation time
+          // (DriveCreateCubit), and sync writes one when the real metadata
+          // lands - but a drive merely discovered by updateUserDrives has only
+          // the placeholder folder row until then. lastBlockHeight cannot
+          // answer this: it defaults to 0, so a freshly created empty drive is
+          // indistinguishable from one that has never synced.
+          if (driveIsEmpty && folderContents.folder.id == drive.rootFolderId) {
+            final rootFolderRevision = await _driveDao
+                .latestFolderRevisionByFolderId(
+                  driveId: driveId,
+                  folderId: drive.rootFolderId,
+                )
+                .getSingleOrNull();
+
+            if (isClosed || driveId != _driveId) {
+              return;
+            }
+
+            if (rootFolderRevision == null) {
+              emit(DriveDetailLoadUnsynced(drive: drive));
+              return;
+            }
+          }
+
           final currentFolderContents = parseEntitiesToDatatableItem(
             folder: folderContents,
             isOwner: isDriveOwner(_auth, drive.ownerAddress),
@@ -362,8 +397,7 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
                 availableRowsPerPage: availableRowsPerPage,
                 currentFolderContents: currentFolderContents,
                 pathSegments: pathSegments,
-                driveIsEmpty: folderContents.files.isEmpty &&
-                    folderContents.subfolders.isEmpty,
+                driveIsEmpty: driveIsEmpty,
                 showSelectedItemDetails: _selectedItem != null,
               ),
             );
@@ -382,8 +416,7 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
                 contentOrderingMode: contentOrderingMode,
                 rowsPerPage: availableRowsPerPage.first,
                 availableRowsPerPage: availableRowsPerPage,
-                driveIsEmpty: folderContents.files.isEmpty &&
-                    folderContents.subfolders.isEmpty,
+                driveIsEmpty: driveIsEmpty,
                 multiselect: false,
                 currentFolderContents: currentFolderContents,
                 columnVisibility: columnsVisibility,

--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -399,17 +399,7 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
 
     _folderSubscription?.onError((e) async {
       if (e is FolderNotFoundInDriveException) {
-        // Check if the drive is unsynced (metadata only, no content)
-        final drive =
-            await _driveDao.driveById(driveId: e.driveId).getSingleOrNull();
-        if (drive != null &&
-            (drive.lastBlockHeight == null || drive.lastBlockHeight == 0)) {
-          // Drive exists but content hasn't been synced - show sync options
-          emit(DriveDetailLoadUnsynced(drive: drive));
-        } else {
-          // Drive is being set up or has an issue
-          emit(DriveInitialLoading());
-        }
+        await _handleFolderNotFound(e.driveId);
         return;
       }
 
@@ -813,16 +803,29 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
     }
   }
 
+  /// The drive's root folder row is missing, so the explorer cannot mount it.
+  ///
+  /// `DriveDao._rootFolderPlaceholder` makes this structurally unreachable for
+  /// any drive written since, and heals already-affected drives on their next
+  /// sync. It is still handled rather than asserted away: whichever way a drive
+  /// gets here, it has to land somewhere the user can act from.
+  ///
+  /// Both outcomes are states a later sync recovers from on its own -
+  /// [DriveDetailLoadUnsynced] is re-checked by [_onSyncCompleted], and it
+  /// renders the drive with whatever did sync. The previous
+  /// [DriveInitialLoading] was a dead end: no retry, no action, and nothing
+  /// that re-triggers it.
   Future<void> _handleFolderNotFound(String driveId) async {
     final drive =
         await _driveDao.driveById(driveId: driveId).getSingleOrNull();
     if (isClosed) return;
-    if (drive != null &&
-        (drive.lastBlockHeight == null || drive.lastBlockHeight == 0)) {
-      emit(DriveDetailLoadUnsynced(drive: drive));
-    } else {
-      emit(DriveInitialLoading());
+
+    if (drive == null) {
+      emit(DriveDetailLoadNotFound());
+      return;
     }
+
+    emit(DriveDetailLoadUnsynced(drive: drive));
   }
 
   @override

--- a/lib/blocs/drive_detail/drive_detail_state.dart
+++ b/lib/blocs/drive_detail/drive_detail_state.dart
@@ -138,8 +138,14 @@ class DriveDetailLoadSuccess extends DriveDetailState {
 /// the user's profile.
 class DriveDetailLoadNotFound extends DriveDetailState {}
 
-/// [DriveDetailLoadUnsynced] means that the drive metadata exists but its content
-/// has not been synced yet (lastBlockHeight == 0 or null).
+/// [DriveDetailLoadUnsynced] means the drive's metadata exists but its content
+/// is not (yet) locally available to open.
+///
+/// Two ways in: the drive has never been synced (`lastBlockHeight` 0 or null),
+/// or it synced but its root folder row is missing, so the explorer has no
+/// folder to mount. Both are recoverable and both are re-checked by
+/// `DriveDetailCubit._onSyncCompleted`, which opens the drive once the content
+/// lands.
 class DriveDetailLoadUnsynced extends DriveDetailState {
   final Drive drive;
   final bool showDriveInfo;

--- a/lib/models/daos/drive_dao/drive_dao.dart
+++ b/lib/models/daos/drive_dao/drive_dao.dart
@@ -442,19 +442,25 @@ class DriveDao extends DatabaseAccessor<Database> with _$DriveDaoMixin {
       }
     }
 
-    await into(drives).insert(
-      companion,
-      onConflict: DoUpdate((_) => companion.copyWith(dateCreated: null)),
-    );
+    // One transaction so the drive and its root folder land together. Written
+    // separately, a stream observer could catch the gap between them and see
+    // exactly the drive-without-a-root-folder state this placeholder exists to
+    // rule out. `updateUserDrives` gets this for free from `db.batch`.
+    await db.transaction(() async {
+      await into(drives).insert(
+        companion,
+        onConflict: DoUpdate((_) => companion.copyWith(dateCreated: null)),
+      );
 
-    await into(folderEntries).insert(
-      _rootFolderPlaceholder(
-        driveId: entity.id!,
-        rootFolderId: entity.rootFolderId!,
-        name: name,
-      ),
-      mode: InsertMode.insertOrIgnore,
-    );
+      await into(folderEntries).insert(
+        _rootFolderPlaceholder(
+          driveId: entity.id!,
+          rootFolderId: entity.rootFolderId!,
+          name: name,
+        ),
+        mode: InsertMode.insertOrIgnore,
+      );
+    });
   }
 
   Future<DrivesCompanion> _addDriveKeyToDriveCompanion(

--- a/lib/models/daos/drive_dao/drive_dao.dart
+++ b/lib/models/daos/drive_dao/drive_dao.dart
@@ -326,6 +326,43 @@ class DriveDao extends DatabaseAccessor<Database> with _$DriveDaoMixin {
     return foldersWithName.isNotEmpty || filesWithName.isNotEmpty;
   }
 
+  /// A stand-in row for a drive's root folder.
+  ///
+  /// A drive row whose `rootFolderId` has no matching folder row cannot be
+  /// opened at all: [watchFolderContents] drops the missing folder with a
+  /// `.where` and its combined stream then never emits, stranding the explorer
+  /// on a spinner that nothing retries. That happens whenever the root
+  /// folder's own metadata transaction fails to resolve during sync while the
+  /// drive entity itself resolves fine - and `rootFolderId` is known from the
+  /// drive entity either way, so the row can always be written.
+  ///
+  /// Two deliberate choices:
+  ///
+  /// * **Insert with [InsertMode.insertOrIgnore].** This must never overwrite a
+  ///   real root folder that already synced, and it is re-run on every sync, so
+  ///   it also heals drives already in this state rather than only preventing
+  ///   new ones.
+  /// * **Not marked `isGhost`.** `FolderRevisionCompanionExtensions
+  ///   .toEntryCompanion` omits `isGhost`, so the upsert that lands the real
+  ///   metadata leaves absent columns untouched and the flag would stick
+  ///   forever. `parentFolderId` is left null for the same care: [createGhosts]
+  ///   points a ghost at `drive.rootFolderId`, which for the root itself would
+  ///   be a self-reference - which is why that method excludes root folders and
+  ///   why this is a placeholder rather than a ghost.
+  FolderEntriesCompanion _rootFolderPlaceholder({
+    required DriveID driveId,
+    required FolderID rootFolderId,
+    required String name,
+  }) =>
+      FolderEntriesCompanion.insert(
+        id: rootFolderId,
+        driveId: driveId,
+        name: name,
+        isHidden: const Value(false),
+        // TODO: path is not used in the app, so it's not necessary to set it
+        path: '',
+      );
+
   /// Adds or updates the user's drives with the provided drive entities.
   Future<void> updateUserDrives(
     Map<DriveEntity, DriveKey?> driveEntities,
@@ -358,6 +395,16 @@ class DriveDao extends DatabaseAccessor<Database> with _$DriveDaoMixin {
               driveCompanion,
               onConflict: DoUpdate(
                   (dynamic _) => driveCompanion.copyWith(dateCreated: null)),
+            );
+
+            b.insert(
+              folderEntries,
+              _rootFolderPlaceholder(
+                driveId: entity.id!,
+                rootFolderId: entity.rootFolderId!,
+                name: entity.name!,
+              ),
+              mode: InsertMode.insertOrIgnore,
             );
           }
         },
@@ -398,6 +445,15 @@ class DriveDao extends DatabaseAccessor<Database> with _$DriveDaoMixin {
     await into(drives).insert(
       companion,
       onConflict: DoUpdate((_) => companion.copyWith(dateCreated: null)),
+    );
+
+    await into(folderEntries).insert(
+      _rootFolderPlaceholder(
+        driveId: entity.id!,
+        rootFolderId: entity.rootFolderId!,
+        name: name,
+      ),
+      mode: InsertMode.insertOrIgnore,
     );
   }
 

--- a/test/blocs/drive_detail/drive_detail_cubit_test.dart
+++ b/test/blocs/drive_detail/drive_detail_cubit_test.dart
@@ -1,0 +1,312 @@
+import 'dart:async';
+
+import 'package:ardrive/blocs/drive_detail/drive_detail_cubit.dart';
+import 'package:ardrive/blocs/drive_detail/utils/breadcrumb_builder.dart';
+import 'package:ardrive/blocs/profile/profile_cubit.dart';
+import 'package:ardrive/core/activity_tracker.dart';
+import 'package:ardrive/core/arfs/repository/drive_repository.dart';
+import 'package:ardrive/models/models.dart';
+import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
+import 'package:ardrive_utils/ardrive_utils.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../test_utils/utils.dart';
+
+class MockDriveRepository extends Mock implements DriveRepository {}
+
+class MockActivityTracker extends Mock implements ActivityTracker {}
+
+class MockBreadcrumbBuilder extends Mock implements BreadcrumbBuilder {}
+
+/// These tests run against a real in-memory database and a real [DriveDao], and
+/// mock only what sits outside the drive explorer. That is deliberate: every
+/// bug this suite exists to catch lived in how the cubit reacts to what the
+/// database streams actually emit - a folder row that is absent, a revision
+/// that is missing, a load that resolves after the user moved on. A DriveDao
+/// stubbed with canned answers reproduces none of that.
+void main() {
+  late Database db;
+  late DriveDao driveDao;
+  late MockDriveRepository driveRepository;
+  late MockSyncBloc syncCubit;
+  late MockProfileCubit profileCubit;
+  late MockActivityTracker activityTracker;
+  late MockBreadcrumbBuilder breadcrumbBuilder;
+  late MockArDriveAuth auth;
+  late MockConfigService configService;
+  late StreamController<SyncState> syncStates;
+
+  const driveId = 'drive-id';
+  const rootFolderId = 'root-folder-id';
+  const ownerAddress = 'owner-address';
+
+  /// Writes the drive and its root folder the way a discovered drive lands:
+  /// the drive row plus the root folder placeholder, and no revision, because
+  /// the root folder's metadata has never been read.
+  Future<void> insertDrive({int? lastBlockHeight}) async {
+    await db.into(db.drives).insert(
+          DrivesCompanion.insert(
+            id: driveId,
+            name: 'Test Drive',
+            ownerAddress: ownerAddress,
+            rootFolderId: rootFolderId,
+            privacy: DrivePrivacyTag.public,
+            lastBlockHeight: Value(lastBlockHeight),
+          ),
+        );
+
+    await db.into(db.folderEntries).insert(
+          FolderEntriesCompanion.insert(
+            id: rootFolderId,
+            driveId: driveId,
+            name: 'Test Drive',
+            path: '',
+          ),
+        );
+  }
+
+  /// The signal that the root folder's metadata has actually been read.
+  Future<void> insertRootFolderRevision() async {
+    await driveDao.insertFolderRevision(
+      FolderRevisionsCompanion.insert(
+        folderId: rootFolderId,
+        driveId: driveId,
+        name: 'Test Drive',
+        metadataTxId: 'metadata-tx-id',
+        action: RevisionAction.create,
+      ),
+    );
+  }
+
+  /// Contents, via a subfolder rather than a file: `driveIsEmpty` counts both,
+  /// and the folder listing is a plain query, where the file listing joins
+  /// revisions and network transactions that say nothing about this behaviour.
+  Future<void> insertSubfolder(String folderId) async {
+    await db.into(db.folderEntries).insert(
+          FolderEntriesCompanion.insert(
+            id: folderId,
+            driveId: driveId,
+            parentFolderId: const Value(rootFolderId),
+            name: folderId,
+            path: '',
+          ),
+        );
+  }
+
+  DriveDetailCubit buildCubit() => DriveDetailCubit(
+        driveId: driveId,
+        profileCubit: profileCubit,
+        driveDao: driveDao,
+        configService: configService,
+        activityTracker: activityTracker,
+        auth: auth,
+        breadcrumbBuilder: breadcrumbBuilder,
+        syncCubit: syncCubit,
+        driveRepository: driveRepository,
+      );
+
+  setUp(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    SharedPreferences.setMockInitialValues({});
+
+    db = getTestDb();
+    driveDao = db.driveDao;
+
+    driveRepository = MockDriveRepository();
+    syncCubit = MockSyncBloc();
+    profileCubit = MockProfileCubit();
+    activityTracker = MockActivityTracker();
+    breadcrumbBuilder = MockBreadcrumbBuilder();
+    auth = MockArDriveAuth();
+    configService = MockConfigService();
+    syncStates = StreamController<SyncState>.broadcast();
+
+    when(() => driveRepository.watchDrive(driveId: any(named: 'driveId')))
+        .thenAnswer((invocation) => driveDao
+            .driveById(
+              driveId: invocation.namedArguments[#driveId] as String,
+            )
+            .watchSingleOrNull());
+
+    when(() => syncCubit.waitCurrentSync()).thenAnswer((_) async {});
+    whenListen(syncCubit, syncStates.stream, initialState: SyncIdle());
+
+    // The cubit reads the profile through `stream.startWith(...)`, so an empty
+    // stream is enough: it renders as a logged-out viewer without write
+    // permissions, which none of these assertions depend on.
+    whenListen(
+      profileCubit,
+      const Stream<ProfileState>.empty(),
+      initialState: ProfileCheckingAvailability(),
+    );
+
+    when(() => activityTracker.isUploading).thenReturn(false);
+    when(() => breadcrumbBuilder.buildForFolder(
+          folderId: any(named: 'folderId'),
+          rootFolderId: any(named: 'rootFolderId'),
+          driveId: any(named: 'driveId'),
+        )).thenAnswer((_) async => []);
+  });
+
+  tearDown(() async {
+    await syncStates.close();
+    await db.close();
+  });
+
+  group('DriveDetailCubit empty vs unsynced', () {
+    /// The regression that matters most: an unsynced drive rendering as an
+    /// empty one tells the user their files are gone.
+    blocTest<DriveDetailCubit, DriveDetailState>(
+      'says "not synced" for a drive whose root metadata never arrived',
+      setUp: () => insertDrive(lastBlockHeight: 0),
+      build: buildCubit,
+      wait: const Duration(milliseconds: 100),
+      verify: (cubit) {
+        expect(cubit.state, isA<DriveDetailLoadUnsynced>());
+      },
+    );
+
+    /// The mirror case, and the reason `lastBlockHeight` cannot be the signal:
+    /// a drive created in-app writes a root revision but never advances its
+    /// watermark, so gating on the watermark would tell someone who just made
+    /// a drive that it needs syncing before they can use it.
+    blocTest<DriveDetailCubit, DriveDetailState>(
+      'renders a locally created empty drive as empty, not unsynced',
+      setUp: () async {
+        await insertDrive(lastBlockHeight: 0);
+        await insertRootFolderRevision();
+      },
+      build: buildCubit,
+      wait: const Duration(milliseconds: 100),
+      verify: (cubit) {
+        final state = cubit.state;
+        expect(state, isA<DriveDetailLoadSuccess>());
+        expect((state as DriveDetailLoadSuccess).driveIsEmpty, isTrue);
+      },
+    );
+
+    blocTest<DriveDetailCubit, DriveDetailState>(
+      'renders a drive that has contents',
+      setUp: () async {
+        await insertDrive(lastBlockHeight: 0);
+        await insertRootFolderRevision();
+        await insertSubfolder('subfolder-1');
+      },
+      build: buildCubit,
+      wait: const Duration(milliseconds: 100),
+      verify: (cubit) {
+        final state = cubit.state;
+        expect(state, isA<DriveDetailLoadSuccess>());
+        expect((state as DriveDetailLoadSuccess).driveIsEmpty, isFalse);
+      },
+    );
+
+    /// A drive that synced normally is opened on its watermark alone, without
+    /// depending on a revision row being present.
+    blocTest<DriveDetailCubit, DriveDetailState>(
+      'opens a drive whose watermark has advanced',
+      setUp: () async {
+        await insertDrive(lastBlockHeight: 100);
+        await insertRootFolderRevision();
+      },
+      build: buildCubit,
+      wait: const Duration(milliseconds: 100),
+      verify: (cubit) {
+        expect(cubit.state, isA<DriveDetailLoadSuccess>());
+      },
+    );
+  });
+
+  group('DriveDetailCubit recovery from unsynced', () {
+    /// An end-to-end guard: metadata arriving must clear the unsynced screen
+    /// even though the watermark never moves. It does not pin any particular
+    /// path - recovery here comes from the folder stream re-firing, so this
+    /// still passes if the sync-completion handler regresses. The
+    /// syncCurrentDrive test below is the one that holds that behaviour.
+    blocTest<DriveDetailCubit, DriveDetailState>(
+      'recovers when the root revision arrives, even with a 0 watermark',
+      setUp: () => insertDrive(lastBlockHeight: 0),
+      build: buildCubit,
+      act: (cubit) async {
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        expect(cubit.state, isA<DriveDetailLoadUnsynced>(),
+            reason: 'precondition: the drive starts out unsynced');
+
+        // Metadata lands, but the watermark never moves.
+        await insertRootFolderRevision();
+        syncStates.add(SyncIdle());
+
+        await Future<void>.delayed(const Duration(milliseconds: 200));
+      },
+      verify: (cubit) {
+        expect(cubit.state, isA<DriveDetailLoadSuccess>());
+      },
+    );
+
+    /// [DriveDetailCubit.syncCurrentDrive] emits directly rather than through
+    /// the folder stream, so it is where an entry/exit mismatch actually
+    /// traps the user: pressing "Sync now" on a drive whose metadata has
+    /// arrived, but whose watermark never moved, re-emitted the same unsynced
+    /// state - the button led back to the screen that offered it.
+    /// Asserted on the emissions rather than the final state, and that is the
+    /// whole point. The folder subscription is still live here, and writing the
+    /// revision touches tables it watches, so the stream re-fires and repairs
+    /// the state a moment later no matter what this path emitted. Checking
+    /// where the cubit ends up therefore passes even when the button is
+    /// broken; only the sequence shows the user being bounced back to the
+    /// screen they just acted on.
+    test(
+        'syncCurrentDrive() does not land back on the unsynced screen when '
+        'metadata arrived with a 0 watermark', () async {
+      await insertDrive(lastBlockHeight: 0);
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      expect(cubit.state, isA<DriveDetailLoadUnsynced>(),
+          reason: 'precondition: the drive starts out unsynced');
+
+      // The sync writes the root revision but never advances the watermark.
+      when(() => syncCubit.startSyncForDrive(
+            driveId: any(named: 'driveId'),
+            deepSync: any(named: 'deepSync'),
+          )).thenAnswer((_) async => insertRootFolderRevision());
+
+      final emitted = <DriveDetailState>[];
+      final subscription = cubit.stream.listen(emitted.add);
+
+      await cubit.syncCurrentDrive();
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+      await subscription.cancel();
+
+      expect(
+        emitted.whereType<DriveDetailLoadUnsynced>(),
+        isEmpty,
+        reason: 'pressing "Sync now" must not return to "Drive Not Synced" '
+            'once the root metadata is readable',
+      );
+      expect(cubit.state, isA<DriveDetailLoadSuccess>());
+    });
+
+    blocTest<DriveDetailCubit, DriveDetailState>(
+      'stays unsynced while the root metadata is still missing',
+      setUp: () => insertDrive(lastBlockHeight: 0),
+      build: buildCubit,
+      act: (cubit) async {
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+
+        syncStates.add(SyncIdle());
+
+        await Future<void>.delayed(const Duration(milliseconds: 200));
+      },
+      verify: (cubit) {
+        expect(cubit.state, isA<DriveDetailLoadUnsynced>());
+      },
+    );
+  });
+}

--- a/test/models/daos/drive_dao_test.dart
+++ b/test/models/daos/drive_dao_test.dart
@@ -1,4 +1,6 @@
+import 'package:ardrive/entities/entities.dart';
 import 'package:ardrive/models/models.dart';
+import 'package:ardrive_utils/ardrive_utils.dart';
 import 'package:test/test.dart';
 
 import '../../test_utils/utils.dart';
@@ -170,6 +172,99 @@ void main() {
         final file = filesInFolderTree[i];
         expect(file.id, equals(expectedTreeResults[i][0]));
       }
+    });
+  });
+
+  /// A drive row whose `rootFolderId` has no folder row cannot be opened:
+  /// `watchFolderContents` filters the absent folder out and its stream then
+  /// never emits, so the explorer sits on a spinner nothing retries. Every path
+  /// that writes a drive must therefore also leave a root folder behind.
+  group('DriveDao root folder guarantee', () {
+    const otherDriveId = 'placeholder-drive-id';
+    const otherRootFolderId = 'placeholder-root-folder-id';
+    const driveName = 'Placeholder Drive';
+    const ownerAddress = 'owner-address';
+
+    DriveEntity driveEntity({String name = driveName}) => DriveEntity(
+          id: otherDriveId,
+          name: name,
+          rootFolderId: otherRootFolderId,
+          privacy: DrivePrivacyTag.public,
+          authMode: DriveAuthModeTag.none,
+        )..ownerAddress = ownerAddress;
+
+    setUp(() async {
+      db = getTestDb();
+      driveDao = db.driveDao;
+    });
+
+    tearDown(() async {
+      await db.close();
+    });
+
+    test('updateUserDrives() writes a root folder the drive can be opened from',
+        () async {
+      await driveDao.updateUserDrives({driveEntity(): null}, null);
+
+      final rootFolder = await driveDao
+          .folderById(folderId: otherRootFolderId)
+          .getSingleOrNull();
+
+      expect(rootFolder, isNotNull);
+      expect(rootFolder!.driveId, equals(otherDriveId));
+
+      // The point of the row: the drive mounts instead of hanging.
+      await expectLater(
+        driveDao.watchFolderContents(otherDriveId).map((f) => f.folder.id),
+        emits(otherRootFolderId),
+      );
+    });
+
+    test('updateUserDrives() does not overwrite an already synced root folder',
+        () async {
+      await driveDao.updateUserDrives({driveEntity(): null}, null);
+
+      // The real metadata lands, renaming the root folder.
+      await driveDao.updateFolderEntries([
+        FolderEntriesCompanion.insert(
+          id: otherRootFolderId,
+          driveId: otherDriveId,
+          name: 'Real Root Name',
+          path: '',
+        ),
+      ]);
+
+      // A later sync re-runs the same insert.
+      await driveDao.updateUserDrives({driveEntity(): null}, null);
+
+      final rootFolder =
+          await driveDao.folderById(folderId: otherRootFolderId).getSingle();
+
+      expect(rootFolder.name, equals('Real Root Name'));
+    });
+
+    test('root folder placeholder is not marked as a ghost', () async {
+      await driveDao.updateUserDrives({driveEntity(): null}, null);
+
+      final rootFolder =
+          await driveDao.folderById(folderId: otherRootFolderId).getSingle();
+
+      // `FolderRevisionsCompanion.toEntryCompanion` omits `isGhost`, and the
+      // upsert that lands real metadata leaves absent columns alone - so a
+      // placeholder marked as a ghost would stay one forever.
+      expect(rootFolder.isGhost, isFalse);
+      expect(rootFolder.parentFolderId, isNull);
+    });
+
+    test('writeDriveEntity() writes a root folder too', () async {
+      await driveDao.writeDriveEntity(name: driveName, entity: driveEntity());
+
+      final rootFolder = await driveDao
+          .folderById(folderId: otherRootFolderId)
+          .getSingleOrNull();
+
+      expect(rootFolder, isNotNull);
+      expect(rootFolder!.name, equals(driveName));
     });
   });
 }

--- a/test/models/daos/drive_dao_test.dart
+++ b/test/models/daos/drive_dao_test.dart
@@ -256,6 +256,51 @@ void main() {
       expect(rootFolder.parentFolderId, isNull);
     });
 
+    /// What tells "genuinely empty" apart from "never synced". A drive created
+    /// in-app writes a root folder revision at creation time, and sync writes
+    /// one when the real metadata lands; a drive merely discovered by
+    /// `updateUserDrives` has only the placeholder until then. Claiming a drive
+    /// is empty on weaker evidence reads to the user as data loss.
+    test('a discovered drive has no root folder revision until one syncs',
+        () async {
+      await driveDao.updateUserDrives({driveEntity(): null}, null);
+
+      final beforeSync = await driveDao
+          .latestFolderRevisionByFolderId(
+            driveId: otherDriveId,
+            folderId: otherRootFolderId,
+          )
+          .getSingleOrNull();
+
+      expect(beforeSync, isNull,
+          reason: 'the placeholder must not read as synced metadata');
+
+      // lastBlockHeight cannot stand in for this: it defaults to 0, so it
+      // cannot tell a freshly created empty drive from an unsynced one.
+      final drive =
+          await driveDao.driveById(driveId: otherDriveId).getSingle();
+      expect(drive.lastBlockHeight, equals(0));
+
+      await driveDao.insertFolderRevision(
+        FolderRevisionsCompanion.insert(
+          folderId: otherRootFolderId,
+          driveId: otherDriveId,
+          name: 'Real Root Name',
+          metadataTxId: 'metadata-tx-id',
+          action: RevisionAction.create,
+        ),
+      );
+
+      final afterSync = await driveDao
+          .latestFolderRevisionByFolderId(
+            driveId: otherDriveId,
+            folderId: otherRootFolderId,
+          )
+          .getSingleOrNull();
+
+      expect(afterSync, isNotNull);
+    });
+
     test('writeDriveEntity() writes a root folder too', () async {
       await driveDao.writeDriveEntity(name: driveName, entity: driveEntity());
 


### PR DESCRIPTION
## The bug

A drive can render a **perpetual spinner** in the explorer, with no retry and nothing that re-triggers it. Reached when a drive row exists but no folder row exists for its `rootFolderId`.

Sync fails to read the root folder's metadata, returns empty bytes rather than an error, the parse exception is swallowed as a warning, the entity never lands — and the watermark advances unconditionally. Pre-existing, but more reachable since sync moved from a four-gateway waterfall to two attempts on one.

## Two dead ends, not one

The obvious one is `_handleFolderNotFound`'s `else` branch emitting `DriveInitialLoading()`. But that is only reachable via `openFolder()` with a **null** folderId.

The path users actually hit is different. `watchFolderContents`' non-null-`folderId` branch (`drive_dao.dart:510`) filters a missing folder out rather than throwing:

```dart
folderStream.where((folder) => folder != null).map((folder) => folder!),
```

`combineLatest3` then never emits — no error, no data — and the cubit is stranded in `DriveDetailLoadInProgress`, a bare `CircularProgressIndicator`. Fixing only `_handleFolderNotFound` would not have fixed the reported bug.

Neither state recovers on its own: `_onSyncCompleted` re-checks only `DriveDetailLoadUnsynced`.

## The fix

**A drive row should never exist without a folder row for its `rootFolderId`.** `rootFolderId` comes off the drive entity itself, independent of whether the root folder's metadata ever resolved, so the row can always be written.

`_rootFolderPlaceholder` is now written alongside every drive in `updateUserDrives` (sync) and `writeDriveEntity` (drive-attach) — mirroring what `createDrive` already did. Inserted with `InsertMode.insertOrIgnore`, so it never overwrites a real root folder.

Because `updateUserDrives` re-runs on every sync, this **heals already-affected drives**, not just prevents new ones — and recovery is live, since the Drift stream is already watching that row.

`_handleFolderNotFound` now emits `DriveDetailLoadNotFound` for a genuinely absent drive and `DriveDetailLoadUnsynced` otherwise, both re-checked by `_onSyncCompleted`. The duplicate inline handler in `openFolder`'s `onError` folds into it.

No schema change: `parentFolderId` is nullable, `isGhost` defaults false.

## Why a placeholder and not a ghost

`createGhosts` **explicitly excludes** root folders (`isRootFolderGhost`), so ghosts never produce a root row — even when children did sync. The reason is visible in the code: a ghost sets `parentFolderId: drive.rootFolderId`, which for the root itself is a self-reference.

The placeholder is also deliberately **not** marked `isGhost`. `FolderRevisionCompanionExtensions.toEntryCompanion` omits that column, and drift's `insertAllOnConflictUpdate` leaves absent columns out of `DO UPDATE SET` — so a ghost-flagged placeholder would stay a ghost permanently, even after real metadata synced.

## Downstream check

Breadcrumbs stop *at* `rootFolderId` and never look it up. `getFolderTree` calls `.getSingle()` on the root and currently **throws** when it is missing, so drive-size, folder download and manifests are broken by this too — the placeholder fixes those as well.

## Verification

- `flutter analyze` clean
- 1326 app tests pass (baseline ~1322 + 4 new), 43 in `packages/ardrive_crypto` pass
- New tests cover: the drive mounts where it previously hung, a synced root is never overwritten, the placeholder is not a ghost and has a null parent, and `writeDriveEntity` writes one too

## Deliberately out of scope

- The `.where()` filter in `watchFolderContents` was **not** changed to throw. It backs all folder navigation, and wait-for-the-row absorbs legitimate sync races; converting it to an error has a far wider blast radius than this bug justifies. Worth a follow-up.
- `DriveInitialLoading` and its `drive_detail_page.dart:206` branch are now unreachable; left in place to avoid touching the `driveDoingInitialSetupMessage` UI.
- Noted landmine: `ghost_fixer_cubit.dart:112` does `ghostFolder.parentFolderId!`, which would crash on any null-parent ghost. Unreachable today since root never renders as a row.
- `docs/SYNC_SKIPPED_ENTITY_PERSISTENCE.md` remains the root-cause fix for the silent drop. This is the resilience fix that makes the symptom survivable in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DnYLXFocWgTt9M2CbGYSUP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of drives whose root folder or local content is unavailable.
  * Drives with missing local metadata now appear as unsynced and can be recovered through synchronization.
  * Ensured synced or newly saved drives always have a usable root folder while preserving existing folder details.

* **Tests**
  * Added coverage for root-folder creation, metadata preservation, and placeholder behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->