### PR TITLE
fix: a wallet with enough drives could not sync at all

### DIFF
--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -18,6 +18,7 @@ import 'package:ardrive/models/folder_revision.dart';
 import 'package:ardrive/services/arweave/arweave.dart'
     hide SnapshotEntityTransaction;
 import 'package:ardrive/services/config/config.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:ardrive/sync/constants.dart';
 import 'package:ardrive/sync/data/snapshot_validation_service.dart';
 import 'package:ardrive/sync/domain/ghost_folder.dart';
@@ -61,6 +62,40 @@ const _txConfirmationBatchTimeout = Duration(seconds: 15);
 const _txStatusUpdateTimeout = Duration(seconds: 30);
 
 abstract class SyncRepository {
+  /// The total transaction-parse budget, shared out across the drives still to
+  /// be synced.
+  @visibleForTesting
+  static const maxTransactionParseBatchSize = 200;
+
+  /// How many transactions each remaining drive may parse per batch.
+  ///
+  /// The budget is divided by the drives left to sync, so a wallet with more of
+  /// them parses in smaller batches. Integer division makes that reach **zero**
+  /// once more than [maxTransactionParseBatchSize] drives remain, and
+  /// `BatchProcessor` throws `ArgumentError('Batch size cannot be 0')` on a
+  /// batch of zero - so past that point a wallet could not sync at all, and the
+  /// failure was an argument error rather than anything naming the cause.
+  ///
+  /// Clamped to at least one. A batch of one is slow; a batch of zero is a
+  /// crash. No wallet is known to hold that many drives today, so this is a
+  /// floor under a future scale rather than a fix for anyone's sync now.
+  ///
+  /// The subtraction is guarded too: `drivesSynced` reaching `drivesCount`
+  /// would divide by zero, which throws a different error for the same reason.
+  @visibleForTesting
+  static int transactionParseBatchSizeFor({
+    required int drivesCount,
+    required int drivesSynced,
+  }) {
+    final remaining = drivesCount - drivesSynced;
+
+    if (remaining <= 1) {
+      return maxTransactionParseBatchSize;
+    }
+
+    return max(1, maxTransactionParseBatchSize ~/ remaining);
+  }
+
   Stream<double> syncDriveById({
     required String driveId,
     required String ownerAddress,
@@ -311,16 +346,13 @@ class _SyncRepository implements SyncRepository {
         if (previouslySyncedDrives.isEmpty) {
           // All drives are never-synced; skip probe entirely
           if (neverSyncedDrives.isNotEmpty) {
-            logger.i(
-                '${neverSyncedDrives.length} drives need first-time sync');
+            logger.i('${neverSyncedDrives.length} drives need first-time sync');
           }
         } else {
           // Group previously-synced drives by owner for efficient probing
           final drivesByOwner = <String, List<Drive>>{};
           for (final drive in previouslySyncedDrives) {
-            drivesByOwner
-                .putIfAbsent(drive.ownerAddress, () => [])
-                .add(drive);
+            drivesByOwner.putIfAbsent(drive.ownerAddress, () => []).add(drive);
           }
 
           final activeDriveIds = <String>{};
@@ -353,8 +385,7 @@ class _SyncRepository implements SyncRepository {
 
           // Add previously-synced drives that have activity
           drivesToSync.addAll(
-            previouslySyncedDrives
-                .where((d) => activeDriveIds.contains(d.id)),
+            previouslySyncedDrives.where((d) => activeDriveIds.contains(d.id)),
           );
 
           final skipped = drives.length - drivesToSync.length;
@@ -362,8 +393,7 @@ class _SyncRepository implements SyncRepository {
             logger.i('Skipping $skipped unchanged drives');
           }
           if (neverSyncedDrives.isNotEmpty) {
-            logger.i(
-                '${neverSyncedDrives.length} drives need first-time sync');
+            logger.i('${neverSyncedDrives.length} drives need first-time sync');
           }
         }
       } catch (e) {
@@ -409,11 +439,10 @@ class _SyncRepository implements SyncRepository {
           // drives (lastBlockHeight=0) don't drag the query back to genesis.
           final syncedHeights = ownerDrives
               .where((d) => (d.lastBlockHeight ?? 0) > 0)
-              .map((d) =>
-                  _calculateSyncLastBlockHeight(d.lastBlockHeight ?? 0));
-          final minBlock = syncedHeights.isNotEmpty
-              ? syncedHeights.reduce(min)
-              : 0;
+              .map(
+                  (d) => _calculateSyncLastBlockHeight(d.lastBlockHeight ?? 0));
+          final minBlock =
+              syncedHeights.isNotEmpty ? syncedHeights.reduce(min) : 0;
 
           var queryFailed = false;
           final snapshotsStream = _arweave.getAllSnapshotsForDrives(
@@ -456,8 +485,7 @@ class _SyncRepository implements SyncRepository {
 
         final withSnapshots =
             prefetchedSnapshots.values.where((v) => v.isNotEmpty).length;
-        logger.i(
-            '[snapshot] prefetched '
+        logger.i('[snapshot] prefetched '
             '${prefetchedSnapshots.values.expand((v) => v).length} '
             'for $withSnapshots of ${prefetchedSnapshots.length} drive(s); '
             'the rest are known to have none and will not be re-queried');
@@ -498,14 +526,13 @@ class _SyncRepository implements SyncRepository {
                 ? 0
                 : _calculateSyncLastBlockHeight(drive.lastBlockHeight ?? 0),
             currentBlockHeight: currentBlockHeight,
-            transactionParseBatchSize:
-                200 ~/ (syncProgress.drivesCount - syncProgress.drivesSynced),
+            transactionParseBatchSize: _transactionParseBatchSize(syncProgress),
             ownerAddress: drive.ownerAddress,
             txFechedCallback: txFechedCallback,
             cancellationToken: token,
             prefetchedSnapshots: prefetchedSnapshots[drive.id],
-            skipPendingTxFetch: walletAddress != null &&
-                drive.ownerAddress != walletAddress,
+            skipPendingTxFetch:
+                walletAddress != null && drive.ownerAddress != walletAddress,
           );
 
           double currentDriveProgress = 0;
@@ -543,10 +570,10 @@ class _SyncRepository implements SyncRepository {
 
           final updatedFailedDrives =
               List<String>.from(syncProgress.failedDriveIds)..add(drive.id);
-          final updatedErrorMessages =
-              Map<String, String>.from(syncProgress.errorMessages)
-                ..putIfAbsent(
-                    drive.id, () => '${drive.name}: ${_extractErrorMessage(e)}');
+          final updatedErrorMessages = Map<String, String>.from(
+              syncProgress.errorMessages)
+            ..putIfAbsent(
+                drive.id, () => '${drive.name}: ${_extractErrorMessage(e)}');
 
           // Still increment progress but mark as failed (cap at 90%)
           totalProgress += 1;
@@ -665,8 +692,7 @@ class _SyncRepository implements SyncRepository {
                 onTimeout: () {
                   // Check if cancelled before timing out
                   token.checkCancellation();
-                  logger.w(
-                      'Transaction status update timed out after '
+                  logger.w('Transaction status update timed out after '
                       '${_txStatusUpdateTimeout.inSeconds}s');
                   // Update status message to indicate timeout but don't treat as error
                   syncProgress = syncProgress.copyWith(
@@ -803,8 +829,7 @@ class _SyncRepository implements SyncRepository {
     _skippedEntityTxIdsByDrive.clear();
 
     // Get the specific drive
-    final drive =
-        await _driveDao.driveById(driveId: driveId).getSingleOrNull();
+    final drive = await _driveDao.driveById(driveId: driveId).getSingleOrNull();
     if (drive == null) {
       yield SyncProgress.emptySyncCompleted();
       return;
@@ -849,8 +874,8 @@ class _SyncRepository implements SyncRepository {
           ownerAddress: drive.ownerAddress,
           txFechedCallback: txFechedCallback,
           cancellationToken: token,
-          skipPendingTxFetch: walletAddress != null &&
-              drive.ownerAddress != walletAddress,
+          skipPendingTxFetch:
+              walletAddress != null && drive.ownerAddress != walletAddress,
         );
 
         await for (var driveProgress in driveSyncProgress) {
@@ -958,8 +983,7 @@ class _SyncRepository implements SyncRepository {
             _txStatusUpdateTimeout,
             onTimeout: () {
               token.checkCancellation();
-              logger.w(
-                  'Transaction status update timed out after '
+              logger.w('Transaction status update timed out after '
                   '${_txStatusUpdateTimeout.inSeconds}s for single drive');
               syncProgress = syncProgress.copyWith(
                 statusMessage: 'Completing sync...',
@@ -990,7 +1014,8 @@ class _SyncRepository implements SyncRepository {
         syncProgressController.add(syncProgress);
         _logSkippedEntities();
 
-        logger.d('Single drive sync completed successfully, closing controller');
+        logger
+            .d('Single drive sync completed successfully, closing controller');
         await syncProgressController.close();
       } catch (e) {
         if (e is SyncCancelledException) {
@@ -1035,7 +1060,8 @@ class _SyncRepository implements SyncRepository {
       _folderIds.clear();
       // Remove any ghost folders for this drive from the instance map
       _ghostFolders.removeWhere((_, v) => v.driveId == driveId);
-      logger.d('Single drive sync failed with error, closing controller: $error');
+      logger
+          .d('Single drive sync failed with error, closing controller: $error');
       if (!syncProgressController.isClosed) {
         syncProgressController.addError(error);
         await syncProgressController.close();
@@ -1061,9 +1087,8 @@ class _SyncRepository implements SyncRepository {
 
     // Load all pending transactions and filter to this drive
     final allPendingTxs = await driveDao.pendingTransactions().get();
-    final drivePendingTxs = allPendingTxs
-        .where((tx) => driveDataTxIds.contains(tx.id))
-        .toList();
+    final drivePendingTxs =
+        allPendingTxs.where((tx) => driveDataTxIds.contains(tx.id)).toList();
 
     logger.i(
         'Loaded ${drivePendingTxs.length} pending transactions for drive (from ${allPendingTxs.length} total)');
@@ -1148,16 +1173,14 @@ class _SyncRepository implements SyncRepository {
           continue;
         }
 
-        final txConfirmed =
-            confirmationCount >= kRequiredTxConfirmationCount;
+        final txConfirmed = confirmationCount >= kRequiredTxConfirmationCount;
         final txNotFound = confirmationCount < 0;
 
         String? txStatus;
         DateTime? transactionDateCreated;
 
         if (pendingTxMap[txId]!.transactionDateCreated != null) {
-          transactionDateCreated =
-              pendingTxMap[txId]!.transactionDateCreated!;
+          transactionDateCreated = pendingTxMap[txId]!.transactionDateCreated!;
         } else {
           transactionDateCreated = dateCreatedCache[txId];
         }
@@ -1331,6 +1354,12 @@ class _SyncRepository implements SyncRepository {
     );
   }
 
+  int _transactionParseBatchSize(SyncProgress progress) =>
+      SyncRepository.transactionParseBatchSizeFor(
+        drivesCount: progress.drivesCount,
+        drivesSynced: progress.drivesSynced,
+      );
+
   int _calculateSyncLastBlockHeight(int lastBlockHeight) {
     logger.d('Calculating sync last block height: $lastBlockHeight');
     if (_lastSync != null) {
@@ -1495,8 +1524,7 @@ class _SyncRepository implements SyncRepository {
           continue;
         }
 
-        final txConfirmed =
-            confirmationCount >= kRequiredTxConfirmationCount;
+        final txConfirmed = confirmationCount >= kRequiredTxConfirmationCount;
         final txNotFound = confirmationCount < 0;
 
         String? txStatus;
@@ -1504,8 +1532,7 @@ class _SyncRepository implements SyncRepository {
         DateTime? transactionDateCreated;
 
         if (pendingTxMap[txId]!.transactionDateCreated != null) {
-          transactionDateCreated =
-              pendingTxMap[txId]!.transactionDateCreated!;
+          transactionDateCreated = pendingTxMap[txId]!.transactionDateCreated!;
         } else {
           transactionDateCreated = dateCreatedCache[txId];
         }
@@ -1552,7 +1579,6 @@ class _SyncRepository implements SyncRepository {
       );
     }
   }
-
 
   bool _isOverThePendingTime(DateTime? transactionCreatedDate) {
     // If don't have the date information we cannot assume that is over the pending time
@@ -1615,8 +1641,8 @@ class _SyncRepository implements SyncRepository {
         final source = prefetchedSnapshots != null ? 'prefetched' : 'per-drive';
         final snapshotsStream = prefetchedSnapshots != null
             ? Stream.fromIterable(prefetchedSnapshots)
-            : _arweave.getAllSnapshotsOfDrive(
-                driveId, lastBlockHeight, ownerAddress: ownerAddress);
+            : _arweave.getAllSnapshotsOfDrive(driveId, lastBlockHeight,
+                ownerAddress: ownerAddress);
 
         snapshotItems = await SnapshotItem.instantiateAll(
           snapshotsStream,
@@ -1830,16 +1856,14 @@ class _SyncRepository implements SyncRepository {
       } else {
         // Check local DB first: only query the gateway if we have
         // locally-tracked pending transactions for this drive
-        final localPending = await _driveDao
-            .pendingTransactionsForDrive(driveId: driveId)
-            .get();
+        final localPending =
+            await _driveDao.pendingTransactionsForDrive(driveId: driveId).get();
 
         if (localPending.isEmpty) {
           logger.d(
               'No locally pending transactions for drive ${drive.id}, skipping GQL query');
         } else {
-          logger.d(
-              'Fetching pending transactions for drive ${drive.id} '
+          logger.d('Fetching pending transactions for drive ${drive.id} '
               '(${localPending.length} locally pending)');
 
           try {

--- a/test/sync/domain/sync_transaction_parse_batch_size_test.dart
+++ b/test/sync/domain/sync_transaction_parse_batch_size_test.dart
@@ -1,0 +1,63 @@
+import 'package:ardrive/sync/domain/repositories/sync_repository.dart';
+import 'package:ardrive/sync/utils/batch_processor.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The transaction-parse budget is shared out across the drives left to sync,
+/// and the sharing is integer division - so the interesting cases are all at
+/// the bottom of the range, where it rounds to nothing.
+void main() {
+  int sizeFor(int drivesCount, {int drivesSynced = 0}) =>
+      SyncRepository.transactionParseBatchSizeFor(
+        drivesCount: drivesCount,
+        drivesSynced: drivesSynced,
+      );
+
+  group('transaction parse batch size', () {
+    test('shares the budget across the drives still to sync', () {
+      expect(sizeFor(1), SyncRepository.maxTransactionParseBatchSize);
+      expect(sizeFor(2), 100);
+      expect(sizeFor(4), 50);
+      expect(sizeFor(200), 1);
+    });
+
+    test('counts only the drives that have not been synced yet', () {
+      // Four drives with two already done leaves two to share the budget.
+      expect(sizeFor(4, drivesSynced: 2), 100);
+    });
+
+    test('never returns zero, however many drives there are', () {
+      // The bug this exists for: `200 ~/ remaining` is integer division, so at
+      // 201 remaining drives it rounds to zero - and a batch size of zero is
+      // not a small batch, it is an ArgumentError out of `BatchProcessor`.
+      for (final drives in [201, 500, 5000]) {
+        expect(
+          sizeFor(drives),
+          greaterThan(0),
+          reason: '$drives drives must still produce a usable batch size',
+        );
+      }
+    });
+
+    test('the clamped size is one `BatchProcessor` will accept', () async {
+      // Tying the two halves together, because the clamp is only correct in
+      // terms of what the consumer rejects.
+      final batchSize = sizeFor(5000);
+
+      expect(
+        () => BatchProcessor().batchProcess<int>(
+          list: const [1, 2, 3],
+          batchSize: batchSize,
+          endOfBatchCallback: (_) => const Stream<double>.empty(),
+        ),
+        returnsNormally,
+      );
+    });
+
+    test('a fully synced wallet does not divide by zero', () {
+      // `drivesSynced == drivesCount` leaves nothing to divide by. Reachable or
+      // not, it throws for the same reason the zero batch did.
+      expect(() => sizeFor(3, drivesSynced: 3), returnsNormally);
+      expect(sizeFor(3, drivesSynced: 3), greaterThan(0));
+    });
+  });
+}

--- a/test/sync/domain/sync_transaction_parse_batch_size_test.dart
+++ b/test/sync/domain/sync_transaction_parse_batch_size_test.dart
@@ -43,13 +43,19 @@ void main() {
       // terms of what the consumer rejects.
       final batchSize = sizeFor(5000);
 
-      expect(
-        () => BatchProcessor().batchProcess<int>(
-          list: const [1, 2, 3],
+      // Consumed, not merely called. `batchProcess` is `async*`, so its
+      // `batchSize` guard does not run until something listens - a test that
+      // only calls it passes with a batch size of zero, which is the single
+      // value the guard exists to reject.
+      //
+      // The list is mutable because `batchProcess` clears it.
+      await expectLater(
+        BatchProcessor().batchProcess<int>(
+          list: [1, 2, 3],
           batchSize: batchSize,
           endOfBatchCallback: (_) => const Stream<double>.empty(),
         ),
-        returnsNormally,
+        emitsDone,
       );
     });
 


### PR DESCRIPTION
The transaction-parse budget is shared across the drives still to be synced, and the sharing is integer division:

```dart
transactionParseBatchSize: 200 ~/ (drivesCount - drivesSynced)
```

Past 200 remaining drives that rounds to **zero**, and `BatchProcessor` rejects a zero batch outright:

```dart
if (batchSize <= 0) {
  throw ArgumentError('Batch size cannot be 0');
}
```

So at that scale sync did not get slower — it stopped, with an argument error naming nothing about drives or batching.

## The fix

Clamped to at least one. A batch of one is slow; a batch of zero is a crash. The subtraction is guarded too — `drivesSynced` reaching `drivesCount` divides by zero, which fails the same way for the same reason.

The policy moves onto `SyncRepository` as `transactionParseBatchSizeFor`, so what the number means can be read and tested without standing up a sync.

## Scope, honestly

**No wallet is known to hold 200+ drives**, so this is a floor under a future scale rather than a fix for anyone's sync today. That is exactly why it is one expression on its own, rather than continuing to wait inside #2162 with 28 other sync commits that need rebasing and re-review against the sync work that has landed since.

## Verification

`flutter analyze` clean; **1443 passing / 4 skipped** (5 new). The new test **fails without the clamp** — checked by reverting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ndA5nwUpt9hGLUx2TAFr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization reliability when processing transactions across multiple drives.
  * Prevented synchronization failures caused by invalid or zero-sized transaction batches.
  * Handled cases where all drives have already been synchronized without errors.

* **Tests**
  * Added coverage for transaction batch sizing across remaining and completed drives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->