### PR TITLE
chore: point the development flavor at turbo-gateway.com

### DIFF
--- a/assets/config/dev.json
+++ b/assets/config/dev.json
@@ -1,9 +1,9 @@
 {
-  "configVersion": 2,
-  "defaultArweaveGatewayUrl": "https://ar-io.dev",
+  "configVersion": 3,
+  "defaultArweaveGatewayUrl": "https://turbo-gateway.com",
   "defaultArweaveGatewayForDataRequest": {
-    "label": "AR.IO Testnet",
-    "url": "https://ar-io.dev"
+    "label": "Turbo Gateway",
+    "url": "https://turbo-gateway.com"
   },
   "useTurboUpload": true,
   "useTurboPayment": true,


### PR DESCRIPTION
PR preview builds compile with `--dart-define=environment=development` (`.github/workflows/pr.yaml:45`), so `assets/config/dev.json` is what every test branch loads — and it pointed at `ar-io.dev`, which had to be changed by hand on each one before anything could be tested against real data.

## What changes

| Field | Was | Now |
| --- | --- | --- |
| `defaultArweaveGatewayUrl` | `https://ar-io.dev` | `https://turbo-gateway.com` |
| `defaultArweaveGatewayForDataRequest` | AR.IO Testnet / `https://ar-io.dev` | Turbo Gateway / `https://turbo-gateway.com` |
| `configVersion` | 2 | 3 |

`defaultArweaveGatewayUrl` is the **GraphQL endpoint** as well as the gateway — `ArweaveService` runs it through `_graphqlUrlFromGateway`, so this moves both GraphQL and data reads onto turbo-gateway.com, which is where staging and production already read their data from.

## Why the version bump is not optional

`ConfigFetcher` only replaces a stored config when the asset's `configVersion` is **greater** than the stored one. Without the bump this file would change nothing for anyone who has already opened a development build — which is everyone it is meant to help.

## Deliberately not touched

`defaultTurboUploadUrl` and `defaultTurboPaymentUrl` still point at the ar-io.dev Turbo services, and the Stripe key is still the test key. Worth a look: dev builds now *read* from turbo-gateway.com while *uploading* through AR.IO's dev Turbo, so if those post somewhere turbo-gateway.com does not serve, an upload → download round trip in a dev build will not resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ndA5nwUpt9hGLUx2TAFr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated the development environment configuration to version 3.
  * Switched default Arweave general and data requests from the AR.IO Testnet gateway to Turbo Gateway.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->