### PR TITLE
PE-9211: Drop two localization keys left behind by the shared file page

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2294,10 +2294,6 @@
   "@sharedFileVersionHistoryTitle": {
     "description": "Title of the collapsed drawer holding the version history of a shared file"
   },
-  "sharedFileVersionHistoryUnavailable": "We couldn’t load the version history right now.",
-  "@sharedFileVersionHistoryUnavailable": {
-    "description": "Shown in the version history drawer when the revisions could not be loaded"
-  },
   "sharedFileViewLatest": "View latest",
   "@sharedFileViewLatest": {
     "description": "Button that opens the newest version of a shared file when the link is pinned to an older one"

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1913,10 +1913,6 @@
       }
     }
   },
-  "sharedFileStoredPermanently": "Este archivo se almacena de forma permanente y se puede descargar en cualquier momento.",
-  "@sharedFileStoredPermanently": {
-    "description": "Reassurance shown at the bottom of the shared file page"
-  },
   "sharedFileUnlockedWithAccessKey": "Desbloqueado con tu clave de acceso. Para todos los demás, este archivo sigue cifrado.",
   "@sharedFileUnlockedWithAccessKey": {
     "description": "Shown after a private shared file has been unlocked with an access key"
@@ -1928,10 +1924,6 @@
   "sharedFileVersionHistoryTitle": "Historial de versiones",
   "@sharedFileVersionHistoryTitle": {
     "description": "Title of the collapsed drawer holding the version history of a shared file"
-  },
-  "sharedFileVersionHistoryUnavailable": "Ahora mismo no hemos podido cargar el historial de versiones.",
-  "@sharedFileVersionHistoryUnavailable": {
-    "description": "Shown in the version history drawer when the revisions could not be loaded"
   },
   "sharedFileViewLatest": "Ver la última",
   "@sharedFileViewLatest": {

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -1913,10 +1913,6 @@
       }
     }
   },
-  "sharedFileStoredPermanently": "यह फ़ाइल स्थायी रूप से संग्रहित है और इसे कभी भी डाउनलोड किया जा सकता है।",
-  "@sharedFileStoredPermanently": {
-    "description": "Reassurance shown at the bottom of the shared file page"
-  },
   "sharedFileUnlockedWithAccessKey": "आपकी ऐक्सेस कुंजी से अनलॉक किया गया। बाकी सभी के लिए यह फ़ाइल एन्क्रिप्टेड ही रहती है।",
   "@sharedFileUnlockedWithAccessKey": {
     "description": "Shown after a private shared file has been unlocked with an access key"
@@ -1928,10 +1924,6 @@
   "sharedFileVersionHistoryTitle": "वर्शन इतिहास",
   "@sharedFileVersionHistoryTitle": {
     "description": "Title of the collapsed drawer holding the version history of a shared file"
-  },
-  "sharedFileVersionHistoryUnavailable": "अभी हम वर्शन इतिहास लोड नहीं कर सके।",
-  "@sharedFileVersionHistoryUnavailable": {
-    "description": "Shown in the version history drawer when the revisions could not be loaded"
   },
   "sharedFileViewLatest": "नवीनतम देखें",
   "@sharedFileViewLatest": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1913,10 +1913,6 @@
       }
     }
   },
-  "sharedFileStoredPermanently": "このファイルは永続的に保存されており、いつでもダウンロードできます。",
-  "@sharedFileStoredPermanently": {
-    "description": "Reassurance shown at the bottom of the shared file page"
-  },
   "sharedFileUnlockedWithAccessKey": "あなたのアクセスキーでロックを解除しました。ほかの人にとっては、このファイルは暗号化されたままです。",
   "@sharedFileUnlockedWithAccessKey": {
     "description": "Shown after a private shared file has been unlocked with an access key"
@@ -1928,10 +1924,6 @@
   "sharedFileVersionHistoryTitle": "バージョン履歴",
   "@sharedFileVersionHistoryTitle": {
     "description": "Title of the collapsed drawer holding the version history of a shared file"
-  },
-  "sharedFileVersionHistoryUnavailable": "現在、バージョン履歴を読み込めませんでした。",
-  "@sharedFileVersionHistoryUnavailable": {
-    "description": "Shown in the version history drawer when the revisions could not be loaded"
   },
   "sharedFileViewLatest": "最新版を見る",
   "@sharedFileViewLatest": {

--- a/lib/l10n/app_zh-HK.arb
+++ b/lib/l10n/app_zh-HK.arb
@@ -1913,10 +1913,6 @@
       }
     }
   },
-  "sharedFileStoredPermanently": "此檔案已永久儲存，隨時都可以下載。",
-  "@sharedFileStoredPermanently": {
-    "description": "Reassurance shown at the bottom of the shared file page"
-  },
   "sharedFileUnlockedWithAccessKey": "已使用你的存取密鑰解鎖。對其他所有人而言，此檔案仍然是加密的。",
   "@sharedFileUnlockedWithAccessKey": {
     "description": "Shown after a private shared file has been unlocked with an access key"
@@ -1928,10 +1924,6 @@
   "sharedFileVersionHistoryTitle": "版本記錄",
   "@sharedFileVersionHistoryTitle": {
     "description": "Title of the collapsed drawer holding the version history of a shared file"
-  },
-  "sharedFileVersionHistoryUnavailable": "目前無法載入版本記錄。",
-  "@sharedFileVersionHistoryUnavailable": {
-    "description": "Shown in the version history drawer when the revisions could not be loaded"
   },
   "sharedFileViewLatest": "查看最新版本",
   "@sharedFileViewLatest": {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1913,10 +1913,6 @@
       }
     }
   },
-  "sharedFileStoredPermanently": "此文件被永久存储，随时都可以下载。",
-  "@sharedFileStoredPermanently": {
-    "description": "Reassurance shown at the bottom of the shared file page"
-  },
   "sharedFileUnlockedWithAccessKey": "已使用你的访问密钥解锁。对其他所有人来说，此文件仍处于加密状态。",
   "@sharedFileUnlockedWithAccessKey": {
     "description": "Shown after a private shared file has been unlocked with an access key"
@@ -1928,10 +1924,6 @@
   "sharedFileVersionHistoryTitle": "版本历史",
   "@sharedFileVersionHistoryTitle": {
     "description": "Title of the collapsed drawer holding the version history of a shared file"
-  },
-  "sharedFileVersionHistoryUnavailable": "目前无法加载版本历史。",
-  "@sharedFileVersionHistoryUnavailable": {
-    "description": "Shown in the version history drawer when the revisions could not be loaded"
   },
   "sharedFileViewLatest": "查看最新版本",
   "@sharedFileViewLatest": {


### PR DESCRIPTION
Two localization keys whose last usages were removed in #2189, left behind when it merged.

- **`sharedFileStoredPermanently`** — the permanence footer was removed from the recipient page and then from the raw transaction view, but the key survived. Worse, it had already been dropped from `app_en.arb` while all five translations kept it, so the template and the locales disagreed about whether the string exists.
- **`sharedFileVersionHistoryUnavailable`** — replaced when the version list became a control with its own failure line.

Found by diffing which identifiers `lib/` references at `dev` against what it references after the change, rather than by reading the ARB diff. A key stops being used when its **call site** goes, which an ARB diff cannot see — that blind spot is why these two survived a cleanup pass that caught four other keys in the same PR.

No behaviour change: nothing reads either key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Removed outdated shared-file storage and version-history messages from several language translations.
  * Updated English, Spanish, Hindi, Japanese, Traditional Chinese, and Simplified Chinese locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->