### PR TITLE
PE-9205: Prototype the drive state artifact ATTACH pipeline in the browser

### DIFF
--- a/docs/drive-state/ATTACH_VFS_PROTOTYPE.md
+++ b/docs/drive-state/ATTACH_VFS_PROTOTYPE.md
@@ -148,3 +148,49 @@ None of it imports application code, and none of it is wired into the app.
 `flutter test` picks up the VM half; the browser half needs the script, because
 `flutter test --platform chrome` serves only the compiled test bundle and not
 the package's own files.
+
+---
+
+## Which storage tier does this origin get?
+
+D12's bounded-memory claim depends on OPFS. Drift picks a tier at runtime, and
+only two of the five give bounded memory:
+
+| tier | requires | bounded memory |
+|---|---|---|
+| `opfsShared` | a shared worker that can spawn a nested dedicated worker | **yes** |
+| `opfsLocks` | cross-origin isolation (`SharedArrayBuffer`) | **yes** |
+| `sharedIndexedDb` | shared workers | no — whole database in RAM |
+| `unsafeIndexedDb` | dedicated workers | no — whole database in RAM |
+| `inMemory` | — | no |
+
+`IndexedDbFileSystem` wraps an `InMemoryFileSystem` and reads the file fully
+into it (`sqlite3-2.4.2/lib/src/wasm/vfs/indexed_db.dart:411,419,524`), so the
+IndexedDB tiers persist asynchronously but do not page.
+
+`WasmDatabase.probe()` answers this, but it is Dart inside `main.dart.js` and
+cannot be called from a console. `tool/drift_storage_probe.js` reproduces the
+same decision in plain JavaScript — the same checks, in the same worker scopes
+— so it can be pasted into DevTools on any origin:
+
+```
+copy(await fetch('...').then(r => r.text()))   // or just paste the file
+```
+
+`storage_probe_smoke_test.dart` runs it in Chrome and asserts it returns one of
+the five tiers, so the snippet is known to work rather than assumed to.
+
+**This matters because the app deploys to two origins.**
+`.github/workflows/production.yaml` deploys to Firebase Hosting *and*, via
+`ar-io/ar-io-deploy`, to Arweave. Response headers are controllable on the
+first and not on the second, and `opfsLocks` needs `Cross-Origin-Opener-Policy`
+and `Cross-Origin-Embedder-Policy`. Run the probe on both before costing the
+migration.
+
+One caution about enabling those headers on the origin where you can:
+`COEP: require-corp` blocks cross-origin subresources that lack a
+`Cross-Origin-Resource-Policy` header. Gateways send
+`access-control-allow-origin: *` but no CORP, so CORS-mode `fetch` still
+succeeds while a plain `<img src>` — which is what Flutter's `Image.network`
+uses on web — would be blocked. `COEP: credentialless` avoids that on Chrome;
+Safari needs checking.

--- a/docs/drive-state/ATTACH_VFS_PROTOTYPE.md
+++ b/docs/drive-state/ATTACH_VFS_PROTOTYPE.md
@@ -1,0 +1,150 @@
+# D12 prototype — `ATTACH` in the browser
+
+The SQLite-file proposal for the drive state artifact (D12, proposed against
+`#2187`) rests on two claims that nobody had executed. This is the executable
+form of both.
+
+```
+tool/drive_state_prototype.sh
+```
+
+**Both hold.** The pipeline in `test/drive_state_prototype/artifact_pipeline.dart`
+is the same SQL on both platforms, and both run it green.
+
+| | vm/ffi | web/wasm (Chrome) |
+|---|---|---|
+| tests | 13 pass | 14 pass |
+| SQLite | 3.45.1 | 3.45.1 |
+| 20,000 rows → artifact | 3,194,880 B | 3,162,112 B |
+| build | 33 ms | 428 ms |
+| import | 47 ms | 418 ms |
+
+For scale, the shipped JSON path measures 4 s to seal and 9 s to import at
+41,767 files (`#2188`). This prototype does about 20,000 rows in 0.43 s each
+way in a browser — but see **What this does not prove**, because the two are
+not measuring the same work.
+
+---
+
+## The two claims
+
+**Case 1, the producer.** `ATTACH` an empty database, build the frozen schema
+in it, copy one drive's rows in through an explicit column projection,
+`DETACH`, and read the bytes back out. Proven on both platforms. On web the
+attached database is a real, separate entry in the virtual filesystem — the
+test asserts its first sixteen bytes are `SQLite format 3`.
+
+**Case 2, the consumer.** Put received bytes in the filesystem, `ATTACH` them,
+refuse anything that is not the exact agreed shape, then merge with
+`INSERT INTO main.x SELECT … FROM artifact.x`. Proven on both platforms. No
+row becomes a Dart object at any point in either direction.
+
+The read gate refuses all six cases it is given: a view, a trigger, an extra
+table, an entity count that disagrees with the body, a foreign drive id, and an
+unimplemented version. Each is checked before anything is written, and the test
+asserts the target database is still empty after the refusal.
+
+---
+
+## Three findings that were not the question
+
+### 1. The app's web database is not a WASM VFS at all
+
+`lib/models/database/web.dart` opens `WebDatabase.withStorage(...)` from
+`package:drift/web.dart` — the **deprecated sql.js backend**, which keeps the
+database in memory and persists a serialised copy to IndexedDB. That is what
+`web/sql-wasm.wasm` and `web/js/sql-wasm.js` are, and `web/index.html:332`
+loads them on every page load.
+
+So the phrase "Drift's WASM VFS" in the D12 write-up describes something this
+app does not currently run. **Adopting D12 means migrating the web database
+layer from `drift/web.dart` to `drift/wasm.dart` first.** That is real work
+this proposal did not account for, and it should be costed before D12 is
+accepted — though it is work worth doing regardless, since the backend in use
+is deprecated.
+
+This prototype therefore proves the claims against `package:sqlite3/wasm.dart`
+directly, not through Drift.
+
+### 2. `web/sqlite3.wasm` is dead weight, and is broken anyway
+
+The repository vendors `web/sqlite3.wasm` (1,348,108 bytes) and `web/worker.js`.
+Nothing references either — not `index.html`, not `lib/`. They look like the
+remains of an abandoned migration to `drift/wasm.dart`.
+
+The file also cannot be loaded by the resolved `sqlite3: 2.4.2`:
+
+```
+LinkError: WebAssembly.instantiate(): Import #0 "dart" "fs_delete":
+function import requires a callable
+```
+
+It is built against a different ABI. The prototype fetches the matching
+`sqlite3.wasm` (697,758 bytes) from the `sqlite3.dart` release that matches
+`pubspec.lock`. Removing the two stale files is a separate, easy cleanup worth
+about 1.3 MB in the deployed build.
+
+### 3. `secure_delete` differs between the platforms, and web is the unsafe one
+
+D12 argues the artifact must be **built up** — copy wanted rows into an empty
+database — rather than **torn down** — copy everything, then delete what must
+not ship. The stated reason was that `DROP TABLE` leaves the dropped bytes on
+the freelist.
+
+Measured, that is true **only when `secure_delete` is off**, and the default is
+not the same everywhere:
+
+| build | `PRAGMA secure_delete` | tear-down result |
+|---|---|---|
+| vm/ffi (macOS) | `2` (fast) | secret **not** recoverable |
+| web/wasm | `0` (off) | secret **recoverable in the file** |
+
+So the original claim was too strong as stated — and the platform where it does
+hold is the browser, which is where the producer runs. The conclusion survives
+and the reasoning improves: the safety of tear-down is not a property of our
+code but of whichever SQLite build the client happens to link, and that is not
+an acceptable thing to have standing between a user's wallet ciphertext and a
+permanent public upload. Building up removes the question.
+
+The suite asserts the leak under an explicit `PRAGMA secure_delete = 0` on both
+platforms, and prints each platform's default rather than depending on it.
+
+---
+
+## What this does not prove
+
+Stated plainly, because the numbers above are easy to over-read.
+
+- **Nothing about Drift.** The prototype drives `package:sqlite3` directly. It
+  does not use `WasmDatabase`, and it does not touch the sql.js backend the app
+  actually runs on web today. Finding 1 is the gap.
+- **Nothing about OPFS.** The browser run uses `InMemoryFileSystem`, so the
+  whole artifact is in memory. Bounded producer memory for a very large drive
+  is exactly what an OPFS-backed VFS would buy, and it is untested here.
+- **No memory measurement.** A browser test cannot take one. The claim that no
+  row becomes a Dart object is a property of the code, readable in
+  `artifact_pipeline.dart`; it is not a measurement.
+- **Not comparable to the `#2188` figures.** 20,000 synthetic rows of one table
+  against 41,767 files across seven sections, with different columns. The
+  timings show the pipeline is not pathological, not that it is 20× faster.
+- **No encryption, signature, gzip or upload.** Everything downstream of
+  `build → …` in D12 is out of scope here.
+- **The projection is illustrative.** `artifactProjection` names a realistic
+  subset of columns, not the real seven-section set from D2.
+
+---
+
+## Layout
+
+| file | what it is |
+|---|---|
+| `test/drive_state_prototype/artifact_pipeline.dart` | the pipeline, as SQL, platform-agnostic |
+| `test/drive_state_prototype/prototype_suite.dart` | the assertions, written once, run on both platforms |
+| `test/drive_state_prototype/attach_vm_test.dart` | VM entry point |
+| `test/drive_state_prototype/attach_web_test.dart` | browser entry point |
+| `tool/drive_state_prototype.sh` | fetches the matching wasm, serves it, runs both |
+
+None of it imports application code, and none of it is wired into the app.
+`flutter test` picks up the VM half; the browser half needs the script, because
+`flutter test --platform chrome` serves only the compiled test bundle and not
+the package's own files.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2064,7 +2064,7 @@ packages:
     source: hosted
     version: "2.5.4"
   sqlite3:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: sqlite3
       sha256: "1abbeb84bf2b1a10e5e1138c913123c8aa9d83cd64e5f9a0dd847b3c83063202"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -186,6 +186,10 @@ dependency_overrides:
     path: ./packages/ardrive_ui
 
 dev_dependencies:
