### PR TITLE
PE-9205: Login reads walk the gateway waterfall they were meant to skip

### DIFF
--- a/lib/authentication/ardrive_auth.dart
+++ b/lib/authentication/ardrive_auth.dart
@@ -340,6 +340,9 @@ class ArDriveAuthImpl implements ArDriveAuth {
           driveKey: checkDriveKey.key,
           driveOwner: await wallet.getAddress(),
           maxRetries: profileQueryMaxRetries,
+          // Login, not a user-initiated fetch: read the configured gateway
+          // twice rather than walking the GAR waterfall behind a spinner.
+          configuredGatewayOnly: true,
         );
 
         if (privateDrive == null) {

--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -47,6 +47,13 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
   StreamSubscription? _syncSubscription;
   bool _initialLoadComplete = false;
   bool _isExplicitSync = false;
+
+  /// Bumped by every [openFolder]. Cancelling `_folderSubscription` does not
+  /// cancel a callback that already began awaiting, so an in-flight load can
+  /// still emit after the user has navigated somewhere else in the same drive
+  /// - where the `_driveId` checks cannot see it, because the drive did not
+  /// change. Callbacks capture this and drop their result if it moved on.
+  int _folderLoadGeneration = 0;
   final _defaultAvailableRowsPerPage = [25, 50, 75, 100];
 
   List<ArDriveDataTableItem> _selectedItems = [];
@@ -140,6 +147,33 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
     });
   }
 
+  /// Whether this drive's root folder metadata has actually been read.
+  ///
+  /// [DriveDetailLoadUnsynced] is entered when the root folder has no
+  /// revision, so every path that leaves it has to test the same thing.
+  /// Gating recovery on `lastBlockHeight` instead lets the two conditions
+  /// disagree, and this is exactly the codebase where they do: a sync that
+  /// writes the root revision and then fails before advancing the watermark
+  /// leaves readable metadata behind a drive pinned on "Drive Not Synced",
+  /// where the sync button only re-emits the same state.
+  ///
+  /// `lastBlockHeight` is still honoured, because a drive synced by an earlier
+  /// build may have advanced its watermark and is by definition synced.
+  Future<bool> _hasRootFolderMetadata(Drive drive) async {
+    if ((drive.lastBlockHeight ?? 0) > 0) {
+      return true;
+    }
+
+    final rootFolderRevision = await _driveDao
+        .latestFolderRevisionByFolderId(
+          driveId: drive.id,
+          folderId: drive.rootFolderId,
+        )
+        .getSingleOrNull();
+
+    return rootFolderRevision != null;
+  }
+
   /// Called when sync completes. Re-checks drive state if we're showing
   /// unsynced or loading state, and loads the drive content if now available.
   Future<void> _onSyncCompleted() async {
@@ -165,7 +199,9 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
         return;
       }
 
-      if (drive.lastBlockHeight != null && drive.lastBlockHeight! > 0) {
+      if (await _hasRootFolderMetadata(drive)) {
+        if (isClosed || state is! DriveDetailLoadUnsynced) return;
+
         openFolder(folderId: drive.rootFolderId, otherDriveId: capturedDriveId);
       }
     }
@@ -231,6 +267,10 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
     DriveOrder contentOrderBy = DriveOrder.name,
     OrderingMode contentOrderingMode = OrderingMode.asc,
   }) async {
+    // Claimed before the first await, so anything already in flight for a
+    // previous folder is stale from here on even when the drive is unchanged.
+    final loadGeneration = ++_folderLoadGeneration;
+
     /// always wait for the current sync to finish before opening a new folder
     await _syncCubit.waitCurrentSync();
 
@@ -355,7 +395,9 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
                 )
                 .getSingleOrNull();
 
-            if (isClosed || driveId != _driveId) {
+            if (isClosed ||
+                driveId != _driveId ||
+                loadGeneration != _folderLoadGeneration) {
               return;
             }
 
@@ -383,6 +425,12 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
             driveId: driveId,
           );
 
