### PR TITLE
fix: a preview timeout that measured duration, not silence

### DIFF
--- a/lib/services/arweave/data_gateway_fallback.dart
+++ b/lib/services/arweave/data_gateway_fallback.dart
@@ -132,15 +132,21 @@ class DataGatewayFallback {
   /// only way to tell a stall timeout from a deadline.
   final Duration _dataRequestTimeout;
 
+  /// Injectable for the same reason: the backstop is three minutes, and a test
+  /// has to be able to reach it to prove the connection is hung up.
+  final Duration _dataTotalTimeout;
+
   DataGatewayFallback({
     required ArioSDK arioSDK,
     Client Function()? clientFactory,
     @visibleForTesting Duration? syncRequestTimeout,
     @visibleForTesting Duration? syncLargeBodyRequestTimeout,
     @visibleForTesting Duration? dataRequestTimeout,
+    @visibleForTesting Duration? dataTotalTimeout,
   })  : _arioSDK = arioSDK,
         _clientFactory = clientFactory ?? Client.new,
         _dataRequestTimeout = dataRequestTimeout ?? _requestTimeout,
+        _dataTotalTimeout = dataTotalTimeout ?? _totalFetchTimeout,
         _syncRequestTimeout = syncRequestTimeout ?? _requestTimeout,
         _syncLargeBodyRequestTimeout =
             syncLargeBodyRequestTimeout ?? largeBodyRequestTimeout;
@@ -152,11 +158,25 @@ class DataGatewayFallback {
   ///
   /// If ALL gateways return 404, throws [TransactionNotFound].
   Future<Response> fetchData(String txId, Arweave primaryClient) async {
-    return _serialFetch(txId, primaryClient).timeout(_totalFetchTimeout,
-        onTimeout: () {
-      logger.w('Total fetch timeout exceeded for tx $txId');
-      throw Exception('Total fetch timeout exceeded for tx $txId');
-    });
+    // One client for the whole waterfall, so the backstop below has something
+    // to hang up with. `Future.timeout` does not cancel what it times out: the
+    // read would otherwise carry on buffering - up to the 100 MiB preview cap -
+    // and holding its connection long after the caller was told it had failed.
+    // Closing the client aborts the request in flight (`BrowserClient.close`
+    // fires its `AbortController`).
+    final httpClient = _clientFactory();
+
+    try {
+      return await _serialFetch(txId, primaryClient, httpClient: httpClient)
+          .timeout(_dataTotalTimeout, onTimeout: () {
+        logger.w('Total fetch timeout exceeded for tx $txId');
+        httpClient.close();
+
+        throw Exception('Total fetch timeout exceeded for tx $txId');
+      });
+    } finally {
+      httpClient.close();
+    }
   }
 
   /// Fetch transaction data for **sync** metadata reads.
@@ -260,7 +280,11 @@ class DataGatewayFallback {
     );
   }
 
-  Future<Response> _serialFetch(String txId, Arweave primaryClient) async {
+  Future<Response> _serialFetch(
+    String txId,
+    Arweave primaryClient, {
+    required Client httpClient,
+  }) async {
     final clients = await _buildClientList(primaryClient);
     var all404 = true;
 
@@ -288,7 +312,7 @@ class DataGatewayFallback {
         var retryable = false;
 
         try {
-          final response = await _tryGatewayStreamed(client, txId);
+          final response = await _tryGatewayStreamed(client, txId, httpClient);
           if (!isPrimary) {
             logger.i('Fallback gateway $gatewayName succeeded for tx $txId');
           }
@@ -628,13 +652,13 @@ class DataGatewayFallback {
   /// there and one less moving part.
   Future<Response> _tryGatewayStreamed(
     Arweave client,
-    String txId, {
+    String txId,
+    Client httpClient, {
     Duration? requestTimeout,
   }) async {
     final budget = requestTimeout ?? _dataRequestTimeout;
-    final httpClient = _clientFactory();
 
-    try {
+    {
       final request = Request(
         'GET',
         Uri.parse(
@@ -671,8 +695,6 @@ class DataGatewayFallback {
         headers: response.headers,
         reasonPhrase: response.reasonPhrase,
       );
-    } finally {
-      httpClient.close();
     }
   }
 

--- a/lib/services/arweave/data_gateway_fallback.dart
+++ b/lib/services/arweave/data_gateway_fallback.dart
@@ -670,6 +670,13 @@ class DataGatewayFallback {
       final response = await httpClient.send(request).timeout(budget);
 
       if (response.statusCode < 200 || response.statusCode > 208) {
+        // Nobody is going to read this body, and the client is shared by every
+        // gateway in the waterfall now - so an abandoned error response would
+        // hold its reader open for the rest of the run rather than until the
+        // end of this attempt. `getSandboxedTx` consumed the body whatever the
+        // status; streaming has to say so.
+        await response.stream.listen(null).cancel();
+
         throw _ErrorFromStatus(response.statusCode, txId);
       }
 

--- a/lib/services/arweave/data_gateway_fallback.dart
+++ b/lib/services/arweave/data_gateway_fallback.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import 'package:ardrive/components/sandboxed_transaction_view/arweave_sandbox_url.dart';
 import 'package:ardrive/download/download_exceptions.dart';
 import 'package:ardrive/services/arweave/arweave_service.dart';
 import 'package:ardrive/utils/logger.dart';
@@ -36,6 +37,7 @@ class DataGatewayFallback {
 
   static const _maxGarFallbacks = 2;
   static const _garListTimeout = Duration(seconds: 5);
+
   /// How long one gateway read waits before being abandoned.
   ///
   /// Ten seconds, not five. Sync reads run through [ArweaveService.runPooled],
@@ -66,7 +68,19 @@ class DataGatewayFallback {
 
   /// Total budget for a large-body read, covering both attempts.
   static const largeBodyTotalTimeout = Duration(seconds: 130);
-  static const _totalFetchTimeout = Duration(seconds: 25);
+
+  /// Backstop for the whole [fetchData] waterfall.
+  ///
+  /// Generous, and not a deadline anyone is meant to reach. Each attempt there
+  /// is bounded by silence rather than duration, so a hung gateway is dropped
+  /// in [_requestTimeout] and four of them cost well under a minute. What this
+  /// still catches is a gateway dribbling bytes indefinitely - fast enough
+  /// never to go quiet, too slow to ever finish.
+  ///
+  /// It was twenty five seconds, which was a deadline: a fifty megabyte
+  /// preview needed 2 MB/s to fit inside it, so the cap ended reads that were
+  /// working.
+  static const _totalFetchTimeout = Duration(minutes: 3);
   static const _hedgeDelay = Duration(milliseconds: 1500);
   static const _downloadTimeout = Duration(seconds: 15);
 
@@ -114,13 +128,19 @@ class DataGatewayFallback {
   final Duration _syncRequestTimeout;
   final Duration _syncLargeBodyRequestTimeout;
 
+  /// Injectable so a test can make a body outlive its own budget, which is the
+  /// only way to tell a stall timeout from a deadline.
+  final Duration _dataRequestTimeout;
+
   DataGatewayFallback({
     required ArioSDK arioSDK,
     Client Function()? clientFactory,
     @visibleForTesting Duration? syncRequestTimeout,
     @visibleForTesting Duration? syncLargeBodyRequestTimeout,
+    @visibleForTesting Duration? dataRequestTimeout,
   })  : _arioSDK = arioSDK,
         _clientFactory = clientFactory ?? Client.new,
+        _dataRequestTimeout = dataRequestTimeout ?? _requestTimeout,
         _syncRequestTimeout = syncRequestTimeout ?? _requestTimeout,
         _syncLargeBodyRequestTimeout =
             syncLargeBodyRequestTimeout ?? largeBodyRequestTimeout;
@@ -132,8 +152,8 @@ class DataGatewayFallback {
   ///
   /// If ALL gateways return 404, throws [TransactionNotFound].
   Future<Response> fetchData(String txId, Arweave primaryClient) async {
-    return _serialFetch(txId, primaryClient)
-        .timeout(_totalFetchTimeout, onTimeout: () {
+    return _serialFetch(txId, primaryClient).timeout(_totalFetchTimeout,
+        onTimeout: () {
       logger.w('Total fetch timeout exceeded for tx $txId');
       throw Exception('Total fetch timeout exceeded for tx $txId');
     });
@@ -170,9 +190,9 @@ class DataGatewayFallback {
     Arweave primaryClient, {
     bool largeBody = false,
   }) async {
-    return _syncFetch(txId, primaryClient, largeBody: largeBody).timeout(
-        largeBody ? largeBodyTotalTimeout : _syncTotalFetchTimeout,
-        onTimeout: () {
+    return _syncFetch(txId, primaryClient, largeBody: largeBody)
+        .timeout(largeBody ? largeBodyTotalTimeout : _syncTotalFetchTimeout,
+            onTimeout: () {
       logger.w('Total sync fetch timeout exceeded for tx $txId');
       throw Exception('Total sync fetch timeout exceeded for tx $txId');
     });
@@ -192,9 +212,8 @@ class DataGatewayFallback {
         return await _tryGateway(
           primaryClient,
           txId,
-          requestTimeout: largeBody
-              ? _syncLargeBodyRequestTimeout
-              : _syncRequestTimeout,
+          requestTimeout:
+              largeBody ? _syncLargeBodyRequestTimeout : _syncRequestTimeout,
         );
       } on _ErrorFromStatus catch (e) {
         // A 404 is NOT treated as final here, and the reasoning that said it
@@ -269,7 +288,7 @@ class DataGatewayFallback {
         var retryable = false;
 
         try {
-          final response = await _tryGateway(client, txId);
+          final response = await _tryGatewayStreamed(client, txId);
           if (!isPrimary) {
             logger.i('Fallback gateway $gatewayName succeeded for tx $txId');
           }
@@ -509,8 +528,8 @@ class DataGatewayFallback {
             if (all404) {
               completer.completeError(DownloadFileNotFoundException(txId));
             } else {
-              completer.completeError(
-                  DownloadNetworkException(txId, e.toString()));
+              completer
+                  .completeError(DownloadNetworkException(txId, e.toString()));
             }
           }
         }),
@@ -533,8 +552,8 @@ class DataGatewayFallback {
       try {
         final response = await _tryManifestGateway(client, txId);
         if (client != primaryClient) {
-          logger.i(
-              'Fallback gateway $gatewayName succeeded for manifest $txId');
+          logger
+              .i('Fallback gateway $gatewayName succeeded for manifest $txId');
         }
         return response;
       } on _ErrorFromStatus catch (e) {
@@ -587,6 +606,74 @@ class DataGatewayFallback {
     }
 
     return clients;
+  }
+
+  /// A gateway read whose budget measures **silence**, not duration.
+  ///
+  /// [_tryGateway] buffers the whole body behind one `Future`, and a `Future`
+  /// timeout is a deadline on the transfer - it cannot tell a gateway that has
+  /// stopped answering from fifty megabytes arriving perfectly well. Previews
+  /// are capped at 100 MiB, so under that deadline a large file could not be
+  /// read from any gateway: each was abandoned mid-body on any connection
+  /// slower than the file divided by the budget, and the user saw
+  /// "unpreviewable" for a file that was arriving fine.
+  ///
+  /// Reading the body as a stream makes the timeout fire only when no chunk
+  /// has arrived for that long. A slow body finishes; a dead gateway is still
+  /// dropped just as quickly. `BrowserClient` reads through a `ReadableStream`,
+  /// so this is chunk-wise on the web too, not only on the VM.
+  ///
+  /// Sync deliberately keeps [_tryGateway]: its reads are a few hundred bytes
+  /// each and there are hundreds of them, so a wall clock is the right shape
+  /// there and one less moving part.
+  Future<Response> _tryGatewayStreamed(
+    Arweave client,
+    String txId, {
+    Duration? requestTimeout,
+  }) async {
+    final budget = requestTimeout ?? _dataRequestTimeout;
+    final httpClient = _clientFactory();
+
+    try {
+      final request = Request(
+        'GET',
+        Uri.parse(
+          arweaveSandboxUrl(txId: txId, gatewayUrl: client.api.gatewayUrl) ??
+              '${client.api.gatewayUrl.origin}/$txId',
+        ),
+      );
+
+      final response = await httpClient.send(request).timeout(budget);
+
+      if (response.statusCode < 200 || response.statusCode > 208) {
+        throw _ErrorFromStatus(response.statusCode, txId);
+      }
+
+      final chunks = <List<int>>[];
+      var length = 0;
+
+      await for (final chunk in response.stream.timeout(budget)) {
+        chunks.add(chunk);
+        length += chunk.length;
+      }
+
+      final body = Uint8List(length);
+      var offset = 0;
+
+      for (final chunk in chunks) {
+        body.setRange(offset, offset + chunk.length, chunk);
+        offset += chunk.length;
+      }
+
+      return Response.bytes(
+        body,
+        response.statusCode,
+        headers: response.headers,
+        reasonPhrase: response.reasonPhrase,
+      );
+    } finally {
+      httpClient.close();
+    }
   }
 
   Future<Response> _tryGateway(

--- a/test/services/arweave/data_gateway_fallback_test.dart
+++ b/test/services/arweave/data_gateway_fallback_test.dart
@@ -26,6 +26,7 @@ class _FakeHttpClient extends BaseClient {
   final StreamedResponse Function(int attempt) _respond;
 
   int sends = 0;
+  bool closed = false;
 
   @override
   Future<StreamedResponse> send(BaseRequest request) async {
@@ -33,6 +34,9 @@ class _FakeHttpClient extends BaseClient {
 
     return _respond(sends);
   }
+
+  @override
+  void close() => closed = true;
 }
 
 StreamedResponse _streamed(String body, int status) =>
@@ -313,6 +317,38 @@ void main() {
           response.body,
           'chunk0chunk1chunk2chunk3chunk4chunk5chunk6chunk7'
           'chunk8chunk9');
+    });
+
+    test('the backstop hangs up on a read that outlives it', () async {
+      // `Future.timeout` does not cancel what it times out. Without closing the
+      // client the read would carry on buffering - up to the 100 MiB preview
+      // cap - and hold its connection long after the caller was told it had
+      // failed. Chunks keep arriving inside the per-chunk budget, so only the
+      // total can end this one.
+      final client = _FakeHttpClient(
+        (_) => StreamedResponse(
+          dribble(count: 50, gap: const Duration(milliseconds: 20)),
+          200,
+        ),
+      );
+
+      final bounded = DataGatewayFallback(
+        arioSDK: arioSDK,
+        clientFactory: () => client,
+        dataRequestTimeout: const Duration(milliseconds: 200),
+        dataTotalTimeout: const Duration(milliseconds: 120),
+      );
+
+      await expectLater(
+        bounded.fetchData(txId, primaryClient),
+        throwsA(isA<Object>()),
+      );
+
+      expect(
+        client.closed,
+        isTrue,
+        reason: 'the connection must be hung up, not left reading',
+      );
     });
 
     test('a gateway that goes quiet is still dropped', () async {

--- a/test/services/arweave/data_gateway_fallback_test.dart
+++ b/test/services/arweave/data_gateway_fallback_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:ardrive/services/arweave/arweave_service.dart';
 import 'package:ardrive/services/arweave/data_gateway_fallback.dart';
 import 'package:ario_sdk/ario_sdk.dart';
@@ -11,6 +13,30 @@ class _MockArioSDK extends Mock implements ArioSDK {}
 class _MockArweave extends Mock implements Arweave {}
 
 class _MockArweaveApi extends Mock implements ArweaveApi {}
+
+/// The HTTP client the preview waterfall reads through.
+///
+/// `fetchData` streams its body so its timeout measures silence rather than
+/// duration, which means it goes through `Client` rather than
+/// `ArweaveApi.getSandboxedTx`. Sync still uses the latter, so those tests keep
+/// mocking the api.
+class _FakeHttpClient extends BaseClient {
+  _FakeHttpClient(this._respond);
+
+  final StreamedResponse Function(int attempt) _respond;
+
+  int sends = 0;
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    sends += 1;
+
+    return _respond(sends);
+  }
+}
+
+StreamedResponse _streamed(String body, int status) =>
+    StreamedResponse(Stream.value(utf8.encode(body)), status);
 
 void main() {
   late _MockArioSDK arioSDK;
@@ -36,7 +62,8 @@ void main() {
   });
 
   group('fetchDataForSync — single configured gateway', () {
-    test('returns the response without retrying when the first attempt '
+    test(
+        'returns the response without retrying when the first attempt '
         'succeeds', () async {
       when(() => primaryApi.getSandboxedTx(txId))
           .thenAnswer((_) async => Response('metadata', 200));
@@ -62,7 +89,8 @@ void main() {
       expect(attempts, 2);
     });
 
-    test('gives up after two attempts on a persistent transient failure, so '
+    test(
+        'gives up after two attempts on a persistent transient failure, so '
         'the caller can skip the item', () async {
       when(() => primaryApi.getSandboxedTx(txId))
           .thenAnswer((_) async => Response('boom', 500));
@@ -116,9 +144,7 @@ void main() {
       var calls = 0;
       when(() => primaryApi.getSandboxedTx(txId)).thenAnswer((_) async {
         calls++;
-        return calls == 1
-            ? Response('boom', 500)
-            : Response('not found', 404);
+        return calls == 1 ? Response('boom', 500) : Response('not found', 404);
       });
 
       await expectLater(
@@ -244,11 +270,81 @@ void main() {
     });
   });
 
+  group('a preview budget measures silence, not duration', () {
+    /// Chunks spaced [gap] apart, so the whole body takes [count] * [gap] to
+    /// arrive while no single wait ever reaches the budget.
+    Stream<List<int>> dribble({
+      required int count,
+      required Duration gap,
+    }) async* {
+      for (var i = 0; i < count; i++) {
+        await Future<void>.delayed(gap);
+        yield utf8.encode('chunk$i');
+      }
+    }
+
+    test('a body that keeps arriving is never cut off for taking a while',
+        () async {
+      // The failure this exists for. `getSandboxedTx` buffers the whole body
+      // behind one `Future`, so its timeout was a deadline on the transfer -
+      // and a 48 MiB preview needs more than any budget sized for metadata.
+      // Every gateway was abandoned mid-body and the file was reported
+      // unpreviewable while it was arriving perfectly well.
+      //
+      // Ten chunks, 50ms apart, is 500ms of transfer under a 200ms budget: it
+      // completes only if the budget is measuring gaps rather than total time.
+      final client = _FakeHttpClient(
+        (_) => StreamedResponse(
+          dribble(count: 10, gap: const Duration(milliseconds: 50)),
+          200,
+        ),
+      );
+
+      final patient = DataGatewayFallback(
+        arioSDK: arioSDK,
+        clientFactory: () => client,
+        dataRequestTimeout: const Duration(milliseconds: 200),
+      );
+
+      final response = await patient.fetchData(txId, primaryClient);
+
+      expect(response.statusCode, 200);
+      expect(
+          response.body,
+          'chunk0chunk1chunk2chunk3chunk4chunk5chunk6chunk7'
+          'chunk8chunk9');
+    });
+
+    test('a gateway that goes quiet is still dropped', () async {
+      // The other half: patience must not become indifference. One chunk, then
+      // nothing for longer than the budget.
+      final client = _FakeHttpClient(
+        (_) => StreamedResponse(
+          dribble(count: 2, gap: const Duration(milliseconds: 400)),
+          200,
+        ),
+      );
+
+      final patient = DataGatewayFallback(
+        arioSDK: arioSDK,
+        clientFactory: () => client,
+        dataRequestTimeout: const Duration(milliseconds: 100),
+      );
+
+      await expectLater(
+        patient.fetchData(txId, primaryClient),
+        throwsA(isA<Object>()),
+      );
+    });
+  });
+
   group('waterfall preserved for non-sync paths', () {
     test('fetchData still consults the GAR (download/preview resilience)',
         () async {
-      when(() => primaryApi.getSandboxedTx(txId))
-          .thenAnswer((_) async => Response('metadata', 200));
+      fallback = DataGatewayFallback(
+        arioSDK: arioSDK,
+        clientFactory: () => _FakeHttpClient((_) => _streamed('metadata', 200)),
+      );
 
       await fallback.fetchData(txId, primaryClient);
 
@@ -269,7 +365,8 @@ void main() {
       verify(() => arioSDK.getGateways()).called(1);
     });
 
-    test('fetchData and fetchDataForSync differ in GAR usage for the same '
+    test(
+        'fetchData and fetchDataForSync differ in GAR usage for the same '
         'transaction', () async {
       when(() => primaryApi.getSandboxedTx(txId))
           .thenAnswer((_) async => Response('metadata', 200));
@@ -277,7 +374,12 @@ void main() {
       await fallback.fetchDataForSync(txId, primaryClient);
       verifyNever(() => arioSDK.getGateways());
 
-      await fallback.fetchData(txId, primaryClient);
+      DataGatewayFallback(
+        arioSDK: arioSDK,
+        clientFactory: () => _FakeHttpClient((_) => _streamed('metadata', 200)),
+      ).fetchData(txId, primaryClient).ignore();
+      await pumpEventQueue();
+
       verify(() => arioSDK.getGateways()).called(1);
     });
 
@@ -288,19 +390,22 @@ void main() {
     /// the configured gateway and nowhere else yet.
     test('retries the configured gateway once on a 404, then succeeds',
         () async {
-      var attempts = 0;
-      when(() => primaryApi.getSandboxedTx(txId)).thenAnswer((_) async {
-        attempts++;
-        return attempts == 1
-            ? Response('not found', 404)
-            : Response('metadata', 200);
-      });
+      final client = _FakeHttpClient(
+        (attempt) => attempt == 1
+            ? _streamed('not found', 404)
+            : _streamed('metadata', 200),
+      );
+
+      fallback = DataGatewayFallback(
+        arioSDK: arioSDK,
+        clientFactory: () => client,
+      );
 
       final response = await fallback.fetchData(txId, primaryClient);
 
       expect(response.statusCode, 200);
       expect(response.body, 'metadata');
-      verify(() => primaryApi.getSandboxedTx(txId)).called(2);
+      expect(client.sends, 2);
     });
 
     /// The extra attempt is for a gateway that is a beat behind, not one that
@@ -312,30 +417,40 @@ void main() {
       // keeps the assertion about retries free of any real network call.
       when(() => primaryApi.gatewayUrl)
           .thenReturn(Uri.parse('https://arweave.net'));
-      when(() => primaryApi.getSandboxedTx(txId))
-          .thenAnswer((_) async => Response('server error', 500));
+
+      final client = _FakeHttpClient((_) => _streamed('server error', 500));
+
+      fallback = DataGatewayFallback(
+        arioSDK: arioSDK,
+        clientFactory: () => client,
+      );
 
       await expectLater(
         fallback.fetchData(txId, primaryClient),
         throwsA(isA<Object>()),
       );
 
-      verify(() => primaryApi.getSandboxedTx(txId)).called(1);
+      expect(client.sends, 1);
     });
 
     test('a persistent 404 on the configured gateway is still not found',
         () async {
       when(() => primaryApi.gatewayUrl)
           .thenReturn(Uri.parse('https://arweave.net'));
-      when(() => primaryApi.getSandboxedTx(txId))
-          .thenAnswer((_) async => Response('not found', 404));
+
+      final client = _FakeHttpClient((_) => _streamed('not found', 404));
+
+      fallback = DataGatewayFallback(
+        arioSDK: arioSDK,
+        clientFactory: () => client,
+      );
 
       await expectLater(
         fallback.fetchData(txId, primaryClient),
         throwsA(isA<TransactionNotFound>()),
       );
 
-      verify(() => primaryApi.getSandboxedTx(txId)).called(2);
+      expect(client.sends, 2);
     });
 
     test('a drive signature read on the sync path never reaches the GAR',


### PR DESCRIPTION
A 48 MiB file could not be previewed from **any** gateway. Both attempts died at exactly the budget:

```
Gateway turbo-gateway.com failed for tx Y2qNfMZM...: TimeoutException after 0:00:10.000000
Gateway permagate.io      failed for tx Y2qNfMZM...: TimeoutException after 0:00:10.000000
```

Nothing was cold and nothing was broken. `getSandboxedTx` buffers the whole body behind one `Future`, and **a `Future` timeout is a deadline on the transfer** — so 10s meant *"this file must arrive at 5 MB/s"*. Previews are capped at 100 MiB, so any large file was abandoned mid-body by every gateway in turn while it was arriving perfectly well. Users saw "unpreviewable", and a second refresh sometimes beat the clock — which is why it looked intermittent.

Measured directly:

| | Result |
| --- | --- |
| `turbo-gateway.com/{tx}` | 302, 145 bytes, 0.39s |
| `{sandbox}.turbo-gateway.com/{tx}` | 200, **50,485,029 bytes**, 3.45s |

DNS 0.23s, TLS 0.47s — neither was the cost. The body was.

## The fix

The waterfall reads the body as a **stream**, and a `Stream` timeout fires only when no chunk has arrived for that long. The budget now means **silence**, which is what a timeout should mean: a slow body finishes, a dead gateway is still dropped in the same 10s.

`BrowserClient` in `http` 1.3.0 reads through a `ReadableStreamDefaultReader`, so this is chunk-wise on the web too, not only on the VM — verified before relying on it.

**No size thresholds and no larger per-read budget.** Those only move the cliff. The one constant that changed is the waterfall total, 25s → a 3 minute backstop; at 25s it was itself a deadline, needing 2 MB/s for the same file.

## Scope

Only the preview waterfall. `_syncFetch` keeps the buffered read and its own budget — sync's reads are a few hundred bytes each and there are hundreds of them, so a wall clock is the right shape there and one less moving part. `_tryGateway` is called from both, which is why the streamed read is a separate method rather than a change to it.

The sandboxed URL is preserved via the app's own `arweaveSandboxUrl` helper, so this does not start relying on the gateway's 302.

## Tests

Both halves pinned:
- a body arriving in chunks over 500ms **completes** under a 200ms budget
- a gateway that goes quiet for longer than its budget is **still dropped**

The first fails if the timeout ever goes back to being a deadline — checked by reverting it.

`flutter analyze` clean; **1440 passing / 4 skipped**.

## The 206 question, settled

`_tryGateway` accepts `200–208` without sending a `Range` header, which looked like it could return a truncated body as a complete file. Tested against every gateway in the waterfall — a plain GET with no `Range`:

| Gateway | Response |
| --- | --- |
| turbo-gateway.com | `200`, full `content-length: 50485029` |
| permagate.io | `200`, full length |
| ardrive.net | `200`, full length |
| arweave.net | `429 Too Many Requests` |

`206` comes back **only** in response to a `Range` request (`content-range: bytes 0-1023/50485029`), exactly as the spec requires. The preview path sends no `Range`, so it cannot receive one. Not reachable, and left alone.

Incidentally: `arweave.net` answered `429` here too — the last resort in this waterfall is rate limited for ordinary reads, which is the same liability #2195 removed from the GraphQL fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ndA5nwUpt9hGLUx2TAFr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when retrieving data through fallback gateways.
  * Slow, steady transfers can now complete without timing out, while stalled connections still fail promptly.
  * Increased the overall retrieval window from 25 seconds to 3 minutes.
  * Preserved fallback behavior when gateways return errors or unavailable responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->