### PR TITLE
PE-9211: The shared file page, rebuilt around the file

### DIFF
--- a/lib/blocs/file_download/file_download_cubit.dart
+++ b/lib/blocs/file_download/file_download_cubit.dart
@@ -46,6 +46,11 @@ abstract class FileDownloadCubit extends Cubit<FileDownloadState> {
   /// arrives would trap the user in a download that has, in fact, finished.
   static const _verdictTimeout = Duration(seconds: 20);
 
+  /// How long a verdict may take before the user is told one is being waited
+  /// on. Short enough to appear promptly on the paths that are genuinely slow,
+  /// long enough that an already-settled verdict never shows the step at all.
+  static const _verdictAnnounceDelay = Duration(milliseconds: 250);
+
   /// Turns [downloader]'s mid-stream recoveries into something the user can
   /// see.
   ///
@@ -93,12 +98,40 @@ abstract class FileDownloadCubit extends Cubit<FileDownloadState> {
   }) async {
     if (isClosed || state is FileDownloadAborted) return;
 
-    emit(FileDownloadVerifying(fileName: fileName));
-
     DataItemIntegrityResult result;
 
+    final verdict = downloader.integrity;
+
+    // Announce the check only if it is actually going to take a moment.
+    //
+    // Every verdict this app can now reach is settled before the last byte is
+    // written: AES-GCM is MAC-checked during the download, and everything else
+    // has no check to run. Emitting "Checking this file" unconditionally meant
+    // a modal that appeared and replaced itself in the same breath - a flash
+    // of a step that never happened. The state is kept rather than deleted
+    // because it is correct the moment a caller asks for `verifyIntegrity`
+    // again, and then it is worth showing.
+    var answered = false;
+    // Swallowed here and read properly below: this is only asking "has it
+    // landed yet", and `integrity` is documented never to complete with an
+    // error anyway.
+    final settled = verdict.then<void>(
+      (_) => answered = true,
+      onError: (Object _) => answered = true,
+    );
+    await Future.any<void>([
+      settled,
+      Future<void>.delayed(_verdictAnnounceDelay),
+    ]);
+
+    if (isClosed || state is FileDownloadAborted) return;
+
+    if (!answered) {
+      emit(FileDownloadVerifying(fileName: fileName));
+    }
+
     try {
-      result = await downloader.integrity.timeout(
+      result = await verdict.timeout(
         _verdictTimeout,
         onTimeout: () => const DataItemIntegrityResult.notVerified(
           'The integrity check did not answer in time',

--- a/lib/blocs/fs_entry_preview/fs_entry_preview_cubit.dart
+++ b/lib/blocs/fs_entry_preview/fs_entry_preview_cubit.dart
@@ -32,6 +32,18 @@ class FsEntryPreviewCubit extends Cubit<FsEntryPreviewState> {
   final ProfileCubit _profileCubit;
   final ArDriveCrypto _crypto;
 
+  /// What the data transaction is encrypted with, when the caller already
+  /// knows.
+  ///
+  /// A share link carries the cipher and IV of the transaction it names, so a
+  /// recipient previewing a private file has them before the page loads. Given
+  /// them, the preview decrypts without asking the gateway to describe a
+  /// transaction it was already told about. They travel together or not at
+  /// all, and only for the transaction they describe - see
+  /// [_decodePrivateData].
+  final String? _cipher;
+  final String? _cipherIv;
+
   final SecretKey? _fileKey;
 
   /// Makes a playable URL out of decrypted bytes. See [PreviewObjectUrls] for
@@ -64,12 +76,16 @@ class FsEntryPreviewCubit extends Cubit<FsEntryPreviewState> {
     SecretKey? fileKey,
     bool isSharedFile = false,
     PreviewObjectUrls? objectUrls,
+    String? cipher,
+    String? cipherIv,
   })  : _driveDao = driveDao,
         _configService = configService,
         _profileCubit = profileCubit,
         _arweave = arweave,
         _crypto = crypto,
         _fileKey = fileKey,
+        _cipher = cipher,
+        _cipherIv = cipherIv,
         _objectUrls = objectUrls ?? PreviewObjectUrls(),
         super(FsEntryPreviewInitial()) {
     if (isSharedFile) {
@@ -1059,20 +1075,36 @@ class FsEntryPreviewCubit extends Cubit<FsEntryPreviewState> {
     SecretKey fileKey,
     String dataTxId,
   ) async {
-    final dataTx = await _getDataTx(dataTxId);
-
-    if (dataTx == null) {
-      return null;
-    }
+    final cipher = _cipher;
+    final cipherIv = _cipherIv;
 
     try {
-      final decodedBytes = await _crypto.decryptDataFromTransaction(
+      // The caller already knew what this is encrypted with, so the lookup
+      // that would have asked is skipped. This is the same saving the download
+      // path makes with the same two values from the same share link: before
+      // it, previewing a private shared file spent a GraphQL round trip
+      // re-reading tags the link had already delivered - on a rate-limited
+      // connection, a call that can fail and cost the preview entirely.
+      if (cipher != null && cipherIv != null) {
+        return await _crypto.decryptDataWithCipher(
+          cipher,
+          cipherIv,
+          dataBytes,
+          fileKey,
+        );
+      }
+
+      final dataTx = await _getDataTx(dataTxId);
+
+      if (dataTx == null) {
+        return null;
+      }
+
+      return await _crypto.decryptDataFromTransaction(
         dataTx,
         dataBytes,
         fileKey,
       );
-
-      return decodedBytes;
     } catch (e) {
       return null;
     }

--- a/lib/blocs/shared_file/shared_file_cubit.dart
+++ b/lib/blocs/shared_file/shared_file_cubit.dart
@@ -1731,8 +1731,8 @@ class SharedFileCubit extends Cubit<SharedFileState> {
         parentFolderId: '',
         name: payload.name ?? '',
         size: payload.size ?? 0,
-        lastModifiedDate: _unknownDate,
-        dateCreated: _unknownDate,
+        lastModifiedDate: unknownDate,
+        dateCreated: unknownDate,
         metadataTxId: payload.metadataTxId ?? '',
         dataTxId: payload.dataTxId!,
         dataContentType: payload.contentType,
@@ -1853,7 +1853,14 @@ class SharedFileCubit extends Cubit<SharedFileState> {
   bool _isStale(int resolution) => isClosed || resolution != _resolution;
 
   /// The link carries no timestamps. Rendered as "unknown", never as 1970.
-  static final _unknownDate = DateTime.fromMillisecondsSinceEpoch(0);
+  static final unknownDate = DateTime.fromMillisecondsSinceEpoch(0);
+
+  /// Whether [date] is the placeholder a link-derived revision carries.
+  ///
+  /// A link carries no timestamps, so anything painted from one has this in
+  /// place of a date. The UI asks rather than rendering it: shown, it reads as
+  /// 1 January 1970, which is worse than showing nothing.
+  static bool isUnknownDate(DateTime date) => date == unknownDate;
 }
 
 /// A revision resolved straight from its metadata transaction.

--- a/lib/blocs/shared_file/shared_file_cubit.dart
+++ b/lib/blocs/shared_file/shared_file_cubit.dart
@@ -326,7 +326,16 @@ class SharedFileCubit extends Cubit<SharedFileState> {
     final resolution = _resolution;
     final fileKey = _lastAttemptedFileKey;
 
-    emit(current.copyWith(activityStatus: SharedFileActivityStatus.loading));
+    emit(current.copyWith(
+      activityStatus: SharedFileActivityStatus.loading,
+      // The version the link named is already in hand - it is what the page is
+      // showing. It renders the moment the list is opened, and the rest of the
+      // history fills in around it, so expanding never costs a wait and a
+      // failed lookup never empties the list.
+      activityRevisions: current.activityRevisions.isEmpty
+          ? [current.sharedRevision]
+          : current.activityRevisions,
+    ));
 
     try {
       final entities = await _bounded(
@@ -369,6 +378,45 @@ class SharedFileCubit extends Cubit<SharedFileState> {
         emit(latest.copyWith(activityStatus: SharedFileActivityStatus.failed));
       }
     }
+  }
+
+  /// Makes [revision] what the page shows and downloads.
+  ///
+  /// The version list's own action. [showLatestRevision] and
+  /// [showSharedRevision] remain the banner's two shortcuts; this is the
+  /// general case behind them, so a recipient can pick any version the file
+  /// has rather than only the two the page happens to offer.
+  ///
+  /// The banner stays honest afterwards because "a newer version exists" is
+  /// re-derived from where the selection landed: on the newest revision there
+  /// is nothing newer to offer, and on any older one there is.
+  ///
+  /// Selecting is deliberate, so unlike the freshness check it *does* move the
+  /// download target - that is the whole point of the control. Nothing moves it
+  /// on the recipient's behalf.
+  Future<void> showRevision(FileRevision revision) async {
+    final current = state;
+
+    if (current is! SharedFileLoadSuccess) {
+      return;
+    }
+
+    // Already the target. Re-emitting would drop the license for no reason.
+    if (revision.dataTxId == current.revision.dataTxId) {
+      return;
+    }
+
+    final history = current.activityRevisions;
+    final isNewest =
+        history.isNotEmpty && revision.dataTxId == history.first.dataTxId;
+
+    emit(_withTarget(current, revision, showsLatestRevision: isNewest));
+
+    await _fetchLicense(
+      revision,
+      current.ownerAddress,
+      resolution: _resolution,
+    );
   }
 
   /// Takes the file's newest revision as what the page shows and downloads.

--- a/lib/blocs/shared_file/shared_file_cubit.dart
+++ b/lib/blocs/shared_file/shared_file_cubit.dart
@@ -402,13 +402,13 @@ class SharedFileCubit extends Cubit<SharedFileState> {
     }
 
     // Already the target. Re-emitting would drop the license for no reason.
-    if (revision.dataTxId == current.revision.dataTxId) {
+    if (isSameRevision(revision, current.revision)) {
       return;
     }
 
     final history = current.activityRevisions;
     final isNewest =
-        history.isNotEmpty && revision.dataTxId == history.first.dataTxId;
+        history.isNotEmpty && isSameRevision(revision, history.first);
 
     emit(_withTarget(current, revision, showsLatestRevision: isNewest));
 

--- a/lib/blocs/shared_file/shared_file_state.dart
+++ b/lib/blocs/shared_file/shared_file_state.dart
@@ -1,5 +1,27 @@
 part of 'shared_file_cubit.dart';
 
+/// Whether two revisions are the same revision.
+///
+/// `dataTxId` is not an identity. A rename or a move writes new metadata
+/// pointing at the *same* bytes - `getPerformedRevisionAction` returns
+/// `rename` on a name change alone - so a file that was renamed once has two
+/// revisions sharing one `dataTxId`. Keyed on that, both rows of the version
+/// list drew as selected and the second could not be chosen at all, because
+/// [SharedFileCubit.showRevision]'s already-selected guard matched it.
+///
+/// `metadataTxId` is the metadata transaction that was written, so it is
+/// unique per revision. The fallback is there because a link that carried no
+/// `mtx` seeds a revision whose `metadataTxId` is empty: while the page is
+/// still showing that seeded revision, comparing by metadata id would match
+/// nothing and leave the list with no selection at all.
+bool isSameRevision(FileRevision a, FileRevision b) {
+  if (a.metadataTxId.isNotEmpty && b.metadataTxId.isNotEmpty) {
+    return a.metadataTxId == b.metadataTxId;
+  }
+
+  return a.dataTxId == b.dataTxId;
+}
+
 /// How the claims a v2 link makes about a file compare with the file's own
 /// record on chain.
 ///

--- a/lib/components/file_download_dialog.dart
+++ b/lib/components/file_download_dialog.dart
@@ -696,8 +696,7 @@ class _DownloadOutcome extends StatelessWidget {
 
   final String fileName;
 
-  /// `null` when no check was run at all, in which case nothing is said about
-  /// one.
+  /// What the integrity check made of the bytes, when one ran.
   final DataItemIntegrityVerdict? integrity;
 
   @override
@@ -717,9 +716,22 @@ class _DownloadOutcome extends StatelessWidget {
             style: ArDriveTypography.body.smallRegular(),
             textAlign: TextAlign.left,
           ),
-          if (verdict != null) ...[
+          // Only a verdict worth having is worth a line.
+          //
+          // "ArDrive couldn't check this file against the original" was on
+          // every public download, because checking against the original means
+          // a data item signature, and that means a GraphQL lookup this app no
+          // longer makes on the download path. Telling a user that a check
+          // they never asked for did not happen is not information; it is a
+          // disclaimer that makes a successful download read as a qualified
+          // one.
+          //
+          // A private AES-GCM file still says so, and means it: the MAC is
+          // computed locally over every byte before any of them are written,
+          // so that verdict costs nothing and is a real guarantee.
+          if (verdict == DataItemIntegrityVerdict.verified) ...[
             const SizedBox(height: 12),
-            _IntegrityNotice(verdict: verdict),
+            const _VerifiedNotice(),
           ],
         ],
       ),
@@ -727,57 +739,39 @@ class _DownloadOutcome extends StatelessWidget {
   }
 }
 
-/// One line about the integrity check, in the icon-plus-caption shape the rest
-/// of the app uses for advisory notices.
-class _IntegrityNotice extends StatelessWidget {
-  const _IntegrityNotice({required this.verdict});
-
-  final DataItemIntegrityVerdict verdict;
+/// One line confirming the bytes checked out, in the icon-plus-caption shape
+/// the rest of the app uses for advisory notices.
+///
+/// Only reachable for a verdict of [DataItemIntegrityVerdict.verified]. The
+/// other two do not come here: `failed` takes over the whole modal, because
+/// bytes that contradict what was signed are the headline rather than a
+/// footnote, and `notVerified` says nothing at all - see [_DownloadOutcome].
+class _VerifiedNotice extends StatelessWidget {
+  const _VerifiedNotice();
 
   @override
   Widget build(BuildContext context) {
     final colors = ArDriveTheme.of(context).themeData.colors;
     final isLight = ArDriveTheme.of(context).themeData.name == 'light';
 
-    final Widget icon;
-    final Color color;
-    final String message;
-
-    switch (verdict) {
-      case DataItemIntegrityVerdict.verified:
-        // `themeSuccessDefault` is green.400 in both themes and reads at only
-        // ~2.2:1 on a light surface, so the light theme takes the muted green
-        // instead - the same substitution the recipient page documents in
-        // [SharedFileColors.success].
-        color = isLight ? colors.themeSuccessMuted : colors.themeSuccessDefault;
-        icon = ArDriveIcons.checkCirle(size: 16, color: color);
-        message = appLocalizationsOf(context).downloadVerified;
-        break;
-      case DataItemIntegrityVerdict.notVerified:
-        // Neutral, never a warning triangle: no verdict is not a problem, and
-        // an alarm icon would say otherwise louder than the sentence next to
-        // it says the opposite.
-        color = colors.themeFgMuted;
-        icon = ArDriveIcons.info(size: 16, color: color);
-        message = appLocalizationsOf(context).downloadNotVerified;
-        break;
-      case DataItemIntegrityVerdict.failed:
-        // Unreachable: a failed verdict takes over the modal.
-        color = colors.themeErrorDefault;
-        icon = ArDriveIcons.triangle(size: 16, color: color);
-        message = appLocalizationsOf(context).downloadVerificationFailed;
-        break;
-    }
+    // `themeSuccessDefault` is green.400 in both themes and reads at only
+    // ~2.2:1 on a light surface, so the light theme takes the muted green
+    // instead - the same substitution the recipient page documents in
+    // [SharedFileColors.success].
+    final color =
+        isLight ? colors.themeSuccessMuted : colors.themeSuccessDefault;
 
     return MergeSemantics(
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          ExcludeSemantics(child: icon),
+          ExcludeSemantics(
+            child: ArDriveIcons.checkCirle(size: 16, color: color),
+          ),
           const SizedBox(width: 8),
           Expanded(
             child: Text(
-              message,
+              appLocalizationsOf(context).downloadVerified,
               style: ArDriveTypography.body.captionRegular(color: color),
             ),
           ),

--- a/lib/components/file_download_dialog.dart
+++ b/lib/components/file_download_dialog.dart
@@ -420,15 +420,23 @@ class FileDownloadDialog extends StatelessWidget {
       );
     }
 
+    // Nothing is said about a check that passed.
+    //
+    // "Verified" claimed more than it did. It never meant the bytes were
+    // checked against what the uploader signed - that is the data item
+    // signature, and it is not fetched here. It meant the AES-GCM MAC checked
+    // out, which is a real cryptographic check but not one the user can ever
+    // learn anything from: a MAC that fails throws out of the download, so the
+    // dialog below is only ever reached when it passed. A label on 100% of
+    // successes carries no information.
+    //
+    // It was also asymmetric. Only private GCM files could earn it, so a badge
+    // on those and silence on everything else implied public downloads were
+    // the lesser thing, which is the opposite of true and not a claim worth
+    // making by accident.
     return _modalWrapper(
       title: appLocalizationsOf(context).downloadFinished,
-      // The file name would normally be the modal's `description`, but
-      // [ArDriveStandardModalNew] renders `description` only when there is no
-      // `content`, so the advisory has to bring the name with it.
-      child: _DownloadOutcome(
-        fileName: state.fileName,
-        integrity: state.integrity,
-      ),
+      description: state.fileName,
       actions: [
         ModalAction(
           action: () {
@@ -688,95 +696,3 @@ class FileDownloadDialog extends StatelessWidget {
 /// [DataItemIntegrityVerdict.failed] never reaches here; it takes over the
 /// whole modal instead. See
 /// [FileDownloadDialog.downloadFinishedWithSuccessDialog].
-class _DownloadOutcome extends StatelessWidget {
-  const _DownloadOutcome({
-    required this.fileName,
-    required this.integrity,
-  });
-
-  final String fileName;
-
-  /// What the integrity check made of the bytes, when one ran.
-  final DataItemIntegrityVerdict? integrity;
-
-  @override
-  Widget build(BuildContext context) {
-    final verdict = integrity;
-
-    return SizedBox(
-      width: kMediumDialogWidth,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(
-            fileName,
-            // The style [ArDriveStandardModalNew] gives its own `description`,
-            // which is where this line sits on every other download dialog.
-            style: ArDriveTypography.body.smallRegular(),
-            textAlign: TextAlign.left,
-          ),
-          // Only a verdict worth having is worth a line.
-          //
-          // "ArDrive couldn't check this file against the original" was on
-          // every public download, because checking against the original means
-          // a data item signature, and that means a GraphQL lookup this app no
-          // longer makes on the download path. Telling a user that a check
-          // they never asked for did not happen is not information; it is a
-          // disclaimer that makes a successful download read as a qualified
-          // one.
-          //
-          // A private AES-GCM file still says so, and means it: the MAC is
-          // computed locally over every byte before any of them are written,
-          // so that verdict costs nothing and is a real guarantee.
-          if (verdict == DataItemIntegrityVerdict.verified) ...[
-            const SizedBox(height: 12),
-            const _VerifiedNotice(),
-          ],
-        ],
-      ),
-    );
-  }
-}
-
-/// One line confirming the bytes checked out, in the icon-plus-caption shape
-/// the rest of the app uses for advisory notices.
-///
-/// Only reachable for a verdict of [DataItemIntegrityVerdict.verified]. The
-/// other two do not come here: `failed` takes over the whole modal, because
-/// bytes that contradict what was signed are the headline rather than a
-/// footnote, and `notVerified` says nothing at all - see [_DownloadOutcome].
-class _VerifiedNotice extends StatelessWidget {
-  const _VerifiedNotice();
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = ArDriveTheme.of(context).themeData.colors;
-    final isLight = ArDriveTheme.of(context).themeData.name == 'light';
-
-    // `themeSuccessDefault` is green.400 in both themes and reads at only
-    // ~2.2:1 on a light surface, so the light theme takes the muted green
-    // instead - the same substitution the recipient page documents in
-    // [SharedFileColors.success].
-    final color =
-        isLight ? colors.themeSuccessMuted : colors.themeSuccessDefault;
-
-    return MergeSemantics(
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          ExcludeSemantics(
-            child: ArDriveIcons.checkCirle(size: 16, color: color),
-          ),
-          const SizedBox(width: 8),
-          Expanded(
-            child: Text(
-              appLocalizationsOf(context).downloadVerified,
-              style: ArDriveTypography.body.captionRegular(color: color),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}

--- a/lib/core/crypto/crypto.dart
+++ b/lib/core/crypto/crypto.dart
@@ -237,6 +237,27 @@ class ArDriveCrypto {
     return decryptedData;
   }
 
+  /// Decrypts data whose cipher and IV the caller already holds.
+  ///
+  /// [decryptDataFromTransaction] reads those two values off a transaction it
+  /// asks the gateway to describe. A share link carries them for the
+  /// transaction it names, so a caller holding one can decrypt without that
+  /// lookup - which is the only reason `c` and `iv` are in the link schema.
+  ///
+  /// Named for what it takes rather than after the top-level
+  /// `decryptTransactionData` it delegates to: an unqualified call to a
+  /// same-named function from inside this class would resolve to the method
+  /// and recurse.
+  ///
+  /// Throws a [TransactionDecryptionException] if decryption fails.
+  Future<Uint8List> decryptDataWithCipher(
+    String cipher,
+    String cipherIvString,
+    Uint8List data,
+    SecretKey key,
+  ) =>
+      decryptTransactionData(cipher, cipherIvString, data, key);
+
   /// Creates a transaction with the provided entity's JSON data encrypted along with the appropriate cipher tags.
   Future<Transaction> createEncryptedEntityTransaction(
           Entity entity, SecretKey key) =>

--- a/lib/download/ardrive_downloader.dart
+++ b/lib/download/ardrive_downloader.dart
@@ -65,6 +65,7 @@ abstract class ArDriveDownloader {
     String? cipher,
     String? cipherIvString,
     bool verifyDownload,
+    bool verifyIntegrity,
   });
   Future<Uint8List> downloadToMemory({
     required String txId,
@@ -92,7 +93,11 @@ abstract class ArDriveDownloader {
   /// - AES-GCM files resolve to [DataItemIntegrityVerdict.verified] the moment
   ///   the MAC checks out, which is before a byte is written.
   /// - AES-CTR and public files resolve when the last byte has streamed
-  ///   through [StreamedDataItemVerifier].
+  ///   through [StreamedDataItemVerifier] - but only when the caller asked for
+  ///   `verifyIntegrity`, which nothing does. Without it the verdict is
+  ///   [DataItemIntegrityVerdict.notVerified], which is the honest answer for
+  ///   a check that was not run and is why the dialog treats `notVerified` as
+  ///   unremarkable and `failed` as the only thing worth interrupting for.
   /// - A resumed download resolves to [DataItemIntegrityVerdict.notVerified]:
   ///   the hash of the bytes before the interruption is gone.
   Future<DataItemIntegrityResult> get integrity;
@@ -256,6 +261,10 @@ class _ArDriveDownloader implements ArDriveDownloader {
     String? cipher,
     String? cipherIvString,
     bool verifyDownload = false,
+    // Off by default, and nothing in the app turns it on. See the long note
+    // at the `verifierFuture` in [_getFileStream] for why a download must not
+    // depend on a GraphQL round trip.
+    bool verifyIntegrity = false,
   }) async {
     _resetIntegrity();
 
@@ -307,6 +316,7 @@ class _ArDriveDownloader implements ArDriveDownloader {
           cipher: cipher,
           cipherIvString: cipherIvString,
           verifyDownload: verifyDownload,
+          verifyIntegrity: verifyIntegrity,
         );
 
         saveStream = prepared.stream;
@@ -765,7 +775,7 @@ class _ArDriveDownloader implements ArDriveDownloader {
     String? cipher,
     String? cipherIvString,
     bool verifyDownload = false,
-    bool verifyIntegrity = true,
+    bool verifyIntegrity = false,
   }) async {
     logger.d('The file is not a manifest. Downloading it from Arweave...');
     logger.d('verifying download: $verifyDownload');
@@ -815,8 +825,33 @@ class _ArDriveDownloader implements ArDriveDownloader {
       keyData = Uint8List.fromList(await fileKey.extractBytes());
     }
 
-    // Started here, not inside the stream, so the GraphQL round trip overlaps
-    // the download instead of delaying its first byte.
+    // Off by default: a download must not depend on a GraphQL round trip.
+    //
+    // This check was added in #2175 and turned out to cost more than it
+    // bought. Three things, each independently disqualifying:
+    //
+    // * It is not free, and not concurrent either. Starting the future here
+    //   was meant to overlap it with the transfer, but the stream awaits it
+    //   before yielding a single byte (`verifier ??= await verifierFuture`),
+    //   so a slow lookup delays the first byte by up to
+    //   [_integrityLookupTimeout].
+    // * It reports failures that are not failures. Gateways return `anchor`
+    //   and `recipient` as empty strings - checked live against goldsky,
+    //   permagate.io, turbo-gateway.com and vilenarios.com - so any data item
+    //   that actually carries one deep-hashes differently here than it did
+    //   when it was signed, and a healthy file is reported as `failed`. That
+    //   verdict is not a footnote: it replaces the success dialog with
+    //   "the file may be corrupted".
+    // * A recipient on a connection that `arweave.net` rate limits gets the
+    //   10s timeout on every download, because that host is what
+    //   [GraphQLRetry] falls back to.
+    //
+    // What is kept is the check that costs nothing: AES-GCM files are still
+    // buffered and MAC-verified (§3.4.1), which is a real integrity guarantee
+    // computed locally over the bytes in hand. Only the signature check, the
+    // one that needs the network to say anything at all, is gone.
+    //
+    // Callers can still ask for it explicitly. Nothing does today.
     final verifierFuture = verifyIntegrity
         ? _verifierFactory(txId)
         : Future.value(StreamedDataItemVerifier.unavailable(

--- a/lib/download/ardrive_downloader.dart
+++ b/lib/download/ardrive_downloader.dart
@@ -1467,11 +1467,30 @@ class DownloadSourceResponse {
 
 /// The production [DownloadSource].
 ///
-/// A download from byte 0 goes through the existing hedged gateway fallback,
-/// unchanged. A resume is a direct `GET {gateway}/{txId}` with a `Range`
-/// header, because the arweave client's `download()` does not expose one; it
-/// walks the same gateway order and takes the first gateway that actually
-/// serves a range.
+/// Every download is a direct `GET {gateway}/{txId}`, resumed or not.
+///
+/// It used to start at the arweave client's `download()`, which turns out to
+/// POST `{gateway}/graphql` before it fetches a single byte - unconditionally,
+/// whether or not verification was asked for, because it wants `dataSize` for
+/// its progress figure. Three ways that breaks a download that would otherwise
+/// have worked:
+///
+/// * The POST is subject to CORS, and the gateways do not all allow it from an
+///   arbitrary origin. `perma.online` answers the preflight with no
+///   `Access-Control-Allow-Origin` at all.
+/// * `arweave.net` rate limits, and a 429 fails the preflight too.
+/// * Either way `_getTransactionData` throws, and it throws *before* the byte
+///   stream exists - so the gateway is recorded as having failed and the next
+///   one is tried, until there are none left and a perfectly downloadable file
+///   reports `unknownError`.
+///
+/// None of it was needed here: the size is already known from the file's own
+/// record, and `verifyDownload` is false for everything the app does.
+///
+/// `verifyDownload: true` still goes the old way. It is the arweave client's
+/// chunk check for L1 transactions, it is the client's to run, and the one
+/// caller that asks for it has already resolved the transaction over GraphQL
+/// to discover it needs it.
 class GatewayDownloadSource implements DownloadSource {
   GatewayDownloadSource(
     this._arweave, {
@@ -1490,7 +1509,7 @@ class GatewayDownloadSource implements DownloadSource {
     int startOffsetBytes = 0,
     bool verifyDownload = false,
   }) async {
-    if (startOffsetBytes == 0) {
+    if (startOffsetBytes == 0 && verifyDownload) {
       final response = await _arweave.gatewayFallback.downloadWithFallback(
         txId: txId,
         primaryClient: _arweave.client,
@@ -1511,8 +1530,13 @@ class GatewayDownloadSource implements DownloadSource {
   Future<DownloadSourceResponse> _openRange(String txId, int offset) async {
     Object? lastError;
     var sawIgnoredRange = false;
+    // Every gateway answering 404 is a different fact from every gateway
+    // failing, and the dialog says something different for each.
+    var tried = 0;
+    var notFound = 0;
 
     for (final origin in _gatewayOrigins()) {
+      tried++;
       final client = _clientFactory();
 
       try {
@@ -1523,6 +1547,7 @@ class GatewayDownloadSource implements DownloadSource {
             await client.send(request).timeout(_rangeRequestTimeout);
 
         if (response.statusCode != 200 && response.statusCode != 206) {
+          if (response.statusCode == 404) notFound++;
           lastError = 'HTTP ${response.statusCode} from $origin';
           await _discard(response);
           client.close();
@@ -1568,6 +1593,10 @@ class GatewayDownloadSource implements DownloadSource {
         startOffsetBytes: 0,
         statusCode: 200,
       );
+    }
+
+    if (tried > 0 && notFound == tried) {
+      throw DownloadFileNotFoundException(txId);
     }
 
     throw DownloadNetworkException(txId, lastError?.toString());

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -613,10 +613,6 @@
       }
     }
   },
-  "downloadVerified": "This file matches what was originally uploaded.",
-  "@downloadVerified": {
-    "description": "Quiet affirmative line on the download success dialog when the integrity check passed"
-  },
   "downloadVerifying": "Checking this file...",
   "@downloadVerifying": {
     "description": "Title of the download dialog shown after the file is saved, while the integrity check is still running"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2146,6 +2146,10 @@
   "@sharedFileAccessKeyStaysOnThisDevice": {
     "description": "Reassurance shown under the access key field on the shared file page"
   },
+  "sharedFileTransactionDetails": "Transaction details",
+  "@sharedFileTransactionDetails": {
+    "description": "Nested disclosure inside the file details tab, holding the identifiers a recipient never needs to see"
+  },
   "sharedFileDetailsDrawerTitle": "File details",
   "@sharedFileDetailsDrawerTitle": {
     "description": "Title of the collapsed drawer holding the technical details of a shared file"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2298,10 +2298,6 @@
       }
     }
   },
-  "sharedFileStoredPermanently": "This file is stored permanently and can be downloaded any time.",
-  "@sharedFileStoredPermanently": {
-    "description": "Reassurance shown at the bottom of the shared file page"
-  },
   "sharedFileUnlockedWithAccessKey": "Unlocked with your access key. This file stays encrypted for everyone else.",
   "@sharedFileUnlockedWithAccessKey": {
     "description": "Shown after a private shared file has been unlocked with an access key"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2362,6 +2362,26 @@
   "@shareDriveSendKeySeparately": {
     "description": "Helper text under the drive key field explaining the two-artifact handover"
   },
+  "sharedFileChooseVersion": "Choose which version to download.",
+  "@sharedFileChooseVersion": {
+    "description": "Helper line above the recipient's list of file versions"
+  },
+  "sharedFileVersionLatest": "Latest",
+  "@sharedFileVersionLatest": {
+    "description": "Chip marking the newest version in the recipient's version list"
+  },
+  "sharedFileVersionFromLink": "This link",
+  "@sharedFileVersionFromLink": {
+    "description": "Chip marking the version the share link points at"
+  },
+  "sharedFileVersionsLooking": "Looking for other versions\u2026",
+  "@sharedFileVersionsLooking": {
+    "description": "Shown while the rest of a file's version history is being fetched"
+  },
+  "sharedFileVersionsUnavailableShort": "Couldn\u2019t check for other versions.",
+  "@sharedFileVersionsUnavailableShort": {
+    "description": "Shown when the version history could not be read; the version the recipient was sent is still listed and downloadable"
+  },
   "attachDriveLookingUp": "Looking up drive…",
   "@attachDriveLookingUp": {
     "description": "Shown while the entered drive ID is being resolved"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2370,6 +2370,10 @@
   "@sharedFileVersionLatest": {
     "description": "Chip marking the newest version in the recipient's version list"
   },
+  "sharedFileVersionPinned": "Pinned",
+  "@sharedFileVersionPinned": {
+    "description": "Chip marking the version a pinned share link deliberately points at, as opposed to merely the version the link carried"
+  },
   "sharedFileVersionFromLink": "This link",
   "@sharedFileVersionFromLink": {
     "description": "Chip marking the version the share link points at"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -591,10 +591,6 @@
   "@downloadMustRestartDescription": {
     "description": "Description of the download failure dialog shown when the download cannot be resumed. Says plainly that retrying restarts from the beginning rather than continuing"
   },
-  "downloadNotVerified": "ArDrive couldn’t check this file against the original. That’s normal for some files and doesn’t mean anything is wrong.",
-  "@downloadNotVerified": {
-    "description": "Advisory line on the download success dialog when no integrity verdict could be reached. Must never imply the file is damaged: this outcome is routine"
-  },
   "downloadReconnecting": "Reconnecting...",
   "@downloadReconnecting": {
     "description": "Status label that replaces Downloading while a download that lost its connection picks itself back up"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2246,10 +2246,6 @@
   "@sharedFilePasteAccessKey": {
     "description": "Placeholder of the access key field on the shared file page"
   },
-  "sharedFilePermanentFileSharing": "Permanent file sharing",
-  "@sharedFilePermanentFileSharing": {
-    "description": "Tagline shown under the ArDrive logo on the shared file page"
-  },
   "sharedFilePreviewPaneHint": "Preview this file here without downloading it.",
   "@sharedFilePreviewPaneHint": {
     "description": "Caption in the preview pane of the shared file page, on a desktop screen, saying what pressing Preview will do"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2370,10 +2370,6 @@
   "@sharedFileVersionPinned": {
     "description": "Chip marking the version a pinned share link deliberately points at, as opposed to merely the version the link carried"
   },
-  "sharedFileVersionFromLink": "This link",
-  "@sharedFileVersionFromLink": {
-    "description": "Chip marking the version the share link points at"
-  },
   "sharedFileVersionsLooking": "Looking for other versions\u2026",
   "@sharedFileVersionsLooking": {
     "description": "Shown while the rest of a file's version history is being fetched"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2186,10 +2186,6 @@
   "@sharedFileGetLatest": {
     "description": "Button that fetches the newest version of a shared file"
   },
-  "sharedFileHidePreview": "Hide preview",
-  "@sharedFileHidePreview": {
-    "description": "Button that closes the preview on the shared file page"
-  },
   "sharedFileIsEncrypted": "This file is encrypted.",
   "@sharedFileIsEncrypted": {
     "description": "Description that says the file is encrypted on shared file page"
@@ -2245,10 +2241,6 @@
   "sharedFilePasteAccessKey": "Paste the access key",
   "@sharedFilePasteAccessKey": {
     "description": "Placeholder of the access key field on the shared file page"
-  },
-  "sharedFilePreviewPaneHint": "Preview this file here without downloading it.",
-  "@sharedFilePreviewPaneHint": {
-    "description": "Caption in the preview pane of the shared file page, on a desktop screen, saying what pressing Preview will do"
   },
   "sharedFilePreviewUnsupported": "This file can’t be previewed here. Download it to open it.",
   "@sharedFilePreviewUnsupported": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -562,10 +562,6 @@
       }
     }
   },
-  "downloadVerified": "Este archivo coincide con lo que se subió originalmente.",
-  "@downloadVerified": {
-    "description": "Quiet affirmative line on the download success dialog when the integrity check passed"
-  },
   "downloadVerifying": "Comprobando este archivo...",
   "@downloadVerifying": {
     "description": "Title of the download dialog shown after the file is saved, while the integrity check is still running"

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -540,10 +540,6 @@
   "@downloadMustRestartDescription": {
     "description": "Description of the download failure dialog shown when the download cannot be resumed. Says plainly that retrying restarts from the beginning rather than continuing"
   },
-  "downloadNotVerified": "ArDrive no ha podido comprobar este archivo con el original. Es algo normal en algunos archivos y no significa que haya ningún problema.",
-  "@downloadNotVerified": {
-    "description": "Advisory line on the download success dialog when no integrity verdict could be reached. Must never imply the file is damaged: this outcome is routine"
-  },
   "downloadReconnecting": "Reconectando...",
   "@downloadReconnecting": {
     "description": "Status label that replaces Downloading while a download that lost its connection picks itself back up"

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1877,10 +1877,6 @@
   "@sharedFilePasteAccessKey": {
     "description": "Placeholder of the access key field on the shared file page"
   },
-  "sharedFilePermanentFileSharing": "Compartir archivos de forma permanente",
-  "@sharedFilePermanentFileSharing": {
-    "description": "Tagline shown under the ArDrive logo on the shared file page"
-  },
   "sharedFilePreviewPaneHint": "Previsualiza este archivo aquí, sin descargarlo.",
   "@sharedFilePreviewPaneHint": {
     "description": "Caption in the preview pane of the shared file page, on a desktop screen, saying what pressing Preview will do"

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1817,10 +1817,6 @@
   "@sharedFileGetLatest": {
     "description": "Button that fetches the newest version of a shared file"
   },
-  "sharedFileHidePreview": "Ocultar la vista previa",
-  "@sharedFileHidePreview": {
-    "description": "Button that closes the preview on the shared file page"
-  },
   "sharedFileIsEncrypted": "El archivo está cifrado.",
   "@sharedFileIsEncrypted": {
     "description": "Description that says the file is encrypted on shared file page"
@@ -1876,10 +1872,6 @@
   "sharedFilePasteAccessKey": "Pega la clave de acceso",
   "@sharedFilePasteAccessKey": {
     "description": "Placeholder of the access key field on the shared file page"
-  },
-  "sharedFilePreviewPaneHint": "Previsualiza este archivo aquí, sin descargarlo.",
-  "@sharedFilePreviewPaneHint": {
-    "description": "Caption in the preview pane of the shared file page, on a desktop screen, saying what pressing Preview will do"
   },
   "sharedFilePreviewUnsupported": "Este archivo no se puede previsualizar aquí. Descárgalo para abrirlo.",
   "@sharedFilePreviewUnsupported": {

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -1817,10 +1817,6 @@
   "@sharedFileGetLatest": {
     "description": "Button that fetches the newest version of a shared file"
   },
-  "sharedFileHidePreview": "प्रीव्यू छिपाएँ",
-  "@sharedFileHidePreview": {
-    "description": "Button that closes the preview on the shared file page"
-  },
   "sharedFileIsEncrypted": "यह फ़ाइल एन्क्रिप्ट की गई है।",
   "@sharedFileIsEncrypted": {
     "description": "Description that says the file is encrypted on shared file page"
@@ -1876,10 +1872,6 @@
   "sharedFilePasteAccessKey": "ऐक्सेस कुंजी चिपकाएँ",
   "@sharedFilePasteAccessKey": {
     "description": "Placeholder of the access key field on the shared file page"
-  },
-  "sharedFilePreviewPaneHint": "इस फ़ाइल को डाउनलोड किए बिना यहीं देखें।",
-  "@sharedFilePreviewPaneHint": {
-    "description": "Caption in the preview pane of the shared file page, on a desktop screen, saying what pressing Preview will do"
   },
   "sharedFilePreviewUnsupported": "इस फ़ाइल का प्रीव्यू यहाँ नहीं दिखाया जा सकता। इसे खोलने के लिए डाउनलोड करें।",
   "@sharedFilePreviewUnsupported": {

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -1877,10 +1877,6 @@
   "@sharedFilePasteAccessKey": {
     "description": "Placeholder of the access key field on the shared file page"
   },
-  "sharedFilePermanentFileSharing": "स्थायी फ़ाइल शेयरिंग",
-  "@sharedFilePermanentFileSharing": {
-    "description": "Tagline shown under the ArDrive logo on the shared file page"
-  },
   "sharedFilePreviewPaneHint": "इस फ़ाइल को डाउनलोड किए बिना यहीं देखें।",
   "@sharedFilePreviewPaneHint": {
     "description": "Caption in the preview pane of the shared file page, on a desktop screen, saying what pressing Preview will do"

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -562,10 +562,6 @@
       }
     }
   },
-  "downloadVerified": "यह फ़ाइल मूल रूप से अपलोड की गई फ़ाइल से मेल खाती है।",
-  "@downloadVerified": {
-    "description": "Quiet affirmative line on the download success dialog when the integrity check passed"
-  },
   "downloadVerifying": "इस फ़ाइल की जाँच हो रही है...",
   "@downloadVerifying": {
     "description": "Title of the download dialog shown after the file is saved, while the integrity check is still running"

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -540,10 +540,6 @@
   "@downloadMustRestartDescription": {
     "description": "Description of the download failure dialog shown when the download cannot be resumed. Says plainly that retrying restarts from the beginning rather than continuing"
   },
-  "downloadNotVerified": "ArDrive इस फ़ाइल की मूल फ़ाइल से जाँच नहीं कर सका। कुछ फ़ाइलों के लिए यह सामान्य है और इसका मतलब यह नहीं कि कुछ गड़बड़ है।",
-  "@downloadNotVerified": {
-    "description": "Advisory line on the download success dialog when no integrity verdict could be reached. Must never imply the file is damaged: this outcome is routine"
-  },
   "downloadReconnecting": "फिर से जुड़ रहे हैं...",
   "@downloadReconnecting": {
     "description": "Status label that replaces Downloading while a download that lost its connection picks itself back up"

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -562,10 +562,6 @@
       }
     }
   },
-  "downloadVerified": "このファイルはアップロードされた元のファイルと一致しています。",
-  "@downloadVerified": {
-    "description": "Quiet affirmative line on the download success dialog when the integrity check passed"
-  },
   "downloadVerifying": "このファイルを確認しています...",
   "@downloadVerifying": {
     "description": "Title of the download dialog shown after the file is saved, while the integrity check is still running"

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1877,10 +1877,6 @@
   "@sharedFilePasteAccessKey": {
     "description": "Placeholder of the access key field on the shared file page"
   },
-  "sharedFilePermanentFileSharing": "永続的なファイル共有",
-  "@sharedFilePermanentFileSharing": {
-    "description": "Tagline shown under the ArDrive logo on the shared file page"
-  },
   "sharedFilePreviewPaneHint": "ダウンロードせずに、このファイルをここでプレビューできます。",
   "@sharedFilePreviewPaneHint": {
     "description": "Caption in the preview pane of the shared file page, on a desktop screen, saying what pressing Preview will do"

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -540,10 +540,6 @@
   "@downloadMustRestartDescription": {
     "description": "Description of the download failure dialog shown when the download cannot be resumed. Says plainly that retrying restarts from the beginning rather than continuing"
   },
-  "downloadNotVerified": "ArDrive はこのファイルを元のファイルと照合できませんでした。一部のファイルでは通常のことで、問題があるという意味ではありません。",
-  "@downloadNotVerified": {
-    "description": "Advisory line on the download success dialog when no integrity verdict could be reached. Must never imply the file is damaged: this outcome is routine"
-  },
   "downloadReconnecting": "再接続しています...",
   "@downloadReconnecting": {
     "description": "Status label that replaces Downloading while a download that lost its connection picks itself back up"

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1817,10 +1817,6 @@
   "@sharedFileGetLatest": {
     "description": "Button that fetches the newest version of a shared file"
   },
-  "sharedFileHidePreview": "プレビューを閉じる",
-  "@sharedFileHidePreview": {
-    "description": "Button that closes the preview on the shared file page"
-  },
   "sharedFileIsEncrypted": "このファイルは暗号化されています。",
   "@sharedFileIsEncrypted": {
     "description": "Description that says the file is encrypted on shared file page"
@@ -1876,10 +1872,6 @@
   "sharedFilePasteAccessKey": "アクセスキーを貼り付け",
   "@sharedFilePasteAccessKey": {
     "description": "Placeholder of the access key field on the shared file page"
-  },
-  "sharedFilePreviewPaneHint": "ダウンロードせずに、このファイルをここでプレビューできます。",
-  "@sharedFilePreviewPaneHint": {
-    "description": "Caption in the preview pane of the shared file page, on a desktop screen, saying what pressing Preview will do"
   },
   "sharedFilePreviewUnsupported": "このファイルはここではプレビューできません。開くにはダウンロードしてください。",
   "@sharedFilePreviewUnsupported": {

--- a/lib/l10n/app_zh-HK.arb
+++ b/lib/l10n/app_zh-HK.arb
@@ -1877,10 +1877,6 @@
   "@sharedFilePasteAccessKey": {
     "description": "Placeholder of the access key field on the shared file page"
   },
-  "sharedFilePermanentFileSharing": "永久檔案分享",
-  "@sharedFilePermanentFileSharing": {
-    "description": "Tagline shown under the ArDrive logo on the shared file page"
-  },
   "sharedFilePreviewPaneHint": "無需下載，即可在這裡預覽此檔案。",
   "@sharedFilePreviewPaneHint": {
     "description": "Caption in the preview pane of the shared file page, on a desktop screen, saying what pressing Preview will do"

--- a/lib/l10n/app_zh-HK.arb
+++ b/lib/l10n/app_zh-HK.arb
@@ -1817,10 +1817,6 @@
   "@sharedFileGetLatest": {
     "description": "Button that fetches the newest version of a shared file"
   },
-  "sharedFileHidePreview": "隱藏預覽",
-  "@sharedFileHidePreview": {
-    "description": "Button that closes the preview on the shared file page"
-  },
   "sharedFileIsEncrypted": "This file is encrypted.",
   "@sharedFileIsEncrypted": {
     "description": "Description that says the file is encrypted on shared file page"
@@ -1876,10 +1872,6 @@
   "sharedFilePasteAccessKey": "貼上存取密鑰",
   "@sharedFilePasteAccessKey": {
     "description": "Placeholder of the access key field on the shared file page"
-  },
-  "sharedFilePreviewPaneHint": "無需下載，即可在這裡預覽此檔案。",
-  "@sharedFilePreviewPaneHint": {
-    "description": "Caption in the preview pane of the shared file page, on a desktop screen, saying what pressing Preview will do"
   },
   "sharedFilePreviewUnsupported": "此檔案無法在這裡預覽。請下載後開啟。",
   "@sharedFilePreviewUnsupported": {

--- a/lib/l10n/app_zh-HK.arb
+++ b/lib/l10n/app_zh-HK.arb
@@ -562,10 +562,6 @@
       }
     }
   },
-  "downloadVerified": "此檔案與最初上載的檔案相符。",
-  "@downloadVerified": {
-    "description": "Quiet affirmative line on the download success dialog when the integrity check passed"
-  },
   "downloadVerifying": "正在檢查此檔案...",
   "@downloadVerifying": {
     "description": "Title of the download dialog shown after the file is saved, while the integrity check is still running"

--- a/lib/l10n/app_zh-HK.arb
+++ b/lib/l10n/app_zh-HK.arb
@@ -540,10 +540,6 @@
   "@downloadMustRestartDescription": {
     "description": "Description of the download failure dialog shown when the download cannot be resumed. Says plainly that retrying restarts from the beginning rather than continuing"
   },
-  "downloadNotVerified": "ArDrive 無法將此檔案與原本的檔案核對。某些檔案出現這種情況是正常的，並不代表有任何問題。",
-  "@downloadNotVerified": {
-    "description": "Advisory line on the download success dialog when no integrity verdict could be reached. Must never imply the file is damaged: this outcome is routine"
-  },
   "downloadReconnecting": "正在重新連線...",
   "@downloadReconnecting": {
     "description": "Status label that replaces Downloading while a download that lost its connection picks itself back up"

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1877,10 +1877,6 @@
   "@sharedFilePasteAccessKey": {
     "description": "Placeholder of the access key field on the shared file page"
   },
-  "sharedFilePermanentFileSharing": "永久文件共享",
-  "@sharedFilePermanentFileSharing": {
-    "description": "Tagline shown under the ArDrive logo on the shared file page"
-  },
   "sharedFilePreviewPaneHint": "无需下载，即可在这里预览此文件。",
   "@sharedFilePreviewPaneHint": {
     "description": "Caption in the preview pane of the shared file page, on a desktop screen, saying what pressing Preview will do"

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1817,10 +1817,6 @@
   "@sharedFileGetLatest": {
     "description": "Button that fetches the newest version of a shared file"
   },
-  "sharedFileHidePreview": "隐藏预览",
-  "@sharedFileHidePreview": {
-    "description": "Button that closes the preview on the shared file page"
-  },
   "sharedFileIsEncrypted": "此文件已加密.",
   "@sharedFileIsEncrypted": {
     "description": "Description that says the file is encrypted on shared file page"
@@ -1876,10 +1872,6 @@
   "sharedFilePasteAccessKey": "粘贴访问密钥",
   "@sharedFilePasteAccessKey": {
     "description": "Placeholder of the access key field on the shared file page"
-  },
-  "sharedFilePreviewPaneHint": "无需下载，即可在这里预览此文件。",
-  "@sharedFilePreviewPaneHint": {
-    "description": "Caption in the preview pane of the shared file page, on a desktop screen, saying what pressing Preview will do"
   },
   "sharedFilePreviewUnsupported": "此文件无法在这里预览。请下载后打开。",
   "@sharedFilePreviewUnsupported": {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -540,10 +540,6 @@
   "@downloadMustRestartDescription": {
     "description": "Description of the download failure dialog shown when the download cannot be resumed. Says plainly that retrying restarts from the beginning rather than continuing"
   },
-  "downloadNotVerified": "ArDrive 无法将此文件与原始文件进行核对。某些文件出现这种情况是正常的，并不表示有任何问题。",
-  "@downloadNotVerified": {
-    "description": "Advisory line on the download success dialog when no integrity verdict could be reached. Must never imply the file is damaged: this outcome is routine"
-  },
   "downloadReconnecting": "正在重新连接...",
   "@downloadReconnecting": {
     "description": "Status label that replaces Downloading while a download that lost its connection picks itself back up"

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -562,10 +562,6 @@
       }
     }
   },
-  "downloadVerified": "此文件与最初上传的文件一致。",
-  "@downloadVerified": {
-    "description": "Quiet affirmative line on the download success dialog when the integrity check passed"
-  },
   "downloadVerifying": "正在检查此文件...",
   "@downloadVerifying": {
     "description": "Title of the download dialog shown after the file is saved, while the integrity check is still running"

--- a/lib/pages/drive_detail/components/fs_entry_preview_widget.dart
+++ b/lib/pages/drive_detail/components/fs_entry_preview_widget.dart
@@ -1503,9 +1503,24 @@ class _ImagePreviewWidgetState extends State<ImagePreviewWidget> {
     final navigationHandlersSet = widget.onPreviousImageNavigate != null &&
         widget.onNextImageNavigate != null;
 
+    // Inline on the share page, the name and type are already on the page -
+    // the name beside the thumbnail at the top of the card, the type in File
+    // details - so repeating them here spent a 96px minimum, a fifth of the
+    // pane, saying what the recipient had already read. Expand is the only
+    // thing in this bar the page cannot say for itself.
+    //
+    // Full screen is the exception and keeps them: the card is gone, so the
+    // name is no longer anywhere else.
+    final isSharePageInline = widget.isSharePage && !widget.isFullScreen;
+
     late Widget actionBar;
 
-    if (isFileExplorer && navigationHandlersSet) {
+    if (isSharePageInline) {
+      actionBar = Row(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: [_buildFullScreenButton(compact: true)],
+      );
+    } else if (isFileExplorer && navigationHandlersSet) {
       actionBar = Column(children: [
         Row(
           mainAxisAlignment: MainAxisAlignment.center,
@@ -1699,14 +1714,19 @@ class _ImagePreviewWidgetState extends State<ImagePreviewWidget> {
     );
   }
 
-  Widget _buildFullScreenButton() {
+  Widget _buildFullScreenButton({bool compact = false}) {
     return SafeArea(
       child: Padding(
-        padding: const EdgeInsets.only(
-          left: 24,
-          top: 24,
-          bottom: 24,
-        ),
+        // The button keeps its 48px tap target either way; only the space
+        // around it goes, since there is no longer a block of text to sit
+        // level with.
+        padding: compact
+            ? const EdgeInsets.all(4)
+            : const EdgeInsets.only(
+                left: 24,
+                top: 24,
+                bottom: 24,
+              ),
         child: IconButton(
           tooltip: widget.isFullScreen
               ? appLocalizationsOf(context).collapse

--- a/lib/pages/raw_transaction_view/raw_transaction_view_page.dart
+++ b/lib/pages/raw_transaction_view/raw_transaction_view_page.dart
@@ -266,7 +266,7 @@ class _RawTransactionReadyViewState extends State<_RawTransactionReadyView> {
 
 /// Where the protocol lives, one deliberate tap away.
 ///
-/// Mirrors `SharedFileDetailsDrawer`, whose row and drawer helpers are private
+/// Mirrors `SharedFileDetailsContent`, whose row and drawer helpers are private
 /// to `shared_file_ready_view.dart` and are built around a `FileRevision` that a
 /// raw transaction does not have. Extracting them would mean reshaping the
 /// recipient page's ready view around a second caller for two rows; this copy

--- a/lib/pages/raw_transaction_view/raw_transaction_view_page.dart
+++ b/lib/pages/raw_transaction_view/raw_transaction_view_page.dart
@@ -190,7 +190,6 @@ class _RawTransactionReadyViewState extends State<_RawTransactionReadyView> {
 
   @override
   Widget build(BuildContext context) {
-    final colors = ArDriveTheme.of(context).themeData.colors;
     final state = widget.state;
 
     return Column(
@@ -215,14 +214,6 @@ class _RawTransactionReadyViewState extends State<_RawTransactionReadyView> {
         RawTransactionPreview(state: state),
         const SizedBox(height: 16),
         _RawTransactionDetailsDrawer(state: state),
-        const SizedBox(height: 12),
-        Text(
-          appLocalizationsOf(context).sharedFileStoredPermanently,
-          textAlign: TextAlign.center,
-          style: ArDriveTypography.body.captionRegular(
-            color: colors.themeFgSubtle,
-          ),
-        ),
       ],
     );
   }

--- a/lib/pages/shared_file/shared_file_frame.dart
+++ b/lib/pages/shared_file/shared_file_frame.dart
@@ -130,14 +130,6 @@ class SharedFileFrame extends StatelessWidget {
             fit: BoxFit.contain,
           ),
         ),
-        const SizedBox(height: 8),
-        Text(
-          appLocalizationsOf(context).sharedFilePermanentFileSharing,
-          textAlign: TextAlign.center,
-          style: ArDriveTypography.body.captionRegular(
-            color: SharedFileColors.subtle(context),
-          ),
-        ),
       ],
     );
   }

--- a/lib/pages/shared_file/shared_file_ready_view.dart
+++ b/lib/pages/shared_file/shared_file_ready_view.dart
@@ -129,8 +129,6 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
       children: [
         ..._buildNotice(context, isWide: false),
         ..._buildActions(context, revision, previewIsInline: true),
-        const SizedBox(height: 12),
-        _buildFooter(context),
       ],
     );
   }
@@ -178,8 +176,6 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
             Expanded(flex: 3, child: _buildPreviewPane(context, revision)),
           ],
         ),
-        const SizedBox(height: 16),
-        _buildFooter(context),
       ],
     );
   }
@@ -319,16 +315,6 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
         onOpened: () => context.read<SharedFileCubit>().loadActivity(),
       ),
     ];
-  }
-
-  Widget _buildFooter(BuildContext context) {
-    return Text(
-      appLocalizationsOf(context).sharedFileStoredPermanently,
-      textAlign: TextAlign.center,
-      style: ArDriveTypography.body.captionRegular(
-        color: SharedFileColors.subtle(context),
-      ),
-    );
   }
 
   /// Where the file goes on a wide screen.

--- a/lib/pages/shared_file/shared_file_ready_view.dart
+++ b/lib/pages/shared_file/shared_file_ready_view.dart
@@ -930,14 +930,57 @@ class SharedFileDetailsDrawer extends StatelessWidget {
   final bool detailsAreResolved;
 
   @override
+  Widget build(BuildContext context) => _SharedFileDrawer(
+        title: appLocalizationsOf(context).sharedFileDetailsDrawerTitle,
+        children: [
+          SharedFileDetailsContent(
+            revision: revision,
+            ownerAddress: ownerAddress,
+            licenseName: licenseName,
+            detailsAreResolved: detailsAreResolved,
+          ),
+        ],
+      );
+}
+
+/// What the details panel says, without the panel.
+///
+/// Split out from [SharedFileDetailsDrawer] so the same rows can be a tab's
+/// content as easily as a disclosure's: the page is moving from stacked
+/// accordions - each of which resized the card - to one panel that swaps its
+/// contents in place. This holds the content half of that.
+class SharedFileDetailsContent extends StatelessWidget {
+  const SharedFileDetailsContent({
+    super.key,
+    required this.revision,
+    this.ownerAddress,
+    this.licenseName,
+    this.detailsAreResolved = true,
+  });
+
+  final FileRevision revision;
+  final String? ownerAddress;
+  final String? licenseName;
+
+  /// Whether [revision] holds the file's own record rather than what the link
+  /// claimed.
+  ///
+  /// A v2 link carries no timestamps, so until the metadata resolves the dates
+  /// on [revision] are the epoch placeholder. Showing those would put
+  /// "1970-01-01" in front of a recipient as though it were the upload date,
+  /// which is worse than showing nothing.
+  final bool detailsAreResolved;
+
+  @override
   Widget build(BuildContext context) {
     final ownerAddress = this.ownerAddress;
     final licenseName = this.licenseName;
 
     final contentType = revision.dataContentType;
 
-    return _SharedFileDrawer(
-      title: appLocalizationsOf(context).sharedFileDetailsDrawerTitle,
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         // Type and dates lead, ahead of the identifiers. A recipient who was
         // sent a link by a stranger has almost no way to judge what they are
@@ -1058,18 +1101,81 @@ class SharedFileVersionsDrawer extends StatelessWidget {
   final bool isPinned;
 
   @override
+  Widget build(BuildContext context) => _SharedFileDrawer(
+        title: appLocalizationsOf(context).sharedFileVersionHistoryTitle,
+        onExpansionChanged: (isExpanded) {
+          if (isExpanded) {
+            onOpened();
+          }
+        },
+        children: [
+          SharedFileVersionsContent(
+            revisions: revisions,
+            status: status,
+            sharedRevision: sharedRevision,
+            currentRevision: currentRevision,
+            onOpened: onOpened,
+            onSelected: onSelected,
+            isDisabled: isDisabled,
+            isPinned: isPinned,
+          ),
+        ],
+      );
+}
+
+/// The version list, without the panel around it.
+///
+/// Split out from [SharedFileVersionsDrawer] for the same reason the details
+/// rows were: the page is moving from stacked accordions - each of which
+/// resized the card - to one panel that swaps its contents in place.
+class SharedFileVersionsContent extends StatelessWidget {
+  const SharedFileVersionsContent({
+    super.key,
+    required this.revisions,
+    required this.status,
+    required this.sharedRevision,
+    required this.currentRevision,
+    required this.onOpened,
+    required this.onSelected,
+    this.isDisabled = false,
+    this.isPinned = false,
+  });
+
+  /// Newest first. Seeded with the shared revision the moment the list opens.
+  final List<FileRevision> revisions;
+
+  final SharedFileActivityStatus status;
+
+  /// The revision the link named - the one that wears the "shared" chip.
+  final FileRevision sharedRevision;
+
+  /// The revision the page is currently showing and would download.
+  final FileRevision currentRevision;
+
+  /// Asks the resolver for the history. Answered once, ignored while it is
+  /// loading or loaded, and tried again after a failure - so it doubles as the
+  /// retry.
+  final VoidCallback onOpened;
+
+  /// Called with the revision the recipient picked.
+  final ValueChanged<FileRevision> onSelected;
+
+  /// True while a download or another selection is in flight - nothing may
+  /// move the target while bytes are on their way.
+  final bool isDisabled;
+
+  /// Whether the link deliberately names one revision.
+  final bool isPinned;
+
+  @override
   Widget build(BuildContext context) {
     final isLoading = status == SharedFileActivityStatus.notLoaded ||
         status == SharedFileActivityStatus.loading;
     final hasFailed = status == SharedFileActivityStatus.failed;
 
-    return _SharedFileDrawer(
-      title: appLocalizationsOf(context).sharedFileVersionHistoryTitle,
-      onExpansionChanged: (isExpanded) {
-        if (isExpanded) {
-          onOpened();
-        }
-      },
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         if (revisions.length > 1)
           Padding(

--- a/lib/pages/shared_file/shared_file_ready_view.dart
+++ b/lib/pages/shared_file/shared_file_ready_view.dart
@@ -64,14 +64,8 @@ class SharedFileReadyView extends StatefulWidget {
 const Key sharedFilePreviewPaneKey = Key('sharedFilePreviewPane');
 
 class _SharedFileReadyViewState extends State<SharedFileReadyView> {
-  /// The left hand column on a wide screen: the same 368 the phone gets, so the
-  /// card reads identically at both ends.
-  ///
-  /// With `SharedFileFrame.maxWideContentWidth` (1040) and the wide card's 24px
-  /// padding that leaves 1040 - 48 - 368 - 24 = 600 for the preview, and at the
-  /// narrowest desktop screen the fork fires on (951) it still leaves ~479.
-  static const double _actionsColumnWidth = 368;
-
+  /// The gap between the two regions, and between the identity and Download
+  /// in the header above them.
   static const double _paneGutter = 24;
 
   /// Reserved whether or not the preview is open, which is the whole point of
@@ -148,7 +142,31 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         ..._buildNotice(context, isWide: false),
-        ..._buildActions(context, revision, previewIsInline: true),
+        _buildIdentity(context, revision, showThumbnail: true),
+        const SizedBox(height: 20),
+        _buildDownload(context, revision, fillWidth: true),
+        ..._buildUnlockedNote(context),
+        // The preview reads the file through its drive, which only the
+        // resolved metadata knows about.
+        if (widget.state.detailsAreResolved) ...[
+          const SizedBox(height: 8),
+          _buildPreviewToggle(context),
+          // Kept mounted while hidden: unloading it turns "hide" into
+          // "download again".
+          Visibility(
+            visible: _isPreviewOpen,
+            maintainState: true,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const SizedBox(height: 8),
+                _buildPreview(context, revision, isInline: true),
+              ],
+            ),
+          ),
+        ],
+        const SizedBox(height: 16),
+        _buildInfoPanel(context, revision, height: _infoPanelHeightNarrow),
       ],
     );
   }
@@ -170,30 +188,40 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         ..._buildNotice(context, isWide: true),
+        // What the file is and the one thing to do with it, across the top.
+        //
+        // Both used to head a narrow left-hand column, which put the primary
+        // action in a third of the card's width and left the identity wrapping
+        // against a preview pane twice its size. Up here they get the whole
+        // width, and the two regions below divide what is left.
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Expanded(
+              // The thumbnail belongs in the pane on this layout, at a size
+              // worth looking at. Showing it twice would be one fetch and one
+              // picture too many.
+              child: _buildIdentity(context, revision, showThumbnail: false),
+            ),
+            const SizedBox(width: _paneGutter),
+            _buildDownload(context, revision, fillWidth: false),
+          ],
+        ),
+        ..._buildUnlockedNote(context),
+        const SizedBox(height: 20),
         Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // Loose rather than fixed: at the narrowest desktop width the
-            // column takes what it is given instead of overflowing the row.
-            Flexible(
+            Expanded(flex: 3, child: _buildPreviewPane(context, revision)),
+            const SizedBox(width: _paneGutter),
+            Expanded(
               flex: 2,
-              child: ConstrainedBox(
-                constraints: const BoxConstraints(
-                  maxWidth: _actionsColumnWidth,
-                ),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: _buildActions(
-                    context,
-                    revision,
-                    previewIsInline: false,
-                  ),
-                ),
+              child: _buildInfoPanel(
+                context,
+                revision,
+                height: _infoPanelHeightWide,
               ),
             ),
-            const SizedBox(width: _paneGutter),
-            Expanded(flex: 3, child: _buildPreviewPane(context, revision)),
           ],
         ),
       ],
@@ -243,114 +271,105 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
   /// [previewIsInline] is the only difference between the two layouts: the
   /// phone opens the preview underneath the button, the desktop card opens it
   /// in the pane beside this column.
-  List<Widget> _buildActions(
+  Widget _buildIdentity(
     BuildContext context,
     FileRevision revision, {
-    required bool previewIsInline,
+    required bool showThumbnail,
   }) {
     final state = widget.state;
     final payload = state.payload;
 
-    final name = revision.name.isEmpty ? null : revision.name;
-    final size = state.detailsAreResolved || revision.size > 0
-        ? revision.size
-        : null;
+    return SharedFileIdentity(
+      name: revision.name.isEmpty ? null : revision.name,
+      size: state.detailsAreResolved || revision.size > 0
+          ? revision.size
+          : null,
+      contentType: revision.dataContentType ?? payload?.contentType,
+      thumbnailTxId:
+          showThumbnail ? _thumbnailTxId(state, revision) : null,
+      // A private file's thumbnail is encrypted under the file key, so the
+      // recipient's own access key is what renders it.
+      fileKey: state.fileKey,
+      ownerAddress: state.ownerAddress ?? payload?.ownerAddress,
+      verification: state.verification,
+      isPrivate: state.fileKey != null,
+      isLoading: !state.detailsAreResolved,
+    );
+  }
 
+  Widget _buildDownload(
+    BuildContext context,
+    FileRevision revision, {
+    required bool fillWidth,
+  }) {
     // The download names the file it saves, so it waits for a name. On the
     // fast path with `n` embedded this is true immediately; with `hid=1` it
     // becomes true a moment later, when the metadata resolves.
-    final canDownload = name != null && revision.dataTxId.isNotEmpty;
+    final canDownload =
+        revision.name.isNotEmpty && revision.dataTxId.isNotEmpty;
+
+    return ArDriveButton(
+      // Keyed by the bytes it fetches: the key changes only when the
+      // recipient has changed the target themselves, never because a newer
+      // revision turned up.
+      key: ValueKey('sharedFileDownload_${revision.dataTxId}'),
+      maxWidth: fillWidth ? double.infinity : null,
+      isDisabled: !canDownload,
+      icon: ArDriveIcons.download(size: 20, color: Colors.white),
+      onPressed: () => _download(context, revision),
+      text: appLocalizationsOf(context).download,
+    );
+  }
+
+  List<Widget> _buildUnlockedNote(BuildContext context) {
+    if (widget.state.fileKey == null) {
+      return const [];
+    }
 
     return [
-      SharedFileIdentity(
-        name: name,
-        size: size,
-        contentType: revision.dataContentType ?? payload?.contentType,
-        // On the desktop card the picture belongs in the pane, at a size worth
-        // looking at. Showing it twice, 400px apart, would be one thumbnail
-        // fetch too many and one picture too many.
-        thumbnailTxId: previewIsInline ? _thumbnailTxId(state, revision) : null,
-        // A private file's thumbnail is encrypted under the file key, so the
-        // recipient's own access key is what renders it.
-        fileKey: state.fileKey,
-        ownerAddress: state.ownerAddress ?? payload?.ownerAddress,
-        verification: state.verification,
-        isPrivate: state.fileKey != null,
-        isLoading: !state.detailsAreResolved,
-      ),
-      const SizedBox(height: 20),
-      ArDriveButton(
-        // Keyed by the bytes it fetches: the key changes only when the
-        // recipient has changed the target themselves, never because a newer
-        // revision turned up.
-        key: ValueKey('sharedFileDownload_${revision.dataTxId}'),
-        maxWidth: double.infinity,
-        isDisabled: !canDownload,
-        icon: ArDriveIcons.download(size: 20, color: Colors.white),
-        onPressed: () => _download(context, revision),
-        text: appLocalizationsOf(context).download,
-      ),
-      // The preview reads the file through its drive, which only the
-      // resolved metadata knows about. On the desktop card the toggle lives in
-      // the pane it acts on, so this column carries it only on a phone.
-      if (previewIsInline && state.detailsAreResolved) ...[
-        const SizedBox(height: 8),
-        _buildPreviewToggle(context),
-        // Kept mounted while hidden, for the reason given on the desktop
-        // pane: unloading it turns "hide" into "download again".
-        Visibility(
-          visible: _isPreviewOpen,
-          maintainState: true,
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const SizedBox(height: 8),
-              _buildPreview(context, revision, isInline: true),
-            ],
-          ),
-        ),
-      ],
-      if (state.fileKey != null) ...[
-        const SizedBox(height: 16),
-        Text(
-          appLocalizationsOf(context).sharedFileUnlockedWithAccessKey,
-          style: ArDriveTypography.body.captionRegular(
-            color: SharedFileColors.subtle(context),
-          ),
-        ),
-      ],
       const SizedBox(height: 16),
-      // One panel, two tabs, one height. These were two stacked accordions, so
-      // opening either pushed everything below it down and reading a date
-      // moved the download button.
-      SharedFileInfoPanel(
-        height: previewIsInline
-            ? _infoPanelHeightNarrow
-            : _infoPanelHeightWide,
-        onVersionsOpened: () => context.read<SharedFileCubit>().loadActivity(),
-        details: SharedFileDetailsContent(
-          revision: revision,
-          ownerAddress: state.ownerAddress ?? payload?.ownerAddress,
-          licenseName: state.latestLicense?.meta.nameWithShortName,
-          detailsAreResolved: state.detailsAreResolved,
-        ),
-        versions: SharedFileVersionsContent(
-          revisions: state.activityRevisions,
-          status: state.activityStatus,
-          currentRevision: revision,
-          sharedRevision: state.sharedRevision,
-          isPinned: state.isPinned,
-          // Nothing may move the target while bytes are on their way, and
-          // nothing may start a second change while one is running - the same
-          // guard the freshness banner's actions use.
-          isDisabled: _isDownloading || _isChangingRevision,
-          onOpened: () => context.read<SharedFileCubit>().loadActivity(),
-          onSelected: (picked) => _changeRevision(
-            () => context.read<SharedFileCubit>().showRevision(picked),
-          ),
+      Text(
+        appLocalizationsOf(context).sharedFileUnlockedWithAccessKey,
+        style: ArDriveTypography.body.captionRegular(
+          color: SharedFileColors.subtle(context),
         ),
       ),
     ];
+  }
+
+  Widget _buildInfoPanel(
+    BuildContext context,
+    FileRevision revision, {
+    required double height,
+  }) {
+    final state = widget.state;
+    final payload = state.payload;
+
+    return SharedFileInfoPanel(
+      height: height,
+      onVersionsOpened: () => context.read<SharedFileCubit>().loadActivity(),
+      details: SharedFileDetailsContent(
+        revision: revision,
+        ownerAddress: state.ownerAddress ?? payload?.ownerAddress,
+        licenseName: state.latestLicense?.meta.nameWithShortName,
+        detailsAreResolved: state.detailsAreResolved,
+      ),
+      versions: SharedFileVersionsContent(
+        revisions: state.activityRevisions,
+        status: state.activityStatus,
+        currentRevision: revision,
+        sharedRevision: state.sharedRevision,
+        isPinned: state.isPinned,
+        // Nothing may move the target while bytes are on their way, and
+        // nothing may start a second change while one is running - the same
+        // guard the freshness banner's actions use.
+        isDisabled: _isDownloading || _isChangingRevision,
+        onOpened: () => context.read<SharedFileCubit>().loadActivity(),
+        onSelected: (picked) => _changeRevision(
+          () => context.read<SharedFileCubit>().showRevision(picked),
+        ),
+      ),
+    );
   }
 
   /// Where the file goes on a wide screen.
@@ -922,50 +941,16 @@ class _SharedFileNoticeCard extends StatelessWidget {
       );
 }
 
-/// Where the protocol lives: collapsed by default, one tap away, and the only
-/// place on this page that says "transaction".
-class SharedFileDetailsDrawer extends StatelessWidget {
-  const SharedFileDetailsDrawer({
-    super.key,
-    required this.revision,
-    this.ownerAddress,
-    this.licenseName,
-    this.detailsAreResolved = true,
-  });
-
-  final FileRevision revision;
-  final String? ownerAddress;
-  final String? licenseName;
-
-  /// Whether [revision] holds the file's own record rather than what the link
-  /// claimed.
-  ///
-  /// A v2 link carries no timestamps, so until the metadata resolves the dates
-  /// on [revision] are the epoch placeholder. Showing those would put
-  /// "1970-01-01" in front of a recipient as though it were the upload date,
-  /// which is worse than showing nothing.
-  final bool detailsAreResolved;
-
-  @override
-  Widget build(BuildContext context) => _SharedFileDrawer(
-        title: appLocalizationsOf(context).sharedFileDetailsDrawerTitle,
-        children: [
-          SharedFileDetailsContent(
-            revision: revision,
-            ownerAddress: ownerAddress,
-            licenseName: licenseName,
-            detailsAreResolved: detailsAreResolved,
-          ),
-        ],
-      );
-}
-
-/// What the details panel says, without the panel.
+/// What the file is, for someone who was sent it by a stranger.
 ///
-/// Split out from [SharedFileDetailsDrawer] so the same rows can be a tab's
-/// content as easily as a disclosure's: the page is moving from stacked
-/// accordions - each of which resized the card - to one panel that swaps its
-/// contents in place. This holds the content half of that.
+/// Leads with what a person can use - type, dates, who shared it, licence -
+/// and keeps the identifiers behind their own disclosure, because this page's
+/// standing rule is that a recipient should be able to get their file without
+/// ever learning what a transaction id is.
+///
+/// Rendered as the first tab of [SharedFileInfoPanel] rather than as its own
+/// disclosure: two stacked accordions each resized the card when opened, so
+/// reading a date moved the download button.
 class SharedFileDetailsContent extends StatelessWidget {
   const SharedFileDetailsContent({
     super.key,
@@ -1067,10 +1052,6 @@ class SharedFileDetailsContent extends StatelessWidget {
 
 /// The file's revisions, newest first, as something the recipient can act on.
 ///
-/// Replaces the share page's old Activity tab: same information, none of the
-/// tab chrome, and - because a revision history costs one metadata fetch per
-/// revision - not fetched at all until the recipient opens it.
-///
 /// The history is [SharedFileLoadSuccess.activityRevisions], never
 /// `fileRevisions`: the latter is the download target and holds exactly one
 /// revision on every v2 link, so reading the history from it would show a
@@ -1084,79 +1065,9 @@ class SharedFileDetailsContent extends StatelessWidget {
 /// it. Nothing here gates Download, the preview, or anything above the card,
 /// and a lookup that fails costs the list and nothing else: the row the
 /// recipient was sent stays, and stays selected.
-class SharedFileVersionsDrawer extends StatelessWidget {
-  const SharedFileVersionsDrawer({
-    super.key,
-    required this.revisions,
-    required this.status,
-    required this.sharedRevision,
-    required this.currentRevision,
-    required this.onOpened,
-    required this.onSelected,
-    this.isDisabled = false,
-    this.isPinned = false,
-  });
-
-  /// Newest first. Seeded with the shared revision the moment the list opens.
-  final List<FileRevision> revisions;
-
-  final SharedFileActivityStatus status;
-
-  /// The revision the link named - the one that wears the "this link" chip.
-  final FileRevision sharedRevision;
-
-  /// The revision the page is currently showing and would download.
-  final FileRevision currentRevision;
-
-  /// Called every time the drawer is opened; the resolver answers the first
-  /// one, ignores the rest, and tries again after a failure.
-  final VoidCallback onOpened;
-
-  /// Called with the revision the recipient picked.
-  final ValueChanged<FileRevision> onSelected;
-
-  /// True while a download or another selection is in flight - nothing may
-  /// move the target while bytes are on their way.
-  final bool isDisabled;
-
-  /// Whether the link deliberately names one revision.
-  ///
-  /// Only changes what the link's own row is *called*. A pinned link is the
-  /// sharer saying which version they mean, not a restriction on the
-  /// recipient - who can reach every other version of the file on chain
-  /// regardless - so selecting away from it stays as free as it already is
-  /// from the freshness banner, which offers a pinned link "View latest" and
-  /// hands it back with [SharedFileCubit.showSharedRevision].
-  final bool isPinned;
-
-  @override
-  Widget build(BuildContext context) => _SharedFileDrawer(
-        title: appLocalizationsOf(context).sharedFileVersionHistoryTitle,
-        onExpansionChanged: (isExpanded) {
-          if (isExpanded) {
-            onOpened();
-          }
-        },
-        children: [
-          SharedFileVersionsContent(
-            revisions: revisions,
-            status: status,
-            sharedRevision: sharedRevision,
-            currentRevision: currentRevision,
-            onOpened: onOpened,
-            onSelected: onSelected,
-            isDisabled: isDisabled,
-            isPinned: isPinned,
-          ),
-        ],
-      );
-}
-
-/// The version list, without the panel around it.
 ///
-/// Split out from [SharedFileVersionsDrawer] for the same reason the details
-/// rows were: the page is moving from stacked accordions - each of which
-/// resized the card - to one panel that swaps its contents in place.
+/// The second tab of [SharedFileInfoPanel], and fetched only when that tab is
+/// chosen - a revision history costs one metadata fetch per revision.
 class SharedFileVersionsContent extends StatelessWidget {
   const SharedFileVersionsContent({
     super.key,
@@ -1591,13 +1502,10 @@ class _SharedFileDrawer extends StatefulWidget {
   const _SharedFileDrawer({
     required this.title,
     required this.children,
-    this.onExpansionChanged,
   });
 
   final String title;
   final List<Widget> children;
-  final ValueChanged<bool>? onExpansionChanged;
-
   @override
   State<_SharedFileDrawer> createState() => _SharedFileDrawerState();
 }
@@ -1618,10 +1526,8 @@ class _SharedFileDrawerState extends State<_SharedFileDrawer> {
         tilePadding: EdgeInsets.zero,
         childrenPadding: EdgeInsets.zero,
         expandedCrossAxisAlignment: CrossAxisAlignment.start,
-        onExpansionChanged: (isExpanded) {
-          setState(() => _isExpanded = isExpanded);
-          widget.onExpansionChanged?.call(isExpanded);
-        },
+        onExpansionChanged: (isExpanded) =>
+            setState(() => _isExpanded = isExpanded),
         title: Semantics(
           header: true,
           expanded: _isExpanded,

--- a/lib/pages/shared_file/shared_file_ready_view.dart
+++ b/lib/pages/shared_file/shared_file_ready_view.dart
@@ -1574,31 +1574,53 @@ class _SharedFileDrawerState extends State<_SharedFileDrawer> {
 
   @override
   Widget build(BuildContext context) {
-    return Theme(
-      // The material divider lines fight the card's own border.
-      data: Theme.of(context).copyWith(
-        dividerColor: Colors.transparent,
-        splashColor: Colors.transparent,
-        highlightColor: Colors.transparent,
-      ),
-      child: ExpansionTile(
-        tilePadding: EdgeInsets.zero,
-        childrenPadding: EdgeInsets.zero,
-        expandedCrossAxisAlignment: CrossAxisAlignment.start,
-        onExpansionChanged: (isExpanded) =>
-            setState(() => _isExpanded = isExpanded),
-        title: Semantics(
+    // Built from the same row primitive as everything else in this panel
+    // rather than from `ExpansionTile`.
+    //
+    // The tile is a `ListTile`, whose one-line minimum is its own - it
+    // measured 58 against the 44 of the rows either side of it, so the list
+    // visibly changed rhythm at the header and changed back after it. None of
+    // the knobs `ExpansionTile` exposes here reach 44: `visualDensity` moves in
+    // steps of four, which overshoots to 42.
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Semantics(
           header: true,
+          button: true,
           expanded: _isExpanded,
-          child: Text(
-            widget.title,
-            style: ArDriveTypography.body.captionBold(
-              color: SharedFileColors.subtle(context),
+          child: InkWell(
+            onTap: () => setState(() => _isExpanded = !_isExpanded),
+            borderRadius: BorderRadius.circular(6),
+            child: Container(
+              constraints: const BoxConstraints(minHeight: _rowHeight),
+              alignment: Alignment.centerLeft,
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      widget.title,
+                      style: ArDriveTypography.body.captionBold(
+                        color: SharedFileColors.subtle(context),
+                      ),
+                    ),
+                  ),
+                  AnimatedRotation(
+                    turns: _isExpanded ? 0.5 : 0,
+                    duration: const Duration(milliseconds: 150),
+                    child: ArDriveIcons.chevronDown(
+                      size: 16,
+                      color: SharedFileColors.subtle(context),
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
         ),
-        children: widget.children,
-      ),
+        if (_isExpanded) ...widget.children,
+      ],
     );
   }
 }

--- a/lib/pages/shared_file/shared_file_ready_view.dart
+++ b/lib/pages/shared_file/shared_file_ready_view.dart
@@ -1152,10 +1152,10 @@ class SharedFileVersionsContent extends StatelessWidget {
         for (final revision in revisions)
           _SharedFileVersionRow(
             revision: revision,
-            isSelected: revision.dataTxId == currentRevision.dataTxId,
-            isNewest: revision.dataTxId == revisions.first.dataTxId &&
+            isSelected: isSameRevision(revision, currentRevision),
+            isNewest: isSameRevision(revision, revisions.first) &&
                 revisions.length > 1,
-            isFromLink: revision.dataTxId == sharedRevision.dataTxId,
+            isFromLink: isSameRevision(revision, sharedRevision),
             isPinned: isPinned,
             isDisabled: isDisabled,
             onSelected: () => onSelected(revision),

--- a/lib/pages/shared_file/shared_file_ready_view.dart
+++ b/lib/pages/shared_file/shared_file_ready_view.dart
@@ -91,7 +91,17 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
   /// to look like a mistake.
   static const double _panePictureSize = 200;
 
-  bool _isPreviewOpen = false;
+  /// Open on arrival.
+  ///
+  /// The page exists to show someone a file, so making them ask to see it is
+  /// one click that should not exist. The pane is laid out either way on the
+  /// desktop card, so this fills a box that was already there rather than
+  /// moving anything; the toggle stays, so it can still be closed.
+  ///
+  /// A type that cannot be shown answers with its own sentence rather than
+  /// nothing, which is a better answer than making the recipient press Preview
+  /// to be told the same thing.
+  bool _isPreviewOpen = true;
 
   /// Whether a download is in flight.
   ///
@@ -1118,6 +1128,20 @@ class _SharedFileVersionRow extends StatelessWidget {
     final colors = ArDriveTheme.of(context).themeData.colors;
     final subtle = SharedFileColors.subtle(context);
 
+    final hasDate = !SharedFileCubit.isUnknownDate(revision.dateCreated);
+
+    // "Pinned" says the sharer chose this version; "This link" says only that
+    // the link carried it. On a pinned link the first is the fact worth
+    // knowing, and it is what makes the way back obvious after selecting
+    // something else.
+    final label = isFromLink
+        ? (isPinned
+            ? appLocalizationsOf(context).sharedFileVersionPinned
+            : appLocalizationsOf(context).sharedFileVersionFromLink)
+        : (isNewest
+            ? appLocalizationsOf(context).sharedFileVersionLatest
+            : null);
+
     return Semantics(
       selected: isSelected,
       inMutuallyExclusiveGroup: true,
@@ -1135,23 +1159,41 @@ class _SharedFileVersionRow extends StatelessWidget {
             children: [
               _VersionRadio(isSelected: isSelected),
               const SizedBox(width: 11),
-              Expanded(
-                child: ArDriveTooltip(
-                  // The row shows the short date so that it still fits beside
-                  // a size and a chip on a phone; the exact timestamp is one
-                  // hover away, the same pairing the drive explorer uses.
-                  message: formatDateToUtcString(revision.dateCreated),
+              // A row's label is what identifies that version, which is
+              // normally its date. The row seeded from the link has no date to
+              // give - a link carries no timestamps - so it is named by what it
+              // is instead, and its chip is not repeated after the label.
+              //
+              // Rendering the placeholder would put "Jan 1, 1970" in front of
+              // the recipient and then silently correct it when the history
+              // arrived, which is exactly what it looked like.
+              if (hasDate)
+                Expanded(
+                  child: ArDriveTooltip(
+                    // The row shows the short date so that it still fits beside
+                    // a size and a chip on a phone; the exact timestamp is one
+                    // hover away, the same pairing the drive explorer uses.
+                    message: formatDateToUtcString(revision.dateCreated),
+                    child: Text(
+                      yMMdDateFormatter.format(revision.dateCreated),
+                      overflow: TextOverflow.ellipsis,
+                      style: isSelected
+                          ? ArDriveTypography.body
+                              .captionBold(color: colors.themeFgDefault)
+                          : ArDriveTypography.body
+                              .captionRegular(color: colors.themeFgDefault),
+                    ),
+                  ),
+                )
+              else
+                Expanded(
                   child: Text(
-                    yMMdDateFormatter.format(revision.dateCreated),
+                    label ?? '',
                     overflow: TextOverflow.ellipsis,
-                    style: isSelected
-                        ? ArDriveTypography.body
-                            .captionBold(color: colors.themeFgDefault)
-                        : ArDriveTypography.body
-                            .captionRegular(color: colors.themeFgDefault),
+                    style: ArDriveTypography.body
+                        .captionBold(color: colors.themeFgDefault),
                   ),
                 ),
-              ),
               const SizedBox(width: 8),
               Text(
                 filesize(revision.size),
@@ -1160,22 +1202,9 @@ class _SharedFileVersionRow extends StatelessWidget {
               // At most one chip. A row that is both the newest and the one the
               // link named would otherwise carry two labels saying much the
               // same thing, and on a phone that is what pushes it over.
-              if (isFromLink) ...[
+              if (hasDate && label != null) ...[
                 const SizedBox(width: 8),
-                _VersionChip(
-                  // "Pinned" says the sharer chose this version; "This link"
-                  // says only that the link carried it. On a pinned link the
-                  // first is the fact worth knowing, and it is what makes the
-                  // way back obvious after selecting something else.
-                  isPinned
-                      ? appLocalizationsOf(context).sharedFileVersionPinned
-                      : appLocalizationsOf(context).sharedFileVersionFromLink,
-                ),
-              ] else if (isNewest) ...[
-                const SizedBox(width: 8),
-                _VersionChip(
-                  appLocalizationsOf(context).sharedFileVersionLatest,
-                ),
+                _VersionChip(label),
               ],
             ],
           ),

--- a/lib/pages/shared_file/shared_file_ready_view.dart
+++ b/lib/pages/shared_file/shared_file_ready_view.dart
@@ -305,6 +305,7 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
         revisions: state.activityRevisions,
         status: state.activityStatus,
         currentRevision: revision,
+        isPinned: state.isPinned,
         // Nothing may move the target while bytes are on their way, and
         // nothing may start a second change while one is running - the same
         // guard the freshness banner's actions use.
@@ -978,6 +979,7 @@ class SharedFileVersionsDrawer extends StatelessWidget {
     required this.onOpened,
     required this.onSelected,
     this.isDisabled = false,
+    this.isPinned = false,
   });
 
   /// Newest first. Seeded with the shared revision the moment the list opens.
@@ -1001,6 +1003,16 @@ class SharedFileVersionsDrawer extends StatelessWidget {
   /// True while a download or another selection is in flight - nothing may
   /// move the target while bytes are on their way.
   final bool isDisabled;
+
+  /// Whether the link deliberately names one revision.
+  ///
+  /// Only changes what the link's own row is *called*. A pinned link is the
+  /// sharer saying which version they mean, not a restriction on the
+  /// recipient - who can reach every other version of the file on chain
+  /// regardless - so selecting away from it stays as free as it already is
+  /// from the freshness banner, which offers a pinned link "View latest" and
+  /// hands it back with [SharedFileCubit.showSharedRevision].
+  final bool isPinned;
 
   @override
   Widget build(BuildContext context) {
@@ -1033,6 +1045,7 @@ class SharedFileVersionsDrawer extends StatelessWidget {
             isNewest: revision.dataTxId == revisions.first.dataTxId &&
                 revisions.length > 1,
             isFromLink: revision.dataTxId == sharedRevision.dataTxId,
+            isPinned: isPinned,
             isDisabled: isDisabled,
             onSelected: () => onSelected(revision),
           ),
@@ -1086,6 +1099,7 @@ class _SharedFileVersionRow extends StatelessWidget {
     required this.isSelected,
     required this.isNewest,
     required this.isFromLink,
+    required this.isPinned,
     required this.isDisabled,
     required this.onSelected,
   });
@@ -1094,6 +1108,7 @@ class _SharedFileVersionRow extends StatelessWidget {
   final bool isSelected;
   final bool isNewest;
   final bool isFromLink;
+  final bool isPinned;
   final bool isDisabled;
   final VoidCallback onSelected;
 
@@ -1147,7 +1162,13 @@ class _SharedFileVersionRow extends StatelessWidget {
               if (isFromLink) ...[
                 const SizedBox(width: 8),
                 _VersionChip(
-                  appLocalizationsOf(context).sharedFileVersionFromLink,
+                  // "Pinned" says the sharer chose this version; "This link"
+                  // says only that the link carried it. On a pinned link the
+                  // first is the fact worth knowing, and it is what makes the
+                  // way back obvious after selecting something else.
+                  isPinned
+                      ? appLocalizationsOf(context).sharedFileVersionPinned
+                      : appLocalizationsOf(context).sharedFileVersionFromLink,
                 ),
               ] else if (isNewest) ...[
                 const SizedBox(width: 8),

--- a/lib/pages/shared_file/shared_file_ready_view.dart
+++ b/lib/pages/shared_file/shared_file_ready_view.dart
@@ -84,6 +84,16 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
   /// sentence gets the height of the sentence; see [_previewFillsItsBox].
   static const double _inlinePreviewHeight = 360;
 
+  /// The info panel's height, fixed so that swapping tabs never resizes it.
+  ///
+  /// Wide matches the preview pane beside it, so the two regions line up.
+  /// Narrow is shorter than the tallest tab on purpose: a phone column is
+  /// already scrolling, and a panel tall enough for every version of every file
+  /// would push the preview off the top of the screen.
+  static const double _infoPanelHeightWide = _previewPaneHeight;
+
+  static const double _infoPanelHeightNarrow = 300;
+
   /// The largest the file's own thumbnail is drawn in the preview pane.
   ///
   /// ArDrive generates thumbnails at a 100px minimum edge, so this is roughly
@@ -310,28 +320,35 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
         ),
       ],
       const SizedBox(height: 16),
-      SharedFileDetailsDrawer(
-        revision: revision,
-        ownerAddress: state.ownerAddress ?? payload?.ownerAddress,
-        licenseName: state.latestLicense?.meta.nameWithShortName,
-        detailsAreResolved: state.detailsAreResolved,
-      ),
-      SharedFileVersionsDrawer(
-        revisions: state.activityRevisions,
-        status: state.activityStatus,
-        currentRevision: revision,
-        isPinned: state.isPinned,
-        // Nothing may move the target while bytes are on their way, and
-        // nothing may start a second change while one is running - the same
-        // guard the freshness banner's actions use.
-        isDisabled: _isDownloading || _isChangingRevision,
-        onSelected: (picked) => _changeRevision(
-          () => context.read<SharedFileCubit>().showRevision(picked),
+      // One panel, two tabs, one height. These were two stacked accordions, so
+      // opening either pushed everything below it down and reading a date
+      // moved the download button.
+      SharedFileInfoPanel(
+        height: previewIsInline
+            ? _infoPanelHeightNarrow
+            : _infoPanelHeightWide,
+        onVersionsOpened: () => context.read<SharedFileCubit>().loadActivity(),
+        details: SharedFileDetailsContent(
+          revision: revision,
+          ownerAddress: state.ownerAddress ?? payload?.ownerAddress,
+          licenseName: state.latestLicense?.meta.nameWithShortName,
+          detailsAreResolved: state.detailsAreResolved,
         ),
-        // The revision the link named, which stays marked as the shared one
-        // even while the newest is being shown.
-        sharedRevision: state.sharedRevision,
-        onOpened: () => context.read<SharedFileCubit>().loadActivity(),
+        versions: SharedFileVersionsContent(
+          revisions: state.activityRevisions,
+          status: state.activityStatus,
+          currentRevision: revision,
+          sharedRevision: state.sharedRevision,
+          isPinned: state.isPinned,
+          // Nothing may move the target while bytes are on their way, and
+          // nothing may start a second change while one is running - the same
+          // guard the freshness banner's actions use.
+          isDisabled: _isDownloading || _isChangingRevision,
+          onOpened: () => context.read<SharedFileCubit>().loadActivity(),
+          onSelected: (picked) => _changeRevision(
+            () => context.read<SharedFileCubit>().showRevision(picked),
+          ),
+        ),
       ),
     ];
   }
@@ -1006,20 +1023,6 @@ class SharedFileDetailsContent extends StatelessWidget {
             canCopy: false,
           ),
         ],
-        _SharedFileDetailRow(
-          label: appLocalizationsOf(context).fileID,
-          value: revision.fileId,
-        ),
-        if (revision.dataTxId.isNotEmpty)
-          _SharedFileDetailRow(
-            label: appLocalizationsOf(context).sharedFileDetailsTransaction,
-            value: revision.dataTxId,
-          ),
-        if (revision.metadataTxId.isNotEmpty)
-          _SharedFileDetailRow(
-            label: appLocalizationsOf(context).sharedFileDetailsMetadata,
-            value: revision.metadataTxId,
-          ),
         if (ownerAddress != null && ownerAddress.isNotEmpty)
           _SharedFileDetailRow(
             label: appLocalizationsOf(context).sharedFileDetailsOwner,
@@ -1031,6 +1034,32 @@ class SharedFileDetailsContent extends StatelessWidget {
             value: licenseName,
             canCopy: false,
           ),
+        // The identifiers, one step further in.
+        //
+        // This file's own rule is that a recipient should be able to get their
+        // file without ever learning what a transaction id is - and until the
+        // details became a tab, a closed drawer was what kept that true. A tab
+        // that opens by default cannot, so the ids move behind their own
+        // disclosure and the tab leads with what a person can actually use.
+        _SharedFileDrawer(
+          title: appLocalizationsOf(context).sharedFileTransactionDetails,
+          children: [
+            _SharedFileDetailRow(
+              label: appLocalizationsOf(context).fileID,
+              value: revision.fileId,
+            ),
+            if (revision.dataTxId.isNotEmpty)
+              _SharedFileDetailRow(
+                label: appLocalizationsOf(context).sharedFileDetailsTransaction,
+                value: revision.dataTxId,
+              ),
+            if (revision.metadataTxId.isNotEmpty)
+              _SharedFileDetailRow(
+                label: appLocalizationsOf(context).sharedFileDetailsMetadata,
+                value: revision.metadataTxId,
+              ),
+          ],
+        ),
       ],
     );
   }
@@ -1402,6 +1431,150 @@ class _VersionChip extends StatelessWidget {
         label,
         style: ArDriveTypography.body.captionBold(
           color: SharedFileColors.subtle(context),
+        ),
+      ),
+    );
+  }
+}
+
+/// Everything *about* the file, in a panel that does not change size.
+///
+/// The card used to carry two accordions and a preview toggle, so opening any
+/// of them pushed everything below it down: reading a date moved the download
+/// button. Details and Versions are tabs here instead. They swap in place, the
+/// panel keeps its height, and nothing outside it moves.
+///
+/// The height is fixed rather than fitted for exactly that reason - a panel
+/// sized to its tallest tab would still jump between them. Content longer than
+/// the panel scrolls inside it.
+class SharedFileInfoPanel extends StatefulWidget {
+  const SharedFileInfoPanel({
+    super.key,
+    required this.details,
+    required this.versions,
+    required this.onVersionsOpened,
+    required this.height,
+  });
+
+  final Widget details;
+  final Widget versions;
+
+  /// Asks the resolver for the history, the first time the Versions tab is
+  /// chosen. The history costs one metadata fetch per revision, so it stays
+  /// unasked-for until somebody looks.
+  final VoidCallback onVersionsOpened;
+
+  final double height;
+
+  @override
+  State<SharedFileInfoPanel> createState() => _SharedFileInfoPanelState();
+}
+
+class _SharedFileInfoPanelState extends State<SharedFileInfoPanel> {
+  int _tab = 0;
+
+  void _select(int tab) {
+    if (tab == _tab) {
+      return;
+    }
+
+    setState(() => _tab = tab);
+
+    if (tab == 1) {
+      widget.onVersionsOpened();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = ArDriveTheme.of(context).themeData.colors;
+
+    return Container(
+      height: widget.height,
+      decoration: BoxDecoration(
+        border: Border.all(color: colors.themeBorderDefault),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(6),
+            child: Row(
+              children: [
+                Expanded(
+                  child: _SharedFileTab(
+                    label: appLocalizationsOf(context)
+                        .sharedFileDetailsDrawerTitle,
+                    isSelected: _tab == 0,
+                    onSelected: () => _select(0),
+                  ),
+                ),
+                const SizedBox(width: 4),
+                Expanded(
+                  child: _SharedFileTab(
+                    label: appLocalizationsOf(context)
+                        .sharedFileVersionHistoryTitle,
+                    isSelected: _tab == 1,
+                    onSelected: () => _select(1),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.fromLTRB(14, 2, 14, 14),
+              child: _tab == 0 ? widget.details : widget.versions,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// One of the panel's two tabs.
+class _SharedFileTab extends StatelessWidget {
+  const _SharedFileTab({
+    required this.label,
+    required this.isSelected,
+    required this.onSelected,
+  });
+
+  final String label;
+  final bool isSelected;
+  final VoidCallback onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = ArDriveTheme.of(context).themeData.colors;
+
+    return Semantics(
+      selected: isSelected,
+      button: true,
+      child: InkWell(
+        onTap: isSelected ? null : onSelected,
+        borderRadius: BorderRadius.circular(6),
+        child: Container(
+          // The same floor the version rows use, so a tab is never a smaller
+          // target than the list it opens.
+          constraints: const BoxConstraints(minHeight: 44),
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: isSelected ? colors.themeBgSubtle : null,
+            borderRadius: BorderRadius.circular(6),
+          ),
+          child: Text(
+            label,
+            style: isSelected
+                ? ArDriveTypography.body.captionBold(
+                    color: colors.themeFgDefault,
+                  )
+                : ArDriveTypography.body.captionRegular(
+                    color: SharedFileColors.subtle(context),
+                  ),
+          ),
         ),
       ),
     );

--- a/lib/pages/shared_file/shared_file_ready_view.dart
+++ b/lib/pages/shared_file/shared_file_ready_view.dart
@@ -1137,7 +1137,7 @@ class _SharedFileVersionRow extends StatelessWidget {
     final label = isFromLink
         ? (isPinned
             ? appLocalizationsOf(context).sharedFileVersionPinned
-            : appLocalizationsOf(context).sharedFileVersionFromLink)
+            : appLocalizationsOf(context).sharedFileSharedVersion)
         : (isNewest
             ? appLocalizationsOf(context).sharedFileVersionLatest
             : null);
@@ -1223,7 +1223,9 @@ class _VersionRadio extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
+    final theme = ArDriveTheme.of(context).themeData;
+    final colors = theme.colors;
+    final colorTokens = theme.colorTokens;
 
     return ExcludeSemantics(
       child: Container(
@@ -1231,10 +1233,11 @@ class _VersionRadio extends StatelessWidget {
         height: 16,
         decoration: BoxDecoration(
           shape: BoxShape.circle,
-          color: isSelected ? colorTokens.containerRed : null,
+          color: isSelected ? colors.themeFgDefault : null,
           border: Border.all(
-            color: isSelected ? colorTokens.containerRed : colorTokens.strokeMid,
-            width: isSelected ? 5 : 1.5,
+            color:
+                isSelected ? colors.themeFgDefault : colorTokens.strokeMid,
+            width: isSelected ? 4.5 : 1.5,
           ),
         ),
       ),

--- a/lib/pages/shared_file/shared_file_ready_view.dart
+++ b/lib/pages/shared_file/shared_file_ready_view.dart
@@ -58,6 +58,14 @@ class SharedFileReadyView extends StatefulWidget {
   State<SharedFileReadyView> createState() => _SharedFileReadyViewState();
 }
 
+/// The height every row in the info panel sits on, in both tabs.
+///
+/// 44 is the smallest a touch target may be, which is what the copy controls
+/// and the version rows were already using; holding the detail rows to it as
+/// well is what makes the two lists read as one instead of alternating between
+/// two rhythms.
+const double _rowHeight = 44;
+
 /// The preview pane, which a widget test measures to prove that opening the
 /// preview cannot move anything.
 @visibleForTesting
@@ -86,7 +94,7 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
   /// would push the preview off the top of the screen.
   static const double _infoPanelHeightWide = _previewPaneHeight;
 
-  static const double _infoPanelHeightNarrow = 300;
+
 
   /// The largest the file's own thumbnail is drawn in the preview pane.
   ///
@@ -166,7 +174,11 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
           ),
         ],
         const SizedBox(height: 16),
-        _buildInfoPanel(context, revision, height: _infoPanelHeightNarrow),
+        // No fixed height on a phone: the column already scrolls, and a panel
+        // that scrolled inside it would put a second scrollbar under the
+        // thumb - and would hide the transaction details behind it rather than
+        // letting the card grow to hold them.
+        _buildInfoPanel(context, revision),
       ],
     );
   }
@@ -340,7 +352,7 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
   Widget _buildInfoPanel(
     BuildContext context,
     FileRevision revision, {
-    required double height,
+    double? height,
   }) {
     final state = widget.state;
     final payload = state.payload;
@@ -383,10 +395,9 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
   /// as something that failed to load, so at rest the pane shows the file's own
   /// thumbnail when the link carried one - real content, already fetched, and
   /// the closest thing to the file itself that costs nothing - and otherwise a
-  /// deliberate placeholder that says what the pane is for. The bar along the
-  /// bottom is the only thing that opens and closes the preview, and it sits in
-  /// the same place in both states so that pressing it never moves it out from
-  /// under the pointer or drops the keyboard's focus.
+  /// deliberate placeholder that says what the pane is for - and the whole box
+  /// is the control that opens it, so there is nothing small to aim at and
+  /// nothing to move out from under the pointer.
   ///
   /// Nothing here is fetched before it is asked for. Opening the preview
   /// automatically would spend every desktop recipient's bandwidth on bytes
@@ -437,13 +448,23 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
               ),
             ),
           ),
-          if (widget.state.detailsAreResolved) _buildPaneBar(context),
+          if (widget.state.detailsAreResolved && _isPreviewOpen)
+            _buildPaneBar(context),
         ],
       ),
     );
   }
 
-  /// The pane before anything has been asked of it.
+  /// The pane before anything has been asked of it - and the way in.
+  ///
+  /// Pressing the box shows the file. It is already the size and shape of the
+  /// preview, carrying the file's own thumbnail where the preview will be, so
+  /// it reads as the thing it opens; a separate "Preview" button below it was
+  /// a second control for a box that already looked pressable.
+  ///
+  /// Closing keeps its own control, in the bar under the open preview: a
+  /// recipient who has decided they do not want to look at what a stranger sent
+  /// them should not have to find the picture to get rid of it.
   Widget _buildPaneAtRest(BuildContext context, FileRevision revision) {
     final state = widget.state;
     final contentType = revision.dataContentType ?? state.payload?.contentType;
@@ -459,36 +480,47 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
       ),
     );
 
-    return Padding(
-      padding: const EdgeInsets.all(24),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          if (thumbnailTxId != null)
-            SharedFileThumbnail(
-              txId: thumbnailTxId,
-              size: _panePictureSize,
-              // The picture is of the file, and here it is the picture the
-              // recipient came to look at rather than a 44px decoration.
-              fit: BoxFit.contain,
-              semanticLabel: revision.name.isEmpty ? null : revision.name,
-              isPrivate: state.fileKey != null,
-              fileKey: state.fileKey,
-              fallback: _buildIconTile(context, icon),
-            )
-          else
-            _buildIconTile(context, icon),
-          const SizedBox(height: 16),
-          Text(
-            state.detailsAreResolved
-                ? appLocalizationsOf(context).sharedFilePreviewPaneHint
-                : appLocalizationsOf(context).sharedFileLoadingDetails,
-            textAlign: TextAlign.center,
-            style: ArDriveTypography.body.captionRegular(
-              color: SharedFileColors.subtle(context),
-            ),
+    final canOpen = state.detailsAreResolved;
+
+    return Semantics(
+      button: canOpen,
+      label: canOpen ? appLocalizationsOf(context).preview : null,
+      child: InkWell(
+        onTap: canOpen
+            ? () => setState(() => _isPreviewOpen = true)
+            : null,
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (thumbnailTxId != null)
+                SharedFileThumbnail(
+                  txId: thumbnailTxId,
+                  size: _panePictureSize,
+                  // The picture is of the file, and here it is the picture the
+                  // recipient came to look at rather than a 44px decoration.
+                  fit: BoxFit.contain,
+                  semanticLabel: revision.name.isEmpty ? null : revision.name,
+                  isPrivate: state.fileKey != null,
+                  fileKey: state.fileKey,
+                  fallback: _buildIconTile(context, icon),
+                )
+              else
+                _buildIconTile(context, icon),
+              const SizedBox(height: 16),
+              Text(
+                canOpen
+                    ? appLocalizationsOf(context).sharedFilePreviewPaneHint
+                    : appLocalizationsOf(context).sharedFileLoadingDetails,
+                textAlign: TextAlign.center,
+                style: ArDriveTypography.body.captionRegular(
+                  color: SharedFileColors.subtle(context),
+                ),
+              ),
+            ],
           ),
-        ],
+        ),
       ),
     );
   }
@@ -509,7 +541,8 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
     );
   }
 
-  /// The pane's own footer: one control, in one place, in both states.
+  /// The pane's own footer, present only while the preview is: the box itself
+  /// is what opens it, so the only thing left for a button is Hide.
   Widget _buildPaneBar(BuildContext context) {
     final colors = ArDriveTheme.of(context).themeData.colors;
 
@@ -521,6 +554,12 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
     );
   }
 
+  /// Hide, when there is something to hide; Preview, when the box that would
+  /// have been pressed is not the one on screen.
+  ///
+  /// On the desktop card the resting pane is itself the way in, so this only
+  /// ever says Hide there. The phone column has no resting pane - the preview
+  /// is simply absent when closed - so it keeps both directions.
   Widget _buildPreviewToggle(BuildContext context) {
     return ArDriveButton(
       style: ArDriveButtonStyle.tertiary,
@@ -997,14 +1036,19 @@ class SharedFileDetailsContent extends StatelessWidget {
             canCopy: false,
           ),
         if (detailsAreResolved) ...[
+          // Read like dates, not like timestamps. The exact instant is a
+          // hover away, which is the pairing the version rows and the drive
+          // explorer both use.
           _SharedFileDetailRow(
             label: appLocalizationsOf(context).dateCreated,
-            value: formatDateToUtcString(revision.dateCreated),
+            value: yMMdDateFormatter.format(revision.dateCreated),
+            tooltip: formatDateToUtcString(revision.dateCreated),
             canCopy: false,
           ),
           _SharedFileDetailRow(
             label: appLocalizationsOf(context).lastUpdated,
-            value: formatDateToUtcString(revision.lastModifiedDate),
+            value: yMMdDateFormatter.format(revision.lastModifiedDate),
+            tooltip: formatDateToUtcString(revision.lastModifiedDate),
             canCopy: false,
           ),
         ],
@@ -1227,7 +1271,7 @@ class _SharedFileVersionRow extends StatelessWidget {
         onTap: isDisabled || isSelected ? null : onSelected,
         borderRadius: BorderRadius.circular(6),
         child: Container(
-          constraints: const BoxConstraints(minHeight: 44),
+          constraints: const BoxConstraints(minHeight: _rowHeight),
           padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
           decoration: BoxDecoration(
             color: isSelected ? colors.themeBgSubtle : null,
@@ -1364,7 +1408,7 @@ class SharedFileInfoPanel extends StatefulWidget {
     required this.details,
     required this.versions,
     required this.onVersionsOpened,
-    required this.height,
+    this.height,
   });
 
   final Widget details;
@@ -1375,7 +1419,13 @@ class SharedFileInfoPanel extends StatefulWidget {
   /// unasked-for until somebody looks.
   final VoidCallback onVersionsOpened;
 
-  final double height;
+  /// A fixed height, or `null` to size to the content.
+  ///
+  /// Fixed on the desktop card, where it lines the panel up with the preview
+  /// pane beside it and where a tab swap would otherwise resize half the card.
+  /// Null on a phone, where the column already scrolls and a panel scrolling
+  /// inside it would be a scroll within a scroll.
+  final double? height;
 
   @override
   State<SharedFileInfoPanel> createState() => _SharedFileInfoPanelState();
@@ -1400,6 +1450,8 @@ class _SharedFileInfoPanelState extends State<SharedFileInfoPanel> {
   Widget build(BuildContext context) {
     final colors = ArDriveTheme.of(context).themeData.colors;
 
+    final isFixed = widget.height != null;
+
     return Container(
       height: widget.height,
       decoration: BoxDecoration(
@@ -1408,6 +1460,7 @@ class _SharedFileInfoPanelState extends State<SharedFileInfoPanel> {
       ),
       clipBehavior: Clip.antiAlias,
       child: Column(
+        mainAxisSize: isFixed ? MainAxisSize.max : MainAxisSize.min,
         children: [
           Padding(
             padding: const EdgeInsets.all(6),
@@ -1433,12 +1486,18 @@ class _SharedFileInfoPanelState extends State<SharedFileInfoPanel> {
               ],
             ),
           ),
-          Expanded(
-            child: SingleChildScrollView(
+          if (isFixed)
+            Expanded(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.fromLTRB(14, 2, 14, 14),
+                child: _tab == 0 ? widget.details : widget.versions,
+              ),
+            )
+          else
+            Padding(
               padding: const EdgeInsets.fromLTRB(14, 2, 14, 14),
               child: _tab == 0 ? widget.details : widget.versions,
             ),
-          ),
         ],
       ),
     );
@@ -1468,9 +1527,9 @@ class _SharedFileTab extends StatelessWidget {
         onTap: isSelected ? null : onSelected,
         borderRadius: BorderRadius.circular(6),
         child: Container(
-          // The same floor the version rows use, so a tab is never a smaller
-          // target than the list it opens.
-          constraints: const BoxConstraints(minHeight: 44),
+          // The same floor the rows use, so a tab is never a smaller target
+          // than the list it opens.
+          constraints: const BoxConstraints(minHeight: _rowHeight),
           alignment: Alignment.center,
           decoration: BoxDecoration(
             color: isSelected ? colors.themeBgSubtle : null,
@@ -1549,18 +1608,30 @@ class _SharedFileDetailRow extends StatelessWidget {
     required this.label,
     required this.value,
     this.canCopy = true,
+    this.tooltip,
   });
 
   final String label;
   final String value;
   final bool canCopy;
 
+  /// The long form of [value], when the row shows a short one.
+  final String? tooltip;
+
   @override
   Widget build(BuildContext context) {
     final colors = ArDriveTheme.of(context).themeData.colors;
 
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 8),
+    return Container(
+      // Every row is the same height whether or not it can be copied.
+      //
+      // Only some values are copyable, and the copy control is 44px because
+      // that is the smallest a touch target may be - so rows with one stood a
+      // head taller than rows without, and a list of six alternated between two
+      // rhythms. The floor is the same 44 the version rows use, so the two
+      // lists in this panel now read as one.
+      constraints: const BoxConstraints(minHeight: _rowHeight),
+      alignment: Alignment.centerLeft,
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
@@ -1574,13 +1645,24 @@ class _SharedFileDetailRow extends StatelessWidget {
             ),
           ),
           Expanded(
-            child: Text(
-              value,
-              overflow: TextOverflow.ellipsis,
-              style: ArDriveTypography.body.captionRegular(
-                color: colors.themeFgDefault,
-              ),
-            ),
+            child: tooltip == null
+                ? Text(
+                    value,
+                    overflow: TextOverflow.ellipsis,
+                    style: ArDriveTypography.body.captionRegular(
+                      color: colors.themeFgDefault,
+                    ),
+                  )
+                : ArDriveTooltip(
+                    message: tooltip!,
+                    child: Text(
+                      value,
+                      overflow: TextOverflow.ellipsis,
+                      style: ArDriveTypography.body.captionRegular(
+                        color: colors.themeFgDefault,
+                      ),
+                    ),
+                  ),
           ),
           if (canCopy) ...[
             const SizedBox(width: 8),

--- a/lib/pages/shared_file/shared_file_ready_view.dart
+++ b/lib/pages/shared_file/shared_file_ready_view.dart
@@ -589,34 +589,49 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
       false,
     );
 
-    return BlocProvider<FsEntryPreviewCubit>(
-      create: (context) => FsEntryPreviewCubit(
-        crypto: ArDriveCrypto(),
-        isSharedFile: true,
-        driveId: revision.driveId,
-        fileKey: widget.state.fileKey,
-        maybeSelectedItem: item,
-        driveDao: context.read<DriveDao>(),
-        profileCubit: context.read<ProfileCubit>(),
-        arweave: context.read<ArweaveService>(),
-        configService: context.read<ConfigService>(),
-      ),
-      child: BlocBuilder<FsEntryPreviewCubit, FsEntryPreviewState>(
-        builder: (context, previewState) {
-          final preview = _buildPreviewBody(context, previewState, item);
+    return AnimatedSwitcher(
+      // Short, and a fade rather than a slide: the pane is not moving, its
+      // contents are being replaced. Long enough not to read as a flicker,
+      // short enough that picking a version still feels immediate.
+      duration: const Duration(milliseconds: 180),
+      child: BlocProvider<FsEntryPreviewCubit>(
+        // Keyed on the bytes being previewed.
+        //
+        // Without this the provider builds its cubit once and keeps it, so
+        // moving the target left the preview showing the revision the page
+        // opened on while Download fetched a different one - two answers to
+        // "what am I looking at", and the quieter one was wrong. That was
+        // already reachable through "Get latest" before the version list
+        // existed; the list only made it easy to hit.
+        key: ValueKey(revision.dataTxId),
+        create: (context) => FsEntryPreviewCubit(
+          crypto: ArDriveCrypto(),
+          isSharedFile: true,
+          driveId: revision.driveId,
+          fileKey: widget.state.fileKey,
+          maybeSelectedItem: item,
+          driveDao: context.read<DriveDao>(),
+          profileCubit: context.read<ProfileCubit>(),
+          arweave: context.read<ArweaveService>(),
+          configService: context.read<ConfigService>(),
+        ),
+        child: BlocBuilder<FsEntryPreviewCubit, FsEntryPreviewState>(
+          builder: (context, previewState) {
+            final preview = _buildPreviewBody(context, previewState, item);
 
-          if (!isInline) {
-            return preview;
-          }
+            if (!isInline) {
+              return preview;
+            }
 
-          // On a phone the preview is part of a scrolling column, so a state
-          // whose content is one sentence gets the height of one sentence. A
-          // fixed 360 band around it left dead space above and below it and
-          // pushed the drawers under it off the screen.
-          return _previewFillsItsBox(previewState)
-              ? SizedBox(height: _inlinePreviewHeight, child: preview)
-              : preview;
-        },
+            // On a phone the preview is part of a scrolling column, so a state
+            // whose content is one sentence gets the height of one sentence. A
+            // fixed 360 band around it left dead space above and below it and
+            // pushed the drawers under it off the screen.
+            return _previewFillsItsBox(previewState)
+                ? SizedBox(height: _inlinePreviewHeight, child: preview)
+                : preview;
+          },
+        ),
       ),
     );
   }

--- a/lib/pages/shared_file/shared_file_ready_view.dart
+++ b/lib/pages/shared_file/shared_file_ready_view.dart
@@ -286,10 +286,19 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
       if (previewIsInline && state.detailsAreResolved) ...[
         const SizedBox(height: 8),
         _buildPreviewToggle(context),
-        if (_isPreviewOpen) ...[
-          const SizedBox(height: 8),
-          _buildPreview(context, revision, isInline: true),
-        ],
+        // Kept mounted while hidden, for the reason given on the desktop
+        // pane: unloading it turns "hide" into "download again".
+        Visibility(
+          visible: _isPreviewOpen,
+          maintainState: true,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const SizedBox(height: 8),
+              _buildPreview(context, revision, isInline: true),
+            ],
+          ),
+        ),
       ],
       if (state.fileKey != null) ...[
         const SizedBox(height: 16),
@@ -364,9 +373,32 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
           Expanded(
             // Centred the way `DetailsPanel` centres the same widget.
             child: Center(
-              child: _isPreviewOpen
-                  ? _buildPreview(context, revision, isInline: false)
-                  : _buildPaneAtRest(context, revision),
+              // Both are built; only one is shown.
+              //
+              // Swapping them meant hiding the preview *unloaded* it: the
+              // subtree went, its cubit went with it, and reopening fetched the
+              // file again. On a connection the gateway is rate limiting, that
+              // second fetch is one that can simply fail - so hiding a file you
+              // had could lose it.
+              //
+              // `maintainState` keeps the preview mounted and its bytes in
+              // hand while it is out of sight. Nothing is cached anywhere new;
+              // the thing just never unloads.
+              child: Stack(
+                alignment: Alignment.center,
+                children: [
+                  Visibility(
+                    visible: !_isPreviewOpen,
+                    maintainState: true,
+                    child: _buildPaneAtRest(context, revision),
+                  ),
+                  Visibility(
+                    visible: _isPreviewOpen,
+                    maintainState: true,
+                    child: _buildPreview(context, revision, isInline: false),
+                  ),
+                ],
+              ),
             ),
           ),
           if (widget.state.detailsAreResolved) _buildPaneBar(context),

--- a/lib/pages/shared_file/shared_file_ready_view.dart
+++ b/lib/pages/shared_file/shared_file_ready_view.dart
@@ -621,6 +621,24 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
       false,
     );
 
+    // The same saving the download makes, on the same two values: a private
+    // preview decrypts with the cipher the link named instead of asking the
+    // gateway to describe a transaction the link already described.
+    //
+    // Guarded on the transaction the way the download is: selecting another
+    // version leaves the link's cipher behind with the bytes it belonged to,
+    // and the lookup comes back for that one.
+    //
+    // Unlike the download this does not also require a bundled data item. That
+    // condition is there because skipping the lookup skips the `App-Name` tag
+    // that decides the arweave client's chunk check, which only applies to an
+    // L1 transaction. The preview reads nothing off that lookup but the two
+    // cipher tags, so there is no second thing to lose by not making it.
+    final payload = widget.state.payload;
+    final linkDescribesTarget = payload != null &&
+        payload.hasCipherDetails &&
+        payload.dataTxId == revision.dataTxId;
+
     return AnimatedSwitcher(
       // Short, and a fade rather than a slide: the pane is not moving, its
       // contents are being replaced. Long enough not to read as a flicker,
@@ -641,6 +659,8 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
           isSharedFile: true,
           driveId: revision.driveId,
           fileKey: widget.state.fileKey,
+          cipher: linkDescribesTarget ? payload.cipher : null,
+          cipherIv: linkDescribesTarget ? payload.cipherIv : null,
           maybeSelectedItem: item,
           driveDao: context.read<DriveDao>(),
           profileCubit: context.read<ProfileCubit>(),

--- a/lib/pages/shared_file/shared_file_ready_view.dart
+++ b/lib/pages/shared_file/shared_file_ready_view.dart
@@ -103,17 +103,6 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
   /// to look like a mistake.
   static const double _panePictureSize = 200;
 
-  /// Open on arrival.
-  ///
-  /// The page exists to show someone a file, so making them ask to see it is
-  /// one click that should not exist. The pane is laid out either way on the
-  /// desktop card, so this fills a box that was already there rather than
-  /// moving anything; the toggle stays, so it can still be closed.
-  ///
-  /// A type that cannot be shown answers with its own sentence rather than
-  /// nothing, which is a better answer than making the recipient press Preview
-  /// to be told the same thing.
-  bool _isPreviewOpen = true;
 
   /// Whether a download is in flight.
   ///
@@ -155,23 +144,12 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
         _buildDownload(context, revision, fillWidth: true),
         ..._buildUnlockedNote(context),
         // The preview reads the file through its drive, which only the
-        // resolved metadata knows about.
+        // resolved metadata knows about. There is no resting box on a phone -
+        // an empty 360px band above the fold would cost more than it says -
+        // so the preview simply appears once there is something to show.
         if (widget.state.detailsAreResolved) ...[
-          const SizedBox(height: 8),
-          _buildPreviewToggle(context),
-          // Kept mounted while hidden: unloading it turns "hide" into
-          // "download again".
-          Visibility(
-            visible: _isPreviewOpen,
-            maintainState: true,
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const SizedBox(height: 8),
-                _buildPreview(context, revision, isInline: true),
-              ],
-            ),
-          ),
+          const SizedBox(height: 16),
+          _buildPreview(context, revision, isInline: true),
         ],
         const SizedBox(height: 16),
         // No fixed height on a phone: the column already scrolls, and a panel
@@ -386,23 +364,25 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
 
   /// Where the file goes on a wide screen.
   ///
-  /// Its height is a constant, not a function of [_isPreviewOpen]: a pane that
-  /// only existed once the preview was open would make Preview a button that
-  /// resizes the page, and the download button would move out from under the
-  /// pointer that is about to press it.
+  /// The preview is the page, not something the page offers: this is a link
+  /// someone followed to look at a file, so the file is shown. There is no
+  /// control to put it away, because there was nothing for one to do - the
+  /// bytes are already fetched by the time it could be pressed, the widget
+  /// stays mounted either way, and anyone who did not want to see what a
+  /// stranger sent them has already seen it. A button that saves no bandwidth,
+  /// frees no memory and prevents nothing is a button that only makes the
+  /// recipient decide something.
   ///
-  /// What it must not be is empty. A 580x430 box holding one 40px glyph reads
-  /// as something that failed to load, so at rest the pane shows the file's own
-  /// thumbnail when the link carried one - real content, already fetched, and
-  /// the closest thing to the file itself that costs nothing - and otherwise a
-  /// deliberate placeholder that says what the pane is for - and the whole box
-  /// is the control that opens it, so there is nothing small to aim at and
-  /// nothing to move out from under the pointer.
+  /// The box still has a resting state, but for the situations the recipient
+  /// did not choose: the metadata has not resolved yet, the type cannot be
+  /// shown, the file is past `previewMaxFileSize` (100 MiB), or the fetch
+  /// failed. Those get the file's own thumbnail or its type icon above a
+  /// sentence, so the pane reads as an answer rather than as something that
+  /// failed to load - and Download, in the column beside it, is still the way
+  /// forward in every one of them.
   ///
-  /// Nothing here is fetched before it is asked for. Opening the preview
-  /// automatically would spend every desktop recipient's bandwidth on bytes
-  /// they may only have wanted to download - up to `previewMaxFileSize`, which
-  /// is 100 MiB - so the pane fills itself with what the page already has.
+  /// The height is a constant so that none of those transitions resize the
+  /// card under the pointer that is on its way to Download.
   Widget _buildPreviewPane(BuildContext context, FileRevision revision) {
     final colors = ArDriveTheme.of(context).themeData.colors;
 
@@ -415,63 +395,54 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
         border: Border.all(color: colors.themeBorderDefault),
       ),
       clipBehavior: Clip.antiAlias,
-      child: Column(
-        children: [
-          Expanded(
-            // Centred the way `DetailsPanel` centres the same widget.
-            child: Center(
-              // Both are built; only one is shown.
-              //
-              // Swapping them meant hiding the preview *unloaded* it: the
-              // subtree went, its cubit went with it, and reopening fetched the
-              // file again. On a connection the gateway is rate limiting, that
-              // second fetch is one that can simply fail - so hiding a file you
-              // had could lose it.
-              //
-              // `maintainState` keeps the preview mounted and its bytes in
-              // hand while it is out of sight. Nothing is cached anywhere new;
-              // the thing just never unloads.
-              child: Stack(
-                alignment: Alignment.center,
-                children: [
-                  Visibility(
-                    visible: !_isPreviewOpen,
-                    maintainState: true,
-                    child: _buildPaneAtRest(context, revision),
-                  ),
-                  Visibility(
-                    visible: _isPreviewOpen,
-                    maintainState: true,
-                    child: _buildPreview(context, revision, isInline: false),
-                  ),
-                ],
-              ),
-            ),
-          ),
-          if (widget.state.detailsAreResolved && _isPreviewOpen)
-            _buildPaneBar(context),
-        ],
+      // Centred the way `DetailsPanel` centres the same widget.
+      child: Center(
+        // The preview reads the file through its drive, which only the
+        // resolved metadata knows about.
+        child: widget.state.detailsAreResolved
+            ? _buildPreview(context, revision, isInline: false)
+            : _buildPaneAtRest(context, revision),
       ),
     );
   }
 
-  /// The pane before anything has been asked of it - and the way in.
+  /// The pane while the metadata is still resolving.
   ///
-  /// Pressing the box shows the file. It is already the size and shape of the
-  /// preview, carrying the file's own thumbnail where the preview will be, so
-  /// it reads as the thing it opens; a separate "Preview" button below it was
-  /// a second control for a box that already looked pressable.
-  ///
-  /// Closing keeps its own control, in the bar under the open preview: a
-  /// recipient who has decided they do not want to look at what a stranger sent
-  /// them should not have to find the picture to get rid of it.
+  /// A 580x430 box holding one 40px glyph reads as something that failed to
+  /// load, so this shows the file's own thumbnail when the link carried one -
+  /// real content, already fetched, and the closest thing to the file itself
+  /// that costs nothing - and otherwise its type icon, given enough weight to
+  /// read as a placeholder.
   Widget _buildPaneAtRest(BuildContext context, FileRevision revision) {
     final state = widget.state;
     final contentType = revision.dataContentType ?? state.payload?.contentType;
     final thumbnailTxId = _thumbnailTxId(state, revision);
 
-    // Decorative in both branches: the file's name and type are written out in
-    // words in the column beside this one.
+    return _buildPanePlaceholder(
+      context,
+      revision: revision,
+      contentType: contentType,
+      thumbnailTxId: thumbnailTxId,
+      message: appLocalizationsOf(context).sharedFileLoadingDetails,
+    );
+  }
+
+  /// A picture of the file over a sentence about it.
+  ///
+  /// Shared by every state that cannot show the file itself, so that "not yet",
+  /// "not this type" and "too big to preview" all look like the same
+  /// deliberate answer instead of three different kinds of empty.
+  Widget _buildPanePlaceholder(
+    BuildContext context, {
+    required FileRevision revision,
+    required String? contentType,
+    required String? thumbnailTxId,
+    required String message,
+  }) {
+    final state = widget.state;
+
+    // Decorative: the file's name and type are written out in words in the
+    // column beside this one.
     final icon = ExcludeSemantics(
       child: getIconForContentType(
         contentType ?? 'application/octet-stream',
@@ -480,47 +451,34 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
       ),
     );
 
-    final canOpen = state.detailsAreResolved;
-
-    return Semantics(
-      button: canOpen,
-      label: canOpen ? appLocalizationsOf(context).preview : null,
-      child: InkWell(
-        onTap: canOpen
-            ? () => setState(() => _isPreviewOpen = true)
-            : null,
-        child: Padding(
-          padding: const EdgeInsets.all(24),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              if (thumbnailTxId != null)
-                SharedFileThumbnail(
-                  txId: thumbnailTxId,
-                  size: _panePictureSize,
-                  // The picture is of the file, and here it is the picture the
-                  // recipient came to look at rather than a 44px decoration.
-                  fit: BoxFit.contain,
-                  semanticLabel: revision.name.isEmpty ? null : revision.name,
-                  isPrivate: state.fileKey != null,
-                  fileKey: state.fileKey,
-                  fallback: _buildIconTile(context, icon),
-                )
-              else
-                _buildIconTile(context, icon),
-              const SizedBox(height: 16),
-              Text(
-                canOpen
-                    ? appLocalizationsOf(context).sharedFilePreviewPaneHint
-                    : appLocalizationsOf(context).sharedFileLoadingDetails,
-                textAlign: TextAlign.center,
-                style: ArDriveTypography.body.captionRegular(
-                  color: SharedFileColors.subtle(context),
-                ),
-              ),
-            ],
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (thumbnailTxId != null)
+            SharedFileThumbnail(
+              txId: thumbnailTxId,
+              size: _panePictureSize,
+              // The picture is of the file, and here it is the picture the
+              // recipient came to look at rather than a 44px decoration.
+              fit: BoxFit.contain,
+              semanticLabel: revision.name.isEmpty ? null : revision.name,
+              isPrivate: state.fileKey != null,
+              fileKey: state.fileKey,
+              fallback: _buildIconTile(context, icon),
+            )
+          else
+            _buildIconTile(context, icon),
+          const SizedBox(height: 16),
+          Text(
+            message,
+            textAlign: TextAlign.center,
+            style: ArDriveTypography.body.captionRegular(
+              color: SharedFileColors.subtle(context),
+            ),
           ),
-        ),
+        ],
       ),
     );
   }
@@ -538,35 +496,6 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
         borderRadius: BorderRadius.circular(8),
       ),
       child: Center(child: icon),
-    );
-  }
-
-  /// The pane's own footer, present only while the preview is: the box itself
-  /// is what opens it, so the only thing left for a button is Hide.
-  Widget _buildPaneBar(BuildContext context) {
-    final colors = ArDriveTheme.of(context).themeData.colors;
-
-    return Container(
-      decoration: BoxDecoration(
-        border: Border(top: BorderSide(color: colors.themeBorderDefault)),
-      ),
-      child: Center(child: _buildPreviewToggle(context)),
-    );
-  }
-
-  /// Hide, when there is something to hide; Preview, when the box that would
-  /// have been pressed is not the one on screen.
-  ///
-  /// On the desktop card the resting pane is itself the way in, so this only
-  /// ever says Hide there. The phone column has no resting pane - the preview
-  /// is simply absent when closed - so it keeps both directions.
-  Widget _buildPreviewToggle(BuildContext context) {
-    return ArDriveButton(
-      style: ArDriveButtonStyle.tertiary,
-      onPressed: () => setState(() => _isPreviewOpen = !_isPreviewOpen),
-      text: _isPreviewOpen
-          ? appLocalizationsOf(context).sharedFileHidePreview
-          : appLocalizationsOf(context).preview,
     );
   }
 
@@ -751,6 +680,7 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
     if (previewState is FsEntryPreviewOversized) {
       return _buildPreviewMessage(
         context,
+        item,
         appLocalizationsOf(context)
             .filePreviewTooLarge(filesize(previewState.maxFileSize)),
       );
@@ -759,6 +689,7 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
     if (previewState is FsEntryPreviewUnavailable) {
       return _buildPreviewMessage(
         context,
+        item,
         appLocalizationsOf(context).sharedFilePreviewUnsupported,
       );
     }
@@ -772,16 +703,43 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
     );
   }
 
-  Widget _buildPreviewMessage(BuildContext context, String message) {
-    return Padding(
-      padding: const EdgeInsets.all(16),
-      child: Text(
-        message,
-        textAlign: TextAlign.center,
-        style: ArDriveTypography.body.captionRegular(
-          color: SharedFileColors.subtle(context),
+  /// Why the file is not on screen, said the same way the pane says
+  /// "not yet".
+  ///
+  /// On the desktop card this is the whole of a 580x430 box, and a lone
+  /// sentence floating in the middle of it reads as a failure rather than as
+  /// an answer - so it gets the same picture-over-a-sentence treatment as the
+  /// resting pane, and Download beside it stays the way forward.
+  ///
+  /// On a phone the column has no box to fill, so the sentence stands on its
+  /// own; `_previewFillsItsBox` already keeps these states out of the fixed
+  /// band for that reason.
+  Widget _buildPreviewMessage(
+    BuildContext context,
+    ArDriveDataTableItem item,
+    String message,
+  ) {
+    if (!widget.isWide) {
+      return Padding(
+        padding: const EdgeInsets.all(16),
+        child: Text(
+          message,
+          textAlign: TextAlign.center,
+          style: ArDriveTypography.body.captionRegular(
+            color: SharedFileColors.subtle(context),
+          ),
         ),
-      ),
+      );
+    }
+
+    final revision = widget.state.revision;
+
+    return _buildPanePlaceholder(
+      context,
+      revision: revision,
+      contentType: revision.dataContentType ?? widget.state.payload?.contentType,
+      thumbnailTxId: _thumbnailTxId(widget.state, revision),
+      message: message,
     );
   }
 

--- a/lib/pages/shared_file/shared_file_ready_view.dart
+++ b/lib/pages/shared_file/shared_file_ready_view.dart
@@ -17,6 +17,7 @@ import 'package:ardrive/pages/shared_file/shared_file_thumbnail.dart';
 import 'package:ardrive/services/services.dart';
 import 'package:ardrive/utils/app_localizations_wrapper.dart';
 import 'package:ardrive/utils/file_revision_base.dart';
+import 'package:ardrive/l11n/l11n.dart';
 import 'package:ardrive/utils/filesize.dart';
 import 'package:ardrive/utils/format_date.dart';
 import 'package:ardrive_ui/ardrive_ui.dart';
@@ -303,6 +304,14 @@ class _SharedFileReadyViewState extends State<SharedFileReadyView> {
       SharedFileVersionsDrawer(
         revisions: state.activityRevisions,
         status: state.activityStatus,
+        currentRevision: revision,
+        // Nothing may move the target while bytes are on their way, and
+        // nothing may start a second change while one is running - the same
+        // guard the freshness banner's actions use.
+        isDisabled: _isDownloading || _isChangingRevision,
+        onSelected: (picked) => _changeRevision(
+          () => context.read<SharedFileCubit>().showRevision(picked),
+        ),
         // The revision the link named, which stays marked as the shared one
         // even while the newest is being shown.
         sharedRevision: state.sharedRevision,
@@ -940,7 +949,7 @@ class SharedFileDetailsDrawer extends StatelessWidget {
   }
 }
 
-/// The file's revisions, newest first.
+/// The file's revisions, newest first, as something the recipient can act on.
 ///
 /// Replaces the share page's old Activity tab: same information, none of the
 /// tab chrome, and - because a revision history costs one metadata fetch per
@@ -950,37 +959,54 @@ class SharedFileDetailsDrawer extends StatelessWidget {
 /// `fileRevisions`: the latter is the download target and holds exactly one
 /// revision on every v2 link, so reading the history from it would show a
 /// one-line history of the file's own current version.
+///
+/// ## Why this never makes the recipient wait
+///
+/// The version the link named is already in hand before the list is opened -
+/// it is what the page is showing - so the resolver seeds the list with it and
+/// this renders that row from the first frame. Everything else fills in around
+/// it. Nothing here gates Download, the preview, or anything above the card,
+/// and a lookup that fails costs the list and nothing else: the row the
+/// recipient was sent stays, and stays selected.
 class SharedFileVersionsDrawer extends StatelessWidget {
   const SharedFileVersionsDrawer({
     super.key,
     required this.revisions,
     required this.status,
     required this.sharedRevision,
+    required this.currentRevision,
     required this.onOpened,
+    required this.onSelected,
+    this.isDisabled = false,
   });
 
-  /// Newest first. Empty until [onOpened] has been answered.
+  /// Newest first. Seeded with the shared revision the moment the list opens.
   final List<FileRevision> revisions;
 
   final SharedFileActivityStatus status;
 
-  /// The revision the link named - the one that gets marked as shared.
+  /// The revision the link named - the one that wears the "this link" chip.
   final FileRevision sharedRevision;
+
+  /// The revision the page is currently showing and would download.
+  final FileRevision currentRevision;
 
   /// Called every time the drawer is opened; the resolver answers the first
   /// one, ignores the rest, and tries again after a failure.
   final VoidCallback onOpened;
 
+  /// Called with the revision the recipient picked.
+  final ValueChanged<FileRevision> onSelected;
+
+  /// True while a download or another selection is in flight - nothing may
+  /// move the target while bytes are on their way.
+  final bool isDisabled;
+
   @override
   Widget build(BuildContext context) {
-    final colors = ArDriveTheme.of(context).themeData.colors;
-
-    // A history that is still coming spins; one that failed says so; one that
-    // arrived empty says the same rather than spinning for ever.
     final isLoading = status == SharedFileActivityStatus.notLoaded ||
         status == SharedFileActivityStatus.loading;
-    final isUnavailable =
-        status == SharedFileActivityStatus.failed || revisions.isEmpty;
+    final hasFailed = status == SharedFileActivityStatus.failed;
 
     return _SharedFileDrawer(
       title: appLocalizationsOf(context).sharedFileVersionHistoryTitle,
@@ -990,59 +1016,202 @@ class SharedFileVersionsDrawer extends StatelessWidget {
         }
       },
       children: [
-        if (isLoading)
-          const Padding(
-            padding: EdgeInsets.only(bottom: 8),
-            child: SizedBox(
-              height: 16,
-              width: 16,
-              child: CircularProgressIndicator(strokeWidth: 2),
-            ),
-          )
-        else if (isUnavailable)
+        if (revisions.length > 1)
           Padding(
-            padding: const EdgeInsets.only(bottom: 8),
+            padding: const EdgeInsets.only(bottom: 4),
             child: Text(
-              appLocalizationsOf(context).sharedFileVersionHistoryUnavailable,
+              appLocalizationsOf(context).sharedFileChooseVersion,
               style: ArDriveTypography.body.captionRegular(
                 color: SharedFileColors.subtle(context),
               ),
             ),
-          )
-        else
-          for (final revision in revisions)
-            Padding(
-              padding: const EdgeInsets.only(bottom: 8),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: Text(
-                      formatDateToUtcString(revision.dateCreated),
-                      style: ArDriveTypography.body.captionRegular(
-                        color: colors.themeFgDefault,
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  Text(
-                    filesize(revision.size),
+          ),
+        for (final revision in revisions)
+          _SharedFileVersionRow(
+            revision: revision,
+            isSelected: revision.dataTxId == currentRevision.dataTxId,
+            isNewest: revision.dataTxId == revisions.first.dataTxId &&
+                revisions.length > 1,
+            isFromLink: revision.dataTxId == sharedRevision.dataTxId,
+            isDisabled: isDisabled,
+            onSelected: () => onSelected(revision),
+          ),
+        if (isLoading)
+          Padding(
+            padding: const EdgeInsets.only(top: 4, bottom: 8),
+            child: Text(
+              appLocalizationsOf(context).sharedFileVersionsLooking,
+              style: ArDriveTypography.body.captionRegular(
+                color: SharedFileColors.subtle(context),
+              ),
+            ),
+          ),
+        if (hasFailed)
+          Padding(
+            padding: const EdgeInsets.only(top: 4, bottom: 8),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    appLocalizationsOf(context)
+                        .sharedFileVersionsUnavailableShort,
                     style: ArDriveTypography.body.captionRegular(
                       color: SharedFileColors.subtle(context),
                     ),
                   ),
-                  if (revision.dataTxId == sharedRevision.dataTxId) ...[
-                    const SizedBox(width: 8),
-                    Text(
-                      appLocalizationsOf(context).sharedFileSharedVersion,
-                      style: ArDriveTypography.body.captionBold(
-                        color: SharedFileColors.subtle(context),
-                      ),
-                    ),
-                  ],
-                ],
-              ),
+                ),
+                const SizedBox(width: 8),
+                // The drawer's own retry: `loadActivity` runs again after a
+                // failure, so pressing this is all it takes.
+                ArDriveTextButton(
+                  text: appLocalizationsOf(context).sharedFileRetry,
+                  onPressed: onOpened,
+                ),
+              ],
             ),
+          ),
       ],
+    );
+  }
+}
+
+/// One version, and the control that selects it.
+///
+/// A row rather than a line of text: choosing a version is what this list is
+/// for. Laid out so the same row works under a thumb - the whole row is the
+/// target, and it is never shorter than 44px.
+class _SharedFileVersionRow extends StatelessWidget {
+  const _SharedFileVersionRow({
+    required this.revision,
+    required this.isSelected,
+    required this.isNewest,
+    required this.isFromLink,
+    required this.isDisabled,
+    required this.onSelected,
+  });
+
+  final FileRevision revision;
+  final bool isSelected;
+  final bool isNewest;
+  final bool isFromLink;
+  final bool isDisabled;
+  final VoidCallback onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = ArDriveTheme.of(context).themeData.colors;
+    final subtle = SharedFileColors.subtle(context);
+
+    return Semantics(
+      selected: isSelected,
+      inMutuallyExclusiveGroup: true,
+      child: InkWell(
+        onTap: isDisabled || isSelected ? null : onSelected,
+        borderRadius: BorderRadius.circular(6),
+        child: Container(
+          constraints: const BoxConstraints(minHeight: 44),
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+          decoration: BoxDecoration(
+            color: isSelected ? colors.themeBgSubtle : null,
+            borderRadius: BorderRadius.circular(6),
+          ),
+          child: Row(
+            children: [
+              _VersionRadio(isSelected: isSelected),
+              const SizedBox(width: 11),
+              Expanded(
+                child: ArDriveTooltip(
+                  // The row shows the short date so that it still fits beside
+                  // a size and a chip on a phone; the exact timestamp is one
+                  // hover away, the same pairing the drive explorer uses.
+                  message: formatDateToUtcString(revision.dateCreated),
+                  child: Text(
+                    yMMdDateFormatter.format(revision.dateCreated),
+                    overflow: TextOverflow.ellipsis,
+                    style: isSelected
+                        ? ArDriveTypography.body
+                            .captionBold(color: colors.themeFgDefault)
+                        : ArDriveTypography.body
+                            .captionRegular(color: colors.themeFgDefault),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                filesize(revision.size),
+                style: ArDriveTypography.body.captionRegular(color: subtle),
+              ),
+              // At most one chip. A row that is both the newest and the one the
+              // link named would otherwise carry two labels saying much the
+              // same thing, and on a phone that is what pushes it over.
+              if (isFromLink) ...[
+                const SizedBox(width: 8),
+                _VersionChip(
+                  appLocalizationsOf(context).sharedFileVersionFromLink,
+                ),
+              ] else if (isNewest) ...[
+                const SizedBox(width: 8),
+                _VersionChip(
+                  appLocalizationsOf(context).sharedFileVersionLatest,
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The selected mark. Drawn rather than themed so that it reads as a choice
+/// even where the platform's own radio does not fit this card's density.
+class _VersionRadio extends StatelessWidget {
+  const _VersionRadio({required this.isSelected});
+
+  final bool isSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
+
+    return ExcludeSemantics(
+      child: Container(
+        width: 16,
+        height: 16,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          color: isSelected ? colorTokens.containerRed : null,
+          border: Border.all(
+            color: isSelected ? colorTokens.containerRed : colorTokens.strokeMid,
+            width: isSelected ? 5 : 1.5,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _VersionChip extends StatelessWidget {
+  const _VersionChip(this.label);
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = ArDriveTheme.of(context).themeData.colors;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 3),
+      decoration: BoxDecoration(
+        color: colors.themeBgSubtle,
+        borderRadius: BorderRadius.circular(3),
+      ),
+      child: Text(
+        label,
+        style: ArDriveTypography.body.captionBold(
+          color: SharedFileColors.subtle(context),
+        ),
+      ),
     );
   }
 }

--- a/test/blocs/fs_entry_preview/fs_entry_preview_cubit_test.dart
+++ b/test/blocs/fs_entry_preview/fs_entry_preview_cubit_test.dart
@@ -205,6 +205,8 @@ void main() {
     SecretKey? fileKey,
     DataGatewayFallback? gatewayFallback,
     PreviewObjectUrls? objectUrls,
+    String? cipher,
+    String? cipherIv,
   }) {
     if (gatewayFallback != null) {
       when(() => mockArweaveService.gatewayFallback)
@@ -222,6 +224,8 @@ void main() {
       fileKey: fileKey,
       isSharedFile: true,
       objectUrls: objectUrls,
+      cipher: cipher,
+      cipherIv: cipherIv,
     );
   }
 
@@ -626,6 +630,83 @@ void main() {
   // decrypted here. What these tests hold down is where the bytes come from,
   // that they never come at all when they must not, and that a public file
   // still has the old open-in-a-new-tab escape hatch when they do not arrive.
+  group('FsEntryPreviewCubit link-supplied cipher', () {
+    late FakePreviewObjectUrls objectUrls;
+
+    setUp(() => objectUrls = FakePreviewObjectUrls());
+
+    blocTest<FsEntryPreviewCubit, FsEntryPreviewState>(
+      'decrypts with the cipher it was given, without describing the '
+      'transaction',
+      build: () {
+        stubPrivateFetchAndDecrypt();
+        when(() => mockCrypto.decryptDataWithCipher(any(), any(), any(), any()))
+            .thenAnswer((_) async => Uint8List.fromList([5, 6, 7, 8]));
+
+        return buildSharedFileCubit(
+          item: createVideoItem(size: underLimitFileSize),
+          fileKey: SecretKey([1, 2, 3]),
+          objectUrls: objectUrls,
+          cipher: 'AES256-GCM',
+          cipherIv: 'aXY=',
+        );
+      },
+      wait: const Duration(milliseconds: 100),
+      expect: () => [
+        const FsEntryPreviewLoading(),
+        const FsEntryPreviewVideo(
+          previewUrl: 'blob:fake/0-video/mp4',
+          filename: 'clip.mp4',
+        ),
+      ],
+      verify: (cubit) {
+        // The whole point: a share link that carried `c` and `iv` costs the
+        // recipient no GraphQL to preview what it named.
+        verifyNever(() => mockArweaveService.getTransactionDetails(any()));
+        verifyNever(
+          () => mockCrypto.decryptDataFromTransaction(any(), any(), any()),
+        );
+        verify(
+          () => mockCrypto.decryptDataWithCipher(
+              'AES256-GCM', 'aXY=', any(), any()),
+        ).called(1);
+
+        // Still the decrypted bytes that reach the player.
+        expect(objectUrls.createdBytes.single,
+            Uint8List.fromList([5, 6, 7, 8]));
+      },
+    );
+
+    blocTest<FsEntryPreviewCubit, FsEntryPreviewState>(
+      'falls back to the lookup when it was given no cipher',
+      build: () {
+        stubPrivateFetchAndDecrypt();
+
+        return buildSharedFileCubit(
+          item: createVideoItem(size: underLimitFileSize),
+          fileKey: SecretKey([1, 2, 3]),
+          objectUrls: objectUrls,
+        );
+      },
+      wait: const Duration(milliseconds: 100),
+      expect: () => [
+        const FsEntryPreviewLoading(),
+        const FsEntryPreviewVideo(
+          previewUrl: 'blob:fake/0-video/mp4',
+          filename: 'clip.mp4',
+        ),
+      ],
+      verify: (cubit) {
+        // A v1 link, or a version the link never described, still resolves the
+        // tags the only other way there is.
+        verify(() => mockArweaveService.getTransactionDetails(any())).called(1);
+        verify(
+          () => mockCrypto.decryptDataFromTransaction(any(), any(), any()),
+        ).called(1);
+      },
+    );
+  });
+
   group('FsEntryPreviewCubit PDF (F9)', () {
     late FakePreviewObjectUrls objectUrls;
     late WaterfallGatewayFallback waterfallGatewayFallback;

--- a/test/blocs/shared_file/shared_file_cubit_test.dart
+++ b/test/blocs/shared_file/shared_file_cubit_test.dart
@@ -82,6 +82,10 @@ void main() {
     required DateTime createdAt,
     String name = 'file.txt',
     String dataTx = dataTxId,
+    // Defaults to the id the v2 link payload names, so a single-revision
+    // fixture verifies against it. A fixture with more than one revision must
+    // give the others their own: two revisions never share a metadata
+    // transaction on chain, and that transaction is what identifies one.
     String metadataTx = metadataTxId,
     int size = 100,
     String owner = ownerAddress,
@@ -1172,6 +1176,8 @@ void main() {
             createdAt: DateTime(2024, 1, 2),
             name: 'newer.txt',
             dataTx: 'data-tx-newer',
+            // Its own record, as a second revision always has.
+            metadataTx: 'metadata-tx-newer',
           ),
         ],
       );
@@ -1209,6 +1215,8 @@ void main() {
             createdAt: DateTime(2024, 1, 2),
             name: 'newer.txt',
             dataTx: 'data-tx-newer',
+            // Its own record, as a second revision always has.
+            metadataTx: 'metadata-tx-newer',
           ),
         ],
       );

--- a/test/blocs/shared_file/shared_file_cubit_test.dart
+++ b/test/blocs/shared_file/shared_file_cubit_test.dart
@@ -1090,6 +1090,167 @@ void main() {
     });
   });
 
+  group('SharedFileCubit version list', () {
+    test('the version already in hand renders before the history arrives',
+        () async {
+      // The link carries the version it points at, so opening the list must
+      // not be a wait. The row is there from the first frame; the rest of the
+      // history fills in around it.
+      when(() => arweave.getFilePrivacyForId(any()))
+          .thenAnswer((_) async => DrivePrivacyTag.public);
+      when(() => arweave.getLatestFileEntityWithId(any(), any())).thenAnswer(
+        (_) async => fileEntity(createdAt: DateTime(2024, 1, 1)),
+      );
+
+      final history = Completer<List<FileEntity>>();
+
+      when(() => arweave.getAllFileEntitiesWithId(any(), any()))
+          .thenAnswer((_) => history.future);
+
+      final cubit = createCubit(payload: v2Payload());
+
+      await cubit.backgroundWork;
+
+      unawaited(cubit.loadActivity());
+      await Future<void>.delayed(Duration.zero);
+
+      final opening = cubit.state as SharedFileLoadSuccess;
+
+      expect(opening.activityStatus, SharedFileActivityStatus.loading);
+      expect(opening.activityRevisions, hasLength(1));
+      expect(
+        opening.activityRevisions.single.dataTxId,
+        opening.sharedRevision.dataTxId,
+      );
+
+      history.complete([
+        fileEntity(createdAt: DateTime(2024, 1, 1), name: 'first.txt'),
+        fileEntity(createdAt: DateTime(2024, 1, 2), name: 'file.txt'),
+      ]);
+      await Future<void>.delayed(Duration.zero);
+
+      final loaded = cubit.state as SharedFileLoadSuccess;
+
+      expect(loaded.activityStatus, SharedFileActivityStatus.loaded);
+      expect(loaded.activityRevisions, hasLength(2));
+    });
+
+    test('a failed lookup keeps the version the recipient was sent', () async {
+      // The state a rate limited connection lands in. It costs the list, never
+      // the file: the row stays, so the page still names what it is offering.
+      when(() => arweave.getFilePrivacyForId(any()))
+          .thenAnswer((_) async => DrivePrivacyTag.public);
+      when(() => arweave.getLatestFileEntityWithId(any(), any())).thenAnswer(
+        (_) async => fileEntity(createdAt: DateTime(2024, 1, 1)),
+      );
+      when(() => arweave.getAllFileEntitiesWithId(any(), any()))
+          .thenAnswer((_) async => throw Exception('gateway is unreachable'));
+
+      final cubit = createCubit(payload: v2Payload());
+
+      await cubit.backgroundWork;
+      await cubit.loadActivity();
+
+      final failed = cubit.state as SharedFileLoadSuccess;
+
+      expect(failed.activityStatus, SharedFileActivityStatus.failed);
+      expect(failed.activityRevisions, hasLength(1));
+      // And the file itself is untouched by any of it.
+      expect(failed.revision.dataTxId, isNotEmpty);
+    });
+
+    test('selecting a version moves the download target to it', () async {
+      when(() => arweave.getFilePrivacyForId(any()))
+          .thenAnswer((_) async => DrivePrivacyTag.public);
+      when(() => arweave.getLatestFileEntityWithId(any(), any())).thenAnswer(
+        (_) async => fileEntity(createdAt: DateTime(2024, 1, 1)),
+      );
+      when(() => arweave.getAllFileEntitiesWithId(any(), any())).thenAnswer(
+        (_) async => [
+          fileEntity(createdAt: DateTime(2024, 1, 1), name: 'first.txt'),
+          fileEntity(
+            createdAt: DateTime(2024, 1, 2),
+            name: 'newer.txt',
+            dataTx: 'data-tx-newer',
+          ),
+        ],
+      );
+
+      final cubit = createCubit(payload: v2Payload());
+
+      await cubit.backgroundWork;
+      await cubit.loadActivity();
+
+      final loaded = cubit.state as SharedFileLoadSuccess;
+      final newest = loaded.activityRevisions.first;
+
+      await cubit.showRevision(newest);
+
+      final selected = cubit.state as SharedFileLoadSuccess;
+
+      expect(selected.revision.dataTxId, newest.dataTxId);
+      // On the newest revision there is nothing newer left to offer.
+      expect(selected.showsLatestRevision, isTrue);
+      expect(selected.newerVersionAvailable, isFalse);
+      // The link's own revision is remembered, so the way back stays open.
+      expect(selected.linkRevision, isNotNull);
+    });
+
+    test('selecting an older version says a newer one exists', () async {
+      when(() => arweave.getFilePrivacyForId(any()))
+          .thenAnswer((_) async => DrivePrivacyTag.public);
+      when(() => arweave.getLatestFileEntityWithId(any(), any())).thenAnswer(
+        (_) async => fileEntity(createdAt: DateTime(2024, 1, 1)),
+      );
+      when(() => arweave.getAllFileEntitiesWithId(any(), any())).thenAnswer(
+        (_) async => [
+          fileEntity(createdAt: DateTime(2024, 1, 1), name: 'first.txt'),
+          fileEntity(
+            createdAt: DateTime(2024, 1, 2),
+            name: 'newer.txt',
+            dataTx: 'data-tx-newer',
+          ),
+        ],
+      );
+
+      final cubit = createCubit(payload: v2Payload());
+
+      await cubit.backgroundWork;
+      await cubit.loadActivity();
+
+      final loaded = cubit.state as SharedFileLoadSuccess;
+      final newest = loaded.activityRevisions.first;
+      final oldest = loaded.activityRevisions.last;
+
+      // Move to the newest first, so that coming back down is a real move.
+      await cubit.showRevision(newest);
+      await cubit.showRevision(oldest);
+
+      final selected = cubit.state as SharedFileLoadSuccess;
+
+      expect(selected.revision.dataTxId, oldest.dataTxId);
+      expect(selected.newerVersionAvailable, isTrue);
+    });
+
+    test('selecting the version already shown changes nothing', () async {
+      when(() => arweave.getFilePrivacyForId(any()))
+          .thenAnswer((_) async => DrivePrivacyTag.public);
+      when(() => arweave.getLatestFileEntityWithId(any(), any())).thenAnswer(
+        (_) async => fileEntity(createdAt: DateTime(2024, 1, 1)),
+      );
+
+      final cubit = createCubit(payload: v2Payload());
+
+      await cubit.backgroundWork;
+
+      final before = cubit.state as SharedFileLoadSuccess;
+
+      await cubit.showRevision(before.revision);
+
+      expect(cubit.state, same(before));
+    });
+  });
+
   group('SharedFileCubit recoverMissingData', () {
     test('adopts the file\'s real data transaction when the link\'s is gone',
         () async {

--- a/test/blocs/shared_file_download_cubit_test.dart
+++ b/test/blocs/shared_file_download_cubit_test.dart
@@ -96,6 +96,10 @@ class _RecordingDownloader implements ArDriveDownloader {
     ));
   }
 
+  /// What the cubit asked for, so a download that quietly starts depending on
+  /// GraphQL again is visible from the test that cares.
+  bool? lastVerifyIntegrity;
+
   @override
   Future<Stream<double>> downloadFile({
     required String txId,
@@ -109,8 +113,10 @@ class _RecordingDownloader implements ArDriveDownloader {
     String? cipher,
     String? cipherIvString,
     bool verifyDownload = false,
+    bool verifyIntegrity = false,
   }) async {
     downloadFileCalls++;
+    lastVerifyIntegrity = verifyIntegrity;
 
     return _logged();
   }

--- a/test/blocs/shared_file_download_cubit_test.dart
+++ b/test/blocs/shared_file_download_cubit_test.dart
@@ -217,7 +217,9 @@ void main() {
       emitsInOrder(<Matcher>[
         isA<FileDownloadInProgress>(),
         isA<FileDownloadWithProgress>(),
-        isA<FileDownloadVerifying>(),
+        // No `FileDownloadVerifying`: this verdict is already settled, and a
+        // step that announces itself and replaces itself in the same breath is
+        // a flash of something that never happened.
         isA<FileDownloadFinishedWithSuccess>(),
       ]),
     );
@@ -253,7 +255,6 @@ void main() {
         emitsInOrder(<Matcher>[
           isA<FileDownloadInProgress>(),
           isA<FileDownloadWithProgress>(),
-          isA<FileDownloadVerifying>(),
           isA<FileDownloadFinishedWithSuccess>()
               .having(
                 (s) => s.integrity,
@@ -345,6 +346,9 @@ void main() {
       final seen = <FileDownloadState>[];
       final subscription = cubit.stream.listen(seen.add);
 
+      // Past the announce delay: a verdict that really is being waited on is
+      // still worth telling the user about, which is why the state was kept.
+      await Future<void>.delayed(const Duration(milliseconds: 300));
       await pumpEventQueue();
 
       expect(seen.last, isA<FileDownloadVerifying>());

--- a/test/components/file_download_dialog_test.dart
+++ b/test/components/file_download_dialog_test.dart
@@ -96,49 +96,37 @@ void main() {
   });
 
   group('the verdict on a finished download', () {
-    testWidgets('a verified file gets one quiet affirmative', (tester) async {
-      await pumpState(
-        tester,
-        const FileDownloadFinishedWithSuccess(
-          fileName: 'holiday.mp4',
-          integrity: DataItemIntegrityVerdict.verified,
-        ),
-      );
-
-      expect(find.text('Download finished!'), findsOneWidget);
-      expect(find.text('holiday.mp4'), findsOneWidget);
-      expect(
-        find.text('This file matches what was originally uploaded.'),
-        findsOneWidget,
-      );
-      expect(find.text('DONE'), findsOneWidget);
-    });
-
-    testWidgets('an unchecked file says nothing about being unchecked',
+    testWidgets('a finished download says it finished, and no more',
         (tester) async {
-      await pumpState(
-        tester,
-        const FileDownloadFinishedWithSuccess(
-          fileName: 'holiday.mp4',
-          integrity: DataItemIntegrityVerdict.notVerified,
-        ),
-      );
+      // Every verdict reads the same here, because none of them is worth a
+      // line. "Verified" claimed the bytes matched what the uploader signed,
+      // which is the data item signature and is not fetched on this path. What
+      // it really meant was that the AES-GCM MAC checked out - a real check,
+      // but one a user can never learn anything from: a MAC that fails throws
+      // out of the download, so this dialog is only ever reached when it
+      // passed.
+      for (final verdict in DataItemIntegrityVerdict.values) {
+        if (verdict == DataItemIntegrityVerdict.failed) continue;
 
-      // A finished download, said plainly. Checking a file "against the
-      // original" means a data item signature, which means a GraphQL lookup
-      // the download path no longer makes - so this verdict is on every public
-      // download, and a disclaimer about a check nobody asked for turns a
-      // success into a qualified one.
-      expect(find.text('Download finished!'), findsOneWidget);
-      expect(find.text('holiday.mp4'), findsOneWidget);
-      expect(find.textContaining('couldn’t check'), findsNothing);
-      expect(find.textContaining('check this file'), findsNothing);
+        await pumpState(
+          tester,
+          FileDownloadFinishedWithSuccess(
+            fileName: 'holiday.mp4',
+            integrity: verdict,
+          ),
+        );
 
-      // Nor anything from either of the verdicts that do have something to
-      // say.
-      expect(find.textContaining('Verified'), findsNothing);
-      expect(find.textContaining('doesn’t match'), findsNothing);
-      expect(find.textContaining('Delete it'), findsNothing);
+        expect(find.text('Download finished!'), findsOneWidget,
+            reason: 'for $verdict');
+        expect(find.text('holiday.mp4'), findsOneWidget, reason: 'for $verdict');
+        expect(find.text('DONE'), findsOneWidget, reason: 'for $verdict');
+
+        // No claim about the bytes, in either direction.
+        expect(find.textContaining('matches what was originally'), findsNothing,
+            reason: 'for $verdict');
+        expect(find.textContaining('couldn’t check'), findsNothing,
+            reason: 'for $verdict');
+      }
     });
 
     testWidgets('a failed verdict takes over the modal and says what to do',

--- a/test/components/file_download_dialog_test.dart
+++ b/test/components/file_download_dialog_test.dart
@@ -114,7 +114,7 @@ void main() {
       expect(find.text('DONE'), findsOneWidget);
     });
 
-    testWidgets('an unchecked file is told so without being alarmed',
+    testWidgets('an unchecked file says nothing about being unchecked',
         (tester) async {
       await pumpState(
         tester,
@@ -124,15 +124,19 @@ void main() {
         ),
       );
 
-      // Still a finished download, because it is one. A resumed download and a
-      // file signed with a wallet ArDrive cannot check both land here, and
-      // both are perfectly good files.
+      // A finished download, said plainly. Checking a file "against the
+      // original" means a data item signature, which means a GraphQL lookup
+      // the download path no longer makes - so this verdict is on every public
+      // download, and a disclaimer about a check nobody asked for turns a
+      // success into a qualified one.
       expect(find.text('Download finished!'), findsOneWidget);
-      expect(find.textContaining('couldn’t check this file'), findsOneWidget);
-      expect(find.textContaining('doesn’t mean anything is wrong'),
-          findsOneWidget);
+      expect(find.text('holiday.mp4'), findsOneWidget);
+      expect(find.textContaining('couldn’t check'), findsNothing);
+      expect(find.textContaining('check this file'), findsNothing);
 
-      // None of the language reserved for a file that really is wrong.
+      // Nor anything from either of the verdicts that do have something to
+      // say.
+      expect(find.textContaining('Verified'), findsNothing);
       expect(find.textContaining('doesn’t match'), findsNothing);
       expect(find.textContaining('Delete it'), findsNothing);
     });

--- a/test/download/ardrive_downloader_resume_test.dart
+++ b/test/download/ardrive_downloader_resume_test.dart
@@ -341,6 +341,37 @@ void main() {
         );
       }
 
+      test('a fresh download is a plain GET, never the client\'s download()',
+          () async {
+        // The arweave client's `download()` POSTs {gateway}/graphql before it
+        // fetches a byte - unconditionally, because it wants `dataSize` for a
+        // progress figure this app does not use. That POST is subject to CORS,
+        // which not every gateway allows from an arbitrary origin, and it
+        // throws before the byte stream exists - so a gateway that could have
+        // served the file is recorded as having failed, and a downloadable
+        // file ends up reported as an unknown error.
+        final body = countedBody(ciphertext);
+        final harness = buildSource(
+          (request) => http.StreamedResponse(body.stream, 206),
+        );
+
+        final response = await harness.source.open(txId: txId);
+
+        expect(response.startOffsetBytes, 0);
+
+        // One request, and it is a GET for the bytes.
+        final request = harness.clients.single.requests.single;
+        expect(request.method, 'GET');
+        expect(request.url, Uri.parse('https://arweave.net/$txId'));
+
+        // Nothing asked a gateway to describe the transaction first.
+        expect(
+          harness.clients.single.requests
+              .where((r) => r.url.path.contains('graphql')),
+          isEmpty,
+        );
+      });
+
       test('a 200 answer to a Range request is reported as byte 0, and its '
           'body is never read', () async {
         final body = countedBody(ciphertext);

--- a/test/download/ardrive_downloader_resume_test.dart
+++ b/test/download/ardrive_downloader_resume_test.dart
@@ -89,6 +89,10 @@ void main() {
   Future<List<Object>> downloadPrivate(
     ArDriveDownloader downloader, {
     bool verifyDownload = false,
+    // The signature check is off unless a caller asks: it is the one thing in
+    // a download that needs the network to say anything, and a download must
+    // not depend on that.
+    bool verifyIntegrity = false,
   }) async {
     final progress = await downloader.downloadFile(
       txId: txId,
@@ -101,6 +105,7 @@ void main() {
       cipher: Cipher.aes256ctr,
       cipherIvString: cipherIvString,
       verifyDownload: verifyDownload,
+      verifyIntegrity: verifyIntegrity,
     );
 
     return drainProgress(progress);
@@ -504,6 +509,38 @@ void main() {
     });
   });
 
+  group('a download does not depend on GraphQL', () {
+    test('the signature check is off unless it is asked for', () async {
+      // The check was added in #2175 and reported healthy files as corrupt:
+      // gateways return `anchor` and `recipient` as empty strings, so any data
+      // item carrying one deep-hashes differently here than it did when it was
+      // signed. That verdict is not a footnote - it replaces the success
+      // dialog with "the file may be corrupted" - and reaching it costs a
+      // GraphQL round trip the stream waits on before its first byte.
+      var asked = false;
+
+      final harness = build(
+        FakeDownloadSource(ciphertext),
+        verifierFactory: (id) async {
+          asked = true;
+          return realShapedVerifier(id);
+        },
+      );
+
+      expect(await downloadPrivate(harness.downloader), isEmpty);
+
+      expect(asked, isFalse,
+          reason: 'nothing may reach for the network to finish a download');
+
+      // The download still succeeds - `downloadPrivate` returning no errors is
+      // that - and the verdict says plainly that no check ran rather than
+      // implying one failed.
+      final verdict = await harness.downloader.integrity;
+      expect(verdict.verdict, DataItemIntegrityVerdict.notVerified);
+      expect(verdict.reason ?? '', contains('not requested'));
+    });
+  });
+
   group('integrity verdicts', () {
     test('an uninterrupted download hashes every ciphertext byte', () async {
       final harness = build(
@@ -511,7 +548,7 @@ void main() {
         verifierFactory: (id) async => realShapedVerifier(id),
       );
 
-      expect(await downloadPrivate(harness.downloader), isEmpty);
+      expect(await downloadPrivate(harness.downloader, verifyIntegrity: true), isEmpty);
 
       final verdict = await harness.downloader.integrity;
 
@@ -529,7 +566,7 @@ void main() {
         verifierFactory: (id) async => verifier,
       );
 
-      expect(await downloadPrivate(harness.downloader), isEmpty);
+      expect(await downloadPrivate(harness.downloader, verifyIntegrity: true), isEmpty);
 
       // The signature covers the bytes as they were posted. Tapping after
       // decryption instead would hash the plaintext - the same *length*, so
@@ -553,7 +590,7 @@ void main() {
         verifierFactory: (id) async => realShapedVerifier(id),
       );
 
-      expect(await downloadPrivate(harness.downloader), isEmpty);
+      expect(await downloadPrivate(harness.downloader, verifyIntegrity: true), isEmpty);
 
       final verdict = await harness.downloader.integrity;
 
@@ -573,7 +610,7 @@ void main() {
         verifierFactory: (id) async => GatedVerifier(gate),
       );
 
-      expect(await downloadPrivate(harness.downloader), isEmpty);
+      expect(await downloadPrivate(harness.downloader, verifyIntegrity: true), isEmpty);
       expect(harness.io.savedBytes, expectedPlaintext);
 
       // Bound *after* the download, deliberately: `downloadFile` resets the
@@ -609,7 +646,7 @@ void main() {
       // reading the verdict without a download in flight reads the value the
       // downloader was *constructed* with - it is already complete, already
       // `notVerified`, and no code under test ever put it there.
-      final errors = downloadPrivate(harness.downloader);
+      final errors = downloadPrivate(harness.downloader, verifyIntegrity: true);
       await source.delivering.future;
 
       await harness.downloader.abortDownload();

--- a/test/download/ardrive_downloader_save_test.dart
+++ b/test/download/ardrive_downloader_save_test.dart
@@ -53,7 +53,11 @@ void main() {
         resumeBackoffStep: resumeBackoffStep,
       );
 
-  Future<Stream<double>> downloadPrivateCtr(ArDriveDownloader downloader) =>
+  Future<Stream<double>> downloadPrivateCtr(
+    ArDriveDownloader downloader, {
+    // The signature check is off unless a caller asks for it.
+    bool verifyIntegrity = false,
+  }) =>
       downloader.downloadFile(
         txId: txId,
         fileSize: fileSize,
@@ -64,6 +68,7 @@ void main() {
         fileKey: ctrKey,
         cipher: Cipher.aes256ctr,
         cipherIvString: cipherIvString,
+        verifyIntegrity: verifyIntegrity,
       );
 
   group('a saver that waits for the downloader to settle finalize', () {
@@ -316,7 +321,7 @@ void main() {
         verifierFactory: (id) async => verifier,
       );
 
-      await drainProgress(await downloadPrivateCtr(downloader))
+      await drainProgress(await downloadPrivateCtr(downloader, verifyIntegrity: true))
           .timeout(const Duration(seconds: 10));
       await downloader.integrity.timeout(const Duration(seconds: 10));
 

--- a/test/pages/drive_detail/components/image_preview_action_bar_test.dart
+++ b/test/pages/drive_detail/components/image_preview_action_bar_test.dart
@@ -1,0 +1,98 @@
+import 'dart:typed_data';
+
+import 'package:ardrive/blocs/fs_entry_preview/fs_entry_preview_cubit.dart';
+import 'package:ardrive/blocs/fs_entry_preview/image_preview_notification.dart';
+import 'package:ardrive/pages/drive_detail/drive_detail_page.dart';
+import 'package:ardrive_ui/ardrive_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockFsEntryPreviewCubit extends Mock implements FsEntryPreviewCubit {}
+
+/// What the bar under an image preview is allowed to spend.
+///
+/// The share page and the file explorer share this widget but do not share
+/// their surroundings, and the bar is sized for the explorer's: a name over a
+/// type, on a 96px floor. On the share page both of those are already on the
+/// card - the name beside the thumbnail, the type in File details - so inline
+/// there the bar is only Expand.
+void main() {
+  Widget wrap(Widget child) {
+    return ArDriveTheme(
+      themeData: lightTheme(),
+      child: MaterialApp(
+        localizationsDelegates: const [
+          AppLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: const [Locale('en', '')],
+        home: Scaffold(body: child),
+      ),
+    );
+  }
+
+  // A 1x1 GIF, so the image itself decodes rather than erroring into a state
+  // that would take the bar down with it.
+  final pixel = Uint8List.fromList([
+    0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00, 0x01, 0x00, 0x80, 0x00, //
+    0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0x21, 0xF9, 0x04, 0x01, 0x00,
+    0x00, 0x00, 0x00, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00,
+    0x00, 0x02, 0x02, 0x44, 0x01, 0x00, 0x3B,
+  ]);
+
+  Future<void> pumpPreview(WidgetTester tester, {required bool isSharePage}) {
+    FsEntryPreviewCubit.imagePreviewNotifier.value = ImagePreviewNotification(
+      dataBytes: pixel,
+      filename: 'Sunset over the bay.png',
+      contentType: 'image/png',
+    );
+
+    return tester.pumpWidget(wrap(
+      SizedBox(
+        height: 430,
+        width: 580,
+        child: ImagePreviewWidget(
+          isSharePage: isSharePage,
+          isFullScreen: false,
+          canNavigateThroughImages: false,
+          previewCubit: MockFsEntryPreviewCubit(),
+        ),
+      ),
+    ));
+  }
+
+  tearDown(() => FsEntryPreviewCubit.imagePreviewNotifier.value = null);
+
+  testWidgets('on the share page the bar is only Expand', (tester) async {
+    await pumpPreview(tester, isSharePage: true);
+
+    expect(find.byTooltip('Expand'), findsOneWidget);
+    // Neither of the two things the card already says.
+    expect(find.text('Sunset over the bay'), findsNothing);
+    expect(find.text('PNG'), findsNothing);
+  });
+
+  testWidgets('the file explorer keeps the name and the type', (tester) async {
+    await pumpPreview(tester, isSharePage: false);
+
+    expect(find.byTooltip('Expand'), findsOneWidget);
+    expect(find.text('Sunset over the bay'), findsOneWidget);
+    expect(find.text('PNG'), findsOneWidget);
+  });
+
+  testWidgets('the share page bar leaves the image more room', (tester) async {
+    await pumpPreview(tester, isSharePage: false);
+    final explorerImage = tester.getSize(find.byType(Flexible).first).height;
+
+    await pumpPreview(tester, isSharePage: true);
+    final shareImage = tester.getSize(find.byType(Flexible).first).height;
+
+    expect(shareImage, greaterThan(explorerImage),
+        reason: 'the room the bar gives back should reach the image');
+  });
+}

--- a/test/pages/shared_file/shared_file_page_test.dart
+++ b/test/pages/shared_file/shared_file_page_test.dart
@@ -97,6 +97,10 @@ void main() {
   FileRevision fileRevision({
     String name = 'Q3 Report.pdf',
     String dataTxId = 'data-tx-newest',
+    // Distinct per revision by default, because the metadata transaction is
+    // what identifies one. Tests that need two revisions over the same bytes -
+    // a rename - set it explicitly.
+    String? metadataTxId,
     int size = 4821133,
     String? dataContentType = 'application/pdf',
     DateTime? lastModifiedDate,
@@ -110,7 +114,7 @@ void main() {
       size: size,
       lastModifiedDate: lastModifiedDate ?? DateTime.utc(2023, 11, 9),
       dataContentType: dataContentType,
-      metadataTxId: 'metadata-tx',
+      metadataTxId: metadataTxId ?? 'metadata-$dataTxId',
       dataTxId: dataTxId,
       dateCreated: dateCreated ?? DateTime.utc(2024, 3, 3),
       action: RevisionAction.create,
@@ -565,13 +569,13 @@ void main() {
       // is open by default now, so what keeps that true is the identifiers
       // sitting one step further in.
       expect(find.text('data-tx-newest'), findsNothing);
-      expect(find.text('metadata-tx'), findsNothing);
+      expect(find.text('metadata-data-tx-newest'), findsNothing);
 
       await tester.tap(find.text('Transaction details'));
       await tester.pumpAndSettle();
 
       expect(find.text('data-tx-newest'), findsOneWidget);
-      expect(find.text('metadata-tx'), findsOneWidget);
+      expect(find.text('metadata-data-tx-newest'), findsOneWidget);
     });
 
     testWidgets(
@@ -884,6 +888,44 @@ void main() {
         find.descendant(of: pane, matching: find.byType(ArDriveIcon)),
         findsWidgets,
       );
+    });
+
+    testWidgets('a renamed file does not select two rows at once',
+        (tester) async {
+      // A rename writes new metadata pointing at the same bytes, so two
+      // revisions share one `dataTxId`. Keyed on that, both rows drew as
+      // selected and the second could not be chosen: `showRevision`'s
+      // already-selected guard matched it and returned.
+      await pumpPage(tester, success(), surface: const Size(1440, 1000));
+
+      // The rename and the revision it renamed: same bytes, two records. The
+      // second row is the one the page is showing.
+      states.add(success(
+        activityRevisions: [
+          fileRevision(
+            name: 'Q3 Report (final).pdf',
+            metadataTxId: 'metadata-rename',
+          ),
+          fileRevision(name: 'Q3 Report.pdf'),
+        ],
+        activityStatus: SharedFileActivityStatus.loaded,
+      ));
+      await tester.pump();
+
+      await tester.tap(find.text('Version history'));
+      await tester.pumpAndSettle();
+
+      final rows = find.byWidgetPredicate(
+          (w) => w.runtimeType.toString() == '_SharedFileVersionRow');
+      expect(rows, findsNWidgets(2));
+
+      // Exactly one, not both.
+      final selected = <bool>[
+        for (var i = 0; i < 2; i++)
+          (tester.widget(rows.at(i)) as dynamic).isSelected as bool,
+      ];
+      expect(selected.where((s) => s).length, 1,
+          reason: 'two rows sharing a dataTxId must not both read as current');
     });
 
     testWidgets('a pinned link names its version pinned, and still lets go',

--- a/test/pages/shared_file/shared_file_page_test.dart
+++ b/test/pages/shared_file/shared_file_page_test.dart
@@ -788,6 +788,28 @@ void main() {
       expect(find.text('Shared'), findsOneWidget);
     });
 
+    testWidgets('hiding the preview does not unload it', (tester) async {
+      // Hiding used to remove the subtree, which disposed the preview cubit -
+      // so reopening fetched the file again. On a rate-limited connection that
+      // second fetch is one that can fail, meaning hiding a file you already
+      // had could lose it.
+      //
+      // The provider is keyed on the bytes it previews, so its presence is
+      // exactly the question "is the preview still loaded".
+      const preview = ValueKey('data-tx-newest');
+
+      await pumpPage(tester, success());
+
+      expect(find.byKey(preview, skipOffstage: false), findsOneWidget);
+
+      await tester.tap(find.text('Hide preview'));
+      await tester.pumpAndSettle();
+
+      // Off screen, still mounted: nothing to fetch again on the way back.
+      expect(find.byKey(preview, skipOffstage: false), findsOneWidget);
+      expect(find.byKey(preview), findsNothing);
+    });
+
     testWidgets('a pinned link names its version pinned, and still lets go',
         (tester) async {
       // Pinning is the sharer saying which version they mean, not a limit on

--- a/test/pages/shared_file/shared_file_page_test.dart
+++ b/test/pages/shared_file/shared_file_page_test.dart
@@ -558,11 +558,13 @@ void main() {
         findsOneWidget,
       );
 
-      // Nothing technical before the recipient asks for it.
+      // Nothing technical before the recipient asks for it. The details tab
+      // is open by default now, so what keeps that true is the identifiers
+      // sitting one step further in.
       expect(find.text('data-tx-newest'), findsNothing);
       expect(find.text('metadata-tx'), findsNothing);
 
-      await tester.tap(find.byType(ExpansionTile).first);
+      await tester.tap(find.text('Transaction details'));
       await tester.pumpAndSettle();
 
       expect(find.text('data-tx-newest'), findsOneWidget);
@@ -578,9 +580,6 @@ void main() {
       // the sole date on the page sat inside the version history, which is
       // collapsed and not fetched until opened.
       await pumpPage(tester, success());
-
-      await tester.tap(find.byType(ExpansionTile).first);
-      await tester.pumpAndSettle();
 
       // Each value is scoped to the row its label is in, so two rows cannot
       // satisfy each other's assertion - a swap between created and modified
@@ -604,7 +603,7 @@ void main() {
 
       verifyNever(() => cubit.loadActivity());
 
-      await tester.tap(find.byType(ExpansionTile).last);
+      await tester.tap(find.text('Version history'));
       await tester.pump();
 
       verify(() => cubit.loadActivity()).called(1);
@@ -633,7 +632,7 @@ void main() {
         'spins for ever', (tester) async {
       await pumpPage(tester, success());
 
-      await tester.tap(find.byType(ExpansionTile).last);
+      await tester.tap(find.text('Version history'));
       await tester.pump();
 
       states.add(success(activityStatus: SharedFileActivityStatus.failed));
@@ -648,7 +647,7 @@ void main() {
         (tester) async {
       await pumpPage(tester, success());
 
-      await tester.tap(find.byType(ExpansionTile).last);
+      await tester.tap(find.text('Version history'));
       await tester.pump();
 
       states.add(success(activityStatus: SharedFileActivityStatus.loaded));
@@ -699,9 +698,6 @@ void main() {
         ),
       );
 
-      await tester.tap(find.byType(ExpansionTile).first);
-      await tester.pumpAndSettle();
-
       expect(find.text('Date created'), findsNothing);
       expect(find.text('Last updated'), findsNothing);
       expect(find.textContaining('1970'), findsNothing);
@@ -722,7 +718,7 @@ void main() {
         ),
       );
 
-      await tester.tap(find.byType(ExpansionTile).last);
+      await tester.tap(find.text('Version history'));
       await tester.pumpAndSettle();
 
       expect(
@@ -746,7 +742,7 @@ void main() {
         ),
       );
 
-      await tester.tap(find.byType(ExpansionTile).last);
+      await tester.tap(find.text('Version history'));
       await tester.pumpAndSettle();
 
       expect(find.text('Latest'), findsOneWidget);
@@ -780,7 +776,7 @@ void main() {
         ),
       );
 
-      await tester.tap(find.byType(ExpansionTile).last);
+      await tester.tap(find.text('Version history'));
       await tester.pumpAndSettle();
 
       expect(find.textContaining('1970'), findsNothing);
@@ -828,7 +824,7 @@ void main() {
         ),
       );
 
-      await tester.tap(find.byType(ExpansionTile).last);
+      await tester.tap(find.text('Version history'));
       await tester.pumpAndSettle();
 
       expect(find.text('Pinned'), findsOneWidget);
@@ -1086,8 +1082,8 @@ void main() {
       // An open drawer can push the card past the bottom of a phone, so each
       // header is scrolled to before it is pressed.
       for (final drawer in [
-        find.byType(ExpansionTile).first,
-        find.byType(ExpansionTile).last,
+        find.text('Version history'),
+        find.text('File details'),
       ]) {
         await tester.ensureVisible(drawer);
         await tester.pumpAndSettle();

--- a/test/pages/shared_file/shared_file_page_test.dart
+++ b/test/pages/shared_file/shared_file_page_test.dart
@@ -49,6 +49,21 @@ class GatedKeySession extends SharedFileKeySession {
 /// The assertions here are about what a *recipient* can see and do: the file
 /// they are being given, one obvious download, a key gate that never lies to
 /// them, and no transaction id in their face.
+/// Only ever handed to `any()`, never read.
+final fileRevisionFallback = FileRevision(
+  fileId: 'fallback',
+  driveId: 'fallback',
+  name: 'fallback',
+  parentFolderId: 'fallback',
+  size: 0,
+  lastModifiedDate: DateTime.utc(2024),
+  metadataTxId: 'fallback',
+  dataTxId: 'fallback',
+  dateCreated: DateTime.utc(2024),
+  action: RevisionAction.create,
+  isHidden: false,
+);
+
 void main() {
   const fileId = 'file-id';
 
@@ -190,6 +205,8 @@ void main() {
     await tester.pump();
   }
 
+  setUpAll(() => registerFallbackValue(fileRevisionFallback));
+
   setUp(() {
     cubit = MockSharedFileCubit();
     states = StreamController<SharedFileState>.broadcast();
@@ -200,6 +217,7 @@ void main() {
     when(() => cubit.loadActivity()).thenAnswer((_) async {});
     when(() => cubit.showLatestRevision()).thenAnswer((_) async {});
     when(() => cubit.showSharedRevision()).thenAnswer((_) async {});
+    when(() => cubit.showRevision(any())).thenAnswer((_) async {});
   });
 
   tearDown(() async {
@@ -536,13 +554,14 @@ void main() {
 
       verifyNever(() => cubit.loadActivity());
 
-      // Deliberately not `pumpAndSettle`: an unanswered history shows a
-      // spinner, and a spinner never settles.
       await tester.tap(find.byType(ExpansionTile).last);
       await tester.pump();
 
       verify(() => cubit.loadActivity()).called(1);
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      // No spinner: the version the link named is already in hand, so the list
+      // says what it is still looking for rather than showing nothing.
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.textContaining('Looking for other versions'), findsOneWidget);
 
       // The history lives on its own list. It is empty on a v2 link until the
       // resolver answers, and `fileRevisions` - the download target - is never
@@ -556,7 +575,7 @@ void main() {
       ));
       await tester.pump();
 
-      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.textContaining('Looking for other versions'), findsNothing);
       expect(find.text(filesize(12)), findsOneWidget);
     });
 
@@ -639,6 +658,54 @@ void main() {
 
       // The type still shows: the link really did carry it.
       expect(find.text('File type'), findsOneWidget);
+    });
+
+    testWidgets('a failed history keeps the version the recipient was sent',
+        (tester) async {
+      // The state a rate limited connection lands in. It costs the list, never
+      // the file - so the row stays, and it stays selected.
+      await pumpPage(
+        tester,
+        success(
+          activityRevisions: [fileRevision()],
+          activityStatus: SharedFileActivityStatus.failed,
+        ),
+      );
+
+      await tester.tap(find.byType(ExpansionTile).last);
+      await tester.pumpAndSettle();
+
+      expect(
+        find.textContaining('Couldn\u2019t check for other versions'),
+        findsOneWidget,
+      );
+      expect(find.text('Retry'), findsOneWidget);
+      // The version itself is still listed, and Download is untouched.
+      expect(find.text('Download'), findsOneWidget);
+    });
+
+    testWidgets('choosing a version asks the resolver for it', (tester) async {
+      await pumpPage(
+        tester,
+        success(
+          activityRevisions: [
+            fileRevision(dataTxId: 'data-tx-newer'),
+            fileRevision(),
+          ],
+          activityStatus: SharedFileActivityStatus.loaded,
+        ),
+      );
+
+      await tester.tap(find.byType(ExpansionTile).last);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Latest'), findsOneWidget);
+      expect(find.text('This link'), findsOneWidget);
+
+      await tester.tap(find.text('Latest'));
+      await tester.pumpAndSettle();
+
+      verify(() => cubit.showRevision(any())).called(1);
     });
 
     testWidgets('shows the verification badge the link earned', (tester) async {

--- a/test/pages/shared_file/shared_file_page_test.dart
+++ b/test/pages/shared_file/shared_file_page_test.dart
@@ -750,7 +750,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Latest'), findsOneWidget);
-      expect(find.text('This link'), findsOneWidget);
+      expect(find.text('Shared'), findsOneWidget);
 
       await tester.tap(find.text('Latest'));
       await tester.pumpAndSettle();
@@ -785,7 +785,7 @@ void main() {
 
       expect(find.textContaining('1970'), findsNothing);
       // Named by what it is instead, so the row still says something true.
-      expect(find.text('This link'), findsOneWidget);
+      expect(find.text('Shared'), findsOneWidget);
     });
 
     testWidgets('a pinned link names its version pinned, and still lets go',
@@ -810,7 +810,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Pinned'), findsOneWidget);
-      expect(find.text('This link'), findsNothing);
+      expect(find.text('Shared'), findsNothing);
 
       // And the newer one is still selectable.
       await tester.tap(find.text('Latest'));

--- a/test/pages/shared_file/shared_file_page_test.dart
+++ b/test/pages/shared_file/shared_file_page_test.dart
@@ -68,6 +68,9 @@ final fileRevisionFallback = FileRevision(
   isHidden: false,
 );
 
+/// The row height `shared_file_ready_view.dart` lays its lists out on.
+const double _rowHeight = 44;
+
 void main() {
   const fileId = 'file-id';
 
@@ -805,6 +808,57 @@ void main() {
       // Off screen, still mounted: nothing to fetch again on the way back.
       expect(find.byKey(preview, skipOffstage: false), findsOneWidget);
       expect(find.byKey(preview), findsNothing);
+    });
+
+    testWidgets('every row in the panel is the same height', (tester) async {
+      // The two lists sit in the same panel and the reader switches between
+      // them, so a row that is a few pixels taller than its neighbours reads
+      // as sloppiness rather than as structure. The copy control sets the
+      // floor at 44 - the smallest a touch target may be - and everything
+      // else meets it: rows with no copy button, the disclosure header that
+      // used to come from a ListTile at 58, and the version rows on the
+      // other tab.
+      await pumpPage(tester, success(), surface: const Size(1440, 1000));
+
+      final rows = find.byWidgetPredicate(
+          (w) => w.runtimeType.toString() == '_SharedFileDetailRow');
+      expect(rows, findsWidgets);
+      for (var i = 0; i < rows.evaluate().length; i++) {
+        expect(tester.getSize(rows.at(i)).height, _rowHeight,
+            reason: 'detail row $i');
+      }
+
+      expect(
+        tester
+            .getSize(find
+                .ancestor(
+                  of: find.text('Transaction details'),
+                  matching: find.byType(InkWell),
+                )
+                .first)
+            .height,
+        _rowHeight,
+        reason: 'the disclosure header',
+      );
+
+      states.add(success(
+        activityRevisions: [
+          fileRevision(),
+          fileRevision(dataTxId: 'data-tx-first', size: 12),
+        ],
+        activityStatus: SharedFileActivityStatus.loaded,
+      ));
+      await tester.pump();
+      await tester.tap(find.text('Version history'));
+      await tester.pumpAndSettle();
+
+      final versions = find.byWidgetPredicate(
+          (w) => w.runtimeType.toString() == '_SharedFileVersionRow');
+      expect(versions, findsNWidgets(2));
+      for (var i = 0; i < versions.evaluate().length; i++) {
+        expect(tester.getSize(versions.at(i)).height, _rowHeight,
+            reason: 'version row $i');
+      }
     });
 
     testWidgets('the resting pane is itself the way into the preview',

--- a/test/pages/shared_file/shared_file_page_test.dart
+++ b/test/pages/shared_file/shared_file_page_test.dart
@@ -4,6 +4,8 @@ import 'package:ardrive/blocs/blocs.dart';
 import 'package:ardrive/models/models.dart';
 import 'package:ardrive/pages/shared_file/shared_file_key_session.dart';
 import 'package:ardrive/pages/shared_file/shared_file_page.dart';
+import 'package:ardrive/services/config/selected_gateway.dart';
+import 'package:ardrive/services/services.dart';
 import 'package:ardrive/pages/shared_file/shared_file_ready_view.dart';
 import 'package:ardrive/utils/filesize.dart';
 import 'package:ardrive/utils/session_key_value_store.dart';
@@ -16,6 +18,8 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+
+import '../../test_utils/mocks.dart';
 
 class MockSharedFileCubit extends MockCubit<SharedFileState>
     implements SharedFileCubit {}
@@ -72,6 +76,10 @@ void main() {
   const wellFormedKey = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopQ';
 
   late MockSharedFileCubit cubit;
+  late MockDriveDao driveDao;
+  late MockArweaveService arweave;
+  late MockConfigService configService;
+  late MockProfileCubit profileCubit;
   late StreamController<SharedFileState> states;
 
   /// The value rendered beside [label] in the details drawer, scoped to that
@@ -163,18 +171,39 @@ void main() {
         mayStillBePropagating: mayStillBePropagating,
       );
 
+  /// The page's own dependencies, plus the four the preview reaches for.
+  ///
+  /// [FsEntryPreviewCubit] resolves `DriveDao`, `ProfileCubit`,
+  /// `ArweaveService` and `ConfigService` out of the tree when it is built.
+  /// Nothing here opened a preview while it was opt-in, so the harness never
+  /// carried them; now that the preview opens on arrival, every test builds one
+  /// and they are all required.
+  ///
+  /// They are inert: the preview is not what these tests are about, and a
+  /// preview that reaches the network from a widget test would be worse than
+  /// one that does nothing.
   Widget wrap(Widget child) {
-    return ArDriveTheme(
-      themeData: lightTheme(),
-      child: MaterialApp(
-        localizationsDelegates: const [
-          AppLocalizations.delegate,
-          GlobalMaterialLocalizations.delegate,
-          GlobalWidgetsLocalizations.delegate,
-          GlobalCupertinoLocalizations.delegate,
-        ],
-        supportedLocales: const [Locale('en', '')],
-        home: child,
+    return MultiRepositoryProvider(
+      providers: [
+        RepositoryProvider<DriveDao>.value(value: driveDao),
+        RepositoryProvider<ArweaveService>.value(value: arweave),
+        RepositoryProvider<ConfigService>.value(value: configService),
+      ],
+      child: BlocProvider<ProfileCubit>.value(
+        value: profileCubit,
+        child: ArDriveTheme(
+          themeData: lightTheme(),
+          child: MaterialApp(
+            localizationsDelegates: const [
+              AppLocalizations.delegate,
+              GlobalMaterialLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+              GlobalCupertinoLocalizations.delegate,
+            ],
+            supportedLocales: const [Locale('en', '')],
+            home: child,
+          ),
+        ),
       ),
     );
   }
@@ -209,6 +238,25 @@ void main() {
 
   setUp(() {
     cubit = MockSharedFileCubit();
+    driveDao = MockDriveDao();
+    arweave = MockArweaveService();
+    configService = MockConfigService();
+    profileCubit = MockProfileCubit();
+
+    when(() => profileCubit.state).thenReturn(ProfilePromptAdd());
+    // The preview reads the config the moment it is built, and reaches the
+    // gateway url out of it. A real AppConfig is simpler than stubbing the
+    // fields one refusal at a time.
+    when(() => configService.config).thenReturn(
+      AppConfig(
+        allowedDataItemSizeForTurbo: 1,
+        stripePublishableKey: 'stripePublishableKey',
+        arweaveGatewayForDataRequest: const SelectedGateway(
+          label: 'Gateway',
+          url: 'https://example.com',
+        ),
+      ),
+    );
     states = StreamController<SharedFileState>.broadcast();
 
     when(() => cubit.fileId).thenReturn(fileId);
@@ -501,7 +549,9 @@ void main() {
         (tester) async {
       await pumpPage(tester, success());
 
-      expect(find.text('Q3 Report.pdf'), findsOneWidget);
+      // The preview opens on arrival and names the file too, so the name is
+      // legitimately on screen more than once.
+      expect(find.text('Q3 Report.pdf'), findsWidgets);
       expect(find.text('Download'), findsOneWidget);
       expect(
         find.byKey(const ValueKey('sharedFileDownload_data-tx-newest')),
@@ -706,6 +756,36 @@ void main() {
       await tester.pumpAndSettle();
 
       verify(() => cubit.showRevision(any())).called(1);
+    });
+
+    testWidgets('a version with no date is never dated 1970', (tester) async {
+      // The list seeds itself with the version the link named so that opening
+      // it costs nothing - but a link carries no timestamps, so that row has
+      // the epoch placeholder. Rendered, it read as 1 Jan 1970 and then
+      // silently corrected itself when the history arrived.
+      await pumpPage(
+        tester,
+        success(
+          revision: fileRevision(
+            dateCreated: SharedFileCubit.unknownDate,
+            lastModifiedDate: SharedFileCubit.unknownDate,
+          ),
+          activityRevisions: [
+            fileRevision(
+              dateCreated: SharedFileCubit.unknownDate,
+              lastModifiedDate: SharedFileCubit.unknownDate,
+            ),
+          ],
+          activityStatus: SharedFileActivityStatus.loading,
+        ),
+      );
+
+      await tester.tap(find.byType(ExpansionTile).last);
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('1970'), findsNothing);
+      // Named by what it is instead, so the row still says something true.
+      expect(find.text('This link'), findsOneWidget);
     });
 
     testWidgets('a pinned link names its version pinned, and still lets go',

--- a/test/pages/shared_file/shared_file_page_test.dart
+++ b/test/pages/shared_file/shared_file_page_test.dart
@@ -588,11 +588,12 @@ void main() {
       // change rewrite the production output and the expectation together.
       expect(detailRowValue('File type', 'application/pdf'), findsOneWidget);
       expect(
-        detailRowValue('Date created', '2024-03-03 00:00:00 GMT+0'),
+        // Friendly, with the exact instant in the tooltip.
+        detailRowValue('Date created', 'Mar 3, 2024'),
         findsOneWidget,
       );
       expect(
-        detailRowValue('Last updated', '2023-11-09 00:00:00 GMT+0'),
+        detailRowValue('Last updated', 'Nov 9, 2023'),
         findsOneWidget,
       );
     });
@@ -804,6 +805,34 @@ void main() {
       // Off screen, still mounted: nothing to fetch again on the way back.
       expect(find.byKey(preview, skipOffstage: false), findsOneWidget);
       expect(find.byKey(preview), findsNothing);
+    });
+
+    testWidgets('the resting pane is itself the way into the preview',
+        (tester) async {
+      // The box is already the size and shape of the preview, with the file's
+      // own thumbnail in it - so it is the thing to press. A separate button
+      // underneath was a second control for something that already looked
+      // pressable.
+      await pumpPage(tester, success(), surface: const Size(1440, 1000));
+
+      await tester.tap(find.text('Hide preview'));
+      await tester.pumpAndSettle();
+
+      // And the box is the ONLY way in - the bar below it is gone, rather
+      // than offering a second button for the same thing.
+      expect(find.byKey(sharedFilePreviewPaneKey), findsOneWidget);
+      expect(find.text('Preview'), findsNothing);
+
+      await tester.tap(
+        find.descendant(
+          of: find.byKey(sharedFilePreviewPaneKey),
+          matching: find.byType(InkWell),
+        ).first,
+      );
+      await tester.pumpAndSettle();
+
+      // Back open, and offering the only direction that still needs a control.
+      expect(find.text('Hide preview'), findsOneWidget);
     });
 
     testWidgets('a pinned link names its version pinned, and still lets go',

--- a/test/pages/shared_file/shared_file_page_test.dart
+++ b/test/pages/shared_file/shared_file_page_test.dart
@@ -788,26 +788,21 @@ void main() {
       expect(find.text('Shared'), findsOneWidget);
     });
 
-    testWidgets('hiding the preview does not unload it', (tester) async {
-      // Hiding used to remove the subtree, which disposed the preview cubit -
-      // so reopening fetched the file again. On a rate-limited connection that
-      // second fetch is one that can fail, meaning hiding a file you already
-      // had could lose it.
+    testWidgets('the preview is the page, with nothing to put it away',
+        (tester) async {
+      // A link someone followed to look at a file shows the file. The toggle
+      // that used to sit under it saved nothing: the bytes are fetched before
+      // it could be pressed, the widget stayed mounted when it was, and
+      // anyone who did not want to see what a stranger sent them had already
+      // seen it by then.
       //
       // The provider is keyed on the bytes it previews, so its presence is
-      // exactly the question "is the preview still loaded".
-      const preview = ValueKey('data-tx-newest');
+      // exactly the question "is the preview loaded".
+      await pumpPage(tester, success(), surface: const Size(1440, 1000));
 
-      await pumpPage(tester, success());
-
-      expect(find.byKey(preview, skipOffstage: false), findsOneWidget);
-
-      await tester.tap(find.text('Hide preview'));
-      await tester.pumpAndSettle();
-
-      // Off screen, still mounted: nothing to fetch again on the way back.
-      expect(find.byKey(preview, skipOffstage: false), findsOneWidget);
-      expect(find.byKey(preview), findsNothing);
+      expect(find.byKey(const ValueKey('data-tx-newest')), findsOneWidget);
+      expect(find.text('Preview'), findsNothing);
+      expect(find.text('Hide preview'), findsNothing);
     });
 
     testWidgets('every row in the panel is the same height', (tester) async {
@@ -861,32 +856,34 @@ void main() {
       }
     });
 
-    testWidgets('the resting pane is itself the way into the preview',
+    testWidgets('the pane answers with a picture while it is still resolving',
         (tester) async {
-      // The box is already the size and shape of the preview, with the file's
-      // own thumbnail in it - so it is the thing to press. A separate button
-      // underneath was a second control for something that already looked
-      // pressable.
-      await pumpPage(tester, success(), surface: const Size(1440, 1000));
-
-      await tester.tap(find.text('Hide preview'));
-      await tester.pumpAndSettle();
-
-      // And the box is the ONLY way in - the bar below it is gone, rather
-      // than offering a second button for the same thing.
-      expect(find.byKey(sharedFilePreviewPaneKey), findsOneWidget);
-      expect(find.text('Preview'), findsNothing);
-
-      await tester.tap(
-        find.descendant(
-          of: find.byKey(sharedFilePreviewPaneKey),
-          matching: find.byType(InkWell),
-        ).first,
+      // The pane is 580x430 on a laptop, and a lone sentence in the middle of
+      // it reads as something that failed rather than as an answer. Every
+      // state that cannot show the file - not yet, not this type, too big -
+      // gets the file's own type icon over the sentence instead, so they all
+      // look like the same deliberate placeholder.
+      await pumpPage(
+        tester,
+        SharedFileLoadSuccess(
+          fileRevisions: [fileRevision()],
+          verification: LinkVerification.pending,
+          detailsAreResolved: false,
+        ),
+        surface: const Size(1440, 1000),
       );
-      await tester.pumpAndSettle();
 
-      // Back open, and offering the only direction that still needs a control.
-      expect(find.text('Hide preview'), findsOneWidget);
+      final pane = find.byKey(sharedFilePreviewPaneKey);
+      expect(pane, findsOneWidget);
+      expect(
+        find.descendant(of: pane, matching: find.text('Loading file details...')),
+        findsOneWidget,
+      );
+      // The picture above it, not a bare line of text in an empty box.
+      expect(
+        find.descendant(of: pane, matching: find.byType(ArDriveIcon)),
+        findsWidgets,
+      );
     });
 
     testWidgets('a pinned link names its version pinned, and still lets go',

--- a/test/pages/shared_file/shared_file_page_test.dart
+++ b/test/pages/shared_file/shared_file_page_test.dart
@@ -708,6 +708,37 @@ void main() {
       verify(() => cubit.showRevision(any())).called(1);
     });
 
+    testWidgets('a pinned link names its version pinned, and still lets go',
+        (tester) async {
+      // Pinning is the sharer saying which version they mean, not a limit on
+      // the recipient - who can reach every other version on chain anyway, and
+      // whom the freshness banner already offers "View latest". So the chip
+      // changes and nothing else does.
+      await pumpPage(
+        tester,
+        success(
+          isPinned: true,
+          activityRevisions: [
+            fileRevision(dataTxId: 'data-tx-newer'),
+            fileRevision(),
+          ],
+          activityStatus: SharedFileActivityStatus.loaded,
+        ),
+      );
+
+      await tester.tap(find.byType(ExpansionTile).last);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Pinned'), findsOneWidget);
+      expect(find.text('This link'), findsNothing);
+
+      // And the newer one is still selectable.
+      await tester.tap(find.text('Latest'));
+      await tester.pumpAndSettle();
+
+      verify(() => cubit.showRevision(any())).called(1);
+    });
+
     testWidgets('shows the verification badge the link earned', (tester) async {
       await pumpPage(tester, success(verification: LinkVerification.verified));
 

--- a/test/pages/shared_file/shared_file_page_test.dart
+++ b/test/pages/shared_file/shared_file_page_test.dart
@@ -1055,12 +1055,12 @@ void main() {
       expect(download.bottom, lessThanOrEqualTo(laptop.height));
       expect(download.height, greaterThanOrEqualTo(44));
 
-      // Download stays a button, not a 1000px banner, and it stays on the
-      // reading side of the card - to the left of the preview, and above it,
-      // so it is the first thing found by eye, pointer and Tab key alike.
+      // Download stays a button, not a 1000px banner, and it stays ahead of
+      // the file itself - in the header across the top rather than beside the
+      // preview, so it is the first thing found by eye, pointer and Tab key
+      // alike whatever the two regions below are doing.
       expect(download.width, lessThanOrEqualTo(368));
-      expect(download.right, lessThanOrEqualTo(pane.left));
-      expect(download.top, lessThan(pane.bottom));
+      expect(download.bottom, lessThanOrEqualTo(pane.top));
       expect(tester.takeException(), isNull);
     });
 


### PR DESCRIPTION
Stacked on #2186 — base is `PE-9210-sharing-hardening`, so this diff is only the redesign.

The shared file page, rebuilt around the thing it exists to show. Three problems drove it: the card resized whenever you touched it, the version list was a readout you could not act on, and the page kept asking the gateway questions the share link had already answered.

## The card stops moving

It had three things that resized it — a preview toggle and two accordions — so anything you clicked moved everything else, including the Download button out from under the pointer on its way to press it.

The file's identity and Download move into a fixed header. Below that: the file on one side, everything about it on the other, as two tabs in a panel of fixed height. **File details** and **Version history** swap in place; the card does not move. On a phone the column already scrolls, so the panel has no fixed height there and transaction details grow the card instead of scrolling inside it.

## The preview is the page

The show/hide toggle is gone. It had quietly lost its purpose: the preview opens on arrival, so the bytes are already fetched by the time Hide could be pressed; the widget stayed mounted, so nothing was freed; and a recipient who did not want to see what a stranger sent them had already seen it. It saved no bandwidth, freed no memory and prevented nothing — it only asked the recipient to decide something.

The box keeps a job, just not as a control. Every state that cannot show the file — still resolving, type unsupported, past the 100 MiB cap — now gets the same picture-over-a-sentence placeholder, so a 580×430 pane never holds one floating line of text, and Download beside it stays the way forward.

Inline on the share page, the bar under an image preview also stops repeating the name and type on a 96px floor: the card above already carries both. Expand is the only thing in that bar the page cannot say for itself, so inline it is the only thing left in it — 40px back to the image (334 → 374). Full screen keeps the name, because the card is gone there. The file explorer is untouched.

## The version list is a control

- `showRevision` is the general case behind the freshness banner's two shortcuts, so a recipient can pick any version the file has. The banner stays honest because "a newer version exists" is re-derived from where the selection landed.
- **Opening the list waits on nothing.** The version the link named is already in hand, so it renders from the first frame and the rest fills in around it.
- **A failed lookup costs the list and nothing else.** The row the recipient was sent stays, stays selected, stays downloadable, with one line and a Retry — the state a rate-limited connection actually lands in.
- A **pinned** link names its version pinned and still lets go: pinning is the sharer saying which version they mean, not a limit on a recipient who can reach every other version on chain anyway.
- Selecting a version moves the preview with the download target, so the page never gives two answers to "what am I looking at".

## Stop asking what the link already said

`getTransactionDetails` was being called on the preview path purely to read the `Cipher` and `Cipher-IV` tags off the data transaction — the two values the link carries as `c` and `iv`, and the same lookup the download path already skips for them. On a connection the gateway rate limits, that is a call that can fail and cost the preview outright.

Private previews now decrypt with what they were given, falling back to the lookup only when they were given nothing — a v1 link, or a version the link never described. Guarded on the transaction the way the download is, so selecting another version leaves the link's cipher behind with the bytes it belonged to.

Where that leaves the page:

| Stage | Requests |
| --- | --- |
| First paint | **0** — `_resolveFromPayload` emits, *then* schedules background work |
| Behind the paint | 1 GraphQL (freshness banner), + license only if one exists |
| Preview (private) | 1 HTTP — **was 1 HTTP + 1 GraphQL** |
| Download | 1 HTTP + 1 GraphQL — the integrity check, not metadata (see below) |
| Thumbnail (private) | 1 HTTP + 1 GraphQL — see below |
| Version history | 1 GraphQL, only when opened, guarded against re-query |

The freshness query is the one that cannot be removed: a link cannot know about revisions made after it was created. It runs behind the paint, so it costs nothing on screen.

**Download's remaining query is not metadata.** It is `_dataItemVerifierFor` fetching the data item's *signature* to verify the bytes (`ardrive_downloader.dart:1131`, added in #2175). It cannot move into the link: the link is the untrusted input being checked, so a signature copied into it would be attacker-controlled. It is not self-certifying either — `verifyDataItem` first checks that `sha256(signature)` equals the data item id the link named, so an attacker cannot substitute their own keypair without a SHA-256 second preimage. It starts before the byte stream so it overlaps the download, and it is capped at 10s.

Worth recording: `FILE_SHARING_REDESIGN_PLAN.md:275` promised this would ride the existing `getTransactionDetails` call rather than being a new round trip. The two really are one query — `getTransactionDetails` delegates to `getTransactionDetailsWithSignature` — but the call sites never shared a result and nothing memoizes them, so a private download used to issue the identical query twice. This PR removed the other one.

## Consistency

Every row in both tabs measures exactly 44px — the copy control sets that floor as the smallest a touch target may be, and the rest meet it. That includes the transaction-details disclosure header, which came from an `ExpansionTile` whose `ListTile` floor measured **58** against the 44 either side of it, so the list changed rhythm at the header and changed back after it. None of the knobs `ExpansionTile` exposes reach 44 (`visualDensity` moves in steps of four and overshoots to 42), so the header is built from the same row primitive as everything else. A test measures all of them rather than asserting the constraint.

Dates read as dates (`Mar 3, 2024`) with the exact UTC instant in a tooltip — the pairing the drive explorer already uses.

## Follow-ups, not in here

- **A private thumbnail still costs one GraphQL call.** The link carries `c`/`iv` for the *data* transaction, but a thumbnail is its own transaction with its own IV. A `tiv` field would close it — the same trick, one field wider.
- **`bundledIn` is carried but not used as a locator.** The link has it as `in`, and today it only proves an item is bundled so the download can skip the lookup safely. If `/{dataTxId}` fails on every gateway, that bundle id is a second route to the same bytes — real work (ANS-104 offset parsing), real resilience.
- **Goldsky as a GraphQL fallback**, so the remaining queries are not backstopped by an `arweave.net` that rate-limits. This is now the highest-value item of the three: it fixes version history, the freshness banner *and* the download integrity check at once. Probing live for a bundled ArDrive data item, `signature` and `owner.key` both come back from goldsky, permagate.io, turbo-gateway.com and vilenarios.com — and `arweave.net` answers `429`. On a rate-limited connection the integrity check therefore burns its 10s timeout and reports `notVerified`, which is a transport problem rather than a problem with the check.

## Removed

`sharedFilePermanentFileSharing`, `sharedFileHidePreview` and `sharedFilePreviewPaneHint` are gone from all six locales along with the things they labelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned shared-file details and version history panels with responsive layouts.
  * Added revision selection, status labels, loading states, retry handling, and accessible controls.
  * Added support for encrypted shared-file previews using link-provided credentials.
  * Improved preview placeholders and compact fullscreen controls.

* **Bug Fixes**
  * Improved revision matching for renamed or moved files.
  * Downloads now avoid unnecessary integrity checks unless requested.
  * Prevented transient verification states for immediately completed downloads.
  * Improved handling of unavailable files across download gateways.

* **Localization**
  * Updated English text and removed obsolete shared-file and download verification messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->