### PR TITLE
PE-9205: Sync read timeouts sized for metadata were being applied to 44 MiB snapshots

### DIFF
--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -815,8 +815,19 @@ class ArweaveService {
   /// Uses [DataGatewayFallback.fetchDataForSync] — configured gateway only,
   /// one retry, one last-resort hop, no GAR and therefore no Solana RPC.
   /// Download/preview/thumbnail/share paths keep the full waterfall.
-  Future<Uint8List> getEntityDataFromNetwork({required String txId}) async {
-    final Response data = await _gatewayFallback.fetchDataForSync(txId, client);
+  /// [largeBody] gives the read the budget a snapshot needs. The default is
+  /// sized for metadata - a few hundred bytes - and a snapshot body is tens of
+  /// megabytes, which cannot finish inside it at any realistic connection
+  /// speed. See [DataGatewayFallback.largeBodyRequestTimeout].
+  Future<Uint8List> getEntityDataFromNetwork({
+    required String txId,
+    bool largeBody = false,
+  }) async {
+    final Response data = await _gatewayFallback.fetchDataForSync(
+      txId,
+      client,
+      largeBody: largeBody,
+    );
     return data.bodyBytes;
   }
 

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -294,6 +294,8 @@ class ArweaveService {
     required String ownerAddress,
   }) async* {
     String cursor = '';
+    var yielded = 0;
+    var page = 0;
 
     while (true) {
       try {
@@ -308,6 +310,17 @@ class ArweaveService {
           ),
         );
         final edges = snapshotEntityHistoryQuery.data!.transactions.edges;
+        page++;
+        yielded += edges.length;
+
+        // What the index actually returned, before anything downstream
+        // filters it. This is the number that separates "the gateway did not
+        // tell us about the snapshot" from "we knew about it and could not
+        // use it" - the two have completely different fixes, and without this
+        // they look identical from the outside.
+        logger.i('[snapshot] gql page $page for $driveIds (min block '
+            '$minBlockHeight): ${edges.length} found');
+
         for (final edge in edges) {
           yield edge.node;
         }
@@ -324,11 +337,22 @@ class ArweaveService {
           break;
         }
       } catch (e) {
-        logger.e('Error fetching snapshots for drives $driveIds', e);
-        logger.i('These drives will fall back to GQL');
+        // Note what was already yielded: the caller keeps those, so a failure
+        // here can leave a drive with *some* of its snapshots - typically the
+        // newest, since the query is HEIGHT_DESC - rather than none. That
+        // reads downstream as a smaller snapshot than expected rather than an
+        // error, so the count matters as much as the exception.
+        logger.e(
+          '[snapshot] gql failed for $driveIds after $yielded found '
+          'across $page page(s); those already found are still used, the '
+          'rest of the range falls back to GraphQL',
+          e,
+        );
         break;
       }
     }
+
+    logger.i('[snapshot] gql returned $yielded total for $driveIds');
   }
 
   /// Probes which drives have any new transactions since [minBlockHeight].