+          if (isClosed ||
+              driveId != _driveId ||
+              loadGeneration != _folderLoadGeneration) {
+            return;
+          }
+
           if (state != null) {
             emit(
               state.copyWith(
@@ -403,6 +451,12 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
             );
           } else {
             final columnsVisibility = await getTableColumnVisibility();
+
+            if (isClosed ||
+                driveId != _driveId ||
+                loadGeneration != _folderLoadGeneration) {
+              return;
+            }
 
             emit(
               DriveDetailLoadSuccess(
@@ -748,7 +802,11 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
         return;
       }
 
-      if (drive.lastBlockHeight != null && drive.lastBlockHeight! > 0) {
+      final hasRootFolderMetadata = await _hasRootFolderMetadata(drive);
+
+      if (isClosed || _driveId != driveId) return;
+
+      if (hasRootFolderMetadata) {
         openFolder(folderId: rootFolderId, otherDriveId: driveId);
       } else {
         emit(DriveDetailLoadUnsynced(drive: drive));
@@ -802,8 +860,12 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
         return;
       }
 
-      if (drive.lastBlockHeight == null || drive.lastBlockHeight == 0) {
-        // Sync reported success but drive content wasn't actually synced
+      final hasRootFolderMetadata = await _hasRootFolderMetadata(drive);
+
+      if (isClosed || _driveId != driveId) return;
+
+      if (!hasRootFolderMetadata) {
+        // Sync reported success but the drive's root metadata never arrived
         emit(DriveDetailLoadUnsynced(drive: drive));
         return;
       }

--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -818,7 +818,9 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
   Future<void> _handleFolderNotFound(String driveId) async {
     final drive =
         await _driveDao.driveById(driveId: driveId).getSingleOrNull();
-    if (isClosed) return;
+    // The drive can be switched out from under this query. Emitting after that
+    // would put the previous drive's state on the new drive's screen.
+    if (isClosed || _driveId != driveId) return;
 
     if (drive == null) {
       emit(DriveDetailLoadNotFound());

--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -330,6 +330,41 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
             }
           }
 
+          final driveIsEmpty = folderContents.files.isEmpty &&
+              folderContents.subfolders.isEmpty;
+
+          // A drive that renders with nothing in it is ambiguous: it may be
+          // genuinely empty, or its contents may simply never have synced.
+          // Telling someone their drive is empty when we have not actually
+          // read it reads as "my data is gone", so only claim emptiness we
+          // can back up. Otherwise fall through to DriveDetailLoadUnsynced,
+          // which already says "Drive Not Synced" and offers to sync.
+          //
+          // The root folder's revision is the honest signal for that. A drive
+          // created in this app writes one at creation time
+          // (DriveCreateCubit), and sync writes one when the real metadata
+          // lands - but a drive merely discovered by updateUserDrives has only
+          // the placeholder folder row until then. lastBlockHeight cannot
+          // answer this: it defaults to 0, so a freshly created empty drive is
+          // indistinguishable from one that has never synced.
+          if (driveIsEmpty && folderContents.folder.id == drive.rootFolderId) {
+            final rootFolderRevision = await _driveDao
+                .latestFolderRevisionByFolderId(
+                  driveId: driveId,
+                  folderId: drive.rootFolderId,
+                )
+                .getSingleOrNull();
+
+            if (isClosed || driveId != _driveId) {
+              return;
+            }
+
+            if (rootFolderRevision == null) {
+              emit(DriveDetailLoadUnsynced(drive: drive));
+              return;
+            }
+          }
+
           final currentFolderContents = parseEntitiesToDatatableItem(
             folder: folderContents,
             isOwner: isDriveOwner(_auth, drive.ownerAddress),
@@ -362,8 +397,7 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
                 availableRowsPerPage: availableRowsPerPage,
                 currentFolderContents: currentFolderContents,
                 pathSegments: pathSegments,
-                driveIsEmpty: folderContents.files.isEmpty &&
-                    folderContents.subfolders.isEmpty,
+                driveIsEmpty: driveIsEmpty,
                 showSelectedItemDetails: _selectedItem != null,
               ),
             );
@@ -382,8 +416,7 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
                 contentOrderingMode: contentOrderingMode,
                 rowsPerPage: availableRowsPerPage.first,
                 availableRowsPerPage: availableRowsPerPage,
-                driveIsEmpty: folderContents.files.isEmpty &&
-                    folderContents.subfolders.isEmpty,
+                driveIsEmpty: driveIsEmpty,
                 multiselect: false,
                 currentFolderContents: currentFolderContents,
                 columnVisibility: columnsVisibility,

--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -399,17 +399,7 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
 
     _folderSubscription?.onError((e) async {
       if (e is FolderNotFoundInDriveException) {
-        // Check if the drive is unsynced (metadata only, no content)
-        final drive =
-            await _driveDao.driveById(driveId: e.driveId).getSingleOrNull();
-        if (drive != null &&
-            (drive.lastBlockHeight == null || drive.lastBlockHeight == 0)) {
-          // Drive exists but content hasn't been synced - show sync options
-          emit(DriveDetailLoadUnsynced(drive: drive));
-        } else {
-          // Drive is being set up or has an issue
-          emit(DriveInitialLoading());
-        }
+        await _handleFolderNotFound(e.driveId);
         return;
       }
 
@@ -813,16 +803,29 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
     }
   }
 
+  /// The drive's root folder row is missing, so the explorer cannot mount it.
+  ///
+  /// `DriveDao._rootFolderPlaceholder` makes this structurally unreachable for
+  /// any drive written since, and heals already-affected drives on their next
+  /// sync. It is still handled rather than asserted away: whichever way a drive
+  /// gets here, it has to land somewhere the user can act from.
+  ///
+  /// Both outcomes are states a later sync recovers from on its own -
+  /// [DriveDetailLoadUnsynced] is re-checked by [_onSyncCompleted], and it
+  /// renders the drive with whatever did sync. The previous
+  /// [DriveInitialLoading] was a dead end: no retry, no action, and nothing
+  /// that re-triggers it.
   Future<void> _handleFolderNotFound(String driveId) async {
     final drive =
         await _driveDao.driveById(driveId: driveId).getSingleOrNull();
     if (isClosed) return;
-    if (drive != null &&
-        (drive.lastBlockHeight == null || drive.lastBlockHeight == 0)) {
-      emit(DriveDetailLoadUnsynced(drive: drive));
-    } else {
-      emit(DriveInitialLoading());
+
+    if (drive == null) {
+      emit(DriveDetailLoadNotFound());
+      return;
     }
+
+    emit(DriveDetailLoadUnsynced(drive: drive));
   }
 
   @override

--- a/lib/blocs/drive_detail/drive_detail_state.dart
+++ b/lib/blocs/drive_detail/drive_detail_state.dart
@@ -138,8 +138,14 @@ class DriveDetailLoadSuccess extends DriveDetailState {
 /// the user's profile.
 class DriveDetailLoadNotFound extends DriveDetailState {}
 
-/// [DriveDetailLoadUnsynced] means that the drive metadata exists but its content
-/// has not been synced yet (lastBlockHeight == 0 or null).
+/// [DriveDetailLoadUnsynced] means the drive's metadata exists but its content
+/// is not (yet) locally available to open.
+///
+/// Two ways in: the drive has never been synced (`lastBlockHeight` 0 or null),
+/// or it synced but its root folder row is missing, so the explorer has no
+/// folder to mount. Both are recoverable and both are re-checked by
+/// `DriveDetailCubit._onSyncCompleted`, which opens the drive once the content
+/// lands.
 class DriveDetailLoadUnsynced extends DriveDetailState {
   final Drive drive;
   final bool showDriveInfo;

--- a/lib/models/daos/drive_dao/drive_dao.dart
+++ b/lib/models/daos/drive_dao/drive_dao.dart
@@ -442,19 +442,25 @@ class DriveDao extends DatabaseAccessor<Database> with _$DriveDaoMixin {
       }
     }
 
-    await into(drives).insert(
-      companion,
-      onConflict: DoUpdate((_) => companion.copyWith(dateCreated: null)),
-    );
+    // One transaction so the drive and its root folder land together. Written
+    // separately, a stream observer could catch the gap between them and see
+    // exactly the drive-without-a-root-folder state this placeholder exists to
+    // rule out. `updateUserDrives` gets this for free from `db.batch`.
+    await db.transaction(() async {
+      await into(drives).insert(
+        companion,
+        onConflict: DoUpdate((_) => companion.copyWith(dateCreated: null)),
+      );
 
-    await into(folderEntries).insert(
-      _rootFolderPlaceholder(
-        driveId: entity.id!,
-        rootFolderId: entity.rootFolderId!,
-        name: name,
-      ),
-      mode: InsertMode.insertOrIgnore,
-    );
+      await into(folderEntries).insert(
+        _rootFolderPlaceholder(
+          driveId: entity.id!,
+          rootFolderId: entity.rootFolderId!,
+          name: name,
+        ),
+        mode: InsertMode.insertOrIgnore,
+      );
+    });
   }
 
   Future<DrivesCompanion> _addDriveKeyToDriveCompanion(

--- a/lib/models/daos/drive_dao/drive_dao.dart
+++ b/lib/models/daos/drive_dao/drive_dao.dart
@@ -326,6 +326,43 @@ class DriveDao extends DatabaseAccessor<Database> with _$DriveDaoMixin {
     return foldersWithName.isNotEmpty || filesWithName.isNotEmpty;
   }
 
+  /// A stand-in row for a drive's root folder.
+  ///
+  /// A drive row whose `rootFolderId` has no matching folder row cannot be
+  /// opened at all: [watchFolderContents] drops the missing folder with a
+  /// `.where` and its combined stream then never emits, stranding the explorer
+  /// on a spinner that nothing retries. That happens whenever the root
+  /// folder's own metadata transaction fails to resolve during sync while the
+  /// drive entity itself resolves fine - and `rootFolderId` is known from the
+  /// drive entity either way, so the row can always be written.
+  ///
+  /// Two deliberate choices:
+  ///
+  /// * **Insert with [InsertMode.insertOrIgnore].** This must never overwrite a
+  ///   real root folder that already synced, and it is re-run on every sync, so
+  ///   it also heals drives already in this state rather than only preventing
+  ///   new ones.
+  /// * **Not marked `isGhost`.** `FolderRevisionCompanionExtensions
+  ///   .toEntryCompanion` omits `isGhost`, so the upsert that lands the real
+  ///   metadata leaves absent columns untouched and the flag would stick
+  ///   forever. `parentFolderId` is left null for the same care: [createGhosts]
+  ///   points a ghost at `drive.rootFolderId`, which for the root itself would
+  ///   be a self-reference - which is why that method excludes root folders and
+  ///   why this is a placeholder rather than a ghost.
+  FolderEntriesCompanion _rootFolderPlaceholder({
+    required DriveID driveId,
+    required FolderID rootFolderId,
+    required String name,
+  }) =>
+      FolderEntriesCompanion.insert(
+        id: rootFolderId,
+        driveId: driveId,
+        name: name,
+        isHidden: const Value(false),
+        // TODO: path is not used in the app, so it's not necessary to set it
+        path: '',
+      );
+
   /// Adds or updates the user's drives with the provided drive entities.
   Future<void> updateUserDrives(
     Map<DriveEntity, DriveKey?> driveEntities,
@@ -358,6 +395,16 @@ class DriveDao extends DatabaseAccessor<Database> with _$DriveDaoMixin {
               driveCompanion,
               onConflict: DoUpdate(
                   (dynamic _) => driveCompanion.copyWith(dateCreated: null)),
+            );
+
+            b.insert(
+              folderEntries,
+              _rootFolderPlaceholder(
+                driveId: entity.id!,
+                rootFolderId: entity.rootFolderId!,
+                name: entity.name!,
+              ),
+              mode: InsertMode.insertOrIgnore,
             );
           }
         },
@@ -398,6 +445,15 @@ class DriveDao extends DatabaseAccessor<Database> with _$DriveDaoMixin {
     await into(drives).insert(
       companion,
       onConflict: DoUpdate((_) => companion.copyWith(dateCreated: null)),
+    );
+
+    await into(folderEntries).insert(
+      _rootFolderPlaceholder(
+        driveId: entity.id!,
+        rootFolderId: entity.rootFolderId!,
+        name: name,
+      ),
+      mode: InsertMode.insertOrIgnore,
     );
   }
 

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -1112,11 +1112,25 @@ class ArweaveService {
   /// by that owner.
   ///
   /// Returns `null` if no valid drive is found or the provided `driveKey` is incorrect.
+  /// Reads the drive entity for [driveId].
+  ///
+  /// [configuredGatewayOnly] picks which read policy the data fetch uses.
+  /// Leave it false for a single read a user is waiting on and can retry -
+  /// attaching a drive by id - where breadth wins and the full waterfall is
+  /// worth its cost.
+  ///
+  /// Pass it for reads on the login and drive-discovery path. Those look like
+  /// user-initiated reads and behave like sync: they run at startup, several
+  /// at a time, with the user watching a spinner. The waterfall is the wrong
+  /// trade there - it walks up to four gateways serially and asks
+  /// `ArioSDK.getGateways()` for the list, which costs a Solana RPC on the
+  /// startup path. See [DataGatewayFallback.fetchDataForSync].
   Future<DriveEntity?> getLatestDriveEntityWithId(
     String driveId, {
     String? driveOwner,
     SecretKey? driveKey,
     int maxRetries = defaultMaxRetries,
+    bool configuredGatewayOnly = false,
   }) async {
     driveOwner ??= await getOwnerForDriveEntityWithId(driveId);
 
@@ -1165,7 +1179,10 @@ class ArweaveService {
       // Use cached bytes if available (e.g., from getUniqueUserDriveEntities)
       final cachedBytes = _cachedEntityDataBytes[fileTx.id];
       final entityBytes = cachedBytes ??
-          (await _gatewayFallback.fetchData(fileTx.id, client)).bodyBytes;
+          (await (configuredGatewayOnly
+                  ? _gatewayFallback.fetchDataForSync(fileTx.id, client)
+                  : _gatewayFallback.fetchData(fileTx.id, client)))
+              .bodyBytes;
 
       try {
         return await DriveEntity.fromTransaction(

--- a/lib/services/arweave/data_gateway_fallback.dart
+++ b/lib/services/arweave/data_gateway_fallback.dart
@@ -43,6 +43,13 @@ class DataGatewayFallback {
   /// Attempts made against the configured gateway by [fetchDataForSync].
   static const syncMaxAttempts = 2;
 
+  /// Attempts against the configured gateway inside the [fetchData] waterfall,
+  /// spent only when it answers 404.
+  static const _primaryAttemptsOn404 = 2;
+
+  /// Delay before that retry.
+  static const _primaryRetryDelay = Duration(milliseconds: 300);
+
   /// Delay before the single same-gateway retry in [fetchDataForSync].
   static const _syncRetryDelay = Duration(milliseconds: 300);
 
@@ -164,18 +171,47 @@ class DataGatewayFallback {
 
     for (final client in clients) {
       final gatewayName = client.api.gatewayUrl.host;
-      try {
-        final response = await _tryGateway(client, txId);
-        if (client != primaryClient) {
-          logger.i('Fallback gateway $gatewayName succeeded for tx $txId');
+      final isPrimary = client == primaryClient;
+
+      // The configured gateway gets one extra attempt, and only on a 404.
+      // [_syncFetch] already spends one for the same reason - a gateway that
+      // has not finished indexing a transaction answers 404 for it and 200 a
+      // moment later - and the reasoning holds at least as well here, because
+      // walking away from the primary is worst for exactly the data most
+      // likely to be a beat behind. Something just uploaded through Turbo can
+      // be on the configured gateway and not yet anywhere else, so falling
+      // through on its first 404 reaches gateways that are further behind it,
+      // not ahead of it.
+      //
+      // Deliberately not extended to timeouts or socket errors: those have
+      // already spent their [_requestTimeout] and say the gateway is unwell
+      // rather than a beat behind, so the next gateway is the better bet and
+      // the total budget stays intact.
+      final attempts = isPrimary ? _primaryAttemptsOn404 : 1;
+
+      for (var attempt = 1; attempt <= attempts; attempt++) {
+        var retryable = false;
+
+        try {
+          final response = await _tryGateway(client, txId);
+          if (!isPrimary) {
+            logger.i('Fallback gateway $gatewayName succeeded for tx $txId');
+          }
+          return response;
+        } on _ErrorFromStatus catch (e) {
+          if (e.statusCode != 404) all404 = false;
+          retryable = e.statusCode == 404;
+          logger.w('Gateway $gatewayName failed for tx $txId: $e');
+        } catch (e) {
+          all404 = false;
+          logger.w('Gateway $gatewayName failed for tx $txId: $e');
         }
-        return response;
-      } on _ErrorFromStatus catch (e) {
-        if (e.statusCode != 404) all404 = false;
-        logger.w('Gateway $gatewayName failed for tx $txId: $e');
-      } catch (e) {
-        all404 = false;
-        logger.w('Gateway $gatewayName failed for tx $txId: $e');
+
+        if (!retryable) break;
+
+        if (attempt < attempts) {
+          await Future.delayed(_primaryRetryDelay);
+        }
       }
     }
 

--- a/test/authentication/ardrive_auth_test.dart
+++ b/test/authentication/ardrive_auth_test.dart
@@ -187,6 +187,7 @@ void main() {
               driveKey: any(named: 'driveKey'),
               maxRetries: any(named: 'maxRetries'),
               driveOwner: any(named: 'driveOwner'),
+              configuredGatewayOnly: any(named: 'configuredGatewayOnly'),
             ),
           ).thenAnswer(
             (invocation) => Future.value(
@@ -259,6 +260,7 @@ void main() {
               driveKey: any(named: 'driveKey'),
               maxRetries: any(named: 'maxRetries'),
               driveOwner: any(named: 'driveOwner'),
+              configuredGatewayOnly: any(named: 'configuredGatewayOnly'),
             ),
           ).thenAnswer(
             (invocation) => Future.value(
@@ -674,6 +676,7 @@ void main() {
             driveKey: any(named: 'driveKey'),
             maxRetries: any(named: 'maxRetries'),
             driveOwner: any(named: 'driveOwner'),
+            configuredGatewayOnly: any(named: 'configuredGatewayOnly'),
           ),
         ).thenAnswer((invocation) => Future.value(DriveEntity(
               id: 'some_id',
@@ -746,6 +749,7 @@ void main() {
             driveKey: any(named: 'driveKey'),
             maxRetries: any(named: 'maxRetries'),
             driveOwner: any(named: 'driveOwner'),
+            configuredGatewayOnly: any(named: 'configuredGatewayOnly'),
           ),
         ).thenAnswer((invocation) => Future.value(DriveEntity(
               id: 'some_id',

--- a/test/blocs/drive_detail/drive_detail_cubit_test.dart
+++ b/test/blocs/drive_detail/drive_detail_cubit_test.dart
@@ -1,0 +1,312 @@
+import 'dart:async';
+
+import 'package:ardrive/blocs/drive_detail/drive_detail_cubit.dart';
+import 'package:ardrive/blocs/drive_detail/utils/breadcrumb_builder.dart';
+import 'package:ardrive/blocs/profile/profile_cubit.dart';
+import 'package:ardrive/core/activity_tracker.dart';
+import 'package:ardrive/core/arfs/repository/drive_repository.dart';
+import 'package:ardrive/models/models.dart';
+import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
+import 'package:ardrive_utils/ardrive_utils.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../test_utils/utils.dart';
+
+class MockDriveRepository extends Mock implements DriveRepository {}
+
+class MockActivityTracker extends Mock implements ActivityTracker {}
+
+class MockBreadcrumbBuilder extends Mock implements BreadcrumbBuilder {}
+
+/// These tests run against a real in-memory database and a real [DriveDao], and
+/// mock only what sits outside the drive explorer. That is deliberate: every
+/// bug this suite exists to catch lived in how the cubit reacts to what the
+/// database streams actually emit - a folder row that is absent, a revision
+/// that is missing, a load that resolves after the user moved on. A DriveDao
+/// stubbed with canned answers reproduces none of that.
+void main() {
+  late Database db;
+  late DriveDao driveDao;
+  late MockDriveRepository driveRepository;
+  late MockSyncBloc syncCubit;
+  late MockProfileCubit profileCubit;
+  late MockActivityTracker activityTracker;
+  late MockBreadcrumbBuilder breadcrumbBuilder;
+  late MockArDriveAuth auth;
+  late MockConfigService configService;
+  late StreamController<SyncState> syncStates;
+
+  const driveId = 'drive-id';
+  const rootFolderId = 'root-folder-id';
+  const ownerAddress = 'owner-address';
+
+  /// Writes the drive and its root folder the way a discovered drive lands:
+  /// the drive row plus the root folder placeholder, and no revision, because
+  /// the root folder's metadata has never been read.
+  Future<void> insertDrive({int? lastBlockHeight}) async {
+    await db.into(db.drives).insert(
+          DrivesCompanion.insert(
+            id: driveId,
+            name: 'Test Drive',
+            ownerAddress: ownerAddress,
+            rootFolderId: rootFolderId,
+            privacy: DrivePrivacyTag.public,
+            lastBlockHeight: Value(lastBlockHeight),
+          ),
+        );
+
+    await db.into(db.folderEntries).insert(
+          FolderEntriesCompanion.insert(
+            id: rootFolderId,
+            driveId: driveId,
+            name: 'Test Drive',
+            path: '',
+          ),
+        );
+  }
+
+  /// The signal that the root folder's metadata has actually been read.
+  Future<void> insertRootFolderRevision() async {
+    await driveDao.insertFolderRevision(
+      FolderRevisionsCompanion.insert(
+        folderId: rootFolderId,
+        driveId: driveId,
+        name: 'Test Drive',
+        metadataTxId: 'metadata-tx-id',
+        action: RevisionAction.create,
+      ),
+    );
+  }
+
+  /// Contents, via a subfolder rather than a file: `driveIsEmpty` counts both,
+  /// and the folder listing is a plain query, where the file listing joins
+  /// revisions and network transactions that say nothing about this behaviour.
+  Future<void> insertSubfolder(String folderId) async {
+    await db.into(db.folderEntries).insert(
+          FolderEntriesCompanion.insert(
+            id: folderId,
+            driveId: driveId,
+            parentFolderId: const Value(rootFolderId),
+            name: folderId,
+            path: '',
+          ),
+        );
+  }
+
+  DriveDetailCubit buildCubit() => DriveDetailCubit(
+        driveId: driveId,
+        profileCubit: profileCubit,
+        driveDao: driveDao,
+        configService: configService,
+        activityTracker: activityTracker,
+        auth: auth,
+        breadcrumbBuilder: breadcrumbBuilder,
+        syncCubit: syncCubit,
+        driveRepository: driveRepository,
+      );
+
+  setUp(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    SharedPreferences.setMockInitialValues({});
+
+    db = getTestDb();
+    driveDao = db.driveDao;
+
+    driveRepository = MockDriveRepository();
+    syncCubit = MockSyncBloc();
+    profileCubit = MockProfileCubit();
+    activityTracker = MockActivityTracker();
+    breadcrumbBuilder = MockBreadcrumbBuilder();
+    auth = MockArDriveAuth();
+    configService = MockConfigService();
+    syncStates = StreamController<SyncState>.broadcast();
+
+    when(() => driveRepository.watchDrive(driveId: any(named: 'driveId')))
+        .thenAnswer((invocation) => driveDao
+            .driveById(
+              driveId: invocation.namedArguments[#driveId] as String,
+            )
+            .watchSingleOrNull());
+
+    when(() => syncCubit.waitCurrentSync()).thenAnswer((_) async {});
+    whenListen(syncCubit, syncStates.stream, initialState: SyncIdle());
+
+    // The cubit reads the profile through `stream.startWith(...)`, so an empty
+    // stream is enough: it renders as a logged-out viewer without write
+    // permissions, which none of these assertions depend on.
+    whenListen(
+      profileCubit,
+      const Stream<ProfileState>.empty(),
+      initialState: ProfileCheckingAvailability(),
+    );
+
+    when(() => activityTracker.isUploading).thenReturn(false);
+    when(() => breadcrumbBuilder.buildForFolder(
+          folderId: any(named: 'folderId'),
+          rootFolderId: any(named: 'rootFolderId'),
+          driveId: any(named: 'driveId'),
+        )).thenAnswer((_) async => []);
+  });
+
+  tearDown(() async {
+    await syncStates.close();
+    await db.close();
+  });
+
+  group('DriveDetailCubit empty vs unsynced', () {
+    /// The regression that matters most: an unsynced drive rendering as an
+    /// empty one tells the user their files are gone.
+    blocTest<DriveDetailCubit, DriveDetailState>(
+      'says "not synced" for a drive whose root metadata never arrived',
+      setUp: () => insertDrive(lastBlockHeight: 0),
+      build: buildCubit,
+      wait: const Duration(milliseconds: 100),
+      verify: (cubit) {
+        expect(cubit.state, isA<DriveDetailLoadUnsynced>());
+      },
+    );
+
+    /// The mirror case, and the reason `lastBlockHeight` cannot be the signal:
+    /// a drive created in-app writes a root revision but never advances its
+    /// watermark, so gating on the watermark would tell someone who just made
+    /// a drive that it needs syncing before they can use it.
+    blocTest<DriveDetailCubit, DriveDetailState>(
+      'renders a locally created empty drive as empty, not unsynced',
+      setUp: () async {
+        await insertDrive(lastBlockHeight: 0);
+        await insertRootFolderRevision();
+      },
+      build: buildCubit,
+      wait: const Duration(milliseconds: 100),
+      verify: (cubit) {
+        final state = cubit.state;
+        expect(state, isA<DriveDetailLoadSuccess>());
+        expect((state as DriveDetailLoadSuccess).driveIsEmpty, isTrue);
+      },
+    );
+
+    blocTest<DriveDetailCubit, DriveDetailState>(
+      'renders a drive that has contents',
+      setUp: () async {
+        await insertDrive(lastBlockHeight: 0);
+        await insertRootFolderRevision();
+        await insertSubfolder('subfolder-1');
+      },
+      build: buildCubit,
+      wait: const Duration(milliseconds: 100),
+      verify: (cubit) {
+        final state = cubit.state;
+        expect(state, isA<DriveDetailLoadSuccess>());
+        expect((state as DriveDetailLoadSuccess).driveIsEmpty, isFalse);
+      },
+    );
+
+    /// A drive that synced normally is opened on its watermark alone, without
+    /// depending on a revision row being present.
+    blocTest<DriveDetailCubit, DriveDetailState>(
+      'opens a drive whose watermark has advanced',
+      setUp: () async {
+        await insertDrive(lastBlockHeight: 100);
+        await insertRootFolderRevision();
+      },
+      build: buildCubit,
+      wait: const Duration(milliseconds: 100),
+      verify: (cubit) {
+        expect(cubit.state, isA<DriveDetailLoadSuccess>());
+      },
+    );
+  });
+
+  group('DriveDetailCubit recovery from unsynced', () {
+    /// An end-to-end guard: metadata arriving must clear the unsynced screen
+    /// even though the watermark never moves. It does not pin any particular
+    /// path - recovery here comes from the folder stream re-firing, so this
+    /// still passes if the sync-completion handler regresses. The
+    /// syncCurrentDrive test below is the one that holds that behaviour.
+    blocTest<DriveDetailCubit, DriveDetailState>(
+      'recovers when the root revision arrives, even with a 0 watermark',
+      setUp: () => insertDrive(lastBlockHeight: 0),
+      build: buildCubit,
+      act: (cubit) async {
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        expect(cubit.state, isA<DriveDetailLoadUnsynced>(),
+            reason: 'precondition: the drive starts out unsynced');
+
+        // Metadata lands, but the watermark never moves.
+        await insertRootFolderRevision();
+        syncStates.add(SyncIdle());
+
+        await Future<void>.delayed(const Duration(milliseconds: 200));
+      },
+      verify: (cubit) {
+        expect(cubit.state, isA<DriveDetailLoadSuccess>());
+      },
+    );
+
+    /// [DriveDetailCubit.syncCurrentDrive] emits directly rather than through
+    /// the folder stream, so it is where an entry/exit mismatch actually
+    /// traps the user: pressing "Sync now" on a drive whose metadata has
+    /// arrived, but whose watermark never moved, re-emitted the same unsynced
+    /// state - the button led back to the screen that offered it.
+    /// Asserted on the emissions rather than the final state, and that is the
+    /// whole point. The folder subscription is still live here, and writing the
+    /// revision touches tables it watches, so the stream re-fires and repairs
+    /// the state a moment later no matter what this path emitted. Checking
+    /// where the cubit ends up therefore passes even when the button is
+    /// broken; only the sequence shows the user being bounced back to the
+    /// screen they just acted on.
+    test(
+        'syncCurrentDrive() does not land back on the unsynced screen when '
+        'metadata arrived with a 0 watermark', () async {
+      await insertDrive(lastBlockHeight: 0);
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      expect(cubit.state, isA<DriveDetailLoadUnsynced>(),
+          reason: 'precondition: the drive starts out unsynced');
+
+      // The sync writes the root revision but never advances the watermark.
+      when(() => syncCubit.startSyncForDrive(
+            driveId: any(named: 'driveId'),
+            deepSync: any(named: 'deepSync'),
+          )).thenAnswer((_) async => insertRootFolderRevision());
+
+      final emitted = <DriveDetailState>[];
+      final subscription = cubit.stream.listen(emitted.add);
+
+      await cubit.syncCurrentDrive();
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+      await subscription.cancel();
+
+      expect(
+        emitted.whereType<DriveDetailLoadUnsynced>(),
+        isEmpty,
+        reason: 'pressing "Sync now" must not return to "Drive Not Synced" '
+            'once the root metadata is readable',
+      );
+      expect(cubit.state, isA<DriveDetailLoadSuccess>());
+    });
+
+    blocTest<DriveDetailCubit, DriveDetailState>(
+      'stays unsynced while the root metadata is still missing',
+      setUp: () => insertDrive(lastBlockHeight: 0),
+      build: buildCubit,
+      act: (cubit) async {
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+
+        syncStates.add(SyncIdle());
+
+        await Future<void>.delayed(const Duration(milliseconds: 200));
+      },
+      verify: (cubit) {
+        expect(cubit.state, isA<DriveDetailLoadUnsynced>());
+      },
+    );
+  });
+}

--- a/test/models/daos/drive_dao_test.dart
+++ b/test/models/daos/drive_dao_test.dart
@@ -1,4 +1,6 @@
+import 'package:ardrive/entities/entities.dart';
 import 'package:ardrive/models/models.dart';
+import 'package:ardrive_utils/ardrive_utils.dart';
 import 'package:test/test.dart';
 
 import '../../test_utils/utils.dart';
@@ -170,6 +172,99 @@ void main() {
         final file = filesInFolderTree[i];
         expect(file.id, equals(expectedTreeResults[i][0]));
       }
+    });
+  });
+
+  /// A drive row whose `rootFolderId` has no folder row cannot be opened:
+  /// `watchFolderContents` filters the absent folder out and its stream then
+  /// never emits, so the explorer sits on a spinner nothing retries. Every path
+  /// that writes a drive must therefore also leave a root folder behind.
+  group('DriveDao root folder guarantee', () {
+    const otherDriveId = 'placeholder-drive-id';
+    const otherRootFolderId = 'placeholder-root-folder-id';
+    const driveName = 'Placeholder Drive';
+    const ownerAddress = 'owner-address';
+
+    DriveEntity driveEntity({String name = driveName}) => DriveEntity(
+          id: otherDriveId,
+          name: name,
+          rootFolderId: otherRootFolderId,
+          privacy: DrivePrivacyTag.public,
+          authMode: DriveAuthModeTag.none,
+        )..ownerAddress = ownerAddress;
+
+    setUp(() async {
+      db = getTestDb();
+      driveDao = db.driveDao;
+    });
+
+    tearDown(() async {
+      await db.close();
+    });
+
+    test('updateUserDrives() writes a root folder the drive can be opened from',
+        () async {
+      await driveDao.updateUserDrives({driveEntity(): null}, null);
+
+      final rootFolder = await driveDao
+          .folderById(folderId: otherRootFolderId)
+          .getSingleOrNull();
+
+      expect(rootFolder, isNotNull);
+      expect(rootFolder!.driveId, equals(otherDriveId));
+
+      // The point of the row: the drive mounts instead of hanging.
+      await expectLater(
+        driveDao.watchFolderContents(otherDriveId).map((f) => f.folder.id),
+        emits(otherRootFolderId),
+      );
+    });
+
+    test('updateUserDrives() does not overwrite an already synced root folder',
+        () async {
+      await driveDao.updateUserDrives({driveEntity(): null}, null);
+
+      // The real metadata lands, renaming the root folder.
+      await driveDao.updateFolderEntries([
+        FolderEntriesCompanion.insert(
+          id: otherRootFolderId,
+          driveId: otherDriveId,
+          name: 'Real Root Name',
+          path: '',
+        ),
+      ]);
+
+      // A later sync re-runs the same insert.
+      await driveDao.updateUserDrives({driveEntity(): null}, null);
+
+      final rootFolder =
+          await driveDao.folderById(folderId: otherRootFolderId).getSingle();
+
+      expect(rootFolder.name, equals('Real Root Name'));
+    });
+
+    test('root folder placeholder is not marked as a ghost', () async {
+      await driveDao.updateUserDrives({driveEntity(): null}, null);
+
+      final rootFolder =
+          await driveDao.folderById(folderId: otherRootFolderId).getSingle();
+
+      // `FolderRevisionsCompanion.toEntryCompanion` omits `isGhost`, and the
+      // upsert that lands real metadata leaves absent columns alone - so a
+      // placeholder marked as a ghost would stay one forever.
+      expect(rootFolder.isGhost, isFalse);
+      expect(rootFolder.parentFolderId, isNull);
+    });
+
+    test('writeDriveEntity() writes a root folder too', () async {
+      await driveDao.writeDriveEntity(name: driveName, entity: driveEntity());
+
+      final rootFolder = await driveDao
+          .folderById(folderId: otherRootFolderId)
+          .getSingleOrNull();
+
+      expect(rootFolder, isNotNull);
+      expect(rootFolder!.name, equals(driveName));
     });
   });
 }

--- a/test/models/daos/drive_dao_test.dart
+++ b/test/models/daos/drive_dao_test.dart
@@ -256,6 +256,51 @@ void main() {
       expect(rootFolder.parentFolderId, isNull);
     });
 
+    /// What tells "genuinely empty" apart from "never synced". A drive created
+    /// in-app writes a root folder revision at creation time, and sync writes
+    /// one when the real metadata lands; a drive merely discovered by
+    /// `updateUserDrives` has only the placeholder until then. Claiming a drive
+    /// is empty on weaker evidence reads to the user as data loss.
+    test('a discovered drive has no root folder revision until one syncs',
+        () async {
+      await driveDao.updateUserDrives({driveEntity(): null}, null);
+
+      final beforeSync = await driveDao
+          .latestFolderRevisionByFolderId(
+            driveId: otherDriveId,
+            folderId: otherRootFolderId,
+          )
+          .getSingleOrNull();
+
+      expect(beforeSync, isNull,
+          reason: 'the placeholder must not read as synced metadata');
+
+      // lastBlockHeight cannot stand in for this: it defaults to 0, so it
+      // cannot tell a freshly created empty drive from an unsynced one.
+      final drive =
+          await driveDao.driveById(driveId: otherDriveId).getSingle();
+      expect(drive.lastBlockHeight, equals(0));
+
+      await driveDao.insertFolderRevision(
+        FolderRevisionsCompanion.insert(
+          folderId: otherRootFolderId,
+          driveId: otherDriveId,
+          name: 'Real Root Name',
+          metadataTxId: 'metadata-tx-id',
+          action: RevisionAction.create,
+        ),
+      );
+
+      final afterSync = await driveDao
+          .latestFolderRevisionByFolderId(
+            driveId: otherDriveId,
+            folderId: otherRootFolderId,
+          )
+          .getSingleOrNull();
+
+      expect(afterSync, isNotNull);
+    });
+
     test('writeDriveEntity() writes a root folder too', () async {
       await driveDao.writeDriveEntity(name: driveName, entity: driveEntity());
 

--- a/test/services/arweave/data_gateway_fallback_test.dart
+++ b/test/services/arweave/data_gateway_fallback_test.dart
@@ -211,6 +211,63 @@ void main() {
       verify(() => arioSDK.getGateways()).called(1);
     });
 
+    /// A gateway mid-index answers 404 and then 200 a moment later, which
+    /// `fetchDataForSync` already accounts for. Walking away from the
+    /// configured gateway on its first 404 is worst for exactly the data most
+    /// likely to be behind: something just uploaded through Turbo can be on
+    /// the configured gateway and nowhere else yet.
+    test('retries the configured gateway once on a 404, then succeeds',
+        () async {
+      var attempts = 0;
+      when(() => primaryApi.getSandboxedTx(txId)).thenAnswer((_) async {
+        attempts++;
+        return attempts == 1
+            ? Response('not found', 404)
+            : Response('metadata', 200);
+      });
+
+      final response = await fallback.fetchData(txId, primaryClient);
+
+      expect(response.statusCode, 200);
+      expect(response.body, 'metadata');
+      verify(() => primaryApi.getSandboxedTx(txId)).called(2);
+    });
+
+    /// The extra attempt is for a gateway that is a beat behind, not one that
+    /// is unwell. A refusal or an error has already cost its timeout and says
+    /// the next gateway is the better bet.
+    test('does not retry the configured gateway on a non-404 failure',
+        () async {
+      // arweave.net as the primary so it is the only client in the list, which
+      // keeps the assertion about retries free of any real network call.
+      when(() => primaryApi.gatewayUrl)
+          .thenReturn(Uri.parse('https://arweave.net'));
+      when(() => primaryApi.getSandboxedTx(txId))
+          .thenAnswer((_) async => Response('server error', 500));
+
+      await expectLater(
+        fallback.fetchData(txId, primaryClient),
+        throwsA(isA<Object>()),
+      );
+
+      verify(() => primaryApi.getSandboxedTx(txId)).called(1);
+    });
+
+    test('a persistent 404 on the configured gateway is still not found',
+        () async {
+      when(() => primaryApi.gatewayUrl)
+          .thenReturn(Uri.parse('https://arweave.net'));
+      when(() => primaryApi.getSandboxedTx(txId))
+          .thenAnswer((_) async => Response('not found', 404));
+
+      await expectLater(
+        fallback.fetchData(txId, primaryClient),
+        throwsA(isA<TransactionNotFound>()),
+      );
+
+      verify(() => primaryApi.getSandboxedTx(txId)).called(2);
+    });
+
     test('a drive signature read on the sync path never reaches the GAR',
         () async {
       // Drive discovery fetches this for every private drive whose key is not


### PR DESCRIPTION
> Stacked on #2181 (`PE-9205-drive-root-folder-resilience`). Review that first; this PR's diff is only the last commit.

## What was happening

Logging in with a wallet holding a private drive: the drive entity read hits the configured gateway, gets a **404**, and immediately moves to `arweave.net` — never retrying the configured gateway.

## Why

PE-9203 moved sync onto the configured gateway alone. But the split was made by *who asked* rather than *how the read behaves*:

- `fetchDataForSync` — configured gateway, 2 attempts, no GAR, no Solana RPC
- `fetchData` — primary → up to 2 GAR → `arweave.net`, **each tried once**

`getLatestDriveEntityWithId` was filed under "single user-initiated operations", so login took the waterfall. But login is bulk, at startup, with the user watching a spinner — exactly the profile PE-9203 was written to protect. It also asks `ArioSDK.getGateways()`, costing a Solana RPC on the startup path.

That also explains why there was no GAR hop in between: `_buildClientList` caches an empty list when the RPC fails or exceeds its 5s timeout, collapsing the waterfall to `primary → arweave.net`.

## Changes

**1. Classify the read by behavior.** `getLatestDriveEntityWithId` takes `configuredGatewayOnly`, and `_validateUser` (login) passes it. Attaching a drive by id is deliberately untouched — that's one read a user is waiting on and can retry, where breadth is worth its cost. This mirrors the `forSync` split already in `_getDriveSignature`.

**2. Give the waterfall's configured gateway one retry, on 404 only.** `_syncFetch` already does this, with reasoning that applies at least as well here:

> A gateway that has not finished indexing a transaction answers 404 for it, and answers 200 a moment later.

Leaving on the first 404 is worst for the data most likely to be behind: something just uploaded through Turbo can be on the configured gateway and **not yet anywhere else**, so falling through reaches gateways further behind it, not ahead. Deliberately not extended to timeouts or socket errors — those have already spent their 5s and say the gateway is unwell rather than a beat behind, so the next gateway is the better bet and the 25s total budget stays intact.

## Verification

- `flutter analyze` clean; 1337 tests pass
- Both new fallback tests were **mutation checked** against a single-attempt primary and fail without the fix
- Auth test stubs gained the new named argument — without it mocktail stops matching and returns null, which is what the 4 initial failures were

## Not included

`_buildClientList` still caches an **empty** GAR list for the whole session, so one slow Solana RPC silently disables GAR fallback for every later read. Real, but a separate change — happy to do it next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DnYLXFocWgTt9M2CbGYSUP