### PR TITLE
PE-9205: Sync goes to the gateway for things the snapshot already gave it

### DIFF
--- a/docs/SNAPSHOT_CREATION_FROM_SNAPSHOTS.md
+++ b/docs/SNAPSHOT_CREATION_FROM_SNAPSHOTS.md
@@ -1,0 +1,136 @@
+# Building a snapshot from the snapshots you already have
+
+## The problem, measured
+
+Creating a snapshot of a 40k-item drive re-reads the entire drive from the
+network, even immediately after a sync that just read the same data.
+
+For drive `0a36156c…` (~42,000 transactions):
+
+| Work | Count |
+|---|---|
+| `DriveEntityHistoryWithoutEntityTypeFilter` pages (`first: 100`) | ~420 |
+| Individual metadata fetches (`_arweave.dataFromTxId`) | ~42,000 |
+| Of those served from cache | ≤ 550 |
+
+`CreateSnapshotCubit` walks blocks `0 → current` over GraphQL
+(`create_snapshot_cubit.dart:239`), then for every transaction calls
+`_jsonMetadataOfTxId` (`:610`), which checks `MetadataCache` and otherwise goes
+to the gateway. `MetadataCache` holds `defaultMaxEntries = 550`
+(`metadata_cache.dart:6`) with `evictionPolicy: null`, so on a drive this size
+it covers ~1.3% and then logs *"Metadata cache is now full and will not accept
+new entries"*.
+
+On a throttled connection this does not finish.
+
+## Why it is redundant
+
+The sync that just ran read 41,767 of those entities' metadata **out of the
+drive's existing snapshots** and then discarded it:
+
+- `SnapshotItemOnChain.dispose(driveId)` clears the per-drive cache when the
+  drive's sync ends.
+- `getDataForTxId` is `getAndRemove` — destructive, so it is one-shot even
+  before disposal.
+- `_jsonMetadataOfTxId` never consults that cache at all. It knows only the
+  550-entry store and the network.
+
+Meanwhile the existing snapshots hold, verbatim, exactly what a new snapshot
+needs.
+
+## What a snapshot entry is, and what we hold
+
+A snapshot body is `{"txSnapshots": [{gqlNode, jsonMetadata}, …]}`.
+
+| Field | Where it can come from |
+|---|---|
+| `gqlNode` — id, owner, bundledIn, block, tags | an existing snapshot ✅ · GraphQL ✅ · **local DB ❌** |
+| `jsonMetadata` — raw entity bytes (base64 when private) | an existing snapshot ✅ · gateway ✅ · **local DB ❌** |
+
+The local database stores *parsed* revisions — name, size, `dataTxId`,
+`metadataTxId`, plus `customJsonMetadata`/`customGQLTags`. It does not keep the
+raw metadata bytes, nor a complete GQL node. **A snapshot cannot be rebuilt
+from the database**, and attempting to reconstruct one would be lossy.
+
+That is the important constraint: the source must be existing snapshots, not
+local state.
+
+## Design
+
+A new snapshot covering `[0 → current]` is assembled as:
+
+1. **`[0 → previousSnapshot.blockEnd]`** — copied verbatim from the existing
+   snapshot bodies. No GraphQL, no metadata fetches.
+2. **`(previousSnapshot.blockEnd → current]`** — the existing path: GraphQL for
+   the range, then a metadata fetch per transaction.
+
+For this drive that is **261 transactions fetched instead of ~42,000**, and one
+44 MiB download the app may already be holding. The ratio improves every time a
+snapshot is taken, rather than degrading.
+
+Entries are copied, not re-derived, so fidelity is not a question: the bytes
+that go into the new snapshot are the bytes that came off chain.
+
+## The correctness question
+
+*"If you have an improperly synced drive, you can end up with a bad snapshot."*
+
+Correct, and it is the reason this design sources from **snapshots** rather than
+from the local database. The two failure modes are different:
+
+- **Local DB as the source** — inherits every silent drop in
+  `docs/SYNC_SKIPPED_ENTITY_PERSISTENCE.md`. A metadata read that failed during
+  sync leaves an entity missing locally while the watermark advances, so the
+  snapshot would bake that gap in permanently and on chain. **Rejected.**
+- **Existing snapshots as the source** — inherits only what the previous
+  snapshot contained. That snapshot is immutable, on chain, and is *already*
+  trusted for exactly this range on every sync. The new snapshot is no more
+  trusted than the one it descends from.
+
+Residual risk: a defective ancestor snapshot propagates forward. Mitigations,
+in increasing cost:
+
+1. **Range assertion (cheap).** The copied entries must cover the ancestor's
+   claimed `Block-Start … Block-End` with no interior gap. Fails loudly rather
+   than writing a short snapshot.
+2. **Count check (moderate).** One id-only GraphQL pagination over the ancestor
+   range, comparing counts. Catches a truncated ancestor without fetching any
+   metadata.
+3. **Full rebuild (expensive).** Today's behaviour, kept as an explicit
+   "rebuild from chain" option for when an ancestor is suspect.
+
+Default to 1, offer 3. 2 is worth measuring before committing to it.
+
+## Phases
+
+**Phase 1 — make the metadata survive.**
+`getDataForTxId` stops being destructive (or gains a non-consuming read), and
+the per-drive cache becomes retainable past `dispose` when a snapshot creation
+is pending. Nothing user-visible; it only stops throwing away what was read.
+
+**Phase 2 — source the covered range from ancestors.**
+`SnapshotItemToBeCreated` takes entries for `[0 → ancestorEnd]` from ancestor
+snapshot bodies, and drives GraphQL only for the tail. Includes the range
+assertion.
+
+**Phase 3 — the escape hatch.**
+Expose "rebuild from chain" for a suspect ancestor, which is the current code
+path unchanged.
+
+**Phase 4 — the modal.**
+Progress currently counts transactions processed. With most entries copied, the
+meaningful units become "copied from existing snapshots" and "fetched for the
+new range". Also the point at which the dialog's structure gets revisited.
+
+## Notes
+
+- Ancestor snapshots record prior snapshot transactions as
+  `TxSnapshot(gqlNode: node, jsonMetadata: null)` (`_isSnapshotTx`). Copying is
+  verbatim, so this needs no special handling — but a rebuild must not treat a
+  null `jsonMetadata` as a fetch failure.
+- Overlapping ancestors already compose through the `obscuredBy` accumulator in
+  `SnapshotItem.instantiateAll`; the copy path should reuse it rather than
+  inventing a second dedup.
+- `MetadataCache`'s 550-entry cap is not worth raising: it is
+  SharedPreferences-backed, and `put` carries a `FIXME` about not checking
+  quota. Copying from snapshots removes the need for it on this path.

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -288,10 +288,18 @@ class ArweaveService {
   /// Caller should filter results by Drive-Id tag and pass each drive's
   /// subset to [SnapshotItem.instantiateAll] with that drive's own
   /// lastBlockHeight to preserve per-drive state isolation.
+  /// [onQueryFailure] fires if the query gave up part-way.
+  ///
+  /// The stream ends the same way either way - a failure is logged and the
+  /// iteration stops - so a caller cannot otherwise tell "this drive has no
+  /// snapshots" from "we stopped asking". The batched prefetch needs that
+  /// distinction: without it, every snapshot-less drive looks unanswered and
+  /// gets asked again individually.
   Stream<SnapshotEntityTransaction> getAllSnapshotsForDrives(
     List<String> driveIds,
     int? minBlockHeight, {
     required String ownerAddress,
+    void Function()? onQueryFailure,
   }) async* {
     String cursor = '';
     var yielded = 0;
@@ -348,6 +356,7 @@ class ArweaveService {
           'rest of the range falls back to GraphQL',
           e,
         );
+        onQueryFailure?.call();
         break;
       }
     }

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -152,6 +152,12 @@ class ArweaveService {
   /// Cache for drive signatures (immutable on-chain, never change).
   final Map<String, DriveSignatureEntity?> _cachedDriveSignatures = {};
 
+  /// Entity metadata reads served from a drive's snapshot, and those that had
+  /// to go to the gateway instead. Keyed by drive id, reported by sync when a
+  /// drive finishes. See [_getEntityData].
+  final Map<String, int> snapshotMetadataHits = {};
+  final Map<String, int> snapshotMetadataMisses = {};
+
   /// Clears the cached result of [getUniqueUserDriveEntityTxs] and entity data.
   /// Call after creating/updating a drive or after a full sync completes.
   void clearUserDriveTxsCache() {
@@ -806,8 +812,17 @@ class ArweaveService {
     );
 
     if (cachedData != null) {
+      snapshotMetadataHits.update(driveId, (v) => v + 1, ifAbsent: () => 1);
       return cachedData;
     }
+
+    // Every miss is a network round trip for a few hundred bytes, and sync
+    // makes one of these per entity. Whether a drive's entities come from its
+    // snapshot or from the gateway is the difference between one download and
+    // tens of thousands of requests, and until now nothing said which was
+    // happening. Counted rather than logged per entity: at 40k entities a log
+    // line each would be the slowest part of the sync.
+    snapshotMetadataMisses.update(driveId, (v) => v + 1, ifAbsent: () => 1);
 
     return getEntityDataFromNetwork(txId: txId).then<Uint8List?>((d) => d)
         .catchError((e) {

--- a/lib/sync/data/snapshot_validation_service.dart
+++ b/lib/sync/data/snapshot_validation_service.dart
@@ -132,9 +132,10 @@ class SnapshotValidationService {
   /// Validates a snapshot is available on the configured gateway.
   ///
   /// Up to [_maxAttempts] HEADs against the configured gateway, spaced by
-  /// [_retryDelays]; anything other than 200/302 on every one of them rejects
-  /// the snapshot, and sync falls back to GQL for that range - correct, but
-  /// expensive enough that it is worth several probes to avoid.
+  /// [_retryDelays]; anything other than 200 on every one of them rejects the
+  /// snapshot, and sync falls back to GQL for that range - correct, but
+  /// expensive enough that it is worth several probes to avoid. A 302 counts
+  /// as a failure rather than a success; see the note on the status check.
   ///
   /// There is deliberately no GAR fallback here, and no second host of any
   /// kind. The GAR cost a Solana RPC via `ArioSDK.getGateways()`, which the

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -1897,6 +1897,17 @@ class _SyncRepository implements SyncRepository {
 
       logger.i(
           'Drive ${drive.name} completed parse phase. Progress by block height: $fetchPhasePercentage%. Starting parse phase. Sync duration: $syncDriveTotalTime ms. Fetching used ${(averageBetweenFetchAndGet * 100).toStringAsFixed(2)}% of drive sync process');
+      // Where this drive's entity metadata actually came from. A snapshot
+      // that covers a range but serves none of its metadata is indis-
+      // tinguishable, from the outside, from one that is working - both look
+      // like "3 snapshots loaded" followed by a long sync. This is the line
+      // that tells them apart.
+      final hits = _arweave.snapshotMetadataHits.remove(drive.id) ?? 0;
+      final misses = _arweave.snapshotMetadataMisses.remove(drive.id) ?? 0;
+      if (hits + misses > 0) {
+        logger.i('[snapshot] ${drive.id}: $hits entity metadata read(s) from '
+            'snapshots, $misses fetched from the gateway');
+      }
     } finally {
       // Always dispose snapshot cache, even on error or cancellation
       await SnapshotItemOnChain.dispose(drive.id);

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -415,10 +415,12 @@ class _SyncRepository implements SyncRepository {
               ? syncedHeights.reduce(min)
               : 0;
 
+          var queryFailed = false;
           final snapshotsStream = _arweave.getAllSnapshotsForDrives(
             ownerDrives.map((d) => d.id).toList(),
             minBlock,
             ownerAddress: entry.key,
+            onQueryFailure: () => queryFailed = true,
           );
 
           await for (final snapshot in snapshotsStream) {
@@ -434,11 +436,31 @@ class _SyncRepository implements SyncRepository {
               logger.w('Snapshot ${snapshot.id} has no Drive-Id tag, skipping');
             }
           }
+
+          // Record an answer for every drive the query covered, including the
+          // ones it found nothing for. `_syncDrive` reads a missing entry as
+          // "nobody asked" and asks again per drive, so without this a drive
+          // with no snapshots pays for a second, identical query on every
+          // sync - the batch already told us the answer was none.
+          //
+          // Only when the query ran to completion: if it gave up part-way, a
+          // drive it never reached would be recorded as having none, and the
+          // per-drive fallback that exists for exactly that case would be
+          // suppressed.
+          if (!queryFailed) {
+            for (final drive in ownerDrives) {
+              prefetchedSnapshots.putIfAbsent(drive.id, () => []);
+            }
+          }
         }
 
+        final withSnapshots =
+            prefetchedSnapshots.values.where((v) => v.isNotEmpty).length;
         logger.i(
-            'Prefetched ${prefetchedSnapshots.values.expand((v) => v).length} '
-            'snapshots across ${prefetchedSnapshots.length} drives');
+            '[snapshot] prefetched '
+            '${prefetchedSnapshots.values.expand((v) => v).length} '
+            'for $withSnapshots of ${prefetchedSnapshots.length} drive(s); '
+            'the rest are known to have none and will not be re-queried');
       } catch (e) {
         logger.w('Snapshot prefetch failed, will fetch per-drive: $e');
         prefetchedSnapshots.clear();

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -1897,18 +1897,25 @@ class _SyncRepository implements SyncRepository {
 
       logger.i(
           'Drive ${drive.name} completed parse phase. Progress by block height: $fetchPhasePercentage%. Starting parse phase. Sync duration: $syncDriveTotalTime ms. Fetching used ${(averageBetweenFetchAndGet * 100).toStringAsFixed(2)}% of drive sync process');
+    } finally {
       // Where this drive's entity metadata actually came from. A snapshot
       // that covers a range but serves none of its metadata is indis-
       // tinguishable, from the outside, from one that is working - both look
       // like "3 snapshots loaded" followed by a long sync. This is the line
       // that tells them apart.
+      //
+      // Drained here rather than at the end of the happy path, for the same
+      // reason the cache below is: a sync that throws or is cancelled would
+      // otherwise leave its counts behind, and they are keyed by drive - so
+      // the next sync of that drive would add to them and report a total that
+      // never happened. Cancelling mid-sync is a normal thing to do.
       final hits = _arweave.snapshotMetadataHits.remove(drive.id) ?? 0;
       final misses = _arweave.snapshotMetadataMisses.remove(drive.id) ?? 0;
       if (hits + misses > 0) {
         logger.i('[snapshot] ${drive.id}: $hits entity metadata read(s) from '
             'snapshots, $misses fetched from the gateway');
       }
-    } finally {
+
       // Always dispose snapshot cache, even on error or cancellation
       await SnapshotItemOnChain.dispose(drive.id);
       logger.d('Disposed snapshot cache for drive ${drive.id}');

--- a/lib/utils/snapshots/snapshot_item.dart
+++ b/lib/utils/snapshots/snapshot_item.dart
@@ -299,15 +299,24 @@ class SnapshotItemOnChain implements SnapshotItem {
 
       final isInRange = range.isInRange(node.block?.height ?? -1);
       if (isInRange) {
-        yield DriveEntityHistoryTransactionModel(transactionCommonMixin: node);
-        yielded++;
-
+        // Cached before the yield, not after.
+        //
+        // `yield` suspends this generator until the consumer asks for the
+        // next item, so anything after it runs *later* than the consumer's
+        // handling of the item just emitted. A consumer that reads an
+        // entity's metadata as soon as it receives the transaction would
+        // therefore find nothing cached and fetch it from the gateway
+        // instead - the one thing the snapshot exists to avoid. Writing
+        // first makes the metadata available the moment the transaction is.
         final String? data = item['jsonMetadata'];
         if (data != null) {
           final TxID txId = node.id;
           final Uint8List dataAsBytes = Uint8List.fromList(utf8.encode(data));
           await _setDataForTxId(driveId, txId, dataAsBytes);
         }
+
+        yield DriveEntityHistoryTransactionModel(transactionCommonMixin: node);
+        yielded++;
       } else {
         skipped++;
       }

--- a/lib/utils/snapshots/snapshot_item.dart
+++ b/lib/utils/snapshots/snapshot_item.dart
@@ -90,8 +90,18 @@ abstract class SnapshotItem implements SegmentedGQLData {
     required ArweaveService arweave,
     @visibleForTesting String? fakeSource,
   }) async* {
+    // Blocks already synced, which a snapshot need not cover again.
+    //
+    // Guarded on `> 0` rather than just non-null. A never-synced drive arrives
+    // here with 0, and `Range(0, 0)` is not "nothing is obscured" - `Range` is
+    // inclusive at both ends, so it obscures block 0. The snapshot's range
+    // then starts at 1, the difference against the total range leaves a
+    // one-block hole, and sync spends a whole GraphQL query asking about the
+    // genesis block, which cannot hold an ArFS transaction. No data was ever
+    // at risk; it is a round trip per drive per first sync, for nothing.
     HeightRange obscuredByAccumulator = HeightRange(rangeSegments: [
-      if (lastBlockHeight != null) Range(start: 0, end: lastBlockHeight),
+      if (lastBlockHeight != null && lastBlockHeight > 0)
+        Range(start: 0, end: lastBlockHeight),
     ]);
 
     await for (SnapshotEntityTransaction item in itemsStream) {

--- a/test/utils/snapshot_item_test.dart
+++ b/test/utils/snapshot_item_test.dart
@@ -292,6 +292,56 @@ void main() {
           );
         },
       );
+
+      /// A never-synced drive arrives with `lastBlockHeight: 0`, which is not
+      /// the same as having synced block 0. `Range` is inclusive at both ends,
+      /// so obscuring `Range(0, 0)` cut the genesis block out of the
+      /// snapshot's range and left sync to ask GraphQL about a single block
+      /// that cannot hold an ArFS transaction - a round trip per drive, per
+      /// first sync, for nothing.
+      test(
+        'a never-synced drive keeps block 0 inside the snapshot range',
+        () async {
+          final totalSnapshotRange = Range(start: 0, end: 10);
+
+          final String snapshotItemSource = await fakeSnapshotSource(
+            totalSnapshotRange,
+          );
+
+          final SnapshotEntityHistory$Query$TransactionConnection$TransactionEdge$Transaction
+              snapshotTx =
+              SnapshotEntityHistory$Query$TransactionConnection$TransactionEdge$Transaction
+                  .fromJson(
+            {
+              'id': 'tx-id',
+              'bundledIn': {'id': 'ASDASDASDASDASDASD'},
+              'owner': {'address': '1234567890'},
+              'tags': [
+                {'name': 'Block-Start', 'value': '0'},
+                {'name': 'Block-End', 'value': '10'},
+                {'name': 'Drive-Id', 'value': 'DRIVE_ID'},
+              ],
+              'block': {
+                'height': 11,
+                'timestamp': DateTime.now().microsecondsSinceEpoch
+              }
+            },
+          );
+
+          final allItems = await SnapshotItem.instantiateAll(
+            Stream.fromIterable([snapshotTx]),
+            lastBlockHeight: 0,
+            arweave: arweave,
+            fakeSource: snapshotItemSource,
+          ).toList();
+
+          expect(
+            allItems.single.subRanges.rangeSegments.single,
+            Range(start: 0, end: 10),
+            reason: 'the snapshot covers its whole range, block 0 included',
+          );
+        },
+      );
     });
 
     group('getDataForTxId method', () {


### PR DESCRIPTION
> Stacked on #2183. Review that first; this PR's diff is its own two commits. It retargets to `dev` once #2183 merges.

A snapshot exists to spare sync the network. Two places went to the network anyway — one asking a question already answered, one for metadata already downloaded.

## 1. Entity metadata could miss the snapshot entirely

`_getNextStream` yielded a transaction and *then* cached its metadata:

```dart
yield DriveEntityHistoryTransactionModel(...);      // suspends here
await _setDataForTxId(driveId, txId, dataAsBytes);  // runs only on the next request
```

`yield` suspends an async generator until the consumer asks for the next item, so the cache write for transaction N ran after the consumer had already handled N. A consumer reading an entity's metadata as soon as it receives the transaction found nothing cached and fetched it from the gateway — the one thing the snapshot exists to prevent. Now cached before the yield.

## 2. A snapshot-less drive was queried twice

```
[snapshot] gql page 1 for [22c7a15f…, 0a36156c…]: 3 found   ← batch covers both drives
[snapshot] gql page 1 for [22c7a15f…]: 0 found              ← same question, asked again
```

The batched prefetch groups results by `Drive-Id`, so a drive it found nothing for has **no entry** — and `_syncDrive` reads a missing entry as "nobody asked" and re-queries it. The batch had already answered: none.

The map now records an answer for every drive the query covered, including the empty ones — but **only when the query completed**. `getAllSnapshotsForDrives` logs a failure and stops rather than throwing, so the stream ends identically either way; it now reports that through `onQueryFailure`. Without that signal, a drive the query never reached would be recorded as having no snapshots, suppressing the per-drive fallback that exists for exactly that case and turning a wasted query into a lost snapshot.

## 3. A never-synced drive spent a query on the genesis block

```
Sub ranges in snapshots: [Range: (1; 1814228)]     ← starts at 1, not 0
Sub ranges in GQL:       [Range: (0; 0), Range: (1814229; 1979131)]
```

Such a drive arrives with `lastBlockHeight: 0`, which is not the same as having synced block 0 — but `Range` is inclusive at both ends, so obscuring `Range(0, 0)` cut block 0 out of the snapshot's range and left a one-block hole for GraphQL. No ArFS transaction can live at the genesis block, so it was a round trip for nothing.

## Instrumentation

Whether a drive's metadata comes from its snapshot or the gateway is the difference between one download and tens of thousands of requests, and nothing said which was happening. Sync now reports both per drive:

```
[snapshot] <driveId>: 39812 entity metadata read(s) from snapshots, 188 fetched from the gateway
```

Counted rather than logged per entity — at 40k entities a line each would be the slowest part of the sync.

## Verification

- `flutter analyze` clean; 1347 tests pass
- The block-0 test is **mutation checked** against the old condition
- Measured against a real sync: the drive's snapshot yields 41,767 entities and its post-snapshot tail is 261 transactions

## Not addressed

None of this was making sync slow — the measured cost is two round trips plus whatever the ordering bug cost. Worth fixing because they are cheap and because the block-0 hole made the logs misstate what a snapshot covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DnYLXFocWgTt9M2CbGYSUP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snapshot loading and pagination reliability, including clearer handling of partial query failures.
  * Fixed snapshot ranges so block 0 is preserved when no blocks have been synced.
  * Rejected redirected snapshot responses that do not return HTTP 200.
  * Improved retrieval of large snapshot data from the network.

* **Diagnostics**
  * Added clearer snapshot validation, coverage, cache, and gateway-fetch logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->