### PR TITLE
Release v2.87.1 — previews that work on old files and large ones

### DIFF
--- a/lib/blocs/fs_entry_preview/fs_entry_preview_cubit.dart
+++ b/lib/blocs/fs_entry_preview/fs_entry_preview_cubit.dart
@@ -1270,7 +1270,19 @@ class FsEntryPreviewCubit extends Cubit<FsEntryPreviewState> {
         dataBytes,
         fileKey,
       );
-    } catch (e) {
+    } catch (e, stacktrace) {
+      // Said out loud. This used to return `null` in silence, and the only
+      // thing downstream of it is "this file can't be previewed here" - so a
+      // file that failed to decrypt was indistinguishable from a file of a
+      // type we do not preview, in the logs as well as on screen. A private
+      // AES-CTR file failed here for years and reported itself as an
+      // unsupported format.
+      logger.e(
+        'Failed to decrypt $dataTxId for preview',
+        e,
+        stacktrace,
+      );
+
       return null;
     }
   }

--- a/lib/services/arweave/data_gateway_fallback.dart
+++ b/lib/services/arweave/data_gateway_fallback.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import 'package:ardrive/components/sandboxed_transaction_view/arweave_sandbox_url.dart';
 import 'package:ardrive/download/download_exceptions.dart';
 import 'package:ardrive/services/arweave/arweave_service.dart';
 import 'package:ardrive/utils/logger.dart';
