### PR TITLE
PE-9205: A button's text can be painted the colour of the panel behind it

### DIFF
--- a/lib/components/create_snapshot_dialog.dart
+++ b/lib/components/create_snapshot_dialog.dart
@@ -131,7 +131,6 @@ Widget _explanationDialog(BuildContext context, Drive drive) {
 
   return ArDriveStandardModalNew(
     title: appLocalizationsOf(context).newSnapshot,
-    width: kMediumDialogWidth,
     content: Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -261,7 +260,6 @@ Widget _successDialog(BuildContext context, String driveName) {
 
   return ArDriveStandardModalNew(
     title: appLocalizationsOf(context).snapshotSuceeded,
-    width: kMediumDialogWidth,
     content: Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -298,7 +296,6 @@ Widget _failureDialog(
 
   return ArDriveStandardModalNew(
     title: appLocalizationsOf(context).snapshotFailed,
-    width: kMediumDialogWidth,
     content: Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -339,7 +336,6 @@ Widget _insufficientBalanceDialog(
 
   return ArDriveStandardModalNew(
     title: appLocalizationsOf(context).insufficientARForUpload,
-    width: kMediumDialogWidth,
     content: Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/components/create_snapshot_dialog.dart
+++ b/lib/components/create_snapshot_dialog.dart
@@ -127,44 +127,42 @@ class CreateSnapshotDialog extends StatelessWidget {
 Widget _explanationDialog(BuildContext context, Drive drive) {
   final createSnapshotCubit = context.read<CreateSnapshotCubit>();
   final typography = ArDriveTypographyNew.of(context);
+  final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
 
   return ArDriveStandardModalNew(
     title: appLocalizationsOf(context).newSnapshot,
-    content: SizedBox(
-      width: kMediumDialogWidth,
-      child: Row(
-        children: [
-          Flexible(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text.rich(
-                  TextSpan(
-                    children: splitTranslationsWithMultipleStyles(
-                      originalText: appLocalizationsOf(context)
-                          .createSnapshotExplanation(drive.name),
-                      defaultMapper: (t) => TextSpan(
-                        text: t,
-                        style: typography.paragraphNormal(),
-                      ),
-                      parts: {
-                        drive.name: (t) => TextSpan(
-                              text: t,
-                              style: typography.paragraphNormal().copyWith(
-                                    fontWeight: FontWeight.bold,
-                                  ),
-                            ),
-                      },
-                    ),
-                  ),
-                  style: typography.paragraphNormal(),
+    width: kMediumDialogWidth,
+    content: Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text.rich(
+          TextSpan(
+            children: splitTranslationsWithMultipleStyles(
+              originalText: appLocalizationsOf(context)
+                  .createSnapshotExplanation(drive.name),
+              defaultMapper: (t) => TextSpan(
+                text: t,
+                style: typography.paragraphNormal(
+                  color: colorTokens.textMid,
                 ),
-              ],
+              ),
+              parts: {
+                drive.name: (t) => TextSpan(
+                      text: t,
+                      style: typography.paragraphNormal(
+                        fontWeight: ArFontWeight.semiBold,
+                        color: colorTokens.textHigh,
+                      ),
+                    ),
+              },
             ),
           ),
-        ],
-      ),
+          style: typography.paragraphNormal(
+            color: colorTokens.textMid,
+          ),
+        ),
+      ],
     ),
     actions: [
       ModalAction(
@@ -259,30 +257,25 @@ String _loadingDialogDescription(
 
 Widget _successDialog(BuildContext context, String driveName) {
   final typography = ArDriveTypographyNew.of(context);
+  final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
 
   return ArDriveStandardModalNew(
     title: appLocalizationsOf(context).snapshotSuceeded,
-    content: SizedBox(
-      width: kMediumDialogWidth,
-      child: Row(
-        children: [
-          Flexible(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text.rich(
-                  TextSpan(
-                    text: appLocalizationsOf(context)
-                        .snapshotCreationSucceeded(driveName),
-                  ),
-                  style: typography.paragraphNormal(),
-                ),
-              ],
-            ),
+    width: kMediumDialogWidth,
+    content: Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text.rich(
+          TextSpan(
+            text: appLocalizationsOf(context)
+                .snapshotCreationSucceeded(driveName),
           ),
-        ],
-      ),
+          style: typography.paragraphNormal(
+            color: colorTokens.textMid,
+          ),
+        ),
+      ],
     ),
     actions: [
       ModalAction(
@@ -301,29 +294,24 @@ Widget _failureDialog(
 ) {
   final createSnapshotCubit = context.read<CreateSnapshotCubit>();
   final typography = ArDriveTypographyNew.of(context);
+  final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
 
   return ArDriveStandardModalNew(
     title: appLocalizationsOf(context).snapshotFailed,
-    content: SizedBox(
-      width: kMediumDialogWidth,
-      child: Row(
-        children: [
-          Flexible(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text.rich(
-                  TextSpan(
-                    text: appLocalizationsOf(context).snapshotCreationFailed,
-                  ),
-                  style: typography.paragraphNormal(),
-                ),
-              ],
-            ),
+    width: kMediumDialogWidth,
+    content: Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text.rich(
+          TextSpan(
+            text: appLocalizationsOf(context).snapshotCreationFailed,
           ),
-        ],
-      ),
+          style: typography.paragraphNormal(
+            color: colorTokens.textMid,
+          ),
+        ),
+      ],
     ),
     actions: [
       ModalAction(
@@ -347,33 +335,27 @@ Widget _insufficientBalanceDialog(
   CreateSnapshotInsufficientBalance state,
 ) {
   final typography = ArDriveTypographyNew.of(context);
+  final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
 
   return ArDriveStandardModalNew(
     title: appLocalizationsOf(context).insufficientARForUpload,
-    content: SizedBox(
-      width: kMediumDialogWidth,
-      child: Row(
-        children: [
-          Flexible(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text.rich(
-                  TextSpan(
-                    text: appLocalizationsOf(context)
-                        .insufficientBalanceForSnapshot(
-                      state.walletBalance,
-                      state.arCost,
-                    ),
-                  ),
-                  style: typography.paragraphNormal(),
-                ),
-              ],
+    width: kMediumDialogWidth,
+    content: Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text.rich(
+          TextSpan(
+            text: appLocalizationsOf(context).insufficientBalanceForSnapshot(
+              state.walletBalance,
+              state.arCost,
             ),
           ),
-        ],
-      ),
+          style: typography.paragraphNormal(
+            color: colorTokens.textMid,
+          ),
+        ),
+      ],
     ),
     actions: [
       ModalAction(
@@ -393,6 +375,7 @@ Widget _confirmDialog(
   CreateSnapshotState state,
 ) {
   final typography = ArDriveTypographyNew.of(context);
+  final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
 
   return ArDriveStandardModalNew(
     title: appLocalizationsOf(context).newSnapshot,
@@ -413,19 +396,24 @@ Widget _confirmDialog(
                               .snapshotOfDrive(drive.name),
                           defaultMapper: (t) => TextSpan(
                             text: t,
-                            style: typography.paragraphNormal(),
+                            style: typography.paragraphNormal(
+                              color: colorTokens.textMid,
+                            ),
                           ),
                           parts: {
                             drive.name: (t) => TextSpan(
                                   text: t,
-                                  style: typography.paragraphNormal().copyWith(
-                                        fontWeight: FontWeight.bold,
-                                      ),
+                                  style: typography.paragraphNormal(
+                                    fontWeight: ArFontWeight.semiBold,
+                                    color: colorTokens.textHigh,
+                                  ),
                                 ),
                           },
                         ),
                       ),
-                      style: typography.paragraphNormal(),
+                      style: typography.paragraphNormal(
+                        color: colorTokens.textMid,
+                      ),
                     ),
                     Text.rich(
                       TextSpan(
@@ -436,7 +424,9 @@ Widget _confirmDialog(
                             ),
                           ),
                         ],
-                        style: typography.paragraphNormal(),
+                        style: typography.paragraphNormal(
+                          color: colorTokens.textMid,
+                        ),
                       ),
                     ),
                     const Divider(),

--- a/packages/ardrive_ui/lib/src/components/button.dart
+++ b/packages/ardrive_ui/lib/src/components/button.dart
@@ -74,13 +74,21 @@ class _ArDriveButtonState extends State<ArDriveButton> {
                 widget.customContent ??
                     Text(
                       widget.text,
-                      style: widget.fontStyle ??
-                          ArDriveTypography.headline.headline5Bold(
+                      // Merged onto the default rather than replacing it, so
+                      // a caller that only wants a different size or weight
+                      // does not silently lose the colour. A `TextStyle` with
+                      // a null colour inherits the button's `foregroundColor`,
+                      // which for the secondary style is the surface colour -
+                      // giving text the colour of the panel behind it. Merge
+                      // keeps whatever the caller did set and fills the rest.
+                      style: ArDriveTypography.headline
+                          .headline5Bold(
                             color: ArDriveTheme.of(context)
                                 .themeData
                                 .colors
                                 .themeFgOnAccent,
-                          ),
+                          )
+                          .merge(widget.fontStyle),
                     ),
                 if (widget.icon != null &&
                     widget.iconAlignment == IconButtonAlignment.right) ...[
@@ -117,13 +125,14 @@ class _ArDriveButtonState extends State<ArDriveButton> {
                 ],
                 Text(
                   widget.text,
-                  style: widget.fontStyle ??
-                      ArDriveTypography.headline.headline5Bold(
+                  style: ArDriveTypography.headline
+                      .headline5Bold(
                         color: ArDriveTheme.of(context)
                             .themeData
                             .colors
                             .themeFgDefault,
-                      ),
+                      )
+                      .merge(widget.fontStyle),
                 ),
                 if (widget.icon != null &&
                     widget.iconAlignment == IconButtonAlignment.right) ...[
@@ -368,15 +377,15 @@ class _ArDriveButtonNewState extends State<ArDriveButtonNew> {
 
     final text = Text(widget.text,
         textAlign: TextAlign.center,
-        style: widget.fontStyle ??
-            typography
-                .paragraphLarge(
-                  color: foregroundColor,
-                  fontWeight: ArFontWeight.semiBold,
-                )
-                .copyWith(
-                  overflow: TextOverflow.ellipsis,
-                ));
+        style: typography
+            .paragraphLarge(
+              color: foregroundColor,
+              fontWeight: ArFontWeight.semiBold,
+            )
+            .copyWith(
+              overflow: TextOverflow.ellipsis,
+            )
+            .merge(widget.fontStyle));
 
     final buttonH = widget.maxHeight ?? buttonDefaultHeight;
 

--- a/packages/ardrive_ui/test/src/components/button_test.dart
+++ b/packages/ardrive_ui/test/src/components/button_test.dart
@@ -118,6 +118,39 @@ void main() {
     expect(find.text('Text'), findsOneWidget);
   });
 
+  /// A caller that only wants a different size or weight must not lose the
+  /// button's colour. `TextStyle.color` left null falls through to the
+  /// button's `foregroundColor`, which for the secondary style is the surface
+  /// colour - text the same colour as the panel behind it, which in dark mode
+  /// reads as absent. 48 call sites across the app pass a style this way.
+  testWidgets('a partial fontStyle keeps the secondary button text colour',
+      (tester) async {
+    late Color expectedColor;
+
+    await tester.pumpWidget(ArDriveApp(
+      builder: (context) => MaterialApp(
+        home: Builder(builder: (context) {
+          expectedColor =
+              ArDriveTheme.of(context).themeData.colors.themeFgDefault;
+          return ArDriveButton(
+            style: ArDriveButtonStyle.secondary,
+            text: 'Text',
+            // Size and weight only - no colour, as the snapshots tab does.
+            fontStyle: const TextStyle(fontSize: 12),
+            onPressed: () {},
+          );
+        }),
+      ),
+    ));
+
+    final text = tester.widget<Text>(find.text('Text'));
+
+    expect(text.style?.fontSize, 12,
+        reason: "the caller's own values still win");
+    expect(text.style?.color, expectedColor,
+        reason: 'the colour it did not set must fall back, not vanish');
+  });
+
   testWidgets('Test if the text is used correctly on Tertiary', (tester) async {
     final button = ArDriveButton(
       style: ArDriveButtonStyle.tertiary,


### PR DESCRIPTION
The "Create Snapshot" button in the snapshots panel is unreadable in dark mode. The cause is in the design system, not that screen.

## The bug

`ArDriveButton` used the caller's `fontStyle` **in place of** its own default style rather than on top of it. The default is where the text colour lives — `themeFgOnAccent` for primary, `themeFgDefault` for secondary — so a caller asking only for a different size or weight lost the colour entirely.

A `TextStyle` with a null colour then inherits the button's `foregroundColor`, and for the secondary style that is:

```dart
foregroundColor: _backgroundColor,   // → themeBgSurface
```

The text is painted **the same colour as the panel behind it**. Dark-on-dark in dark mode, light-on-light in light mode.

The default is now merged with the caller's style, so whatever the caller set wins and whatever it omitted falls back instead of vanishing. Applied to primary, secondary and `ArDriveButtonNew`.

**This was not a one-off: 48 call sites pass a `fontStyle` without a colour.** Any of them on a secondary button had the same defect — topup preset selectors, manifest options, note create, and more. Fixing the component fixes them together; fixing the call site would have left the trap armed for the next caller.

## Modal styling

The create-snapshot modal, measured against the file-sharing and Turbo topup dialogs. It was already on the current primitives, so what dated it was how they were used:

| Was | Now |
|---|---|
| `typography.paragraphNormal()` — no colour | `paragraphNormal(color: colorTokens.textMid)` |
| `.copyWith(fontWeight: FontWeight.bold)` | `fontWeight: ArFontWeight.semiBold` |
| `SizedBox > Row > Flexible > Column` per modal | a plain `Column` |

Ten text spans across six modals asked for a size and never a colour — the same defect as the button, and why this modal looked washed out beside the sharing one.

## Mobile

The layout flattening initially moved the width onto the modal's `width` parameter, which is **not** equivalent to a `SizedBox` inside the content. `ArDriveStandardModalNew` caps itself at `modalStandardMaxWidthSize` (350) or the device width when narrower, and `width` *replaces* that cap (`maxWidth: width ?? maxWidth`). At `kMediumDialogWidth` (384) that opted the modals out of the clamp that keeps them on screen. Corrected: the modal keeps its own responsive width and the content fills it.

Both branches of the snapshots tab are affected — it switches at `constraints.maxWidth < 400`, and both the narrow and wide variants pass a colourless `fontStyle` — so the button was unreadable on mobile and desktop alike.

## Verification

- `flutter analyze` clean; 1347 app tests and 53 `ardrive_ui` tests pass
- New regression test: a secondary button given a size-only `fontStyle` must still render the theme foreground colour. **Mutation checked** — against the previous `??` the colour comes back `null`, which is precisely what made it take the surface colour
- No copy or flow changes; the dialog still mixes explanation, confirmation, progress and failure across six builders, which is a bigger question than a restyle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DnYLXFocWgTt9M2CbGYSUP