### PR TITLE
chore: point the staging flavor's GraphQL at turbo-gateway.com

### DIFF
--- a/assets/config/staging.json
+++ b/assets/config/staging.json
@@ -1,6 +1,6 @@
 {
-  "configVersion": 2,
-  "defaultArweaveGatewayUrl": "https://ardrive.net",
+  "configVersion": 3,
+  "defaultArweaveGatewayUrl": "https://turbo-gateway.com",
   "defaultArweaveGatewayForDataRequest": {
     "label": "Turbo Gateway",
     "url": "https://turbo-gateway.com"


### PR DESCRIPTION
Staging already read its **data** from turbo-gateway.com but resolved **GraphQL** through `ardrive.net`.

| | Was | Now |
| --- | --- | --- |
| `defaultArweaveGatewayUrl` (GraphQL) | `https://ardrive.net` | `https://turbo-gateway.com` |
| `defaultArweaveGatewayForDataRequest` | turbo-gateway.com | unchanged |
| `configVersion` | 2 | 3 |

`ardrive.net` is a pure proxy of turbo-gateway.com — the same index behind it — so this is not a different data source, just one less layer in front of it. Exactly the shape of the fallback hop removed in #2195: a proxy that can rate limit or fail on its own while the backend is healthy.

`defaultArweaveGatewayUrl` is the GraphQL endpoint as well as the gateway name: `ArweaveService` runs it through `_graphqlUrlFromGateway`.

## Why the version bump is not optional

`ConfigFetcher` only replaces a stored config when the asset's `configVersion` is **greater** than the stored one. Without the bump, nobody who has already opened staging would ever see this change.

## Scope

Only `staging.json`. Turbo upload/payment URLs and the Stripe key are untouched. **`prod.json` still points GraphQL at `ardrive.net` and is deliberately not changed here** — worth a separate decision, since it carries the same proxy hop.

Staging deploys from `dev`, so this takes effect on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ndA5nwUpt9hGLUx2TAFr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated staging configuration to use the latest configuration version.
  * Switched the default Arweave gateway to Turbo Gateway.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->