+  # Used only by test/drive_state_prototype (see
+  # docs/drive-state/ATTACH_VFS_PROTOTYPE.md). Pinned to whatever drift
+  # already resolves; the prototype fetches the matching sqlite3.wasm.
+  sqlite3: ^2.4.2
   integration_test:
     sdk: flutter
   flutter_test:

--- a/test/drive_state_prototype/artifact_pipeline.dart
+++ b/test/drive_state_prototype/artifact_pipeline.dart
@@ -1,0 +1,248 @@
+/// The D12 drive-state artifact pipeline, expressed once, in SQL.
+///
+/// This is a **prototype**, not production code. It exists to answer the two
+/// questions `docs/drive-state/ATTACH_VFS_PROTOTYPE.md` poses, and it is
+/// written against `package:sqlite3/common.dart` so that the identical
+/// statements run on the Dart VM (FFI) and in a browser (WASM). If the SQL
+/// below works on both, D12's producer and consumer are both O(1) in drive
+/// size with no serialisation code of our own.
+///
+/// Nothing here touches Drift, the app database, or any app code.
+library;
+
+import 'dart:typed_data';
+
+import 'package:sqlite3/common.dart';
+
+/// Reads the bytes of [path] out of whatever filesystem the caller's SQLite
+/// is using — a real file on the VM, a VFS entry in the browser.
+typedef ByteReader = Uint8List Function(String path);
+
+/// Places [bytes] at [path] in that same filesystem, so SQLite can `ATTACH`
+/// them.
+typedef ByteWriter = void Function(String path, Uint8List bytes);
+
+/// The columns each artifact table carries, named explicitly and never `*`.
+///
+/// This map is the **projection**, and in D12 it is also the security
+/// boundary: a column absent from here cannot reach the artifact, because the
+/// artifact is built by selecting these names into an empty database. There is
+/// no step that removes anything, so there is no step that can be forgotten.
+///
+/// `profiles` is deliberately absent. It is not filtered out — it is never
+/// named, anywhere, at any point in the pipeline.
+const artifactProjection = <String, List<String>>{
+  'drives': [
+    // Note what is *not* here: encryptedKey, keyEncryptionIv,
+    // driveKeyGenerated, lastBlockHeight, syncCursor.
+    'id',
+    'name',
+    'ownerAddress',
+    'privacy',
+    'rootFolderId',
+  ],
+  'file_revisions': [
+    'fileId',
+    'driveId',
+    'name',
+    'parentFolderId',
+    'size',
+    'lastModifiedDate',
+    'dataContentType',
+    'metadataTxId',
+    'dataTxId',
+    'dateCreated',
+    'action',
+    'isHidden',
+  ],
+};
+
+/// The frozen artifact schema — D12's, not Drift's.
+///
+/// Deliberately not the app's schema: no indexes (dead weight that measured
+/// 1.66x on the compressed size), no foreign keys, and ids left as they come.
+/// A reader compares the artifact's `sqlite_master` against exactly this text,
+/// so it is written once and read by both halves.
+const artifactSchema = <String, String>{
+  'meta': 'CREATE TABLE meta ('
+      'version TEXT NOT NULL, '
+      'driveId TEXT NOT NULL, '
+      'blockEnd INTEGER NOT NULL, '
+      'entityCount INTEGER NOT NULL)',
+  'drives': 'CREATE TABLE drives ('
+      'id TEXT NOT NULL, '
+      'name TEXT, '
+      'ownerAddress TEXT NOT NULL, '
+      'privacy TEXT NOT NULL, '
+      'rootFolderId TEXT NOT NULL)',
+  'file_revisions': 'CREATE TABLE file_revisions ('
+      'fileId TEXT NOT NULL, '
+      'driveId TEXT NOT NULL, '
+      'name TEXT NOT NULL, '
+      'parentFolderId TEXT NOT NULL, '
+      'size INTEGER NOT NULL, '
+      'lastModifiedDate INTEGER NOT NULL, '
+      'dataContentType TEXT, '
+      'metadataTxId TEXT NOT NULL, '
+      'dataTxId TEXT NOT NULL, '
+      'dateCreated INTEGER NOT NULL, '
+      'action TEXT NOT NULL, '
+      'isHidden INTEGER NOT NULL)',
+};
+
+/// Case 1 — the producer.
+///
+/// Attaches an **empty** database at [artifactPath], builds the frozen schema
+/// inside it, copies one drive's rows in through the explicit projection, and
+/// detaches. Returns the artifact's bytes.
+///
+/// Memory is whatever SQLite's page cache decides; no row ever becomes a Dart
+/// object. That is the whole claim being tested.
+Uint8List buildArtifact(
+  CommonDatabase source, {
+  required String artifactPath,
+  required String driveId,
+  required String version,
+  required int blockEnd,
+  required ByteReader readBytes,
+}) {
+  source.execute('ATTACH DATABASE ? AS artifact', [artifactPath]);
+  try {
+    for (final ddl in artifactSchema.values) {
+      source.execute(ddl.replaceFirst('CREATE TABLE ', 'CREATE TABLE artifact.'));
+    }
+
+    for (final entry in artifactProjection.entries) {
+      final table = entry.key;
+      final columns = entry.value.join(', ');
+      final idColumn = table == 'drives' ? 'id' : 'driveId';
+      source.execute(
+        'INSERT INTO artifact.$table ($columns) '
+        'SELECT $columns FROM main.$table WHERE $idColumn = ?',
+        [driveId],
+      );
+    }
+
+    final entityCount = source
+        .select('SELECT count(*) AS c FROM artifact.file_revisions')
+        .single['c'] as int;
+    source.execute(
+      'INSERT INTO artifact.meta (version, driveId, blockEnd, entityCount) '
+      'VALUES (?, ?, ?, ?)',
+      [version, driveId, blockEnd, entityCount],
+    );
+  } finally {
+    source.execute('DETACH DATABASE artifact');
+  }
+
+  return readBytes(artifactPath);
+}
+
+/// Why a received artifact was refused. Every one is a fallback, never an
+/// error — the caller syncs the ordinary way.
+enum ArtifactRejection {
+  integrityCheckFailed,
+  unexpectedSchema,
+  versionMismatch,
+  driveIdMismatch,
+  entityCountMismatch,
+}
+
+class ArtifactRejected implements Exception {
+  final ArtifactRejection reason;
+  final String detail;
+  ArtifactRejected(this.reason, this.detail);
+  @override
+  String toString() => 'ArtifactRejected($reason): $detail';
+}
+
+/// Case 2 — the consumer.
+///
+/// Places [bytes] in the filesystem, attaches them, refuses the file unless it
+/// is exactly the shape this reader agreed to, then merges one drive's rows
+/// with `INSERT INTO main.x SELECT ... FROM artifact.x`.
+///
+/// Returns the number of `file_revisions` rows merged.
+int importArtifact(
+  CommonDatabase target,
+  Uint8List bytes, {
+  required String artifactPath,
+  required String expectedVersion,
+  required String expectedDriveId,
+  required ByteWriter writeBytes,
+}) {
+  writeBytes(artifactPath, bytes);
+  target.execute('ATTACH DATABASE ? AS artifact', [artifactPath]);
+  try {
+    // (1) The file is a well-formed database.
+    final integrity =
+        target.select('PRAGMA artifact.integrity_check').first.values.first;
+    if (integrity != 'ok') {
+      throw ArtifactRejected(
+          ArtifactRejection.integrityCheckFailed, '$integrity');
+    }
+
+    // (2) It is *only* the shape we agreed to. This is §2.4's first argument
+    //     made explicit: no views, no triggers, no virtual tables, no indexes,
+    //     and every table's DDL byte-identical to the frozen schema.
+    final objects = target.select(
+      'SELECT type, name, sql FROM artifact.sqlite_master '
+      "WHERE name NOT LIKE 'sqlite_%'",
+    );
+    final seen = <String, String>{};
+    for (final row in objects) {
+      if (row['type'] != 'table') {
+        throw ArtifactRejected(ArtifactRejection.unexpectedSchema,
+            'found ${row['type']} "${row['name']}"');
+      }
+      seen[row['name'] as String] = row['sql'] as String;
+    }
+    if (seen.length != artifactSchema.length) {
+      throw ArtifactRejected(ArtifactRejection.unexpectedSchema,
+          'expected ${artifactSchema.keys.toList()}, found ${seen.keys.toList()}');
+    }
+    for (final entry in artifactSchema.entries) {
+      if (seen[entry.key] != entry.value) {
+        throw ArtifactRejected(ArtifactRejection.unexpectedSchema,
+            'table "${entry.key}" is not the frozen schema');
+      }
+    }
+
+    // (3) The claims inside the file match what we asked for.
+    final meta = target.select('SELECT * FROM artifact.meta').single;
+    if (meta['version'] != expectedVersion) {
+      throw ArtifactRejected(
+          ArtifactRejection.versionMismatch, '${meta['version']}');
+    }
+    if (meta['driveId'] != expectedDriveId) {
+      throw ArtifactRejected(
+          ArtifactRejection.driveIdMismatch, '${meta['driveId']}');
+    }
+    final actual = target
+        .select('SELECT count(*) AS c FROM artifact.file_revisions')
+        .single['c'] as int;
+    if (actual != meta['entityCount']) {
+      throw ArtifactRejected(ArtifactRejection.entityCountMismatch,
+          'tag says ${meta['entityCount']}, body has $actual');
+    }
+
+    // (4) The merge. No Dart object is created for any row.
+    target.execute('BEGIN');
+    try {
+      for (final entry in artifactProjection.entries) {
+        final columns = entry.value.join(', ');
+        target.execute(
+          'INSERT OR REPLACE INTO main.${entry.key} ($columns) '
+          'SELECT $columns FROM artifact.${entry.key}',
+        );
+      }
+      target.execute('COMMIT');
+    } catch (_) {
+      target.execute('ROLLBACK');
+      rethrow;
+    }
+    return actual;
+  } finally {
+    target.execute('DETACH DATABASE artifact');
+  }
+}

