### PR TITLE
fix: send the GraphQL fallback to Goldsky instead of through arweave.net

### DIFF
--- a/lib/utils/graphql_retry.dart
+++ b/lib/utils/graphql_retry.dart
@@ -9,15 +9,29 @@ import 'package:retry/retry.dart';
 
 /// Retry every GraphQL query for `ArtemisClient`
 ///
-/// On 429 or 5xx errors, falls back to arweave.net/graphql (Goldsky proxy)
-/// since most AR.IO gateways don't index ArDrive L2 data.
+/// On 429 or 5xx errors, falls back to Goldsky since most AR.IO gateways don't
+/// index ArDrive L2 data.
 class GraphQLRetry {
   GraphQLRetry(this._client,
       {required InternetChecker internetChecker,
       String? fallbackGraphqlUrl})
       : _internetChecker = internetChecker,
         _fallbackGraphqlUrl =
-            fallbackGraphqlUrl ?? 'https://arweave.net/graphql';
+            fallbackGraphqlUrl ?? defaultFallbackGraphqlUrl;
+
+  /// Where a query goes when the primary endpoint will not serve it.
+  ///
+  /// Goldsky directly, rather than `arweave.net/graphql`, which is a proxy in
+  /// front of this same index: going through it adds a hop that applies its
+  /// own rate limiting, so a fallback armed *because* the primary returned 429
+  /// could arrive at another 429 earned by nobody. The backend answering is
+  /// the same either way.
+  ///
+  /// Note this endpoint clamps `first` above 100 to 100 edges while still
+  /// reporting `hasNextPage: false`, so a paginating caller must not ask it
+  /// for more than 100.
+  static const defaultFallbackGraphqlUrl =
+      'https://arweave-search.goldsky.com/graphql';
 
   final ArtemisClient _client;
   final InternetChecker _internetChecker;


### PR DESCRIPTION
`arweave.net/graphql` is a proxy in front of Goldsky, so the fallback was reaching the right index by way of a hop that applies its own rate limiting.

That hop is worst exactly when it is used. The fallback only arms on a **429 or a 5xx** — so a client already being rate limited would then earn a *second* 429 from the proxy rather than from the index. Same backend, one less thing in front of it.

```dart
static const defaultFallbackGraphqlUrl =
    'https://arweave-search.goldsky.com/graphql';
```

## The URL was effectively hardcoded

`GraphQLRetry` accepts a `fallbackGraphqlUrl`, but neither construction site in `arweave_service.dart` — the constructor, and `updateGraphQLEndpoint` — passes one. The default was always what ran. It is now a named constant instead of a literal buried in an initialiser list, so the next reader can find it.

## Blast radius

This is the fallback for **every** GraphQL call in the app, sync included, which is why it is its own PR rather than folded into anything else. No test asserts the endpoint. Goldsky's documented quirk — it clamps `first` above 100 to 100 edges while still reporting `hasNextPage: false` — is now noted on the constant, since a paginating caller that lands here must not ask for more than 100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ndA5nwUpt9hGLUx2TAFr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default GraphQL fallback endpoint to improve reliability.
  * Added support for the endpoint’s 100-edge pagination limit.

* **Documentation**
  * Clarified the fallback endpoint configuration and pagination behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->