### PR TITLE
fix: a private AES-CTR file could never be previewed

### DIFF
--- a/lib/blocs/fs_entry_preview/fs_entry_preview_cubit.dart
+++ b/lib/blocs/fs_entry_preview/fs_entry_preview_cubit.dart
@@ -1270,7 +1270,19 @@ class FsEntryPreviewCubit extends Cubit<FsEntryPreviewState> {
         dataBytes,
         fileKey,
       );
-    } catch (e) {
+    } catch (e, stacktrace) {
+      // Said out loud. This used to return `null` in silence, and the only
+      // thing downstream of it is "this file can't be previewed here" - so a
+      // file that failed to decrypt was indistinguishable from a file of a
+      // type we do not preview, in the logs as well as on screen. A private
+      // AES-CTR file failed here for years and reported itself as an
+      // unsupported format.
+      logger.e(
+        'Failed to decrypt $dataTxId for preview',
+        e,
+        stacktrace,
+      );
+
       return null;
     }
   }

--- a/packages/ardrive_crypto/lib/src/ciphers.dart
+++ b/packages/ardrive_crypto/lib/src/ciphers.dart
@@ -5,12 +5,33 @@ import 'package:ardrive_crypto/src/constants.dart';
 import 'package:ardrive_crypto/src/stream_aes.dart';
 import 'package:ardrive_crypto/src/stream_cipher.dart';
 import 'package:cryptography/cryptography.dart' hide Cipher;
+// `Cipher` is hidden above because this package has its own: the constant
+// names that go on a transaction's tags. The algorithm type still has to be
+// nameable, so it comes back under a prefix.
+import 'package:cryptography/cryptography.dart' as crypto show Cipher;
 