--- a/test/drive_state_prototype/attach_vm_test.dart
+++ b/test/drive_state_prototype/attach_vm_test.dart
@@ -1,0 +1,38 @@
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:sqlite3/sqlite3.dart';
+import 'package:test/test.dart';
+
+import 'prototype_suite.dart';
+
+/// The VM half of the prototype. It proves the SQL in `artifact_pipeline.dart`
+/// is correct; it says nothing about whether the browser can run it, which is
+/// what `attach_web_test.dart` is for.
+void main() {
+  late Directory dir;
+
+  runAttachPrototypeSuite(
+    platform: 'vm/ffi',
+    open: (path) => sqlite3.open(path),
+    readBytes: (path) => File(path).readAsBytesSync(),
+    writeBytes: (path, bytes) => File(path).writeAsBytesSync(bytes),
+    pathFor: (name) => '${dir.path}/$name',
+    reset: () {
+      if (dir.existsSync()) dir.deleteSync(recursive: true);
+      dir = Directory.systemTemp.createTempSync('d12_prototype');
+    },
+  );
+
+  setUpAll(() => dir = Directory.systemTemp.createTempSync('d12_prototype'));
+  tearDownAll(() {
+    if (dir.existsSync()) dir.deleteSync(recursive: true);
+  });
+
+  test('reports the library version this run proved things against', () {
+    printOnFailure('sqlite ${sqlite3.version.libVersion}');
+    expect(sqlite3.version.libVersion, isNotEmpty);
+  });
+}