@@ -36,6 +37,7 @@ class DataGatewayFallback {
 
   static const _maxGarFallbacks = 2;
   static const _garListTimeout = Duration(seconds: 5);
+
   /// How long one gateway read waits before being abandoned.
   ///
   /// Ten seconds, not five. Sync reads run through [ArweaveService.runPooled],
@@ -66,7 +68,19 @@ class DataGatewayFallback {
 
   /// Total budget for a large-body read, covering both attempts.
   static const largeBodyTotalTimeout = Duration(seconds: 130);
-  static const _totalFetchTimeout = Duration(seconds: 25);
+
+  /// Backstop for the whole [fetchData] waterfall.
+  ///
+  /// Generous, and not a deadline anyone is meant to reach. Each attempt there
+  /// is bounded by silence rather than duration, so a hung gateway is dropped
+  /// in [_requestTimeout] and four of them cost well under a minute. What this
+  /// still catches is a gateway dribbling bytes indefinitely - fast enough
+  /// never to go quiet, too slow to ever finish.
+  ///
+  /// It was twenty five seconds, which was a deadline: a fifty megabyte
+  /// preview needed 2 MB/s to fit inside it, so the cap ended reads that were
+  /// working.
+  static const _totalFetchTimeout = Duration(minutes: 3);
   static const _hedgeDelay = Duration(milliseconds: 1500);
   static const _downloadTimeout = Duration(seconds: 15);
 
@@ -114,13 +128,25 @@ class DataGatewayFallback {
   final Duration _syncRequestTimeout;
   final Duration _syncLargeBodyRequestTimeout;
 
+  /// Injectable so a test can make a body outlive its own budget, which is the
+  /// only way to tell a stall timeout from a deadline.
+  final Duration _dataRequestTimeout;
+
+  /// Injectable for the same reason: the backstop is three minutes, and a test
+  /// has to be able to reach it to prove the connection is hung up.
+  final Duration _dataTotalTimeout;
+
   DataGatewayFallback({
     required ArioSDK arioSDK,
     Client Function()? clientFactory,
     @visibleForTesting Duration? syncRequestTimeout,
     @visibleForTesting Duration? syncLargeBodyRequestTimeout,
+    @visibleForTesting Duration? dataRequestTimeout,
+    @visibleForTesting Duration? dataTotalTimeout,
   })  : _arioSDK = arioSDK,
         _clientFactory = clientFactory ?? Client.new,
+        _dataRequestTimeout = dataRequestTimeout ?? _requestTimeout,
+        _dataTotalTimeout = dataTotalTimeout ?? _totalFetchTimeout,
         _syncRequestTimeout = syncRequestTimeout ?? _requestTimeout,
         _syncLargeBodyRequestTimeout =
             syncLargeBodyRequestTimeout ?? largeBodyRequestTimeout;
@@ -132,11 +158,25 @@ class DataGatewayFallback {
   ///
   /// If ALL gateways return 404, throws [TransactionNotFound].
   Future<Response> fetchData(String txId, Arweave primaryClient) async {
-    return _serialFetch(txId, primaryClient)
-        .timeout(_totalFetchTimeout, onTimeout: () {
-      logger.w('Total fetch timeout exceeded for tx $txId');
-      throw Exception('Total fetch timeout exceeded for tx $txId');
-    });
+    // One client for the whole waterfall, so the backstop below has something
+    // to hang up with. `Future.timeout` does not cancel what it times out: the
+    // read would otherwise carry on buffering - up to the 100 MiB preview cap -
+    // and holding its connection long after the caller was told it had failed.
+    // Closing the client aborts the request in flight (`BrowserClient.close`
+    // fires its `AbortController`).
+    final httpClient = _clientFactory();
+
+    try {
+      return await _serialFetch(txId, primaryClient, httpClient: httpClient)
+          .timeout(_dataTotalTimeout, onTimeout: () {
+        logger.w('Total fetch timeout exceeded for tx $txId');
+        httpClient.close();
+
+        throw Exception('Total fetch timeout exceeded for tx $txId');
+      });
+    } finally {
+      httpClient.close();
+    }
   }
 
   /// Fetch transaction data for **sync** metadata reads.
@@ -170,9 +210,9 @@ class DataGatewayFallback {
     Arweave primaryClient, {
     bool largeBody = false,
   }) async {
-    return _syncFetch(txId, primaryClient, largeBody: largeBody).timeout(
-        largeBody ? largeBodyTotalTimeout : _syncTotalFetchTimeout,
-        onTimeout: () {
+    return _syncFetch(txId, primaryClient, largeBody: largeBody)
+        .timeout(largeBody ? largeBodyTotalTimeout : _syncTotalFetchTimeout,
+            onTimeout: () {
       logger.w('Total sync fetch timeout exceeded for tx $txId');
       throw Exception('Total sync fetch timeout exceeded for tx $txId');
     });
@@ -192,9 +232,8 @@ class DataGatewayFallback {
         return await _tryGateway(
           primaryClient,
           txId,
-          requestTimeout: largeBody
-              ? _syncLargeBodyRequestTimeout
-              : _syncRequestTimeout,
+          requestTimeout:
+              largeBody ? _syncLargeBodyRequestTimeout : _syncRequestTimeout,
         );
       } on _ErrorFromStatus catch (e) {
         // A 404 is NOT treated as final here, and the reasoning that said it
@@ -241,7 +280,11 @@ class DataGatewayFallback {
     );
   }
 
-  Future<Response> _serialFetch(String txId, Arweave primaryClient) async {
+  Future<Response> _serialFetch(
+    String txId,
+    Arweave primaryClient, {
+    required Client httpClient,
+  }) async {
     final clients = await _buildClientList(primaryClient);
     var all404 = true;
 
@@ -269,7 +312,7 @@ class DataGatewayFallback {
         var retryable = false;
 
         try {
-          final response = await _tryGateway(client, txId);
+          final response = await _tryGatewayStreamed(client, txId, httpClient);
           if (!isPrimary) {
             logger.i('Fallback gateway $gatewayName succeeded for tx $txId');
           }
@@ -509,8 +552,8 @@ class DataGatewayFallback {
             if (all404) {
               completer.completeError(DownloadFileNotFoundException(txId));
             } else {
-              completer.completeError(
-                  DownloadNetworkException(txId, e.toString()));
+              completer
+                  .completeError(DownloadNetworkException(txId, e.toString()));
             }
           }
         }),
@@ -533,8 +576,8 @@ class DataGatewayFallback {
       try {
         final response = await _tryManifestGateway(client, txId);
         if (client != primaryClient) {
-          logger.i(
-              'Fallback gateway $gatewayName succeeded for manifest $txId');
+          logger
+              .i('Fallback gateway $gatewayName succeeded for manifest $txId');
         }
         return response;
       } on _ErrorFromStatus catch (e) {
@@ -587,6 +630,79 @@ class DataGatewayFallback {
     }
 
     return clients;
+  }
+
+  /// A gateway read whose budget measures **silence**, not duration.
+  ///
+  /// [_tryGateway] buffers the whole body behind one `Future`, and a `Future`
+  /// timeout is a deadline on the transfer - it cannot tell a gateway that has
+  /// stopped answering from fifty megabytes arriving perfectly well. Previews
+  /// are capped at 100 MiB, so under that deadline a large file could not be
+  /// read from any gateway: each was abandoned mid-body on any connection
+  /// slower than the file divided by the budget, and the user saw
+  /// "unpreviewable" for a file that was arriving fine.
+  ///
+  /// Reading the body as a stream makes the timeout fire only when no chunk
+  /// has arrived for that long. A slow body finishes; a dead gateway is still
+  /// dropped just as quickly. `BrowserClient` reads through a `ReadableStream`,
+  /// so this is chunk-wise on the web too, not only on the VM.
+  ///
+  /// Sync deliberately keeps [_tryGateway]: its reads are a few hundred bytes
+  /// each and there are hundreds of them, so a wall clock is the right shape
+  /// there and one less moving part.
+  Future<Response> _tryGatewayStreamed(
+    Arweave client,
+    String txId,
+    Client httpClient, {
+    Duration? requestTimeout,
+  }) async {
+    final budget = requestTimeout ?? _dataRequestTimeout;
+
+    {
+      final request = Request(
+        'GET',
+        Uri.parse(
+          arweaveSandboxUrl(txId: txId, gatewayUrl: client.api.gatewayUrl) ??
+              '${client.api.gatewayUrl.origin}/$txId',
+        ),
+      );
+
+      final response = await httpClient.send(request).timeout(budget);
+
+      if (response.statusCode < 200 || response.statusCode > 208) {
+        // Nobody is going to read this body, and the client is shared by every
+        // gateway in the waterfall now - so an abandoned error response would
+        // hold its reader open for the rest of the run rather than until the
+        // end of this attempt. `getSandboxedTx` consumed the body whatever the
+        // status; streaming has to say so.
+        await response.stream.listen(null).cancel();
+
+        throw _ErrorFromStatus(response.statusCode, txId);
+      }
+
+      final chunks = <List<int>>[];
+      var length = 0;
+
+      await for (final chunk in response.stream.timeout(budget)) {
+        chunks.add(chunk);
+        length += chunk.length;
+      }
+
+      final body = Uint8List(length);
+      var offset = 0;
+
+      for (final chunk in chunks) {
+        body.setRange(offset, offset + chunk.length, chunk);
+        offset += chunk.length;
+      }
+
+      return Response.bytes(
+        body,
+        response.statusCode,
+        headers: response.headers,
+        reasonPhrase: response.reasonPhrase,
+      );
+    }
   }
 
   Future<Response> _tryGateway(

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -18,6 +18,7 @@ import 'package:ardrive/models/folder_revision.dart';
 import 'package:ardrive/services/arweave/arweave.dart'
     hide SnapshotEntityTransaction;
 import 'package:ardrive/services/config/config.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:ardrive/sync/constants.dart';
 import 'package:ardrive/sync/data/snapshot_validation_service.dart';
 import 'package:ardrive/sync/domain/ghost_folder.dart';
@@ -61,6 +62,40 @@ const _txConfirmationBatchTimeout = Duration(seconds: 15);
 const _txStatusUpdateTimeout = Duration(seconds: 30);
 
 abstract class SyncRepository {
+  /// The total transaction-parse budget, shared out across the drives still to
+  /// be synced.
+  @visibleForTesting
+  static const maxTransactionParseBatchSize = 200;
+
+  /// How many transactions each remaining drive may parse per batch.
+  ///
+  /// The budget is divided by the drives left to sync, so a wallet with more of
+  /// them parses in smaller batches. Integer division makes that reach **zero**
+  /// once more than [maxTransactionParseBatchSize] drives remain, and
+  /// `BatchProcessor` throws `ArgumentError('Batch size cannot be 0')` on a
+  /// batch of zero - so past that point a wallet could not sync at all, and the
+  /// failure was an argument error rather than anything naming the cause.
+  ///
+  /// Clamped to at least one. A batch of one is slow; a batch of zero is a
+  /// crash. No wallet is known to hold that many drives today, so this is a
+  /// floor under a future scale rather than a fix for anyone's sync now.
+  ///
+  /// The subtraction is guarded too: `drivesSynced` reaching `drivesCount`
+  /// would divide by zero, which throws a different error for the same reason.
+  @visibleForTesting
+  static int transactionParseBatchSizeFor({
+    required int drivesCount,
+    required int drivesSynced,
+  }) {
+    final remaining = drivesCount - drivesSynced;
+
+    if (remaining <= 1) {
+      return maxTransactionParseBatchSize;
+    }
+
+    return max(1, maxTransactionParseBatchSize ~/ remaining);
+  }
+
   Stream<double> syncDriveById({
     required String driveId,
     required String ownerAddress,
@@ -311,16 +346,13 @@ class _SyncRepository implements SyncRepository {
         if (previouslySyncedDrives.isEmpty) {
           // All drives are never-synced; skip probe entirely
           if (neverSyncedDrives.isNotEmpty) {
-            logger.i(
-                '${neverSyncedDrives.length} drives need first-time sync');
+            logger.i('${neverSyncedDrives.length} drives need first-time sync');
           }
         } else {
           // Group previously-synced drives by owner for efficient probing
           final drivesByOwner = <String, List<Drive>>{};
           for (final drive in previouslySyncedDrives) {
-            drivesByOwner
-                .putIfAbsent(drive.ownerAddress, () => [])
-                .add(drive);
+            drivesByOwner.putIfAbsent(drive.ownerAddress, () => []).add(drive);
           }
 
           final activeDriveIds = <String>{};
@@ -353,8 +385,7 @@ class _SyncRepository implements SyncRepository {
 
           // Add previously-synced drives that have activity
           drivesToSync.addAll(
-            previouslySyncedDrives
-                .where((d) => activeDriveIds.contains(d.id)),
+            previouslySyncedDrives.where((d) => activeDriveIds.contains(d.id)),
           );
 
           final skipped = drives.length - drivesToSync.length;
@@ -362,8 +393,7 @@ class _SyncRepository implements SyncRepository {
             logger.i('Skipping $skipped unchanged drives');
           }
           if (neverSyncedDrives.isNotEmpty) {
-            logger.i(
-                '${neverSyncedDrives.length} drives need first-time sync');
+            logger.i('${neverSyncedDrives.length} drives need first-time sync');
           }
         }
       } catch (e) {
@@ -409,11 +439,10 @@ class _SyncRepository implements SyncRepository {
           // drives (lastBlockHeight=0) don't drag the query back to genesis.
           final syncedHeights = ownerDrives
               .where((d) => (d.lastBlockHeight ?? 0) > 0)
-              .map((d) =>
-                  _calculateSyncLastBlockHeight(d.lastBlockHeight ?? 0));
-          final minBlock = syncedHeights.isNotEmpty
-              ? syncedHeights.reduce(min)
-              : 0;
+              .map(
+                  (d) => _calculateSyncLastBlockHeight(d.lastBlockHeight ?? 0));
+          final minBlock =
+              syncedHeights.isNotEmpty ? syncedHeights.reduce(min) : 0;
 
           var queryFailed = false;
           final snapshotsStream = _arweave.getAllSnapshotsForDrives(
@@ -456,8 +485,7 @@ class _SyncRepository implements SyncRepository {
 
         final withSnapshots =
             prefetchedSnapshots.values.where((v) => v.isNotEmpty).length;
-        logger.i(
-            '[snapshot] prefetched '
+        logger.i('[snapshot] prefetched '
             '${prefetchedSnapshots.values.expand((v) => v).length} '
             'for $withSnapshots of ${prefetchedSnapshots.length} drive(s); '
             'the rest are known to have none and will not be re-queried');
@@ -498,14 +526,13 @@ class _SyncRepository implements SyncRepository {
                 ? 0
                 : _calculateSyncLastBlockHeight(drive.lastBlockHeight ?? 0),
             currentBlockHeight: currentBlockHeight,
-            transactionParseBatchSize:
-                200 ~/ (syncProgress.drivesCount - syncProgress.drivesSynced),
+            transactionParseBatchSize: _transactionParseBatchSize(syncProgress),
             ownerAddress: drive.ownerAddress,
             txFechedCallback: txFechedCallback,
             cancellationToken: token,
             prefetchedSnapshots: prefetchedSnapshots[drive.id],
-            skipPendingTxFetch: walletAddress != null &&
-                drive.ownerAddress != walletAddress,
+            skipPendingTxFetch:
+                walletAddress != null && drive.ownerAddress != walletAddress,
           );
 
           double currentDriveProgress = 0;
@@ -543,10 +570,10 @@ class _SyncRepository implements SyncRepository {
 
           final updatedFailedDrives =
               List<String>.from(syncProgress.failedDriveIds)..add(drive.id);
-          final updatedErrorMessages =
-              Map<String, String>.from(syncProgress.errorMessages)
-                ..putIfAbsent(
-                    drive.id, () => '${drive.name}: ${_extractErrorMessage(e)}');
+          final updatedErrorMessages = Map<String, String>.from(
+              syncProgress.errorMessages)
+            ..putIfAbsent(
+                drive.id, () => '${drive.name}: ${_extractErrorMessage(e)}');
 
           // Still increment progress but mark as failed (cap at 90%)
           totalProgress += 1;
@@ -665,8 +692,7 @@ class _SyncRepository implements SyncRepository {
                 onTimeout: () {
                   // Check if cancelled before timing out
                   token.checkCancellation();
-                  logger.w(
-                      'Transaction status update timed out after '
+                  logger.w('Transaction status update timed out after '
                       '${_txStatusUpdateTimeout.inSeconds}s');
                   // Update status message to indicate timeout but don't treat as error
                   syncProgress = syncProgress.copyWith(
@@ -803,8 +829,7 @@ class _SyncRepository implements SyncRepository {
     _skippedEntityTxIdsByDrive.clear();
 
     // Get the specific drive
-    final drive =
-        await _driveDao.driveById(driveId: driveId).getSingleOrNull();
+    final drive = await _driveDao.driveById(driveId: driveId).getSingleOrNull();
     if (drive == null) {
       yield SyncProgress.emptySyncCompleted();
       return;
@@ -849,8 +874,8 @@ class _SyncRepository implements SyncRepository {
           ownerAddress: drive.ownerAddress,
           txFechedCallback: txFechedCallback,
           cancellationToken: token,
-          skipPendingTxFetch: walletAddress != null &&
-              drive.ownerAddress != walletAddress,
+          skipPendingTxFetch:
+              walletAddress != null && drive.ownerAddress != walletAddress,
         );
 
         await for (var driveProgress in driveSyncProgress) {
@@ -958,8 +983,7 @@ class _SyncRepository implements SyncRepository {
             _txStatusUpdateTimeout,
             onTimeout: () {
               token.checkCancellation();
-              logger.w(
-                  'Transaction status update timed out after '
+              logger.w('Transaction status update timed out after '
                   '${_txStatusUpdateTimeout.inSeconds}s for single drive');
               syncProgress = syncProgress.copyWith(
                 statusMessage: 'Completing sync...',
@@ -990,7 +1014,8 @@ class _SyncRepository implements SyncRepository {
         syncProgressController.add(syncProgress);
         _logSkippedEntities();
 
-        logger.d('Single drive sync completed successfully, closing controller');
+        logger
+            .d('Single drive sync completed successfully, closing controller');
         await syncProgressController.close();
       } catch (e) {
         if (e is SyncCancelledException) {
@@ -1035,7 +1060,8 @@ class _SyncRepository implements SyncRepository {
       _folderIds.clear();
       // Remove any ghost folders for this drive from the instance map
       _ghostFolders.removeWhere((_, v) => v.driveId == driveId);
-      logger.d('Single drive sync failed with error, closing controller: $error');
+      logger
+          .d('Single drive sync failed with error, closing controller: $error');
       if (!syncProgressController.isClosed) {
         syncProgressController.addError(error);
         await syncProgressController.close();
@@ -1061,9 +1087,8 @@ class _SyncRepository implements SyncRepository {
 
     // Load all pending transactions and filter to this drive
     final allPendingTxs = await driveDao.pendingTransactions().get();
-    final drivePendingTxs = allPendingTxs
-        .where((tx) => driveDataTxIds.contains(tx.id))
-        .toList();
+    final drivePendingTxs =
+        allPendingTxs.where((tx) => driveDataTxIds.contains(tx.id)).toList();
 
     logger.i(
         'Loaded ${drivePendingTxs.length} pending transactions for drive (from ${allPendingTxs.length} total)');
@@ -1148,16 +1173,14 @@ class _SyncRepository implements SyncRepository {
           continue;
         }
 
-        final txConfirmed =
-            confirmationCount >= kRequiredTxConfirmationCount;
+        final txConfirmed = confirmationCount >= kRequiredTxConfirmationCount;
         final txNotFound = confirmationCount < 0;
 
         String? txStatus;
         DateTime? transactionDateCreated;
 
         if (pendingTxMap[txId]!.transactionDateCreated != null) {
-          transactionDateCreated =
-              pendingTxMap[txId]!.transactionDateCreated!;
+          transactionDateCreated = pendingTxMap[txId]!.transactionDateCreated!;
         } else {
           transactionDateCreated = dateCreatedCache[txId];
         }
@@ -1331,6 +1354,12 @@ class _SyncRepository implements SyncRepository {
     );
   }
 
+  int _transactionParseBatchSize(SyncProgress progress) =>
+      SyncRepository.transactionParseBatchSizeFor(
+        drivesCount: progress.drivesCount,
+        drivesSynced: progress.drivesSynced,
+      );
+
   int _calculateSyncLastBlockHeight(int lastBlockHeight) {
     logger.d('Calculating sync last block height: $lastBlockHeight');
     if (_lastSync != null) {
@@ -1495,8 +1524,7 @@ class _SyncRepository implements SyncRepository {
           continue;
         }
 
-        final txConfirmed =
-            confirmationCount >= kRequiredTxConfirmationCount;
+        final txConfirmed = confirmationCount >= kRequiredTxConfirmationCount;
         final txNotFound = confirmationCount < 0;
 
         String? txStatus;
@@ -1504,8 +1532,7 @@ class _SyncRepository implements SyncRepository {
         DateTime? transactionDateCreated;
 
         if (pendingTxMap[txId]!.transactionDateCreated != null) {
-          transactionDateCreated =
-              pendingTxMap[txId]!.transactionDateCreated!;
+          transactionDateCreated = pendingTxMap[txId]!.transactionDateCreated!;
         } else {
           transactionDateCreated = dateCreatedCache[txId];
         }
@@ -1552,7 +1579,6 @@ class _SyncRepository implements SyncRepository {
       );
     }
   }
-
 
   bool _isOverThePendingTime(DateTime? transactionCreatedDate) {
     // If don't have the date information we cannot assume that is over the pending time
@@ -1615,8 +1641,8 @@ class _SyncRepository implements SyncRepository {
         final source = prefetchedSnapshots != null ? 'prefetched' : 'per-drive';
         final snapshotsStream = prefetchedSnapshots != null
             ? Stream.fromIterable(prefetchedSnapshots)
-            : _arweave.getAllSnapshotsOfDrive(
-                driveId, lastBlockHeight, ownerAddress: ownerAddress);
+            : _arweave.getAllSnapshotsOfDrive(driveId, lastBlockHeight,
+                ownerAddress: ownerAddress);
 
         snapshotItems = await SnapshotItem.instantiateAll(
           snapshotsStream,
@@ -1830,16 +1856,14 @@ class _SyncRepository implements SyncRepository {
       } else {
         // Check local DB first: only query the gateway if we have
         // locally-tracked pending transactions for this drive
-        final localPending = await _driveDao
-            .pendingTransactionsForDrive(driveId: driveId)
-            .get();
+        final localPending =
+            await _driveDao.pendingTransactionsForDrive(driveId: driveId).get();
 
         if (localPending.isEmpty) {
           logger.d(
               'No locally pending transactions for drive ${drive.id}, skipping GQL query');
         } else {
-          logger.d(
-              'Fetching pending transactions for drive ${drive.id} '
+          logger.d('Fetching pending transactions for drive ${drive.id} '
               '(${localPending.length} locally pending)');
 
           try {

--- a/packages/ardrive_crypto/lib/src/ciphers.dart
+++ b/packages/ardrive_crypto/lib/src/ciphers.dart
@@ -5,16 +5,62 @@ import 'package:ardrive_crypto/src/constants.dart';
 import 'package:ardrive_crypto/src/stream_aes.dart';
 import 'package:ardrive_crypto/src/stream_cipher.dart';
 import 'package:cryptography/cryptography.dart' hide Cipher;
+// `Cipher` is hidden above because this package has its own: the constant
+// names that go on a transaction's tags. The algorithm type still has to be
+// nameable, so it comes back under a prefix.
+import 'package:cryptography/cryptography.dart' as crypto show Cipher;
 
-AesGcm cipherBufferImpl(String cipherName) {
-  final impls = {
+/// The buffered cipher for [cipherName], for data small enough to decrypt
+/// whole.
+///
+/// AES-CTR sat commented out here for years, with the note that this
+/// implementation "generates a 16 byte nonce by default". That is true of
+/// *generating* one - `newNonce()` returns sixteen bytes where ArDrive's
+/// `Cipher-IV` is twelve - but it says nothing about decrypting, which is all
+/// this function is used for. `AesCtr` zero pads a short nonce into the
+/// counter block, so the twelve byte IV on a transaction is already the block
+/// its data was encrypted under. Verified: encrypting under a 12 byte nonce
+/// and under that nonce followed by four zero bytes gives identical ciphertext.
+///
+/// What leaving it out actually did was throw [ArgumentError] for CTR, one
+/// line before the `switch` in `decryptTransactionData` that handles it
+/// carefully. Callers that swallow errors turned that into "this file cannot
+/// be previewed", so **every private AES-CTR file failed to preview** - while
+/// downloading the same file worked, because downloads go through
+/// [cipherStreamDecryptImpl], which always implemented CTR.
+crypto.Cipher cipherBufferImpl(String cipherName) {
+  final impls = <String, crypto.Cipher>{
     Cipher.aes256gcm: AesGcm.with256bits(),
-    // Avoid this implementation because it generates a 16 byte nonce by default...
-    // Cipher.aes256ctr: AesCtr.with256bits(macAlgorithm: MacAlgorithm.empty),
+    Cipher.aes256ctr: AesCtr.with256bits(macAlgorithm: MacAlgorithm.empty),
   };
   final impl = impls[cipherName];
   if (impl == null) throw ArgumentError();
   return impl;
+}
+
+/// The buffered cipher for *encrypting* [cipherName].
+///
+/// AES-GCM only, deliberately, even though [cipherBufferImpl] can now decrypt
+/// AES-CTR as well. `Cipher.encrypt` generates its own nonce when none is
+/// given, and `AesCtr`'s is **16 bytes** where every ArDrive reader expects
+/// **12** - `AesCtrStream` throws on any other length. Encrypting CTR through
+/// here would therefore tag `Cipher-IV` with sixteen bytes and write a file to
+/// Arweave that nothing can ever decrypt, permanently and silently.
+///
+/// That is the hazard the note on [cipherBufferImpl] was pointing at. It is
+/// real, and it belongs here on the encrypt path rather than as an absence on
+/// the decrypt one - where all it did was make private CTR files unpreviewable.
+crypto.Cipher cipherBufferEncryptImpl(String cipherName) {
+  if (cipherName != Cipher.aes256gcm) {
+    throw ArgumentError.value(
+      cipherName,
+      'cipherName',
+      'Buffered encryption is AES-GCM only: this path cannot choose the nonce, '
+          'and a generated AES-CTR nonce is the wrong length for every reader.',
+    );
+  }
+
+  return AesGcm.with256bits();
 }
 
 FutureOr<DecryptStream> cipherStreamDecryptImpl(

--- a/packages/ardrive_crypto/lib/src/entities.dart
+++ b/packages/ardrive_crypto/lib/src/entities.dart
@@ -117,7 +117,7 @@ Future<Transaction> createEncryptedTransaction(
   SecretKey key, {
   String cipher = Cipher.aes256gcm,
 }) async {
-  final impl = cipherBufferImpl(cipher);
+  final impl = cipherBufferEncryptImpl(cipher);
 
   final encryptionRes = await impl.encrypt(data, secretKey: key);
 
@@ -166,7 +166,7 @@ Future<DataItem> createEncryptedDataItem(
   SecretKey key, {
   String cipher = Cipher.aes256gcm,
 }) async {
-  final impl = cipherBufferImpl(cipher);
+  final impl = cipherBufferEncryptImpl(cipher);
 
   final encryptionRes = await impl.encrypt(data.toList(), secretKey: key);
 

--- a/packages/ardrive_crypto/test/ctr_buffered_test.dart
+++ b/packages/ardrive_crypto/test/ctr_buffered_test.dart
@@ -1,0 +1,90 @@
+import 'dart:typed_data';
+
+import 'package:ardrive_crypto/ardrive_crypto.dart';
+import 'package:arweave/utils.dart' as utils;
+import 'package:cryptography/cryptography.dart' hide Cipher;
+import 'package:flutter_test/flutter_test.dart';
+
+/// AES-CTR through the *buffered* decryptor, which is what previews use.
+///
+/// Downloads have always used the streaming decryptor, so CTR worked there and
+/// only there: `cipherBufferImpl` had CTR commented out and threw
+/// `ArgumentError` one line before the `switch` that handles it. Every private
+/// CTR file therefore failed to preview, and silently, because the callers
+/// swallow the error.
+void main() {
+  test('a 12 byte Cipher-IV decrypts a whole body', () async {
+    // A real transaction carries a twelve byte `Cipher-IV`, and this is the
+    // whole body decrypted from it.
+    final key = SecretKey(List<int>.generate(32, (i) => i));
+    final nonce = Uint8List.fromList(
+      List<int>.generate(12, (i) => (i * 7 + 3) % 256),
+    );
+
+    // Well past one AES block, so a wrong counter block cannot pass by luck.
+    final plaintext = Uint8List.fromList(
+      List<int>.generate(5000, (i) => i % 256),
+    );
+
+    final aesCtr = AesCtr.with256bits(macAlgorithm: MacAlgorithm.empty);
+    final encrypted = await aesCtr.encrypt(
+      plaintext,
+      secretKey: key,
+      nonce: nonce,
+    );
+
+    // Why no counter block is assembled anywhere: `AesCtr` zero pads a short
+    // nonce into one, so the twelve bytes a transaction carries already *are*
+    // the block its data was encrypted under. The note that kept CTR out of
+    // `cipherBufferImpl` was about generating a nonce, not decrypting with one.
+    final underFullBlock = await aesCtr.encrypt(
+      plaintext,
+      secretKey: key,
+      nonce: Uint8List.fromList([...nonce, 0, 0, 0, 0]),
+    );
+
+    expect(encrypted.cipherText, equals(underFullBlock.cipherText));
+
+    final decrypted = await decryptTransactionData(
+      Cipher.aes256ctr,
+      utils.encodeBytesToBase64(nonce),
+      Uint8List.fromList(encrypted.cipherText),
+      key,
+    );
+
+    expect(decrypted, equals(plaintext));
+  });
+
+  test('encryption stays AES-GCM only', () async {
+    // Adding CTR to the *decrypt* map must not quietly enable it for writing.
+    // `Cipher.encrypt` picks its own nonce when none is given, and AesCtr's is
+    // 16 bytes where every ArDrive reader requires 12 - `AesCtrStream` throws
+    // on any other length. Encrypting CTR here would tag `Cipher-IV` with the
+    // wrong length and put a permanently undecryptable file on Arweave.
+    expect(() => cipherBufferEncryptImpl(Cipher.aes256gcm), returnsNormally);
+    expect(
+      () => cipherBufferEncryptImpl(Cipher.aes256ctr),
+      throwsArgumentError,
+      reason: 'a generated CTR nonce is the wrong length for every reader',
+    );
+
+    final key = SecretKey(List<int>.generate(32, (i) => i));
+
+    await expectLater(
+      createEncryptedTransaction(
+        Uint8List.fromList([1, 2, 3]),
+        key,
+        cipher: Cipher.aes256ctr,
+      ),
+      throwsArgumentError,
+    );
+  });
+
+  test('the buffered cipher knows both algorithms', () {
+    // The regression itself: this threw ArgumentError for CTR, so every
+    // private CTR preview died before reaching any decryption at all.
+    expect(() => cipherBufferImpl(Cipher.aes256gcm), returnsNormally);
+    expect(() => cipherBufferImpl(Cipher.aes256ctr), returnsNormally);
+    expect(() => cipherBufferImpl('AES256-NOPE'), throwsArgumentError);
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Secure, permanent storage
 
 publish_to: 'none'
 
-version: 2.86.0
+version: 2.87.1
 
 environment:
   sdk: '>=3.2.0 <4.0.0'

--- a/test/services/arweave/data_gateway_fallback_test.dart
+++ b/test/services/arweave/data_gateway_fallback_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:ardrive/services/arweave/arweave_service.dart';
 import 'package:ardrive/services/arweave/data_gateway_fallback.dart';
 import 'package:ario_sdk/ario_sdk.dart';
@@ -11,6 +13,34 @@ class _MockArioSDK extends Mock implements ArioSDK {}
 class _MockArweave extends Mock implements Arweave {}
 
 class _MockArweaveApi extends Mock implements ArweaveApi {}
+
+/// The HTTP client the preview waterfall reads through.
+///
+/// `fetchData` streams its body so its timeout measures silence rather than
+/// duration, which means it goes through `Client` rather than
+/// `ArweaveApi.getSandboxedTx`. Sync still uses the latter, so those tests keep
+/// mocking the api.
+class _FakeHttpClient extends BaseClient {
+  _FakeHttpClient(this._respond);
+
+  final StreamedResponse Function(int attempt) _respond;
+
+  int sends = 0;
+  bool closed = false;
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    sends += 1;
+
+    return _respond(sends);
+  }
+
+  @override
+  void close() => closed = true;
+}
+
+StreamedResponse _streamed(String body, int status) =>
+    StreamedResponse(Stream.value(utf8.encode(body)), status);
 
 void main() {
   late _MockArioSDK arioSDK;
@@ -36,7 +66,8 @@ void main() {
   });
 
   group('fetchDataForSync — single configured gateway', () {
-    test('returns the response without retrying when the first attempt '
+    test(
+        'returns the response without retrying when the first attempt '
         'succeeds', () async {
       when(() => primaryApi.getSandboxedTx(txId))
           .thenAnswer((_) async => Response('metadata', 200));
@@ -62,7 +93,8 @@ void main() {
       expect(attempts, 2);
     });
 
-    test('gives up after two attempts on a persistent transient failure, so '
+    test(
+        'gives up after two attempts on a persistent transient failure, so '
         'the caller can skip the item', () async {
       when(() => primaryApi.getSandboxedTx(txId))
           .thenAnswer((_) async => Response('boom', 500));
@@ -116,9 +148,7 @@ void main() {
       var calls = 0;
       when(() => primaryApi.getSandboxedTx(txId)).thenAnswer((_) async {
         calls++;
-        return calls == 1
-            ? Response('boom', 500)
-            : Response('not found', 404);
+        return calls == 1 ? Response('boom', 500) : Response('not found', 404);
       });
 
       await expectLater(
@@ -244,11 +274,113 @@ void main() {
     });
   });
 
+  group('a preview budget measures silence, not duration', () {
+    /// Chunks spaced [gap] apart, so the whole body takes [count] * [gap] to
+    /// arrive while no single wait ever reaches the budget.
+    Stream<List<int>> dribble({
+      required int count,
+      required Duration gap,
+    }) async* {
+      for (var i = 0; i < count; i++) {
+        await Future<void>.delayed(gap);
+        yield utf8.encode('chunk$i');
+      }
+    }
+
+    test('a body that keeps arriving is never cut off for taking a while',
+        () async {
+      // The failure this exists for. `getSandboxedTx` buffers the whole body
+      // behind one `Future`, so its timeout was a deadline on the transfer -
+      // and a 48 MiB preview needs more than any budget sized for metadata.
+      // Every gateway was abandoned mid-body and the file was reported
+      // unpreviewable while it was arriving perfectly well.
+      //
+      // Ten chunks, 50ms apart, is 500ms of transfer under a 200ms budget: it
+      // completes only if the budget is measuring gaps rather than total time.
+      final client = _FakeHttpClient(
+        (_) => StreamedResponse(
+          dribble(count: 10, gap: const Duration(milliseconds: 50)),
+          200,
+        ),
+      );
+
+      final patient = DataGatewayFallback(
+        arioSDK: arioSDK,
+        clientFactory: () => client,
+        dataRequestTimeout: const Duration(milliseconds: 200),
+      );
+
+      final response = await patient.fetchData(txId, primaryClient);
+
+      expect(response.statusCode, 200);
+      expect(
+          response.body,
+          'chunk0chunk1chunk2chunk3chunk4chunk5chunk6chunk7'
+          'chunk8chunk9');
+    });
+
+    test('the backstop hangs up on a read that outlives it', () async {
+      // `Future.timeout` does not cancel what it times out. Without closing the
+      // client the read would carry on buffering - up to the 100 MiB preview
+      // cap - and hold its connection long after the caller was told it had
+      // failed. Chunks keep arriving inside the per-chunk budget, so only the
+      // total can end this one.
+      final client = _FakeHttpClient(
+        (_) => StreamedResponse(
+          dribble(count: 50, gap: const Duration(milliseconds: 20)),
+          200,
+        ),
+      );
+
+      final bounded = DataGatewayFallback(
+        arioSDK: arioSDK,
+        clientFactory: () => client,
+        dataRequestTimeout: const Duration(milliseconds: 200),
+        dataTotalTimeout: const Duration(milliseconds: 120),
+      );
+
+      await expectLater(
+        bounded.fetchData(txId, primaryClient),
+        throwsA(isA<Object>()),
+      );
+
+      expect(
+        client.closed,
+        isTrue,
+        reason: 'the connection must be hung up, not left reading',
+      );
+    });
+
+    test('a gateway that goes quiet is still dropped', () async {
+      // The other half: patience must not become indifference. One chunk, then
+      // nothing for longer than the budget.
+      final client = _FakeHttpClient(
+        (_) => StreamedResponse(
+          dribble(count: 2, gap: const Duration(milliseconds: 400)),
+          200,
+        ),
+      );
+
+      final patient = DataGatewayFallback(
+        arioSDK: arioSDK,
+        clientFactory: () => client,
+        dataRequestTimeout: const Duration(milliseconds: 100),
+      );
+
+      await expectLater(
+        patient.fetchData(txId, primaryClient),
+        throwsA(isA<Object>()),
+      );
+    });
+  });
+
   group('waterfall preserved for non-sync paths', () {
     test('fetchData still consults the GAR (download/preview resilience)',
         () async {
-      when(() => primaryApi.getSandboxedTx(txId))
-          .thenAnswer((_) async => Response('metadata', 200));
+      fallback = DataGatewayFallback(
+        arioSDK: arioSDK,
+        clientFactory: () => _FakeHttpClient((_) => _streamed('metadata', 200)),
+      );
 
       await fallback.fetchData(txId, primaryClient);
 
@@ -269,7 +401,8 @@ void main() {
       verify(() => arioSDK.getGateways()).called(1);
     });
 
-    test('fetchData and fetchDataForSync differ in GAR usage for the same '
+    test(
+        'fetchData and fetchDataForSync differ in GAR usage for the same '
         'transaction', () async {
       when(() => primaryApi.getSandboxedTx(txId))
           .thenAnswer((_) async => Response('metadata', 200));
@@ -277,7 +410,12 @@ void main() {
       await fallback.fetchDataForSync(txId, primaryClient);
       verifyNever(() => arioSDK.getGateways());
 
-      await fallback.fetchData(txId, primaryClient);
+      DataGatewayFallback(
+        arioSDK: arioSDK,
+        clientFactory: () => _FakeHttpClient((_) => _streamed('metadata', 200)),
+      ).fetchData(txId, primaryClient).ignore();
+      await pumpEventQueue();
+
       verify(() => arioSDK.getGateways()).called(1);
     });
 
@@ -288,19 +426,22 @@ void main() {
     /// the configured gateway and nowhere else yet.
     test('retries the configured gateway once on a 404, then succeeds',
         () async {
-      var attempts = 0;
-      when(() => primaryApi.getSandboxedTx(txId)).thenAnswer((_) async {
-        attempts++;
-        return attempts == 1
-            ? Response('not found', 404)
-            : Response('metadata', 200);
-      });
+      final client = _FakeHttpClient(
+        (attempt) => attempt == 1
+            ? _streamed('not found', 404)
+            : _streamed('metadata', 200),
+      );
+
+      fallback = DataGatewayFallback(
+        arioSDK: arioSDK,
+        clientFactory: () => client,
+      );
 
       final response = await fallback.fetchData(txId, primaryClient);
 
       expect(response.statusCode, 200);
       expect(response.body, 'metadata');
-      verify(() => primaryApi.getSandboxedTx(txId)).called(2);
+      expect(client.sends, 2);
     });
 
     /// The extra attempt is for a gateway that is a beat behind, not one that
@@ -312,30 +453,40 @@ void main() {
       // keeps the assertion about retries free of any real network call.
       when(() => primaryApi.gatewayUrl)
           .thenReturn(Uri.parse('https://arweave.net'));
-      when(() => primaryApi.getSandboxedTx(txId))
-          .thenAnswer((_) async => Response('server error', 500));
+
+      final client = _FakeHttpClient((_) => _streamed('server error', 500));
+
+      fallback = DataGatewayFallback(
+        arioSDK: arioSDK,
+        clientFactory: () => client,
+      );
 
       await expectLater(
         fallback.fetchData(txId, primaryClient),
         throwsA(isA<Object>()),
       );
 
-      verify(() => primaryApi.getSandboxedTx(txId)).called(1);
+      expect(client.sends, 1);
     });
 
     test('a persistent 404 on the configured gateway is still not found',
         () async {
       when(() => primaryApi.gatewayUrl)
           .thenReturn(Uri.parse('https://arweave.net'));
-      when(() => primaryApi.getSandboxedTx(txId))
-          .thenAnswer((_) async => Response('not found', 404));
+
+      final client = _FakeHttpClient((_) => _streamed('not found', 404));
+
+      fallback = DataGatewayFallback(
+        arioSDK: arioSDK,
+        clientFactory: () => client,
+      );
 
       await expectLater(
         fallback.fetchData(txId, primaryClient),
         throwsA(isA<TransactionNotFound>()),
       );
 
-      verify(() => primaryApi.getSandboxedTx(txId)).called(2);
+      expect(client.sends, 2);
     });
 
     test('a drive signature read on the sync path never reaches the GAR',

--- a/test/sync/domain/sync_transaction_parse_batch_size_test.dart
+++ b/test/sync/domain/sync_transaction_parse_batch_size_test.dart
@@ -1,0 +1,69 @@
+import 'package:ardrive/sync/domain/repositories/sync_repository.dart';
+import 'package:ardrive/sync/utils/batch_processor.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The transaction-parse budget is shared out across the drives left to sync,
+/// and the sharing is integer division - so the interesting cases are all at
+/// the bottom of the range, where it rounds to nothing.
+void main() {
+  int sizeFor(int drivesCount, {int drivesSynced = 0}) =>
+      SyncRepository.transactionParseBatchSizeFor(
+        drivesCount: drivesCount,
+        drivesSynced: drivesSynced,
+      );
+
+  group('transaction parse batch size', () {
+    test('shares the budget across the drives still to sync', () {
+      expect(sizeFor(1), SyncRepository.maxTransactionParseBatchSize);
+      expect(sizeFor(2), 100);
+      expect(sizeFor(4), 50);
+      expect(sizeFor(200), 1);
+    });
+
+    test('counts only the drives that have not been synced yet', () {
+      // Four drives with two already done leaves two to share the budget.
+      expect(sizeFor(4, drivesSynced: 2), 100);
+    });
+
+    test('never returns zero, however many drives there are', () {
+      // The bug this exists for: `200 ~/ remaining` is integer division, so at
+      // 201 remaining drives it rounds to zero - and a batch size of zero is
+      // not a small batch, it is an ArgumentError out of `BatchProcessor`.
+      for (final drives in [201, 500, 5000]) {
+        expect(
+          sizeFor(drives),
+          greaterThan(0),
+          reason: '$drives drives must still produce a usable batch size',
+        );
+      }
+    });
+
+    test('the clamped size is one `BatchProcessor` will accept', () async {
+      // Tying the two halves together, because the clamp is only correct in
+      // terms of what the consumer rejects.
+      final batchSize = sizeFor(5000);
+
+      // Consumed, not merely called. `batchProcess` is `async*`, so its
+      // `batchSize` guard does not run until something listens - a test that
+      // only calls it passes with a batch size of zero, which is the single
+      // value the guard exists to reject.
+      //
+      // The list is mutable because `batchProcess` clears it.
+      await expectLater(
+        BatchProcessor().batchProcess<int>(
+          list: [1, 2, 3],
+          batchSize: batchSize,
+          endOfBatchCallback: (_) => const Stream<double>.empty(),
+        ),
+        emitsDone,
+      );
+    });
+
+    test('a fully synced wallet does not divide by zero', () {
+      // `drivesSynced == drivesCount` leaves nothing to divide by. Reachable or
+      // not, it throws for the same reason the zero batch did.
+      expect(() => sizeFor(3, drivesSynced: 3), returnsNormally);
+      expect(sizeFor(3, drivesSynced: 3), greaterThan(0));
+    });
+  });
+}


### PR DESCRIPTION
# Release v2.87.1

`dev` → `master`. Version `2.87.1` (`pubspec.yaml:6`). Deployed and verified on staging at `c6c83e75a`.

Three fixes, all of them things a user could hit. Two are previews: a large file, and a file uploaded by an old client. The third is a crash that no wallet is big enough to reach yet.

## 👀 A private file uploaded by an older client can be previewed again

`cipherBufferImpl` knew only AES-GCM. AES-CTR was there but **commented out**, so every private CTR file threw `ArgumentError` from that lookup — one line before the `switch` that handles CTR carefully. The preview swallowed it and said *"This file can't be previewed here"*, which reads as an unsupported format rather than a decryption that never happened.

Downloading the same file worked throughout, because downloads decrypt through a different implementation that always supported CTR. That asymmetry — **downloads fine, previews not** — is what located it.

Today's uploader writes GCM below 100 MiB and CTR above, but **older clients wrote CTR at any size**: the file that surfaced this was 47 MiB, written by ArDrive-App 2.19.1.

The note that kept CTR out said the implementation "generates a 16 byte nonce by default". True of *generating* one, and irrelevant to decrypting: `AesCtr` zero pads a short nonce into the counter block, so the 12 byte `Cipher-IV` on a transaction already is the block its data was encrypted under. Verified rather than assumed — encrypting under a 12 byte nonce and under that nonce plus four zero bytes gives identical ciphertext.

**Encryption is unchanged.** Adding CTR to that map also, accidentally, let `createEncryptedTransaction(cipher: aes256ctr)` succeed where it used to throw — which would have written a file whose `Cipher-IV` no reader accepts, permanently and silently. Buffered encryption now goes through a GCM-only path that says why. No caller could reach it, but the guard belongs there.

## ⏱️ A large file is no longer abandoned while it is still arriving

A 48 MiB preview died at exactly ten seconds on every gateway in turn:

```
Gateway turbo-gateway.com failed for tx …: TimeoutException after 0:00:10.000000
Gateway permagate.io      failed for tx …: TimeoutException after 0:00:10.000000
```

Nothing was slow or broken. The body was buffered behind a single `Future`, and **a `Future` timeout is a deadline on the transfer** — so ten seconds meant *"this file must arrive at 5 MB/s"*. Previews are capped at 100 MiB, so any large file was abandoned mid-body by every gateway while it was arriving perfectly well. A second refresh sometimes beat the clock, which is why it looked intermittent.

The waterfall now reads the body as a stream, where the budget measures **silence** rather than duration: a slow body finishes, and a gateway that has actually stopped answering is still dropped in the same ten seconds. No size thresholds and no larger per-read budget — those only move the cliff.

Also here: the waterfall's own backstop now hangs up on a read it has given up on. `Future.timeout` does not cancel what it times out, so a read could carry on buffering toward the preview cap long after the caller was told it had failed.

## ⚡ Sync at scale

The transaction-parse budget is shared across the drives still to sync, by integer division — which reaches **zero** past 200 remaining drives, and a zero batch size is rejected outright. Sync would not have slowed at that scale, it would have stopped, with an error naming nothing about drives or batching.

**No wallet is known to hold that many drives**, so this is a floor under a future scale rather than a fix for anyone's sync today.

## Verification

`flutter analyze` clean; **1441 passing / 4 skipped**, plus `ardrive_crypto` (46) and `ardrive_uploader` (57). The CTR fix was confirmed against a real 47 MiB private video on a preview build.

Included: #2201, #2202, #2203.
