### PR TITLE
chore: point production's GraphQL at turbo-gateway.com

### DIFF
--- a/assets/config/prod.json
+++ b/assets/config/prod.json
@@ -1,6 +1,6 @@
 {
-  "configVersion": 2,
-  "defaultArweaveGatewayUrl": "https://ardrive.net",
+  "configVersion": 3,
+  "defaultArweaveGatewayUrl": "https://turbo-gateway.com",
   "defaultArweaveGatewayForDataRequest": {
     "label": "Turbo Gateway",
     "url": "https://turbo-gateway.com"


### PR DESCRIPTION
Production read its **data** from turbo-gateway.com but resolved **GraphQL** through `ardrive.net`.

| | Was | Now |
| --- | --- | --- |
| `defaultArweaveGatewayUrl` (GraphQL) | `https://ardrive.net` | `https://turbo-gateway.com` |
| `defaultArweaveGatewayForDataRequest` | turbo-gateway.com | unchanged |
| `configVersion` | 2 | 3 |

`ardrive.net` is a pure proxy of turbo-gateway.com — the same index behind it — so this is not a different data source, just one less layer that can rate limit or fail while the backend is healthy. Combined with #2195, the pair becomes **turbo-gateway direct, falling back to Goldsky direct**.

## ⚠️ The version bump resets stored user settings

This is the part worth a second read before merging. `ConfigFetcher` does **not** merge — it replaces a stored config whose version is lower:

```dart
// The stored config is from a previous release. Replace it.
// Any developer-specific customizations will be reset, which is acceptable.
```

`updateAppConfig` is wired to user-facing settings, not only dev tools, so on production every user with a stored config is reset to these defaults. That includes:

- **`arweaveGatewayUrl`** — a gateway the user picked themselves in the profile panel (`profile_card.dart:802`). Putting everyone on turbo-gateway is the *intent* here, but it does override a deliberate choice.
- **`autoSync`** (`profile_card.dart:280`), and any Turbo upload/payment URL set in settings (`settings_popover.dart:154`).
- **AR.IO gateway detection does not re-run.** It only runs when there is no stored config at all, so someone being served through an AR.IO gateway loses data locality and is pinned to turbo-gateway.com.

Without the bump, though, this change reaches nobody who has already opened the app — so the bump is not optional, only its consequences are worth stating.

## Scope

Only `prod.json`. Data URL, Turbo service URLs and the Stripe key are untouched. Staging is handled separately in #2199.

Production deploys from `master`, so this reaches users when the next release merges — not on merge here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ndA5nwUpt9hGLUx2TAFr