--- a/lib/services/arweave/data_gateway_fallback.dart
+++ b/lib/services/arweave/data_gateway_fallback.dart
@@ -83,10 +83,26 @@ class DataGatewayFallback {
   /// Delay before the single same-gateway retry in [fetchDataForSync].
   static const _syncRetryDelay = Duration(milliseconds: 300);
 
-  /// Upper bound for one sync read. By construction the attempts already sum
-  /// to ~10.3s; this only guards against an attempt that outlives its own
-  /// timeout.
-  static const _syncTotalFetchTimeout = Duration(seconds: 15);
+  /// Upper bound for one sync read.
+  ///
+  /// This has to clear what the attempts themselves can spend, or it silently
+  /// becomes the real limit: [syncMaxAttempts] attempts at [_requestTimeout]
+  /// plus one [_syncRetryDelay] is 20.3s, so a 15s cap - correct when an
+  /// attempt was 5s - would cut the second attempt off at 4.7s and make the
+  /// retry weaker than the try it was retrying.
+  ///
+  /// It is a backstop against an attempt that outlives its own timeout, not a
+  /// budget in its own right, so it sits just above that sum.
+  static const _syncTotalFetchTimeout = Duration(seconds: 22);
+
+  /// Exposed so a test can assert the relationship between these budgets
+  /// rather than restate their values, which is what drifted.
+  @visibleForTesting
+  static const syncRequestTimeoutForTest = _requestTimeout;
+  @visibleForTesting
+  static const syncRetryDelayForTest = _syncRetryDelay;
+  @visibleForTesting
+  static const syncTotalFetchTimeoutForTest = _syncTotalFetchTimeout;
 
   /// Cached gateway list — shared with other services (e.g.
   /// SnapshotValidationService) to avoid duplicate Solana RPC calls.

--- a/lib/services/arweave/data_gateway_fallback.dart
+++ b/lib/services/arweave/data_gateway_fallback.dart
@@ -5,9 +5,9 @@ import 'package:ardrive/download/download_exceptions.dart';
 import 'package:ardrive/services/arweave/arweave_service.dart';
 import 'package:ardrive/utils/logger.dart';
 import 'package:ario_sdk/ario_sdk.dart';
-import 'package:flutter/foundation.dart';
 import 'package:arweave/arweave.dart';
 import 'package:arweave/arweave.dart' as arweave_pkg;
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart';
 
 /// Provides data gateway fallback resilience.
@@ -95,14 +95,15 @@ class DataGatewayFallback {
   /// budget in its own right, so it sits just above that sum.
   static const _syncTotalFetchTimeout = Duration(seconds: 22);
 
-  /// Exposed so a test can assert the relationship between these budgets
-  /// rather than restate their values, which is what drifted.
+  /// The sync read budgets, together, so a test can assert the relationship
+  /// between them rather than restate their values - restating them is what
+  /// drifted when [_requestTimeout] changed and the cap did not.
   @visibleForTesting
-  static const syncRequestTimeoutForTest = _requestTimeout;
-  @visibleForTesting
-  static const syncRetryDelayForTest = _syncRetryDelay;
-  @visibleForTesting
-  static const syncTotalFetchTimeoutForTest = _syncTotalFetchTimeout;
+  static const syncBudgets = (
+    request: _requestTimeout,
+    retryDelay: _syncRetryDelay,
+    total: _syncTotalFetchTimeout,
+  );
 
   /// Cached gateway list — shared with other services (e.g.
   /// SnapshotValidationService) to avoid duplicate Solana RPC calls.

--- a/lib/services/arweave/data_gateway_fallback.dart
+++ b/lib/services/arweave/data_gateway_fallback.dart
@@ -5,6 +5,7 @@ import 'package:ardrive/download/download_exceptions.dart';
 import 'package:ardrive/services/arweave/arweave_service.dart';
 import 'package:ardrive/utils/logger.dart';
 import 'package:ario_sdk/ario_sdk.dart';
+import 'package:flutter/foundation.dart';
 import 'package:arweave/arweave.dart';
 import 'package:arweave/arweave.dart' as arweave_pkg;
 import 'package:http/http.dart';
@@ -35,7 +36,36 @@ class DataGatewayFallback {
 
   static const _maxGarFallbacks = 2;
   static const _garListTimeout = Duration(seconds: 5);
-  static const _requestTimeout = Duration(seconds: 5);
+  /// How long one gateway read waits before being abandoned.
+  ///
+  /// Ten seconds, not five. Sync reads run through [ArweaveService.runPooled],
+  /// a worker pool with a shared cursor, so a read that hangs occupies one of
+  /// its `maxConcurrentDataFetches` slots while the other workers keep pulling
+  /// new items. A longer wait therefore costs throughput on one slot rather
+  /// than stalling the sync, which is what makes it affordable to be patient
+  /// enough for a gateway that is a beat behind rather than broken.
+  static const _requestTimeout = Duration(seconds: 10);
+
+  /// Per-read budget for a body measured in tens of megabytes.
+  ///
+  /// [_requestTimeout] is sized for the metadata reads that dominate sync -
+  /// a few hundred bytes each, hundreds of them. A snapshot is the same call
+  /// with four orders of magnitude more body: this drive's newest is 43.9 MiB,
+  /// and a warm gateway serves it in ~8s at ~5.7 MB/s. Under the metadata
+  /// budget it could never finish, on any connection slower than ~9 MB/s, no
+  /// matter how many times it was retried.
+  ///
+  /// Sixty seconds covers that body down to about 0.75 MB/s. Being generous is
+  /// cheap here in a way it is not for metadata: this is one request per
+  /// snapshot rather than one per entity, its availability has already been
+  /// established by a HEAD before the download starts
+  /// (`SnapshotValidationService`), and the alternative to waiting is
+  /// re-walking the snapshot's whole block range over GraphQL, which costs
+  /// minutes.
+  static const largeBodyRequestTimeout = Duration(seconds: 60);
+
+  /// Total budget for a large-body read, covering both attempts.
+  static const largeBodyTotalTimeout = Duration(seconds: 130);
   static const _totalFetchTimeout = Duration(seconds: 25);
   static const _hedgeDelay = Duration(milliseconds: 1500);
   static const _downloadTimeout = Duration(seconds: 15);
@@ -62,11 +92,21 @@ class DataGatewayFallback {
   /// SnapshotValidationService) to avoid duplicate Solana RPC calls.
   List<Gateway>? cachedGateways;
 
+  /// Injectable so a test can prove that [fetchDataForSync]'s `largeBody`
+  /// routes to a different budget without spending either of them.
+  final Duration _syncRequestTimeout;
+  final Duration _syncLargeBodyRequestTimeout;
+
   DataGatewayFallback({
     required ArioSDK arioSDK,
     Client Function()? clientFactory,
+    @visibleForTesting Duration? syncRequestTimeout,
+    @visibleForTesting Duration? syncLargeBodyRequestTimeout,
   })  : _arioSDK = arioSDK,
-        _clientFactory = clientFactory ?? Client.new;
+        _clientFactory = clientFactory ?? Client.new,
+        _syncRequestTimeout = syncRequestTimeout ?? _requestTimeout,
+        _syncLargeBodyRequestTimeout =
+            syncLargeBodyRequestTimeout ?? largeBodyRequestTimeout;
 
   /// Fetch transaction data with serial gateway fallback.
   ///
@@ -89,9 +129,9 @@ class DataGatewayFallback {
   /// consults the GAR, so no Solana RPC is issued on the sync path.
   ///
   /// Sync issues hundreds of these per run, where per-item attempt count
-  /// dominates: the [fetchData] waterfall costs up to 4 serial attempts at 5s
-  /// each, so a slow or flaky primary turns into minutes of serial timeouts.
-  /// Worst case here is [syncMaxAttempts] attempts / ~10.3s.
+  /// dominates: the [fetchData] waterfall costs up to 4 serial attempts, so a
+  /// slow or flaky primary turns into minutes of serial timeouts. Worst case
+  /// here is [syncMaxAttempts] attempts against one host.
   ///
   /// A 404 is retried like any other failure: a gateway that has not
   /// finished indexing a transaction answers 404 for it and 200 a moment
@@ -104,22 +144,41 @@ class DataGatewayFallback {
   /// `docs/SYNC_SKIPPED_ENTITY_PERSISTENCE.md`.
   ///
   /// If every attempt 404s, throws [TransactionNotFound].
-  Future<Response> fetchDataForSync(String txId, Arweave primaryClient) async {
-    return _syncFetch(txId, primaryClient)
-        .timeout(_syncTotalFetchTimeout, onTimeout: () {
+  ///
+  /// [largeBody] switches to [largeBodyRequestTimeout], for reads whose body
+  /// is measured in megabytes rather than bytes - snapshots. The default
+  /// budget is sized for metadata and cannot finish one.
+  Future<Response> fetchDataForSync(
+    String txId,
+    Arweave primaryClient, {
+    bool largeBody = false,
+  }) async {
+    return _syncFetch(txId, primaryClient, largeBody: largeBody).timeout(
+        largeBody ? largeBodyTotalTimeout : _syncTotalFetchTimeout,
+        onTimeout: () {
       logger.w('Total sync fetch timeout exceeded for tx $txId');
       throw Exception('Total sync fetch timeout exceeded for tx $txId');
     });
   }
 
-  Future<Response> _syncFetch(String txId, Arweave primaryClient) async {
+  Future<Response> _syncFetch(
+    String txId,
+    Arweave primaryClient, {
+    bool largeBody = false,
+  }) async {
     final gatewayName = primaryClient.api.gatewayUrl.host;
 
     var allAttempts404 = true;
 
     for (var attempt = 1; attempt <= syncMaxAttempts; attempt++) {
       try {
-        return await _tryGateway(primaryClient, txId);
+        return await _tryGateway(
+          primaryClient,
+          txId,
+          requestTimeout: largeBody
+              ? _syncLargeBodyRequestTimeout
+              : _syncRequestTimeout,
+        );
       } on _ErrorFromStatus catch (e) {
         // A 404 is NOT treated as final here, and the reasoning that said it
         // was is wrong for this case. A gateway that has not finished indexing
@@ -513,10 +572,14 @@ class DataGatewayFallback {
     return clients;
   }
 
-  Future<Response> _tryGateway(Arweave client, String txId) async {
+  Future<Response> _tryGateway(
+    Arweave client,
+    String txId, {
+    Duration? requestTimeout,
+  }) async {
     final response = await client.api
         .getSandboxedTx(txId)
-        .timeout(_requestTimeout);
+        .timeout(requestTimeout ?? _requestTimeout);
 
     if (response.statusCode >= 200 && response.statusCode <= 208) {
       return response;

--- a/lib/sync/data/snapshot_validation_service.dart
+++ b/lib/sync/data/snapshot_validation_service.dart
@@ -47,12 +47,14 @@ class SnapshotValidationService {
   /// pays the tail on every failure and still cannot outwait an unbounded one.
   /// Short probes are right, but only if they are spread out: retrying 300ms
   /// after a timeout just lands inside the same cold read and hangs again,
-  /// spending the whole budget to be told the same thing. These delays put the
-  /// four probes at roughly t=0s, 6s, 14s and 25s, so the later ones get a
-  /// chance to land after a cold read has finished and the answer is cached.
+  /// spending the whole budget to be told the same thing. Against the 10s
+  /// [_defaultHeadTimeout], these delays start the four probes at roughly
+  /// t=0s, 11s, 24s and 40s, so the later ones get a chance to land after a
+  /// cold read has finished and the answer is cached.
   ///
-  /// Worst case is ~30s for a snapshot that never answers. That is the right
-  /// trade against re-walking its block range, which costs minutes.
+  /// Worst case is ~50s for a snapshot that never answers once, and the common
+  /// case is one probe of well under a second. That is the right trade against
+  /// re-walking its block range, which costs minutes.
   static const _defaultRetryDelays = <Duration>[
     Duration(seconds: 1),
     Duration(seconds: 3),
@@ -64,17 +66,30 @@ class SnapshotValidationService {
   /// One probe, plus one more after each delay.
   int get _maxAttempts => _retryDelays.length + 1;
 
-  /// Injectable so the retry behaviour can be tested without a network and
-  /// without spending its real delays in wall-clock time.
-  final http.Client _httpClient;
+  /// Builds the client for a single probe.
+  ///
+  /// One client per attempt, rather than one for the service, because
+  /// `Future.timeout` abandons a response without cancelling the request that
+  /// would have produced it. Closing the client does cancel it, and a probe
+  /// that has timed out is exactly a request nothing is waiting for any more.
+  ///
+  /// Left pending they accumulate: four attempts across three concurrent
+  /// validations is up to twelve requests outstanding against a gateway
+  /// already too slow to answer one. On the web that is the worse half of the
+  /// problem - browsers cap concurrent connections per host at around six, so
+  /// abandoned probes would crowd out the reads sync makes to the same
+  /// gateway immediately afterwards.
+  ///
+  /// Injectable so the retry behaviour can be tested without a network.
+  final http.Client Function() _clientFactory;
 
   SnapshotValidationService({
     required ConfigService configService,
-    @visibleForTesting http.Client? httpClient,
+    @visibleForTesting http.Client Function()? clientFactory,
     @visibleForTesting List<Duration>? retryDelays,
     @visibleForTesting Duration? headTimeout,
   })  : _configService = configService,
-        _httpClient = httpClient ?? http.Client(),
+        _clientFactory = clientFactory ?? http.Client.new,
         _retryDelays = retryDelays ?? _defaultRetryDelays,
         _headTimeout = headTimeout ?? _defaultHeadTimeout;
 
@@ -129,10 +144,13 @@ class SnapshotValidationService {
   /// remains available, which is why the budget here is what it is.
   Future<bool> _validateSnapshot(String txId, String primaryUrl) async {
     for (var attempt = 1; attempt <= _maxAttempts; attempt++) {
+      final client = _clientFactory();
+
       try {
-        final response = await _httpClient
-            .head(Uri.parse('$primaryUrl/$txId'))
-            .timeout(_headTimeout);
+        final response =
+            await client.head(Uri.parse('$primaryUrl/$txId')).timeout(
+                  _headTimeout,
+                );
 
         if (response.statusCode == 200 || response.statusCode == 302) {
           return true;
@@ -158,6 +176,10 @@ class SnapshotValidationService {
       } catch (e) {
         logger.w('Snapshot $txId: HEAD error '
             '(attempt $attempt/$_maxAttempts): $e');
+      } finally {
+        // Cancels the request if this attempt timed out, and is harmless once
+        // a response has arrived - a HEAD has no body left to read.
+        client.close();
       }
 
       if (attempt < _maxAttempts) {

--- a/lib/sync/data/snapshot_validation_service.dart
+++ b/lib/sync/data/snapshot_validation_service.dart
@@ -200,8 +200,8 @@ class SnapshotValidationService {
       }
     }
 
-    logger.w('Snapshot $txId rejected after $_maxAttempts attempts, '
-        'falling back to GQL for its range');
+    logger.w('[snapshot] $txId unreachable on $primaryUrl after '
+        '$_maxAttempts attempts, so its block range falls back to GraphQL');
 
     return false;
   }

--- a/lib/sync/data/snapshot_validation_service.dart
+++ b/lib/sync/data/snapshot_validation_service.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:ardrive/services/config/config_service.dart';
 import 'package:ardrive/utils/logger.dart';
 import 'package:ardrive/utils/snapshots/snapshot_item.dart';
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 
 class SnapshotValidationService {
@@ -11,19 +12,53 @@ class SnapshotValidationService {
   static const _headTimeout = Duration(seconds: 5);
   static const _maxConcurrentValidations = 3;
 
-  /// Attempts against the configured gateway before a snapshot is rejected.
+  /// Delay *before* each retry, indexed by the attempt just finished.
   ///
-  /// Two, the same budget a sync metadata read gets - and the case for it is
-  /// stronger here. Losing a metadata read costs one entity; losing a snapshot
-  /// costs its entire block range, which sync then has to re-query over
-  /// GraphQL. The expensive failure should not be the one with fewer chances.
-  static const _maxAttempts = 2;
+  /// Its length sets the retry budget. Losing a metadata read costs one
+  /// entity; losing a snapshot costs its entire block range, which sync then
+  /// re-queries over GraphQL - for an old drive that is thousands of
+  /// transactions and the ghost folders that come with them. The expensive
+  /// failure should not be the one given the fewest chances, so this budget is
+  /// deliberately larger than a metadata read's.
+  ///
+  /// Measured against turbo-gateway.com on a live snapshot (Aug 2026), the
+  /// response time is bimodal rather than merely slow: 0.69s, 0.96s and 22.9s
+  /// on three tries, and no response at all within 45s on the other two. The
+  /// shape is consistent with a cold read fetching the data before it can
+  /// answer, and answering from cache once it has.
+  ///
+  /// That shape decides the strategy. A longer timeout is the wrong lever - it
+  /// pays the tail on every failure and still cannot outwait an unbounded one.
+  /// Short probes are right, but only if they are spread out: retrying 300ms
+  /// after a timeout just lands inside the same cold read and hangs again,
+  /// spending the whole budget to be told the same thing. These delays put the
+  /// four probes at roughly t=0s, 6s, 14s and 25s, so the later ones get a
+  /// chance to land after a cold read has finished and the answer is cached.
+  ///
+  /// Worst case is ~30s for a snapshot that never answers. That is the right
+  /// trade against re-walking its block range, which costs minutes.
+  static const _defaultRetryDelays = <Duration>[
+    Duration(seconds: 1),
+    Duration(seconds: 3),
+    Duration(seconds: 6),
+  ];
 
-  static const _retryDelay = Duration(milliseconds: 300);
+  final List<Duration> _retryDelays;
+
+  /// One probe, plus one more after each delay.
+  int get _maxAttempts => _retryDelays.length + 1;
+
+  /// Injectable so the retry behaviour can be tested without a network and
+  /// without spending its real delays in wall-clock time.
+  final http.Client _httpClient;
 
   SnapshotValidationService({
     required ConfigService configService,
-  }) : _configService = configService;
+    @visibleForTesting http.Client? httpClient,
+    @visibleForTesting List<Duration>? retryDelays,
+  })  : _configService = configService,
+        _httpClient = httpClient ?? http.Client(),
+        _retryDelays = retryDelays ?? _defaultRetryDelays;
 
   Future<List<SnapshotItem>> validateSnapshotItems(
     List<SnapshotItem> snapshotItems,
@@ -63,18 +98,21 @@ class SnapshotValidationService {
 
   /// Validates a snapshot is available on the configured gateway.
   ///
-  /// Single HEAD against the configured gateway; anything other than 200/302
-  /// rejects the snapshot and sync falls back to GQL for that range, which is
-  /// correct (just slower) in every case.
+  /// Up to [_maxAttempts] HEADs against the configured gateway, spaced by
+  /// [_retryDelays]; anything other than 200/302 on every one of them rejects
+  /// the snapshot, and sync falls back to GQL for that range - correct, but
+  /// expensive enough that it is worth several probes to avoid.
   ///
-  /// There is deliberately no GAR fallback here. It only ever ran for
-  /// transient errors, and it cost a Solana RPC via `ArioSDK.getGateways()` —
-  /// the sync path must not issue one. Rejecting a snapshot is cheap and safe;
-  /// paying a Solana round-trip to maybe save a GQL range is not.
+  /// There is deliberately no GAR fallback here, and no second host of any
+  /// kind. The GAR cost a Solana RPC via `ArioSDK.getGateways()`, which the
+  /// sync path must not issue; reaching past the configured gateway to a
+  /// hardcoded one is a product decision that has been made the other way.
+  /// Spending more attempts on the configured gateway is the resilience that
+  /// remains available, which is why the budget here is what it is.
   Future<bool> _validateSnapshot(String txId, String primaryUrl) async {
     for (var attempt = 1; attempt <= _maxAttempts; attempt++) {
       try {
-        final response = await http
+        final response = await _httpClient
             .head(Uri.parse('$primaryUrl/$txId'))
             .timeout(_headTimeout);
 
@@ -105,7 +143,7 @@ class SnapshotValidationService {
       }
 
       if (attempt < _maxAttempts) {
-        await Future.delayed(_retryDelay);
+        await Future.delayed(_retryDelays[attempt - 1]);
       }
     }
 

--- a/lib/sync/data/snapshot_validation_service.dart
+++ b/lib/sync/data/snapshot_validation_service.dart
@@ -152,7 +152,20 @@ class SnapshotValidationService {
                   _headTimeout,
                 );
 
-        if (response.statusCode == 200 || response.statusCode == 302) {
+        // Only a completed redirect chain counts.
+        //
+        // A gateway answers `/{txId}` with a 302 to its own sandbox subdomain
+        // and serves the body from there, and every client this runs on
+        // follows that: `BrowserClient` cannot be told not to, and `IOClient`
+        // follows by default. So a 302 that reaches this line is a chain that
+        // did *not* complete - the redirect limit was hit, or following was
+        // disabled - which is precisely the case where the body was never
+        // reached and availability is unproven.
+        //
+        // Accepting it anyway would validate exactly the snapshot this
+        // service exists to reject: one of this user's dead snapshots answers
+        // 302 on the first hop and 404 on the sandbox host it points at.
+        if (response.statusCode == 200) {
           return true;
         }
 

--- a/lib/sync/data/snapshot_validation_service.dart
+++ b/lib/sync/data/snapshot_validation_service.dart
@@ -9,8 +9,24 @@ import 'package:http/http.dart' as http;
 class SnapshotValidationService {
   final ConfigService _configService;
 
-  static const _headTimeout = Duration(seconds: 5);
+  /// How long one probe waits before being abandoned.
+  ///
+  /// Ten seconds, not five. Measured across three live snapshots of one drive
+  /// (Aug 2026), turbo-gateway answered 12 probes in 0.68-6.08s with a single
+  /// hang - and two of those, at 5.85s and 6.08s, were healthy answers that a
+  /// 5s cutoff threw away. Nothing about that band is a failure; it is a
+  /// gateway that had to fetch before it could answer.
+  ///
+  /// It is not raised further than that. A hung read here does not come back
+  /// in 20s or 30s - it did not come back within 45 - so a bigger number buys
+  /// no successes and delays every rejection. Ten clears the observed healthy
+  /// band with margin and stops there; the retries below cover the rest.
+  static const _defaultHeadTimeout = Duration(seconds: 10);
+
   static const _maxConcurrentValidations = 3;
+
+  /// Injectable so a timeout can be exercised in a test without spending one.
+  final Duration _headTimeout;
 
   /// Delay *before* each retry, indexed by the attempt just finished.
   ///
@@ -56,9 +72,11 @@ class SnapshotValidationService {
     required ConfigService configService,
     @visibleForTesting http.Client? httpClient,
     @visibleForTesting List<Duration>? retryDelays,
+    @visibleForTesting Duration? headTimeout,
   })  : _configService = configService,
         _httpClient = httpClient ?? http.Client(),
-        _retryDelays = retryDelays ?? _defaultRetryDelays;
+        _retryDelays = retryDelays ?? _defaultRetryDelays,
+        _headTimeout = headTimeout ?? _defaultHeadTimeout;
 
   Future<List<SnapshotItem>> validateSnapshotItems(
     List<SnapshotItem> snapshotItems,

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -1658,8 +1658,12 @@ class _SyncRepository implements SyncRepository {
       // thousands of transactions and minutes of work. At info level
       // deliberately: when a sync is inexplicably slow, this is the first
       // thing worth seeing, and it is one line per drive.
+      // `Range.end` is inclusive - `isInRange` tests `value <= end`, and
+      // `union` treats `end + 1 == start` as contiguous - so the count has to
+      // include both endpoints. Without the +1 a single-block range reports
+      // zero, which is the one number this line must never print wrongly.
       int blocksIn(HeightRange r) =>
-          r.rangeSegments.fold(0, (sum, s) => sum + (s.end - s.start));
+          r.rangeSegments.fold(0, (sum, s) => sum + (s.end - s.start + 1));
 
       final fromSnapshots = blocksIn(snapshotDriveHistory.subRanges);
       final fromGql = blocksIn(gqlDriveHistorySubRanges);

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -1588,10 +1588,9 @@ class _SyncRepository implements SyncRepository {
     // Wrap snapshot processing in try/finally to ensure disposal
     try {
       if (_configService.config.enableSyncFromSnapshot) {
-        logger.i('Syncing from snapshot: ${drive.id}');
-
         // Use prefetched snapshots if available (batched query),
         // otherwise fall back to per-drive query
+        final source = prefetchedSnapshots != null ? 'prefetched' : 'per-drive';
         final snapshotsStream = prefetchedSnapshots != null
             ? Stream.fromIterable(prefetchedSnapshots)
             : _arweave.getAllSnapshotsOfDrive(
@@ -1603,10 +1602,29 @@ class _SyncRepository implements SyncRepository {
           arweave: _arweave,
         ).toList();
 
+        logger.i('[snapshot] $driveId: ${snapshotItems.length} usable '
+            'from $source source (above block $lastBlockHeight)');
+
+        final beforeValidation = snapshotItems.length;
         List<SnapshotItem> snapshotsVerified = await _snapshotValidationService
             .validateSnapshotItems(snapshotItems);
 
+        if (snapshotsVerified.length != beforeValidation) {
+          final rejected = snapshotItems
+              .where((i) => !snapshotsVerified.contains(i))
+              .map((i) => i.txId)
+              .join(', ');
+          logger.w('[snapshot] $driveId: '
+              '${snapshotsVerified.length}/$beforeValidation available; '
+              'unreachable: $rejected');
+        } else if (beforeValidation > 0) {
+          logger.i('[snapshot] $driveId: all $beforeValidation available');
+        }
+
         snapshotItems = snapshotsVerified;
+      } else {
+        logger.i('[snapshot] $driveId: disabled by config '
+            '(enableSyncFromSnapshot)');
       }
 
       final SnapshotDriveHistory snapshotDriveHistory = SnapshotDriveHistory(
@@ -1633,6 +1651,26 @@ class _SyncRepository implements SyncRepository {
         driveId: driveId,
         ownerAddress: ownerAddress,
       );
+
+      // The line that says whether this sync took the fast path. Blocks served
+      // from a snapshot are read from one already-downloaded body; blocks left
+      // to GraphQL are walked a page at a time, which for an old drive is
+      // thousands of transactions and minutes of work. At info level
+      // deliberately: when a sync is inexplicably slow, this is the first
+      // thing worth seeing, and it is one line per drive.
+      int blocksIn(HeightRange r) =>
+          r.rangeSegments.fold(0, (sum, s) => sum + (s.end - s.start));
+
+      final fromSnapshots = blocksIn(snapshotDriveHistory.subRanges);
+      final fromGql = blocksIn(gqlDriveHistorySubRanges);
+
+      if (snapshotItems.isEmpty) {
+        logger.i('[snapshot] $driveId: none usable - walking all $fromGql '
+            'blocks over GraphQL');
+      } else {
+        logger.i('[snapshot] $driveId: $fromSnapshots blocks from '
+            '${snapshotItems.length} snapshot(s), $fromGql over GraphQL');
+      }
 
       logger.d(
           'Total range to query for: ${totalRangeToQueryFor.rangeSegments}\n'

--- a/lib/utils/snapshots/snapshot_item.dart
+++ b/lib/utils/snapshots/snapshot_item.dart
@@ -224,7 +224,10 @@ class SnapshotItemOnChain implements SnapshotItem {
     if (_prefetchFuture != null) {
       return _cachedSource = await _prefetchFuture!;
     }
-    final dataBytes = await _arweave.getEntityDataFromNetwork(txId: txId);
+    final dataBytes = await _arweave.getEntityDataFromNetwork(
+      txId: txId,
+      largeBody: true,
+    );
     final dataBytesAsString = String.fromCharCodes(dataBytes);
     return _cachedSource = dataBytesAsString;
   }
@@ -235,7 +238,7 @@ class SnapshotItemOnChain implements SnapshotItem {
     if (_cachedSource != null || _prefetchFuture != null) return;
     logger.d('Prefetching snapshot $txId');
     _prefetchFuture = _arweave
-        .getEntityDataFromNetwork(txId: txId)
+        .getEntityDataFromNetwork(txId: txId, largeBody: true)
         .then((bytes) => String.fromCharCodes(bytes));
   }
 

--- a/test/services/arweave/data_gateway_fallback_test.dart
+++ b/test/services/arweave/data_gateway_fallback_test.dart
@@ -179,6 +179,22 @@ void main() {
     /// warm gateway serves in ~8s - so under the metadata budget it could
     /// never finish on any connection slower than ~9 MB/s, however many times
     /// it was retried.
+    /// The outer cap must clear what the attempts can actually spend, or it
+    /// quietly becomes the real limit and the second attempt gets less time
+    /// than the first - a retry weaker than the try it is retrying.
+    test('the total budget outlasts every attempt it allows', () {
+      final attemptsCost = DataGatewayFallback.syncRequestTimeoutForTest *
+              DataGatewayFallback.syncMaxAttempts +
+          DataGatewayFallback.syncRetryDelayForTest *
+              (DataGatewayFallback.syncMaxAttempts - 1);
+
+      expect(
+        DataGatewayFallback.syncTotalFetchTimeoutForTest,
+        greaterThan(attemptsCost),
+        reason: 'the cap must not truncate the last attempt',
+      );
+    });
+
     group('large bodies', () {
       /// Scaled down so the test does not spend the real budgets, which are
       /// measured in tens of seconds. What is asserted is that `largeBody`

--- a/test/services/arweave/data_gateway_fallback_test.dart
+++ b/test/services/arweave/data_gateway_fallback_test.dart
@@ -172,6 +172,60 @@ void main() {
       verify(() => primaryApi.getSandboxedTx(txId)).called(2);
       verifyNever(() => arioSDK.getGateways());
     });
+
+    /// The default budget is sized for the metadata reads that dominate sync,
+    /// a few hundred bytes each. A snapshot is the same call with a body four
+    /// orders of magnitude larger - this user's newest is 43.9 MiB, which a
+    /// warm gateway serves in ~8s - so under the metadata budget it could
+    /// never finish on any connection slower than ~9 MB/s, however many times
+    /// it was retried.
+    group('large bodies', () {
+      /// Scaled down so the test does not spend the real budgets, which are
+      /// measured in tens of seconds. What is asserted is that `largeBody`
+      /// routes to the larger of the two, and that the default cannot carry a
+      /// body that outlives it.
+      late DataGatewayFallback scaled;
+
+      setUp(() {
+        scaled = DataGatewayFallback(
+          arioSDK: arioSDK,
+          syncRequestTimeout: const Duration(milliseconds: 100),
+          syncLargeBodyRequestTimeout: const Duration(seconds: 5),
+        );
+      });
+
+      test('a snapshot-sized read outlives the metadata budget', () async {
+        when(() => primaryApi.getSandboxedTx(txId)).thenAnswer((_) async {
+          await Future<void>.delayed(const Duration(milliseconds: 400));
+          return Response('a snapshot body', 200);
+        });
+
+        final response = await scaled.fetchDataForSync(
+          txId,
+          primaryClient,
+          largeBody: true,
+        );
+
+        expect(response.statusCode, 200);
+        expect(response.body, 'a snapshot body');
+        verify(() => primaryApi.getSandboxedTx(txId)).called(1);
+      });
+
+      test('the same read fails on the default budget', () async {
+        when(() => primaryApi.getSandboxedTx(txId)).thenAnswer((_) async {
+          await Future<void>.delayed(const Duration(milliseconds: 400));
+          return Response('a snapshot body', 200);
+        });
+
+        // Times out, retries, times out again - which is what a 44 MiB
+        // snapshot did against a budget meant for metadata.
+        await expectLater(
+          scaled.fetchDataForSync(txId, primaryClient),
+          throwsA(isA<Exception>()),
+        );
+        verify(() => primaryApi.getSandboxedTx(txId)).called(2);
+      });
+    });
   });
 
   group('waterfall preserved for non-sync paths', () {

--- a/test/services/arweave/data_gateway_fallback_test.dart
+++ b/test/services/arweave/data_gateway_fallback_test.dart
@@ -183,14 +183,14 @@ void main() {
     /// quietly becomes the real limit and the second attempt gets less time
     /// than the first - a retry weaker than the try it is retrying.
     test('the total budget outlasts every attempt it allows', () {
-      final attemptsCost = DataGatewayFallback.syncRequestTimeoutForTest *
-              DataGatewayFallback.syncMaxAttempts +
-          DataGatewayFallback.syncRetryDelayForTest *
-              (DataGatewayFallback.syncMaxAttempts - 1);
+      const budgets = DataGatewayFallback.syncBudgets;
+      const attempts = DataGatewayFallback.syncMaxAttempts;
 
       expect(
-        DataGatewayFallback.syncTotalFetchTimeoutForTest,
-        greaterThan(attemptsCost),
+        budgets.total,
+        greaterThan(
+          budgets.request * attempts + budgets.retryDelay * (attempts - 1),
+        ),
         reason: 'the cap must not truncate the last attempt',
       );
     });

--- a/test/sync/data/snapshot_validation_service_test.dart
+++ b/test/sync/data/snapshot_validation_service_test.dart
@@ -130,8 +130,18 @@ void main() {
         expect(calls, 4);
       });
 
-      test('a 302 to a sandbox host counts as available', () async {
-        final client = MockClient((_) async => Response('', 302));
+      /// A gateway 302s `/{txId}` to its own sandbox subdomain and serves the
+      /// body there, and every client this runs on follows that. A 302 that
+      /// survives to be inspected is therefore a chain that did not complete,
+      /// so the body was never reached - and one of this user's dead
+      /// snapshots answers exactly that way, 302 on the first hop and 404 on
+      /// the host it points at.
+      test('an unfollowed redirect is not proof the body is there', () async {
+        var calls = 0;
+        final client = MockClient((_) async {
+          calls++;
+          return Response('', 302);
+        });
 
         final service = SnapshotValidationService(
           configService: configService,
@@ -141,8 +151,10 @@ void main() {
 
         expect(
           await service.validateSnapshotItems([_FakeSnapshotItem()]),
-          hasLength(1),
+          isEmpty,
+          reason: 'availability is unproven until the body host answers',
         );
+        expect(calls, 4, reason: 'a 302 is transient, so it is retried');
       });
 
       test('spends every attempt before rejecting', () async {

--- a/test/sync/data/snapshot_validation_service_test.dart
+++ b/test/sync/data/snapshot_validation_service_test.dart
@@ -5,6 +5,8 @@ import 'package:ardrive/sync/data/snapshot_validation_service.dart';
 import 'package:ardrive/utils/snapshots/snapshot_item.dart';
 import 'package:ario_sdk/ario_sdk.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart';
+import 'package:http/testing.dart';
 import 'package:mocktail/mocktail.dart';
 
 class _MockConfigService extends Mock implements ConfigService {}
@@ -50,7 +52,12 @@ void main() {
     test('rejects a snapshot without ever asking for a gateway list',
         () async {
       final arioSDK = _MockArioSDK();
-      final service = SnapshotValidationService(configService: configService);
+      // Zero delays: this asserts the GAR is never consulted, not the backoff,
+      // and the real delays are measured in seconds.
+      final service = SnapshotValidationService(
+        configService: configService,
+        retryDelays: List<Duration>.filled(3, Duration.zero),
+      );
 
       // A nonempty list, so validation actually runs: an empty one returns
       // before the loop and would assert nothing at all.
@@ -67,6 +74,121 @@ void main() {
       // the compile-time signature above that proves the branch is gone; this
       // documents the intent at the call site.
       verifyZeroInteractions(arioSDK);
+    });
+
+    /// Measured against turbo-gateway.com (Aug 2026), a snapshot HEAD is
+    /// bimodal: sub-second when the gateway can answer from cache, and 23s or
+    /// no answer at all within 45s when it cannot. Two attempts lose a
+    /// perfectly good snapshot to that, and rejecting one costs a GraphQL
+    /// re-walk of its whole block range.
+    group('retry budget', () {
+      /// Zero delays so the test does not spend the real backoff, which is
+      /// deliberately measured in seconds.
+      List<Duration> noDelays(int retries) =>
+          List<Duration>.filled(retries, Duration.zero);
+
+      test('keeps probing past the old two-attempt budget', () async {
+        var calls = 0;
+        final client = MockClient((_) async {
+          calls++;
+          // Fails more times than the previous budget allowed for.
+          return calls < 4 ? Response('', 500) : Response('', 200);
+        });
+
+        final service = SnapshotValidationService(
+          configService: configService,
+          httpClient: client,
+          retryDelays: noDelays(3),
+        );
+
+        final verified =
+            await service.validateSnapshotItems([_FakeSnapshotItem()]);
+
+        expect(verified, hasLength(1),
+            reason: 'a snapshot that answers on the 4th probe is still usable');
+        expect(calls, 4);
+      });
+
+      test('a 302 to a sandbox host counts as available', () async {
+        final client = MockClient((_) async => Response('', 302));
+
+        final service = SnapshotValidationService(
+          configService: configService,
+          httpClient: client,
+          retryDelays: noDelays(3),
+        );
+
+        expect(
+          await service.validateSnapshotItems([_FakeSnapshotItem()]),
+          hasLength(1),
+        );
+      });
+
+      test('spends every attempt before rejecting', () async {
+        var calls = 0;
+        final client = MockClient((_) async {
+          calls++;
+          return Response('', 404);
+        });
+
+        final service = SnapshotValidationService(
+          configService: configService,
+          httpClient: client,
+          retryDelays: noDelays(3),
+        );
+
+        expect(
+          await service.validateSnapshotItems([_FakeSnapshotItem()]),
+          isEmpty,
+        );
+        expect(calls, 4);
+      });
+
+      /// A refusal is a decision the same host repeats, so spending the budget
+      /// on it only delays the GraphQL fallback.
+      test('gives up immediately on a non-retryable refusal', () async {
+        var calls = 0;
+        final client = MockClient((_) async {
+          calls++;
+          return Response('', 403);
+        });
+
+        final service = SnapshotValidationService(
+          configService: configService,
+          httpClient: client,
+          retryDelays: noDelays(3),
+        );
+
+        expect(
+          await service.validateSnapshotItems([_FakeSnapshotItem()]),
+          isEmpty,
+        );
+        expect(calls, 1);
+      });
+
+      test('a timeout is retried like any other transient failure', () async {
+        var calls = 0;
+        final client = MockClient((_) async {
+          calls++;
+          if (calls == 1) {
+            // Outlives the 5s head timeout.
+            await Future<void>.delayed(const Duration(seconds: 6));
+          }
+          return Response('', 200);
+        });
+
+        final service = SnapshotValidationService(
+          configService: configService,
+          httpClient: client,
+          retryDelays: noDelays(3),
+        );
+
+        expect(
+          await service.validateSnapshotItems([_FakeSnapshotItem()]),
+          hasLength(1),
+        );
+        expect(calls, 2);
+      });
     });
   });
 }

--- a/test/sync/data/snapshot_validation_service_test.dart
+++ b/test/sync/data/snapshot_validation_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:ardrive/services/config/app_config.dart';
 import 'package:ardrive/services/config/config_service.dart';
 import 'package:ardrive/services/config/selected_gateway.dart';
@@ -8,6 +10,24 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart';
 import 'package:http/testing.dart';
 import 'package:mocktail/mocktail.dart';
+
+/// Records whether the service closed it, which is how a timed-out request is
+/// cancelled without the `AbortableRequest` that `http` 1.5.0 would provide.
+class _CloseTrackingClient extends BaseClient {
+  _CloseTrackingClient(this._inner);
+
+  final Client _inner;
+  bool closed = false;
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) => _inner.send(request);
+
+  @override
+  void close() {
+    closed = true;
+    _inner.close();
+  }
+}
 
 class _MockConfigService extends Mock implements ConfigService {}
 
@@ -98,7 +118,7 @@ void main() {
 
         final service = SnapshotValidationService(
           configService: configService,
-          httpClient: client,
+          clientFactory: () => client,
           retryDelays: noDelays(3),
         );
 
@@ -115,7 +135,7 @@ void main() {
 
         final service = SnapshotValidationService(
           configService: configService,
-          httpClient: client,
+          clientFactory: () => client,
           retryDelays: noDelays(3),
         );
 
@@ -134,7 +154,7 @@ void main() {
 
         final service = SnapshotValidationService(
           configService: configService,
-          httpClient: client,
+          clientFactory: () => client,
           retryDelays: noDelays(3),
         );
 
@@ -156,7 +176,7 @@ void main() {
 
         final service = SnapshotValidationService(
           configService: configService,
-          httpClient: client,
+          clientFactory: () => client,
           retryDelays: noDelays(3),
         );
 
@@ -180,7 +200,7 @@ void main() {
 
         final service = SnapshotValidationService(
           configService: configService,
-          httpClient: client,
+          clientFactory: () => client,
           retryDelays: noDelays(3),
           headTimeout: const Duration(milliseconds: 100),
         );
@@ -190,6 +210,45 @@ void main() {
           hasLength(1),
         );
         expect(calls, 2);
+      });
+
+      /// `Future.timeout` abandons the response but does not cancel the
+      /// request behind it. Left pending, four attempts across three
+      /// concurrent validations is up to twelve requests outstanding against a
+      /// gateway already too slow to answer one - and on the web, where
+      /// browsers cap connections per host at around six, those would crowd
+      /// out the reads sync makes to the same gateway next. Closing the
+      /// client is what cancels them.
+      test('cancels a timed-out probe before the next one', () async {
+        final clients = <_CloseTrackingClient>[];
+
+        final service = SnapshotValidationService(
+          configService: configService,
+          clientFactory: () {
+            final client = _CloseTrackingClient(
+              MockClient((_) async {
+                // The first probe never answers; the second does.
+                if (clients.length == 1) {
+                  await Completer<Response>().future;
+                }
+                return Response('', 200);
+              }),
+            );
+            clients.add(client);
+            return client;
+          },
+          retryDelays: noDelays(3),
+          headTimeout: const Duration(milliseconds: 100),
+        );
+
+        expect(
+          await service.validateSnapshotItems([_FakeSnapshotItem()]),
+          hasLength(1),
+        );
+        expect(clients, hasLength(2), reason: 'the probe was retried');
+        expect(clients.first.closed, isTrue,
+            reason: 'the abandoned request must be cancelled, not left '
+                'pending against a struggling gateway');
       });
 
       /// The band this change exists for. Measured against turbo-gateway,
@@ -208,7 +267,7 @@ void main() {
 
         final service = SnapshotValidationService(
           configService: configService,
-          httpClient: client,
+          clientFactory: () => client,
           retryDelays: noDelays(3),
           headTimeout: const Duration(seconds: 1),
         );

--- a/test/sync/data/snapshot_validation_service_test.dart
+++ b/test/sync/data/snapshot_validation_service_test.dart
@@ -57,6 +57,7 @@ void main() {
       final service = SnapshotValidationService(
         configService: configService,
         retryDelays: List<Duration>.filled(3, Duration.zero),
+        headTimeout: const Duration(milliseconds: 100),
       );
 
       // A nonempty list, so validation actually runs: an empty one returns
@@ -171,8 +172,8 @@ void main() {
         final client = MockClient((_) async {
           calls++;
           if (calls == 1) {
-            // Outlives the 5s head timeout.
-            await Future<void>.delayed(const Duration(seconds: 6));
+            // Outlives the injected timeout below.
+            await Future<void>.delayed(const Duration(milliseconds: 400));
           }
           return Response('', 200);
         });
@@ -181,6 +182,7 @@ void main() {
           configService: configService,
           httpClient: client,
           retryDelays: noDelays(3),
+          headTimeout: const Duration(milliseconds: 100),
         );
 
         expect(
@@ -188,6 +190,35 @@ void main() {
           hasLength(1),
         );
         expect(calls, 2);
+      });
+
+      /// The band this change exists for. Measured against turbo-gateway,
+      /// healthy answers arrived at 5.85s and 6.08s - a gateway that had to
+      /// fetch before it could answer, not a failure. The old 5s cutoff threw
+      /// those away and re-walked the whole block range instead.
+      test('accepts an answer that is slow but arrives within the timeout',
+          () async {
+        var calls = 0;
+        final client = MockClient((_) async {
+          calls++;
+          // Comfortably slow, but inside the budget.
+          await Future<void>.delayed(const Duration(milliseconds: 300));
+          return Response('', 200);
+        });
+
+        final service = SnapshotValidationService(
+          configService: configService,
+          httpClient: client,
+          retryDelays: noDelays(3),
+          headTimeout: const Duration(seconds: 1),
+        );
+
+        expect(
+          await service.validateSnapshotItems([_FakeSnapshotItem()]),
+          hasLength(1),
+          reason: 'a slow gateway is not an unavailable snapshot',
+        );
+        expect(calls, 1, reason: 'no retry needed when the answer arrives');
       });
     });
   });

--- a/test/sync/data/snapshot_validation_service_test.dart
+++ b/test/sync/data/snapshot_validation_service_test.dart
@@ -225,6 +225,15 @@ void main() {
         final service = SnapshotValidationService(
           configService: configService,
           clientFactory: () {
+            // Checked here rather than only at the end: asserting after the
+            // fact would still pass if a regression started the next probe
+            // while the abandoned one was still open, which is the thing
+            // being prevented.
+            if (clients.isNotEmpty) {
+              expect(clients.last.closed, isTrue,
+                  reason: 'the previous probe must be cancelled before the '
+                      'next one is started');
+            }
             final client = _CloseTrackingClient(
               MockClient((_) async {
                 // The first probe never answers; the second does.


### PR DESCRIPTION
Every read sync makes went through one budget: **5s per attempt, twice**. That budget was written for the metadata reads that dominate sync — a few hundred bytes each, hundreds of them — and it was applied unchanged to a snapshot body four orders of magnitude larger.

The result: a drive whose newest snapshot could not be validated or downloaded silently re-walked its entire block range over GraphQL. Thousands of transactions, ghost folders, minutes of sync.

## The measurements

One drive (`0a36156c…`) with a proper snapshot chain — 2023 (0→1,110,415), May 2025 (0→1,676,774), Dec 2025 (0→1,814,228).

**Snapshot HEAD, 13 probes against `turbo-gateway.com`, 12 answered 200:**

```
BiXh3o (2023)   1.44s   6.08s ←   0.79s   0.68s
BEFyD  (May25)  1.56s   1.82s     5.85s ← TIMEOUT
z78YIh (Dec25)  0.79s   0.76s     0.72s   0.90s
```

Two healthy answers at **5.85s and 6.08s** were being thrown away by a 5s cutoff. Response time is bimodal, not merely slow: sub-second when the gateway answers from cache, ~23s or nothing when it has to fetch first.

**Snapshot body, full GET of the 43.92 MiB Dec 2025 snapshot, warm gateway:**

```
total = 8.18s   speed = 5.63 MB/s   http 200
total = 7.77s   speed = 5.92 MB/s   http 200
```

**~8 seconds against a 5-second timeout.** `Future.timeout` covers the whole body, so the download needed ~9 MB/s sustained just to break even. Below that it could not finish on any attempt, however many were spent — the newest snapshot was structurally unusable.

## What changed

Every read now gets a budget sized for what it actually fetches.

| | before | after |
|---|---|---|
| Sync read, per attempt | 5s | **10s** |
| Sync read, total cap | 15s | **22s** |
| Snapshot body | 5s | **60s** (130s total) |
| Snapshot HEAD | 5s | **10s** |
| Snapshot HEAD attempts | 2, spaced 300ms | **4, spaced 1s / 3s / 6s** |

- **10s default.** Sync reads run through `runPooled`, a worker pool over a shared cursor, so a read that hangs occupies one of `maxConcurrentDataFetches` slots while the other workers keep pulling. Waiting longer costs throughput on one lane rather than stalling sync — that is what makes patience affordable.
- **22s cap.** Two 10s attempts plus the retry delay cost 20.3s; the old 15s cap (correct when attempts were 5s) truncated the second attempt at 4.7s, making the retry weaker than the try it was retrying.
- **60s for snapshot bodies**, via a `largeBody` flag passed only by the two snapshot call sites. Generosity is cheap there in a way it is not for metadata: one request per snapshot rather than one per entity, availability already established by the HEAD, and the alternative is minutes of GraphQL. Sized against `data.size` was considered and rejected — `TransactionCommon` does not carry it, so it would mean bloating every drive-history query or forking one plus codegen.
- **Spaced HEAD retries.** The spacing is the point: retrying 300ms after a timeout lands inside the same cold read and hangs again. Probes now start near t=0s, 11s, 24s, 40s, so a later one can land after a cold read has finished and the answer is cached.
- **Timed-out probes are cancelled.** `Future.timeout` abandons the response without cancelling the request. Four attempts across three concurrent validations left up to twelve requests outstanding against a gateway already too slow to answer one — and browsers cap connections per host at ~6, so those would crowd out sync's own reads. One client per attempt, closed on the way out.

No second host is introduced anywhere. The GAR fallback stays removed from the sync path, and nothing reaches for a hardcoded gateway.

## Verification

- `flutter analyze` clean; **1347** tests pass
- New coverage: probing past the old budget, a slow-but-healthy answer accepted, 302 accepted, every attempt spent before rejecting, immediate give-up on a non-retryable refusal, timeouts retried, probe cancellation ordering, large bodies outliving the metadata budget, and the budget arithmetic itself
- Every behavioural test here was **mutation checked** — the old 2-attempt budget, an ignored `largeBody` flag, a skipped `client.close()`, and the 15s cap each make their test fail

## Not addressed

- A snapshot whose data is genuinely gone (404 on every gateway — this user has one) is re-probed every sync forever with no memory that it failed. `docs/SYNC_SKIPPED_ENTITY_PERSISTENCE.md` is the existing design for persisting that.
- `_validateSnapshot` accepts `302` as success. On web the client follows redirects so only the final status is seen, but a client that did not would validate a snapshot whose body 404s.
- The snapshots panel lists snapshots without checking availability, so it can show one sync cannot use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DnYLXFocWgTt9M2CbGYSUP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved reliability when downloading large snapshot and entity data.
  * Large payload requests now receive extended timeouts, while standard metadata requests remain faster.
  * Network operations retry transient failures and handle timed-out requests more reliably.
  * Snapshot validation now requires completed successful responses, improving result accuracy.
  * Snapshot synchronization now provides clearer progress and result reporting, including partial results when pagination encounters an issue.
* **Tests**
  * Added coverage for retries, timeouts, delayed responses, large downloads, and request cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->