--- a/test/drive_state_prototype/attach_web_test.dart
+++ b/test/drive_state_prototype/attach_web_test.dart
@@ -1,0 +1,68 @@
+// Prints platform facts the findings document quotes.
+// ignore_for_file: avoid_print
+
+@TestOn('browser')
+library;
+
+import 'dart:typed_data';
+
+import 'package:sqlite3/wasm.dart';
+import 'package:test/test.dart';
+
+import 'prototype_suite.dart';
+
+/// The browser half, and the one D12 rests on.
+///
+/// Requires `sqlite3.wasm` to be served with CORS. `tool/drive_state_prototype.sh`
+/// starts that server and runs this file; see
+/// `docs/drive-state/ATTACH_VFS_PROTOTYPE.md` for why the copy vendored at
+/// `web/sqlite3.wasm` cannot be used.
+const wasmUrl = String.fromEnvironment(
+  'SQLITE_WASM_URL',
+  defaultValue: 'http://127.0.0.1:8099/sqlite3.wasm',
+);
+
+void main() {
+  late WasmSqlite3 sqlite;
+  late InMemoryFileSystem vfs;
+
+  setUpAll(() async {
+    sqlite = await WasmSqlite3.loadFromUrl(Uri.parse(wasmUrl));
+    vfs = InMemoryFileSystem();
+    sqlite.registerVirtualFileSystem(vfs, makeDefault: true);
+  });
+
+  runAttachPrototypeSuite(
+    platform: 'web/wasm',
+    open: (path) => sqlite.open(path),
+    readBytes: (path) => Uint8List.fromList(vfs.fileData[path]!),
+    writeBytes: (path, bytes) => vfs.fileData[path] = Uint8List.fromList(bytes),
+    pathFor: (name) => '/$name',
+    reset: () => vfs.fileData.clear(),
+  );
+
+  test('the VFS is what actually held the attached databases', () {
+    vfs.fileData.clear();
+    final source = sqlite.open('/source.db');
+    createSourceDatabase(source, fileRows: 10);
+    source.execute("ATTACH DATABASE '/second.db' AS artifact");
+    source.execute('CREATE TABLE artifact.t (a TEXT)');
+    source.execute("INSERT INTO artifact.t VALUES ('written through ATTACH')");
+    source.execute('DETACH DATABASE artifact');
+    source.dispose();
+
+    // The attached database is a real, separate entry in the virtual
+    // filesystem, not a fiction inside the first connection.
+    expect(vfs.fileData.keys, contains('/second.db'));
+    expect(vfs.fileData['/second.db']!.length, greaterThan(0));
+    expect(
+      String.fromCharCodes(vfs.fileData['/second.db']!.sublist(0, 15)),
+      'SQLite format 3',
+    );
+  });
+
+  test('reports the wasm library version this run proved things against', () {
+    print('[web/wasm] sqlite ${sqlite.version.libVersion}');
+    expect(sqlite.version.libVersion, isNotEmpty);
+  });
+}