-AesGcm cipherBufferImpl(String cipherName) {
-  final impls = {
+/// The buffered cipher for [cipherName], for data small enough to decrypt
+/// whole.
+///
+/// AES-CTR sat commented out here for years, with the note that this
+/// implementation "generates a 16 byte nonce by default". That is true of
+/// *generating* one - `newNonce()` returns sixteen bytes where ArDrive's
+/// `Cipher-IV` is twelve - but it says nothing about decrypting, which is all
+/// this function is used for. `AesCtr` zero pads a short nonce into the
+/// counter block, so the twelve byte IV on a transaction is already the block
+/// its data was encrypted under. Verified: encrypting under a 12 byte nonce
+/// and under that nonce followed by four zero bytes gives identical ciphertext.
+///
+/// What leaving it out actually did was throw [ArgumentError] for CTR, one
+/// line before the `switch` in `decryptTransactionData` that handles it
+/// carefully. Callers that swallow errors turned that into "this file cannot
+/// be previewed", so **every private AES-CTR file failed to preview** - while
+/// downloading the same file worked, because downloads go through
+/// [cipherStreamDecryptImpl], which always implemented CTR.
+crypto.Cipher cipherBufferImpl(String cipherName) {
+  final impls = <String, crypto.Cipher>{
     Cipher.aes256gcm: AesGcm.with256bits(),
-    // Avoid this implementation because it generates a 16 byte nonce by default...
-    // Cipher.aes256ctr: AesCtr.with256bits(macAlgorithm: MacAlgorithm.empty),
+    Cipher.aes256ctr: AesCtr.with256bits(macAlgorithm: MacAlgorithm.empty),
   };
   final impl = impls[cipherName];
   if (impl == null) throw ArgumentError();

--- a/packages/ardrive_crypto/lib/src/ciphers.dart
+++ b/packages/ardrive_crypto/lib/src/ciphers.dart
@@ -38,6 +38,31 @@ crypto.Cipher cipherBufferImpl(String cipherName) {
   return impl;
 }
 
+/// The buffered cipher for *encrypting* [cipherName].
+///
+/// AES-GCM only, deliberately, even though [cipherBufferImpl] can now decrypt
+/// AES-CTR as well. `Cipher.encrypt` generates its own nonce when none is
+/// given, and `AesCtr`'s is **16 bytes** where every ArDrive reader expects
+/// **12** - `AesCtrStream` throws on any other length. Encrypting CTR through
+/// here would therefore tag `Cipher-IV` with sixteen bytes and write a file to
+/// Arweave that nothing can ever decrypt, permanently and silently.
+///
+/// That is the hazard the note on [cipherBufferImpl] was pointing at. It is
+/// real, and it belongs here on the encrypt path rather than as an absence on
+/// the decrypt one - where all it did was make private CTR files unpreviewable.
+crypto.Cipher cipherBufferEncryptImpl(String cipherName) {
+  if (cipherName != Cipher.aes256gcm) {
+    throw ArgumentError.value(
+      cipherName,
+      'cipherName',
+      'Buffered encryption is AES-GCM only: this path cannot choose the nonce, '
+          'and a generated AES-CTR nonce is the wrong length for every reader.',
+    );
+  }
+
+  return AesGcm.with256bits();
+}
+
 FutureOr<DecryptStream> cipherStreamDecryptImpl(
   String cipherName, {
   required Uint8List keyData,

--- a/packages/ardrive_crypto/lib/src/entities.dart
+++ b/packages/ardrive_crypto/lib/src/entities.dart
@@ -117,7 +117,7 @@ Future<Transaction> createEncryptedTransaction(
   SecretKey key, {
   String cipher = Cipher.aes256gcm,
 }) async {
-  final impl = cipherBufferImpl(cipher);
+  final impl = cipherBufferEncryptImpl(cipher);
 
   final encryptionRes = await impl.encrypt(data, secretKey: key);
 
@@ -166,7 +166,7 @@ Future<DataItem> createEncryptedDataItem(
   SecretKey key, {
   String cipher = Cipher.aes256gcm,
 }) async {
-  final impl = cipherBufferImpl(cipher);
+  final impl = cipherBufferEncryptImpl(cipher);
 
   final encryptionRes = await impl.encrypt(data.toList(), secretKey: key);
 

--- a/packages/ardrive_crypto/test/ctr_buffered_test.dart
+++ b/packages/ardrive_crypto/test/ctr_buffered_test.dart
@@ -55,6 +55,31 @@ void main() {
     expect(decrypted, equals(plaintext));
   });
 
+  test('encryption stays AES-GCM only', () async {
+    // Adding CTR to the *decrypt* map must not quietly enable it for writing.
+    // `Cipher.encrypt` picks its own nonce when none is given, and AesCtr's is
+    // 16 bytes where every ArDrive reader requires 12 - `AesCtrStream` throws
+    // on any other length. Encrypting CTR here would tag `Cipher-IV` with the
+    // wrong length and put a permanently undecryptable file on Arweave.
+    expect(() => cipherBufferEncryptImpl(Cipher.aes256gcm), returnsNormally);
+    expect(
+      () => cipherBufferEncryptImpl(Cipher.aes256ctr),
+      throwsArgumentError,
+      reason: 'a generated CTR nonce is the wrong length for every reader',
+    );
+
+    final key = SecretKey(List<int>.generate(32, (i) => i));
+
+    await expectLater(
+      createEncryptedTransaction(
+        Uint8List.fromList([1, 2, 3]),
+        key,
+        cipher: Cipher.aes256ctr,
+      ),
+      throwsArgumentError,
+    );
+  });
+
   test('the buffered cipher knows both algorithms', () {
     // The regression itself: this threw ArgumentError for CTR, so every
     // private CTR preview died before reaching any decryption at all.

--- a/packages/ardrive_crypto/test/ctr_buffered_test.dart
+++ b/packages/ardrive_crypto/test/ctr_buffered_test.dart
@@ -1,0 +1,65 @@
+import 'dart:typed_data';
+
+import 'package:ardrive_crypto/ardrive_crypto.dart';
+import 'package:arweave/utils.dart' as utils;
+import 'package:cryptography/cryptography.dart' hide Cipher;
+import 'package:flutter_test/flutter_test.dart';
+
+/// AES-CTR through the *buffered* decryptor, which is what previews use.
+///
+/// Downloads have always used the streaming decryptor, so CTR worked there and
+/// only there: `cipherBufferImpl` had CTR commented out and threw
+/// `ArgumentError` one line before the `switch` that handles it. Every private
+/// CTR file therefore failed to preview, and silently, because the callers
+/// swallow the error.
+void main() {
+  test('a 12 byte Cipher-IV decrypts a whole body', () async {
+    // A real transaction carries a twelve byte `Cipher-IV`, and this is the
+    // whole body decrypted from it.
+    final key = SecretKey(List<int>.generate(32, (i) => i));
+    final nonce = Uint8List.fromList(
+      List<int>.generate(12, (i) => (i * 7 + 3) % 256),
+    );
+
+    // Well past one AES block, so a wrong counter block cannot pass by luck.
+    final plaintext = Uint8List.fromList(
+      List<int>.generate(5000, (i) => i % 256),
+    );
+
+    final aesCtr = AesCtr.with256bits(macAlgorithm: MacAlgorithm.empty);
+    final encrypted = await aesCtr.encrypt(
+      plaintext,
+      secretKey: key,
+      nonce: nonce,
+    );
+
+    // Why no counter block is assembled anywhere: `AesCtr` zero pads a short
+    // nonce into one, so the twelve bytes a transaction carries already *are*
+    // the block its data was encrypted under. The note that kept CTR out of
+    // `cipherBufferImpl` was about generating a nonce, not decrypting with one.
+    final underFullBlock = await aesCtr.encrypt(
+      plaintext,
+      secretKey: key,
+      nonce: Uint8List.fromList([...nonce, 0, 0, 0, 0]),
+    );
+
+    expect(encrypted.cipherText, equals(underFullBlock.cipherText));
+
+    final decrypted = await decryptTransactionData(
+      Cipher.aes256ctr,
+      utils.encodeBytesToBase64(nonce),
+      Uint8List.fromList(encrypted.cipherText),
+      key,
+    );
+
+    expect(decrypted, equals(plaintext));
+  });
+
+  test('the buffered cipher knows both algorithms', () {
+    // The regression itself: this threw ArgumentError for CTR, so every
+    // private CTR preview died before reaching any decryption at all.
+    expect(() => cipherBufferImpl(Cipher.aes256gcm), returnsNormally);
+    expect(() => cipherBufferImpl(Cipher.aes256ctr), returnsNormally);
+    expect(() => cipherBufferImpl('AES256-NOPE'), throwsArgumentError);
+  });
+}


### PR DESCRIPTION
A private `.mp4` showed **"This file can't be previewed here. Download it to open it"** — while downloading the very same file worked.

The file's data transaction carries `Cipher = AES256-CTR`, written by ArDrive-App **2.19.1** at 47 MiB, a size today's uploader writes as GCM.

```dart
AesGcm cipherBufferImpl(String cipherName) {
  final impls = {
    Cipher.aes256gcm: AesGcm.with256bits(),
    // Avoid this implementation because it generates a 16 byte nonce by default...
    // Cipher.aes256ctr: AesCtr.with256bits(macAlgorithm: MacAlgorithm.empty),
  };
  final impl = impls[cipherName];
  if (impl == null) throw ArgumentError();   // ← every CTR file lands here
```

So CTR threw `ArgumentError` from that lookup — **one line before** the `switch` in `decryptTransactionData` that handles CTR carefully. Downloads were never affected: they decrypt through `cipherStreamDecryptImpl`, which has always implemented CTR.

## The note was true of the wrong thing

`newNonce()` does return 16 bytes where ArDrive's `Cipher-IV` is 12 — but that is nonce *generation*, and this function is only ever used to **decrypt**. `AesCtr` zero pads a short nonce into the counter block, so the 12 bytes a transaction carries already **are** the block its data was encrypted under.

Checked rather than assumed: encrypting under a 12 byte nonce, and under that same nonce followed by four zero bytes, produces **identical ciphertext**. No counter block needs assembling — the fix is one map entry.

## Also: the failure is now audible

`_decodePrivateData` returned `null` in silence, and the only thing downstream is that same "can't be previewed" message. A decryption failure was therefore indistinguishable from an unsupported file type — on screen *and* in the logs. That silence is why this surfaced as a suspected gateway timeout and took a full investigation to locate.

## Tests

- a whole body encrypted under a real 12-byte `Cipher-IV` decrypts through the buffered path
- the 12-byte-nonce / full-counter-block equivalence is asserted, so the reasoning above is pinned rather than written in a comment
- `cipherBufferImpl` accepts both algorithms and still rejects an unknown one

Both fail if CTR is removed from the map again — verified.

`flutter analyze` clean; app suite **1438 passing / 4 skipped**, `ardrive_crypto` **45 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ndA5nwUpt9hGLUx2TAFr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed buffered AES-CTR decryption for transaction data using 12-byte IVs.
  * Improved decryption failure logging while preserving graceful failure behavior.
  * Added support for valid AES-GCM and AES-CTR cipher selections, with invalid algorithms rejected.

* **Tests**
  * Added coverage for large encrypted payloads, short IV handling, and supported cipher validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->