### PR TITLE
chore(version): bring dev's version up to what shipped

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Secure, permanent storage
 
 publish_to: 'none'
 
-version: 2.86.0
+version: 2.87.1
 
 environment:
   sdk: '>=3.2.0 <4.0.0'


### PR DESCRIPTION
`dev` said **2.86.0** while production ran **2.87.1**, so every staging build has been reporting a version two releases old.

## Why it drifts

Structural, not an oversight. A release branch is cut from `dev`, the version is bumped **on that branch**, and it merges to `master` — so the bump never travels back. It happened for both releases done this way and will happen again on the next one unless the bump lands on `dev` instead.

## Scope

One line. The code on `dev` and `master` is **byte identical** (`git diff origin/dev origin/master -- . ':(exclude)pubspec.yaml'` is empty) — this is only the string they report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ndA5nwUpt9hGLUx2TAFr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 2.87.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->