--- a/test/drive_state_prototype/prototype_suite.dart
+++ b/test/drive_state_prototype/prototype_suite.dart
@@ -1,0 +1,389 @@
+// Prints the measurements the findings document quotes.
+// ignore_for_file: avoid_print
+
+/// The assertions behind `docs/drive-state/ATTACH_VFS_PROTOTYPE.md`, written
+/// once and run on both platforms.
+///
+/// The VM run proves the SQL is right. The browser run is the one that decides
+/// D12, because "does `ATTACH` work in the browser's virtual filesystem" is the
+/// question the whole proposal rests on, and this repository has never
+/// exercised a second database on web.
+///
+/// Both runs execute this identical file. A check that passed on one platform
+/// and not the other would be exactly the finding worth having.
+library;
+
+import 'dart:typed_data';
+
+import 'package:sqlite3/common.dart';
+import 'package:test/test.dart';
+
+import 'artifact_pipeline.dart';
+
+typedef DatabaseOpener = CommonDatabase Function(String path);
+
+/// A value planted in `profiles` that must never reach an artifact. Long and
+/// unmistakable so that finding it in a byte array cannot be a coincidence.
+const plantedSecret = 'PE9205-ENCRYPTED-WALLET-MUST-NEVER-BE-PUBLISHED';
+
+const testDriveId = '0a36156c-6274-41a2-87b0-372f4da7f568';
+
+/// Builds a database shaped like the app's: the two tables an artifact copies
+/// from, plus the `profiles` table §2.1 says must never travel.
+void createSourceDatabase(CommonDatabase db, {int fileRows = 500}) {
+  db.execute('CREATE TABLE profiles ('
+      'id TEXT NOT NULL, encryptedWallet TEXT NOT NULL, keySalt BLOB NOT NULL)');
+  db.execute('CREATE TABLE drives ('
+      'id TEXT NOT NULL, name TEXT, ownerAddress TEXT NOT NULL, '
+      'privacy TEXT NOT NULL, rootFolderId TEXT NOT NULL, '
+      'encryptedKey BLOB, keyEncryptionIv BLOB, lastBlockHeight INTEGER)');
+  db.execute('CREATE TABLE file_revisions ('
+      'fileId TEXT NOT NULL, driveId TEXT NOT NULL, name TEXT NOT NULL, '
+      'parentFolderId TEXT NOT NULL, size INTEGER NOT NULL, '
+      'lastModifiedDate INTEGER NOT NULL, dataContentType TEXT, '
+      'metadataTxId TEXT NOT NULL, dataTxId TEXT NOT NULL, '
+      'dateCreated INTEGER NOT NULL, action TEXT NOT NULL, '
+      'isHidden INTEGER NOT NULL)');
+
+  db.execute('INSERT INTO profiles VALUES (?, ?, ?)',
+      ['profile-1', plantedSecret, Uint8List.fromList(List.filled(32, 7))]);
+  db.execute(
+    'INSERT INTO drives VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+    [
+      testDriveId,
+      'A private drive',
+      'owner-address-under-test',
+      'private',
+      'root-folder-id',
+      Uint8List.fromList(List.filled(32, 9)), // encryptedKey — must not travel
+      Uint8List.fromList(List.filled(12, 3)), // keyEncryptionIv — likewise
+      1814228,
+    ],
+  );
+
+  final stmt = db.prepare('INSERT INTO file_revisions VALUES '
+      '(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)');
+  for (var i = 0; i < fileRows; i++) {
+    stmt.execute([
+      'file-$i',
+      testDriveId,
+      'document_$i.pdf',
+      'folder-${i % 17}',
+      1000 + i,
+      1639422086000 + i * 1000,
+      'application/pdf',
+      'metadata-tx-$i',
+      'data-tx-$i',
+      1639422086000 + i * 1000,
+      'create',
+      0,
+    ]);
+  }
+  stmt.dispose();
+}
+
+/// Creates the destination tables an importing client would already have.
+void createTargetDatabase(CommonDatabase db) {
+  db.execute('CREATE TABLE drives ('
+      'id TEXT NOT NULL, name TEXT, ownerAddress TEXT NOT NULL, '
+      'privacy TEXT NOT NULL, rootFolderId TEXT NOT NULL, '
+      'encryptedKey BLOB, keyEncryptionIv BLOB, lastBlockHeight INTEGER)');
+  db.execute('CREATE TABLE file_revisions ('
+      'fileId TEXT NOT NULL, driveId TEXT NOT NULL, name TEXT NOT NULL, '
+      'parentFolderId TEXT NOT NULL, size INTEGER NOT NULL, '
+      'lastModifiedDate INTEGER NOT NULL, dataContentType TEXT, '
+      'metadataTxId TEXT NOT NULL, dataTxId TEXT NOT NULL, '
+      'dateCreated INTEGER NOT NULL, action TEXT NOT NULL, '
+      'isHidden INTEGER NOT NULL)');
+}
+
+bool bytesContain(Uint8List haystack, String needle) {
+  final n = needle.codeUnits;
+  outer:
+  for (var i = 0; i + n.length <= haystack.length; i++) {
+    for (var j = 0; j < n.length; j++) {
+      if (haystack[i + j] != n[j]) continue outer;
+    }
+    return true;
+  }
+  return false;
+}
+
+/// [platform] names the run in test output. [pathFor] maps a bare name onto
+/// whatever this platform calls a path. [reset] clears any state between tests.
+void runAttachPrototypeSuite({
+  required String platform,
+  required DatabaseOpener open,
+  required ByteReader readBytes,
+  required ByteWriter writeBytes,
+  required String Function(String name) pathFor,
+  required void Function() reset,
+}) {
+  group('[$platform] D12 prototype', () {
+    setUp(reset);
+
+    test('case 1: ATTACH builds an artifact, and its bytes come back out',
+        () {
+      final source = open(pathFor('source.db'));
+      createSourceDatabase(source);
+
+      final bytes = buildArtifact(
+        source,
+        artifactPath: pathFor('artifact.db'),
+        driveId: testDriveId,
+        version: '1.0',
+        blockEnd: 1814228,
+        readBytes: readBytes,
+      );
+      source.dispose();
+
+      // A SQLite file, and a non-trivial one.
+      expect(bytes.length, greaterThan(4096));
+      expect(String.fromCharCodes(bytes.sublist(0, 15)), 'SQLite format 3');
+    });
+
+    test('case 2: a received artifact ATTACHes and merges with INSERT…SELECT',
+        () {
+      final source = open(pathFor('source.db'));
+      createSourceDatabase(source);
+      final bytes = buildArtifact(
+        source,
+        artifactPath: pathFor('artifact.db'),
+        driveId: testDriveId,
+        version: '1.0',
+        blockEnd: 1814228,
+        readBytes: readBytes,
+      );
+      source.dispose();
+
+      final target = open(pathFor('target.db'));
+      createTargetDatabase(target);
+
+      final merged = importArtifact(
+        target,
+        bytes,
+        artifactPath: pathFor('received.db'),
+        expectedVersion: '1.0',
+        expectedDriveId: testDriveId,
+        writeBytes: writeBytes,
+      );
+
+      expect(merged, 500);
+      expect(
+        target.select('SELECT count(*) AS c FROM file_revisions').single['c'],
+        500,
+      );
+      expect(
+        target.select('SELECT name FROM file_revisions WHERE fileId = ?',
+            ['file-42']).single['name'],
+        'document_42.pdf',
+      );
+      expect(
+        target.select('SELECT privacy FROM drives').single['privacy'],
+        'private',
+      );
+      target.dispose();
+    });
+
+    test('the artifact carries no key material, because none was ever written',
+        () {
+      final source = open(pathFor('source.db'));
+      createSourceDatabase(source);
+      final bytes = buildArtifact(
+        source,
+        artifactPath: pathFor('artifact.db'),
+        driveId: testDriveId,
+        version: '1.0',
+        blockEnd: 1814228,
+        readBytes: readBytes,
+      );
+      source.dispose();
+
+      expect(bytesContain(bytes, plantedSecret), isFalse,
+          reason: 'profiles.encryptedWallet reached the artifact');
+      expect(bytesContain(bytes, 'profiles'), isFalse,
+          reason: 'the word "profiles" appears in the artifact at all');
+      expect(bytesContain(bytes, 'encryptedKey'), isFalse,
+          reason: 'the drives projection leaked a withheld column name');
+    });
+
+    test('tear-down leaks the secret whenever secure_delete is off', () {
+      // The obvious implementation is to copy the whole database and then
+      // delete what must not ship. This test is why D12 does not do that.
+      //
+      // SQLite reclaims dropped pages to the freelist. Whether it *zeroes*
+      // them first is decided by `secure_delete`, a per-connection pragma
+      // whose compiled-in default varies by build — so the safety of
+      // tear-down is not a property of the code, it is a property of whichever
+      // SQLite the client happens to be running. Measured here rather than
+      // assumed, on both platforms, because they are different builds.
+      final probe = open(pathFor('probe.db'));
+      final platformDefault =
+          probe.select('PRAGMA secure_delete').single.values.first;
+      probe.dispose();
+      printOnFailure('$platform secure_delete default = $platformDefault');
+
+      final source = open(pathFor('source.db'));
+      source.execute('PRAGMA secure_delete = 0');
+      createSourceDatabase(source);
+      source.execute('DROP TABLE profiles');
+      source.dispose();
+
+      expect(
+        bytesContain(readBytes(pathFor('source.db')), plantedSecret),
+        isTrue,
+        reason: 'With secure_delete off, DROP TABLE left the wallet ciphertext '
+            'in the file. That is the failure D12 removes by never writing it.',
+      );
+    });
+
+    test('the platform default for secure_delete is recorded, not relied on',
+        () {
+      final db = open(pathFor('probe.db'));
+      final value = db.select('PRAGMA secure_delete').single.values.first;
+      db.dispose();
+      // No assertion on the value: the point is that D12 must hold whatever
+      // it is. Printed so the prototype's findings can quote it per platform.
+      print('[$platform] PRAGMA secure_delete default = $value');
+      expect(value, anyOf(0, 1, 2));
+    });
+
+    test('the pipeline holds at 20,000 rows, with no row becoming an object',
+        () {
+      // Not a memory measurement — a browser test cannot take one. What it
+      // does show is that both halves are pure SQL at size: no Dart object is
+      // constructed per row anywhere in `artifact_pipeline.dart`, so whatever
+      // SQLite's page cache costs is the whole cost.
+      final source = open(pathFor('source.db'));
+      createSourceDatabase(source, fileRows: 20000);
+
+      final built = DateTime.now();
+      final bytes = buildArtifact(
+        source,
+        artifactPath: pathFor('artifact.db'),
+        driveId: testDriveId,
+        version: '1.0',
+        blockEnd: 1814228,
+        readBytes: readBytes,
+      );
+      final buildMs = DateTime.now().difference(built).inMilliseconds;
+      source.dispose();
+
+      final target = open(pathFor('target.db'));
+      createTargetDatabase(target);
+      final imported = DateTime.now();
+      final merged = importArtifact(
+        target,
+        bytes,
+        artifactPath: pathFor('received.db'),
+        expectedVersion: '1.0',
+        expectedDriveId: testDriveId,
+        writeBytes: writeBytes,
+      );
+      final importMs = DateTime.now().difference(imported).inMilliseconds;
+
+      expect(merged, 20000);
+      expect(
+        target.select('SELECT count(*) AS c FROM file_revisions').single['c'],
+        20000,
+      );
+      target.dispose();
+
+      print('[$platform] 20k rows: artifact ${bytes.length} B, '
+          'build $buildMs ms, import $importMs ms');
+    }, timeout: const Timeout(Duration(minutes: 3)));
+
+    group('the read gate refuses', () {
+      late Uint8List good;
+
+      setUp(() {
+        final source = open(pathFor('source.db'));
+        createSourceDatabase(source);
+        good = buildArtifact(
+          source,
+          artifactPath: pathFor('artifact.db'),
+          driveId: testDriveId,
+          version: '1.0',
+          blockEnd: 1814228,
+          readBytes: readBytes,
+        );
+        source.dispose();
+      });
+
+      Uint8List tamper(void Function(CommonDatabase db) change) {
+        writeBytes(pathFor('tampered.db'), good);
+        final db = open(pathFor('tampered.db'));
+        change(db);
+        db.dispose();
+        return readBytes(pathFor('tampered.db'));
+      }
+
+      void expectRejected(Uint8List bytes, ArtifactRejection reason) {
+        final target = open(pathFor('target.db'));
+        createTargetDatabase(target);
+        expect(
+          () => importArtifact(
+            target,
+            bytes,
+            artifactPath: pathFor('received.db'),
+            expectedVersion: '1.0',
+            expectedDriveId: testDriveId,
+            writeBytes: writeBytes,
+          ),
+          throwsA(isA<ArtifactRejected>()
+              .having((e) => e.reason, 'reason', reason)),
+        );
+        // Nothing was written before the refusal.
+        expect(
+          target.select('SELECT count(*) AS c FROM file_revisions').single['c'],
+          0,
+        );
+        target.dispose();
+      }
+
+      test('a view — the classic hostile-schema vector', () {
+        expectRejected(
+          tamper((db) => db.execute(
+              'CREATE VIEW sneaky AS SELECT * FROM file_revisions')),
+          ArtifactRejection.unexpectedSchema,
+        );
+      });
+
+      test('a trigger', () {
+        expectRejected(
+          tamper((db) => db.execute('CREATE TRIGGER t AFTER INSERT ON meta '
+              'BEGIN DELETE FROM file_revisions; END')),
+          ArtifactRejection.unexpectedSchema,
+        );
+      });
+
+      test('an extra table', () {
+        expectRejected(
+          tamper((db) => db.execute('CREATE TABLE extra (x TEXT)')),
+          ArtifactRejection.unexpectedSchema,
+        );
+      });
+
+      test('an entity count that disagrees with the body', () {
+        expectRejected(
+          tamper((db) => db.execute('UPDATE meta SET entityCount = 9999')),
+          ArtifactRejection.entityCountMismatch,
+        );
+      });
+
+      test('a drive id that is not the one being synced', () {
+        expectRejected(
+          tamper((db) => db.execute("UPDATE meta SET driveId = 'other-drive'")),
+          ArtifactRejection.driveIdMismatch,
+        );
+      });
+
+      test('a version this reader does not implement', () {
+        expectRejected(
+          tamper((db) => db.execute("UPDATE meta SET version = '2.0'")),
+          ArtifactRejection.versionMismatch,
+        );
+      });
+    });
+  });
+}

--- a/test/drive_state_prototype/storage_probe_smoke_test.dart
+++ b/test/drive_state_prototype/storage_probe_smoke_test.dart
@@ -1,0 +1,159 @@
+@TestOn('browser')
+library;
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import 'package:test/test.dart';
+
+@JS('eval')
+external JSAny? _eval(String code);
+
+const probeJs = r"""
+// Reports which drift WasmStorageImplementation this origin would get.
+//
+// Paste into the DevTools console on the page you want to test. Reproduces the
+// decision in drift 2.16's WasmDatabaseOpener.probe() (lib/src/web/wasm_setup.dart
+// and wasm_setup/shared.dart) using the same feature checks, in the same worker
+// scopes, without needing drift itself.
+//
+// Tiers, best first: opfsShared, opfsLocks, sharedIndexedDb, unsafeIndexedDb,
+// inMemory. Only the two opfs tiers give bounded memory; the indexedDb tiers
+// hold the whole database in RAM.
+(async () => {
+  // Runs inside BOTH a dedicated worker and a shared worker's nested worker.
+  const workerProbe = `
+    async function checkOpfs() {
+      try {
+        if (!navigator.storage || !navigator.storage.getDirectory) return false;
+        const root = await navigator.storage.getDirectory();
+        const fh = await root.getFileHandle('_drift_feature_detection', {create: true});
+        const h = await fh.createSyncAccessHandle();
+        // Older drafts made getSize() async; drift rejects those browsers.
+        const size = h.getSize();
+        const ok = typeof size === 'number';
+        if (size instanceof Promise) await size;
+        h.close();
+        await root.removeEntry('_drift_feature_detection').catch(() => {});
+        return ok;
+      } catch (e) { return false; }
+    }
+    async function checkIdb() {
+      try {
+        if (typeof indexedDB === 'undefined') return false;
+        await new Promise((res, rej) => {
+          const r = indexedDB.open('_drift_feature_detection');
+          r.onsuccess = () => { r.result.close(); res(); };
+          r.onerror = () => rej(r.error);
+        });
+        indexedDB.deleteDatabase('_drift_feature_detection');
+        return true;
+      } catch (e) { return false; }
+    }
+    async function report() {
+      return {
+        nestedWorkers: typeof Worker !== 'undefined',
+        sharedArrayBuffers: typeof SharedArrayBuffer !== 'undefined',
+        opfs: await checkOpfs(),
+        indexedDb: await checkIdb(),
+      };
+    }`;
+
+  const dedicatedSrc = workerProbe +
+    `\nreport().then(r => postMessage(r));`;
+
+  // A shared worker cannot touch OPFS itself; drift asks whether it can spawn a
+  // dedicated worker that can. That nesting is the Firefox-only part.
+  const sharedSrc = `
+    onconnect = (e) => {
+      const port = e.ports[0];
+      (async () => {
+        let nested = typeof Worker !== 'undefined';
+        let nestedOpfs = false, idb = false;
+        try {
+          ${workerProbe.replace(/\n/g, '\n          ')}
+          idb = await checkIdb();
+        } catch (err) { }
+        if (nested) {
+          try {
+            const inner = new Worker(URL.createObjectURL(new Blob([
+              ${JSON.stringify(dedicatedSrc)}
+            ], {type: 'text/javascript'})));
+            nestedOpfs = await new Promise((res) => {
+              const t = setTimeout(() => res(false), 5000);
+              inner.onmessage = (m) => { clearTimeout(t); res(!!m.data.opfs); };
+              inner.onerror = () => { clearTimeout(t); res(false); };
+            });
+          } catch (err) { nested = false; }
+        }
+        port.postMessage({nested, nestedOpfs, indexedDb: idb});
+      })();
+    };`;
+
+  const blobUrl = (src) =>
+    URL.createObjectURL(new Blob([src], {type: 'text/javascript'}));
+
+  const runDedicated = () => new Promise((res) => {
+    try {
+      const w = new Worker(blobUrl(dedicatedSrc));
+      const t = setTimeout(() => res(null), 8000);
+      w.onmessage = (m) => { clearTimeout(t); w.terminate(); res(m.data); };
+      w.onerror = () => { clearTimeout(t); res(null); };
+    } catch (e) { res(null); }
+  });
+
+  const runShared = () => new Promise((res) => {
+    if (typeof SharedWorker === 'undefined') return res(null);
+    try {
+      const w = new SharedWorker(blobUrl(sharedSrc), 'drift probe');
+      const t = setTimeout(() => res(null), 10000);
+      w.port.onmessage = (m) => { clearTimeout(t); res(m.data); };
+      w.onerror = () => { clearTimeout(t); res(null); };
+      w.port.start();
+    } catch (e) { res(null); }
+  });
+
+  const [dedicated, shared] = await Promise.all([runDedicated(), runShared()]);
+
+  const available = [];
+  if (shared && shared.nested && shared.nestedOpfs) available.push('opfsShared');
+  if (dedicated && dedicated.nestedWorkers && dedicated.opfs &&
+      dedicated.sharedArrayBuffers) available.push('opfsLocks');
+  if (shared && shared.indexedDb) available.push('sharedIndexedDb');
+  if (dedicated && dedicated.indexedDb) available.push('unsafeIndexedDb');
+  available.push('inMemory');
+
+  const chosen = available[0];
+  const bounded = chosen === 'opfsShared' || chosen === 'opfsLocks';
+
+  console.log('%c drift storage probe ', 'background:#222;color:#fff');
+  console.log('origin                :', location.origin);
+  console.log('crossOriginIsolated   :', self.crossOriginIsolated);
+  console.log('SharedArrayBuffer     :', typeof SharedArrayBuffer !== 'undefined');
+  console.log('dedicated worker      :', dedicated);
+  console.log('shared worker         :', shared);
+  console.log('available (best first):', available);
+  console.log('%cWOULD USE: ' + chosen, 'font-weight:bold;font-size:14px');
+  console.log(bounded
+    ? 'Bounded memory: YES (OPFS, paged on disk)'
+    : 'Bounded memory: NO — the whole database is held in RAM');
+  return {origin: location.origin, chosen, bounded, available, dedicated, shared,
+          crossOriginIsolated: self.crossOriginIsolated};
+})();
+
+""";
+
+void main() {
+  test('the console probe runs and returns a verdict', () async {
+    final result = await (_eval(probeJs) as JSPromise).toDart;
+    final o = result as JSObject;
+    final chosen = (o.getProperty('chosen'.toJS) as JSString).toDart;
+    // ignore: avoid_print
+    print('probe chose: $chosen  (coi='
+        '${(o.getProperty('crossOriginIsolated'.toJS) as JSBoolean?)?.toDart})');
+    expect(
+      chosen,
+      anyOf('opfsShared', 'opfsLocks', 'sharedIndexedDb', 'unsafeIndexedDb',
+          'inMemory'),
+    );
+  }, timeout: const Timeout(Duration(minutes: 2)));
+}

--- a/tool/drift_storage_probe.js
+++ b/tool/drift_storage_probe.js
@@ -1,0 +1,130 @@
+// Reports which drift WasmStorageImplementation this origin would get.
+//
+// Paste into the DevTools console on the page you want to test. Reproduces the
+// decision in drift 2.16's WasmDatabaseOpener.probe() (lib/src/web/wasm_setup.dart
+// and wasm_setup/shared.dart) using the same feature checks, in the same worker
+// scopes, without needing drift itself.
+//
+// Tiers, best first: opfsShared, opfsLocks, sharedIndexedDb, unsafeIndexedDb,
+// inMemory. Only the two opfs tiers give bounded memory; the indexedDb tiers
+// hold the whole database in RAM.
+(async () => {
+  // Runs inside BOTH a dedicated worker and a shared worker's nested worker.
+  const workerProbe = `
+    async function checkOpfs() {
+      try {
+        if (!navigator.storage || !navigator.storage.getDirectory) return false;
+        const root = await navigator.storage.getDirectory();
+        const fh = await root.getFileHandle('_drift_feature_detection', {create: true});
+        const h = await fh.createSyncAccessHandle();
+        // Older drafts made getSize() async; drift rejects those browsers.
+        const size = h.getSize();
+        const ok = typeof size === 'number';
+        if (size instanceof Promise) await size;
+        h.close();
+        await root.removeEntry('_drift_feature_detection').catch(() => {});
+        return ok;
+      } catch (e) { return false; }
+    }
+    async function checkIdb() {
+      try {
+        if (typeof indexedDB === 'undefined') return false;
+        await new Promise((res, rej) => {
+          const r = indexedDB.open('_drift_feature_detection');
+          r.onsuccess = () => { r.result.close(); res(); };
+          r.onerror = () => rej(r.error);
+        });
+        indexedDB.deleteDatabase('_drift_feature_detection');
+        return true;
+      } catch (e) { return false; }
+    }
+    async function report() {
+      return {
+        nestedWorkers: typeof Worker !== 'undefined',
+        sharedArrayBuffers: typeof SharedArrayBuffer !== 'undefined',
+        opfs: await checkOpfs(),
+        indexedDb: await checkIdb(),
+      };
+    }`;
+
+  const dedicatedSrc = workerProbe +
+    `\nreport().then(r => postMessage(r));`;
+
+  // A shared worker cannot touch OPFS itself; drift asks whether it can spawn a
+  // dedicated worker that can. That nesting is the Firefox-only part.
+  const sharedSrc = `
+    onconnect = (e) => {
+      const port = e.ports[0];
+      (async () => {
+        let nested = typeof Worker !== 'undefined';
+        let nestedOpfs = false, idb = false;
+        try {
+          ${workerProbe.replace(/\n/g, '\n          ')}
+          idb = await checkIdb();
+        } catch (err) { }
+        if (nested) {
+          try {
+            const inner = new Worker(URL.createObjectURL(new Blob([
+              ${JSON.stringify(dedicatedSrc)}
+            ], {type: 'text/javascript'})));
+            nestedOpfs = await new Promise((res) => {
+              const t = setTimeout(() => res(false), 5000);
+              inner.onmessage = (m) => { clearTimeout(t); res(!!m.data.opfs); };
+              inner.onerror = () => { clearTimeout(t); res(false); };
+            });
+          } catch (err) { nested = false; }
+        }
+        port.postMessage({nested, nestedOpfs, indexedDb: idb});
+      })();
+    };`;
+
+  const blobUrl = (src) =>
+    URL.createObjectURL(new Blob([src], {type: 'text/javascript'}));
+
+  const runDedicated = () => new Promise((res) => {
+    try {
+      const w = new Worker(blobUrl(dedicatedSrc));
+      const t = setTimeout(() => res(null), 8000);
+      w.onmessage = (m) => { clearTimeout(t); w.terminate(); res(m.data); };
+      w.onerror = () => { clearTimeout(t); res(null); };
+    } catch (e) { res(null); }
+  });
+
+  const runShared = () => new Promise((res) => {
+    if (typeof SharedWorker === 'undefined') return res(null);
+    try {
+      const w = new SharedWorker(blobUrl(sharedSrc), 'drift probe');
+      const t = setTimeout(() => res(null), 10000);
+      w.port.onmessage = (m) => { clearTimeout(t); res(m.data); };
+      w.onerror = () => { clearTimeout(t); res(null); };
+      w.port.start();
+    } catch (e) { res(null); }
+  });
+
+  const [dedicated, shared] = await Promise.all([runDedicated(), runShared()]);
+
+  const available = [];
+  if (shared && shared.nested && shared.nestedOpfs) available.push('opfsShared');
+  if (dedicated && dedicated.nestedWorkers && dedicated.opfs &&
+      dedicated.sharedArrayBuffers) available.push('opfsLocks');
+  if (shared && shared.indexedDb) available.push('sharedIndexedDb');
+  if (dedicated && dedicated.indexedDb) available.push('unsafeIndexedDb');
+  available.push('inMemory');
+
+  const chosen = available[0];
+  const bounded = chosen === 'opfsShared' || chosen === 'opfsLocks';
+
+  console.log('%c drift storage probe ', 'background:#222;color:#fff');
+  console.log('origin                :', location.origin);
+  console.log('crossOriginIsolated   :', self.crossOriginIsolated);
+  console.log('SharedArrayBuffer     :', typeof SharedArrayBuffer !== 'undefined');
+  console.log('dedicated worker      :', dedicated);
+  console.log('shared worker         :', shared);
+  console.log('available (best first):', available);
+  console.log('%cWOULD USE: ' + chosen, 'font-weight:bold;font-size:14px');
+  console.log(bounded
+    ? 'Bounded memory: YES (OPFS, paged on disk)'
+    : 'Bounded memory: NO — the whole database is held in RAM');
+  return {origin: location.origin, chosen, bounded, available, dedicated, shared,
+          crossOriginIsolated: self.crossOriginIsolated};
+})();

--- a/tool/drive_state_prototype.sh
+++ b/tool/drive_state_prototype.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Runs the D12 ATTACH prototype on both platforms.
+#
+#   tool/drive_state_prototype.sh
+#
+# The browser half needs `sqlite3.wasm` served with CORS, because
+# `flutter test --platform chrome` serves only the compiled test bundle and not
+# the package's own files. This script fetches the build that matches the
+# resolved `sqlite3` package, serves it on 127.0.0.1:8099, runs both test
+# files, and stops the server again.
+#
+# It writes nothing outside .dart_tool/ and changes no application code.
+# See docs/drive-state/ATTACH_VFS_PROTOTYPE.md for what it proves.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+PORT=8099
+CACHE=".dart_tool/drive_state_prototype"
+WASM="$CACHE/sqlite3.wasm"
+
+version="$(awk '/^  sqlite3:$/{f=1} f&&/version:/{gsub(/"/,"",$2); print $2; exit}' pubspec.lock)"
+if [ -z "$version" ]; then
+  echo "could not read the sqlite3 version from pubspec.lock" >&2
+  exit 1
+fi
+
+mkdir -p "$CACHE"
+if [ ! -s "$WASM" ]; then
+  url="https://github.com/simolus3/sqlite3.dart/releases/download/sqlite3-$version/sqlite3.wasm"
+  echo "fetching sqlite3.wasm for sqlite3 $version"
+  echo "  $url"
+  if ! curl -fsSL -o "$WASM" "$url"; then
+    echo >&2
+    echo "Could not download sqlite3.wasm for sqlite3 $version." >&2
+    echo "The copy vendored at web/sqlite3.wasm will NOT work: it is built" >&2
+    echo "against a different ABI and fails with" >&2
+    echo '  LinkError: Import #0 "dart" "fs_delete"' >&2
+    exit 1
+  fi
+fi
+echo "using $WASM ($(wc -c < "$WASM" | tr -d ' ') bytes)"
+
+python3 - "$PWD/$CACHE" "$PORT" <<'PY' &
+import functools, http.server, sys
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def end_headers(self):
+        self.send_header('Access-Control-Allow-Origin', '*')
+        super().end_headers()
+    def log_message(self, *a):
+        pass
+http.server.HTTPServer(
+    ('127.0.0.1', int(sys.argv[2])),
+    functools.partial(Handler, directory=sys.argv[1]),
+).serve_forever()
+PY
+server=$!
+trap 'kill $server 2>/dev/null || true' EXIT
+
+for _ in $(seq 1 25); do
+  curl -sf -o /dev/null "http://127.0.0.1:$PORT/sqlite3.wasm" && break
+  sleep 0.2
+done
+
+echo
+echo "=== vm/ffi ==="
+flutter test test/drive_state_prototype/attach_vm_test.dart
+
+echo
+echo "=== web/wasm (chrome) ==="
+flutter test test/drive_state_prototype/attach_web_test.dart --platform chrome


### PR DESCRIPTION
Executes the two claims D12 rests on ([#2187 comment](https://github.com/ardriveapp/ardrive-web/pull/2187#issuecomment-5441998500)). Both hold.

D12 proposes making the drive state artifact a SQLite file rather than the JSON D1 chose. I argued it there from measurements, but the load-bearing part was unexecuted: *can a browser `ATTACH` a second database at all?* This branch answers that, and turns up three things that were not the question.

```
tool/drive_state_prototype.sh
```

| | vm/ffi | web/wasm (Chrome) |
|---|---|---|
| tests | 13 pass | 14 pass |
| SQLite | 3.45.1 | 3.45.1 |
| 20,000 rows → artifact | 3,194,880 B | 3,162,112 B |
| build | 37 ms | 460 ms |
| import | 45 ms | 461 ms |

**Case 1, the producer.** `ATTACH` an empty database, build the frozen schema, copy one drive's rows through an explicit column projection, `DETACH`, read the bytes back. On web the attached database is a real, separate VFS entry — the test asserts its first sixteen bytes are `SQLite format 3`.

**Case 2, the consumer.** Place received bytes, `ATTACH`, refuse anything that is not the exact agreed shape, merge with `INSERT INTO main.x SELECT … FROM artifact.x`. The read gate refuses all six cases it is given — a view, a trigger, an extra table, a disagreeing entity count, a foreign drive id, an unimplemented version — and the test asserts the target is still empty after each refusal.

No row becomes a Dart object in either direction. That is the property D12 is buying.

## Three findings that were not the question

**The app's web database is not a WASM VFS.** `lib/models/database/web.dart` opens `WebDatabase.withStorage(...)` — drift's **deprecated sql.js backend**, which is what `web/sql-wasm.wasm` and `web/index.html:332` are for. So "Drift's WASM VFS" in my D12 write-up describes something this app does not run. **Adopting D12 means migrating the web database layer to `drift/wasm.dart` first**, and that cost is not in the proposal. It should be costed before D12 is accepted — though the backend in use is deprecated, so the work is worth doing either way. The prototype therefore drives `package:sqlite3` directly, not Drift.

**`web/sqlite3.wasm` is dead weight, and broken anyway.** It and `web/worker.js` are referenced by nothing — not `index.html`, not `lib/`. The wasm also cannot load under the resolved `sqlite3: 2.4.2`:

```
LinkError: WebAssembly.instantiate(): Import #0 "dart" "fs_delete":
function import requires a callable
```

Wrong ABI; the matching build is 697,758 bytes against the vendored 1,348,108. Removing both files is an easy separate cleanup worth ~1.3 MB in the deployed build.

**`secure_delete` differs by platform, and the browser is the unsafe one.** D12 argues the artifact must be *built up* rather than *torn down*, because `DROP TABLE` leaves dropped bytes on the freelist. Measured, that is true only when `secure_delete` is off:

| build | `PRAGMA secure_delete` | tear-down result |
|---|---|---|
| vm/ffi (macOS) | `2` (fast) | secret **not** recoverable |
| web/wasm | `0` (off) | secret **recoverable in the file** |

**I stated that claim unconditionally in the D12 comment and should not have.** The correction narrows it and strengthens the conclusion: the platform where it holds is the browser, which is where the producer runs, and the safety of tear-down turns out to be a property of whichever SQLite the client links rather than of our code. That is not an acceptable thing to stand between a user's wallet ciphertext and a permanent public upload. The suite asserts the leak under an explicit `PRAGMA secure_delete = 0` on both platforms and prints each default rather than depending on it.

## What this does not prove

- **Nothing about Drift.** Direct `package:sqlite3`; no `WasmDatabase`, and it never touches the sql.js backend the app runs on web today.
- **Nothing about OPFS.** The browser run uses `InMemoryFileSystem`, so the artifact is in memory. Bounded producer memory for a very large drive is exactly what an OPFS VFS would buy, and it is untested here.
- **No memory measurement.** A browser test cannot take one. "No row becomes a Dart object" is a property of the code, readable in `artifact_pipeline.dart`, not a measurement.
- **Not comparable to #2188's 4 s / 9 s.** 20,000 synthetic rows of one table against 41,767 files across seven sections, different columns. These timings show the pipeline is not pathological, not that it is 20× faster.
- **No encryption, signature, gzip or upload**, and `artifactProjection` is an illustrative column subset, not D2's real seven sections.

## Scope

Nothing imports application code and nothing is wired into the app. `flutter test` picks up the VM half; the browser half needs the script, because `flutter test --platform chrome` serves only the compiled test bundle and not the package's own files, so `sqlite3.wasm` has to be fetched and served with CORS. `sqlite3` is added as a dev dependency for the same reason.

This is a prototype for a decision, not a feature. If D12 is rejected, it should be deleted; if D12 is accepted, `artifact_pipeline.dart` is the shape the real thing takes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3CbaePfsFZsPqijauuBrD


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a prototype for creating and importing drive-state artifacts across VM and browser platforms.
  * Excludes sensitive profile and key data from exported artifacts.
  * Validates artifact integrity, schema, version, drive identity, and entity counts before importing.
  * Falls back to standard synchronization when artifacts are rejected.

* **Tests**
  * Added cross-platform coverage for artifact persistence, large datasets, secure deletion, and invalid artifacts.

* **Documentation**
  * Documented prototype findings, benchmarks, platform behavior, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->