### PR TITLE
feat: say what sync is doing during the two phases that said nothing

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2713,6 +2713,14 @@
   "@syncCheckingForChanges": {
     "description": "Status message shown during drive activity probe"
   },
+  "syncConnectingToNetwork": "Connecting to the network...",
+  "@syncConnectingToNetwork": {
+    "description": "Status message shown while fetching the current block height"
+  },
+  "syncDownloadingSnapshots": "Downloading drive snapshots...",
+  "@syncDownloadingSnapshots": {
+    "description": "Status message shown while snapshots are prefetched for all drives"
+  },
   "retryFailedDrives": "Retry Failed",
   "@retryFailedDrives": {
     "description": "Button to retry syncing only the drives that failed"

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -309,6 +309,14 @@ class _SyncRepository implements SyncRepository {
 
     yield syncProgress;
 
+    // The first network call of a sync, and the one that has nothing local to
+    // fall back on. Until now the dialog sat at 0% with nothing to say while a
+    // slow gateway was asked for the chain head.
+    syncProgress = syncProgress.copyWith(
+      statusMessage: 'Connecting to the network...',
+    );
+    yield syncProgress;
+
     final currentBlockHeight = await retry(
       () async => await _arweave.getCurrentBlockHeight(),
       onRetry: (exception) => logger.w(
@@ -323,6 +331,13 @@ class _SyncRepository implements SyncRepository {
     List<Drive> drivesToSync;
     if (syncDeep) {
       drivesToSync = drives;
+      // A deep sync passes lastBlockHeight: 0 for every drive below, so every
+      // drive is read from the start of its history - not just the ones that
+      // have never been synced. Nothing is skipped, so skippedDriveCount is
+      // left at its zero default.
+      syncProgress = syncProgress.copyWith(
+        firstTimeSyncDriveCount: drives.length,
+      );
     } else {
       syncProgress = syncProgress.copyWith(
         statusMessage: 'Checking for changes...',
@@ -348,6 +363,9 @@ class _SyncRepository implements SyncRepository {
           if (neverSyncedDrives.isNotEmpty) {
             logger.i('${neverSyncedDrives.length} drives need first-time sync');
           }
+          syncProgress = syncProgress.copyWith(
+            firstTimeSyncDriveCount: neverSyncedDrives.length,
+          );
         } else {
           // Group previously-synced drives by owner for efficient probing
           final drivesByOwner = <String, List<Drive>>{};
@@ -395,10 +413,22 @@ class _SyncRepository implements SyncRepository {
           if (neverSyncedDrives.isNotEmpty) {
             logger.i('${neverSyncedDrives.length} drives need first-time sync');
           }
+          syncProgress = syncProgress.copyWith(
+            firstTimeSyncDriveCount: neverSyncedDrives.length,
+            skippedDriveCount: skipped,
+          );
         }
       } catch (e) {
         logger.w('Drive activity probe failed, syncing all drives: $e');
         drivesToSync = drives;
+        // The probe could not answer, so every drive is synced and none is
+        // skipped. Each still walks from its own watermark, so the drives read
+        // from the start of their history are exactly the never-synced ones.
+        syncProgress = syncProgress.copyWith(
+          firstTimeSyncDriveCount:
+              drives.where((d) => (d.lastBlockHeight ?? 0) == 0).length,
+          skippedDriveCount: 0,
+        );
       }
     }
 
@@ -411,7 +441,12 @@ class _SyncRepository implements SyncRepository {
     if (numberOfDrivesToSync == 0) {
       // Probe found no drives with activity — this is a successful no-op sync
       logger.i('No drives need syncing');
-      yield SyncProgress.emptySyncCompleted();
+      // Carry the probe's counts through. "Nothing to do" is exactly the sync
+      // where the number of drives it skipped is the whole story.
+      yield SyncProgress.emptySyncCompleted().copyWith(
+        firstTimeSyncDriveCount: syncProgress.firstTimeSyncDriveCount,
+        skippedDriveCount: syncProgress.skippedDriveCount,
+      );
       _lastSync = DateTime.now();
       return;
     }
@@ -424,6 +459,13 @@ class _SyncRepository implements SyncRepository {
     // each drive's sync to avoid redundant per-drive snapshot queries.
     final prefetchedSnapshots = <String, List<SnapshotEntityTransaction>>{};
     if (_configService.config.enableSyncFromSnapshot && !syncDeep) {
+      // The single largest download of a sync - tens of MB for a wallet with
+      // history - and the longest stretch of it that said nothing at all.
+      syncProgress = syncProgress.copyWith(
+        statusMessage: 'Downloading drive snapshots...',
+      );
+      yield syncProgress;
+
       try {
         // Reuse the drivesByOwner grouping from the probe (or rebuild it)
         final snapshotDrivesByOwner = <String, List<Drive>>{};
@@ -493,6 +535,10 @@ class _SyncRepository implements SyncRepository {
         logger.w('Snapshot prefetch failed, will fetch per-drive: $e');
         prefetchedSnapshots.clear();
       }
+
+      // Clear the prefetch status message
+      syncProgress = syncProgress.copyWith(statusMessage: null);
+      yield syncProgress;
     }
 
     double totalProgress = 0;
@@ -839,6 +885,19 @@ class _SyncRepository implements SyncRepository {
       drivesCount: 1,
       isSingleDriveSync: true,
       driveName: drive.name,
+      // Same question this path already answers below when it decides where to
+      // start the walk: a deep sync reads from block zero, and so does a drive
+      // that has never been synced. Set here rather than left at its default,
+      // because a field that is only correct on the all-drives path is worse
+      // than one that is absent - a caller cannot tell which it is holding.
+      firstTimeSyncDriveCount:
+          syncDeep || (drive.lastBlockHeight ?? 0) == 0 ? 1 : 0,
+    );
+    yield syncProgress;
+
+    // Same silent first call as the all-drives path.
+    syncProgress = syncProgress.copyWith(
+      statusMessage: 'Connecting to the network...',
     );
     yield syncProgress;
 
@@ -848,6 +907,11 @@ class _SyncRepository implements SyncRepository {
         'Retrying for get the current block height',
       ),
     );
+
+    // Clear it again: the drive walk that follows is reported as a percentage,
+    // and the dialog already names this drive in its title.
+    syncProgress = syncProgress.copyWith(statusMessage: null);
+    yield syncProgress;
 
     final StreamController<SyncProgress> syncProgressController =
         StreamController<SyncProgress>.broadcast();

--- a/lib/sync/domain/sync_progress.dart
+++ b/lib/sync/domain/sync_progress.dart
@@ -21,6 +21,8 @@ class SyncProgress extends LinearProgress {
     this.driveName,
     this.skippedEntityCount = 0,
     this.skippedEntityTxIdsByDrive = const {},
+    this.firstTimeSyncDriveCount = 0,
+    this.skippedDriveCount = 0,
   });
 
   factory SyncProgress.initial() {
@@ -84,6 +86,17 @@ class SyncProgress extends LinearProgress {
   /// "failed files" in the UI. See `docs/SYNC_SKIPPED_ENTITY_PERSISTENCE.md`.
   final Map<String, List<String>> skippedEntityTxIdsByDrive;
 
+  /// Number of drives in this sync that are read from the start of their
+  /// history rather than from a watermark, and so cost a full history walk:
+  /// the drives that have never been synced before, and — in a deep sync,
+  /// which rewinds every drive to block zero — all of them.
+  final int firstTimeSyncDriveCount;
+
+  /// Number of drives the activity probe found unchanged and left out of this
+  /// sync. Zero for a deep sync, and zero when the probe could not answer -
+  /// in both of those cases nothing was skipped.
+  final int skippedDriveCount;
+
   /// Flat list of every skipped transaction id, drive association discarded.
   List<String> get skippedEntityTxIds =>
       [...skippedEntityTxIdsByDrive.values.expand((txIds) => txIds)];
@@ -110,6 +123,8 @@ class SyncProgress extends LinearProgress {
     Object? driveName = _absent,
     int? skippedEntityCount,
     Map<String, List<String>>? skippedEntityTxIdsByDrive,
+    int? firstTimeSyncDriveCount,
+    int? skippedDriveCount,
   }) {
     return SyncProgress(
       numberOfEntities: numberOfEntities ?? this.numberOfEntities,
@@ -131,6 +146,9 @@ class SyncProgress extends LinearProgress {
       skippedEntityCount: skippedEntityCount ?? this.skippedEntityCount,
       skippedEntityTxIdsByDrive:
           skippedEntityTxIdsByDrive ?? this.skippedEntityTxIdsByDrive,
+      firstTimeSyncDriveCount:
+          firstTimeSyncDriveCount ?? this.firstTimeSyncDriveCount,
+      skippedDriveCount: skippedDriveCount ?? this.skippedDriveCount,
     );
   }
 }

--- a/test/sync/domain/sync_progress_test.dart
+++ b/test/sync/domain/sync_progress_test.dart
@@ -62,5 +62,47 @@ void main() {
 
       expect(updated.driveName, 'Test Drive');
     });
+
+    test('drive counts start at zero', () {
+      final progress = SyncProgress.initial();
+
+      expect(progress.firstTimeSyncDriveCount, 0);
+      expect(progress.skippedDriveCount, 0);
+    });
+
+    test('sets firstTimeSyncDriveCount and skippedDriveCount', () {
+      final progress = SyncProgress.initial().copyWith(
+        firstTimeSyncDriveCount: 2,
+        skippedDriveCount: 7,
+      );
+
+      expect(progress.firstTimeSyncDriveCount, 2);
+      expect(progress.skippedDriveCount, 7);
+    });
+
+    test('retains the drive counts when not provided', () {
+      final progress = SyncProgress.initial().copyWith(
+        firstTimeSyncDriveCount: 2,
+        skippedDriveCount: 7,
+      );
+
+      final updated = progress.copyWith(drivesCount: 9);
+
+      expect(updated.firstTimeSyncDriveCount, 2);
+      expect(updated.skippedDriveCount, 7);
+      expect(updated.drivesCount, 9);
+    });
+
+    test('overwrites each drive count independently', () {
+      final progress = SyncProgress.initial().copyWith(
+        firstTimeSyncDriveCount: 2,
+        skippedDriveCount: 7,
+      );
+
+      final updated = progress.copyWith(skippedDriveCount: 0);
+
+      expect(updated.firstTimeSyncDriveCount, 2);
+      expect(updated.skippedDriveCount, 0);
+    });
   });
 }

--- a/test/sync/domain/sync_repository_phase_messages_test.dart
+++ b/test/sync/domain/sync_repository_phase_messages_test.dart
@@ -1,0 +1,581 @@
+import 'package:ardrive/arns/domain/arns_repository.dart';
+import 'package:ardrive/models/database/database.dart';
+import 'package:ardrive/services/arweave/data_gateway_fallback.dart';
+import 'package:ardrive/services/config/app_config.dart';
+import 'package:ardrive/sync/data/snapshot_validation_service.dart';
+import 'package:ardrive/sync/domain/repositories/sync_repository.dart';
+import 'package:ardrive/sync/domain/sync_progress.dart';
+import 'package:ardrive/sync/utils/batch_processor.dart';
+import 'package:ardrive/user/repositories/user_preferences_repository.dart';
+import 'package:ardrive/user/user_preferences.dart';
+import 'package:ardrive_ui/ardrive_ui.dart';
+import 'package:ario_sdk/ario_sdk.dart';
+import 'package:arweave/arweave.dart';
+import 'package:cryptography/cryptography.dart';
+import 'package:drift/drift.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../test_utils/mocks.dart';
+
+// Mocks not available in shared mocks file
+class MockBatchProcessor extends Mock implements BatchProcessor {}
+
+class MockSnapshotValidationService extends Mock
+    implements SnapshotValidationService {}
+
+class _MockARNSRepository extends Mock implements ARNSRepository {}
+
+class MockUserPreferencesRepository extends Mock
+    implements UserPreferencesRepository {}
+
+class _MockWallet extends Mock implements Wallet {}
+
+class _MockDataGatewayFallback extends Mock implements DataGatewayFallback {}
+
+class _FakeWallet extends Fake implements Wallet {}
+
+class _FakeSecretKey extends Fake implements SecretKey {}
+
+class FakeSelectable<T> extends Fake implements Selectable<T> {
+  final List<T> _data;
+  FakeSelectable(this._data);
+
+  @override
+  Future<List<T>> get() async => _data;
+
+  @override
+  Future<T> getSingle() async => _data.single;
+
+  @override
+  Future<T?> getSingleOrNull() async => _data.isEmpty ? null : _data.single;
+
+  @override
+  Selectable<N> map<N>(N Function(T) f) {
+    return FakeSelectable(_data.map(f).toList());
+  }
+}
+
+// Helper to create a Drive with specific fields
+Drive _makeDrive({
+  required String id,
+  required String ownerAddress,
+  int? lastBlockHeight,
+  String name = 'Test Drive',
+}) {
+  return Drive(
+    id: id,
+    rootFolderId: 'root-$id',
+    ownerAddress: ownerAddress,
+    name: name,
+    lastBlockHeight: lastBlockHeight,
+    privacy: 'public',
+    isHidden: false,
+    dateCreated: DateTime(2024),
+    lastUpdated: DateTime(2024),
+  );
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeWallet());
+    registerFallbackValue(_FakeSecretKey());
+  });
+
+  late MockArweaveService mockArweave;
+  late MockDriveDao mockDriveDao;
+  late MockConfigService mockConfigService;
+  late MockBatchProcessor mockBatchProcessor;
+  late MockSnapshotValidationService mockSnapshotValidation;
+  late _MockARNSRepository mockArnsRepository;
+  late MockUserPreferencesRepository mockUserPrefsRepo;
+  late SyncRepository syncRepository;
+  late _MockWallet mockWallet;
+
+  const ownerAddress = 'owner-address-123';
+
+  const connecting = 'Connecting to the network...';
+  const checking = 'Checking for changes...';
+  const downloading = 'Downloading drive snapshots...';
+
+  /// Configures the repository. Snapshot prefetch is off by default, matching
+  /// the other sync repository tests; the prefetch group turns it on.
+  void buildRepository({bool enableSyncFromSnapshot = false}) {
+    when(() => mockConfigService.config).thenReturn(AppConfig(
+      allowedDataItemSizeForTurbo: 0,
+      stripePublishableKey: '',
+      enableSyncFromSnapshot: enableSyncFromSnapshot,
+      autoSync: true,
+    ));
+
+    syncRepository = SyncRepository(
+      arweave: mockArweave,
+      driveDao: mockDriveDao,
+      configService: mockConfigService,
+      batchProcessor: mockBatchProcessor,
+      snapshotValidationService: mockSnapshotValidation,
+      arnsRepository: mockArnsRepository,
+      userPreferencesRepository: mockUserPrefsRepo,
+    );
+  }
+
+  /// Stubs everything a drive walk and the post-sync phase touch, so the
+  /// listed drives actually sync to completion and the stream reaches its
+  /// 'Sync complete' emission. Each drive walks an empty transaction stream.
+  void stubSuccessfulDriveSync(List<Drive> drives) {
+    for (final drive in drives) {
+      when(() => mockDriveDao.driveById(driveId: drive.id))
+          .thenReturn(FakeSelectable([drive]));
+      when(() => mockDriveDao.pendingTransactionsForDrive(driveId: drive.id))
+          .thenReturn(FakeSelectable(<NetworkTransaction>[]));
+    }
+
+    when(() => mockArweave.getSegmentedTransactionsFromDrive(
+          any(),
+          ownerAddress: any(named: 'ownerAddress'),
+          minBlockHeight: any(named: 'minBlockHeight'),
+          maxBlockHeight: any(named: 'maxBlockHeight'),
+          strategy: any(named: 'strategy'),
+        )).thenAnswer((_) => const Stream.empty());
+    when(() => mockArweave.snapshotMetadataHits).thenReturn(<String, int>{});
+    when(() => mockArweave.snapshotMetadataMisses).thenReturn(<String, int>{});
+    when(() => mockArweave.clearUserDriveTxsCache()).thenReturn(null);
+
+    // Post-sync phase.
+    when(() => mockArnsRepository.waitForARNSRecordsToUpdate())
+        .thenAnswer((_) async {});
+    when(() => mockArnsRepository.saveAllFilesWithAssignedNames())
+        .thenAnswer((_) async {});
+    when(() => mockDriveDao.hasHiddenItems())
+        .thenReturn(FakeSelectable([false]));
+    when(() => mockUserPrefsRepo.saveUserHasHiddenItem(any()))
+        .thenAnswer((_) async {});
+    when(() => mockUserPrefsRepo.load()).thenAnswer(
+      (_) async => const UserPreferences(
+        currentTheme: ArDriveThemes.light,
+        lastSelectedDriveId: null,
+      ),
+    );
+    when(() => mockDriveDao.pinnedFileRevisions())
+        .thenReturn(FakeSelectable(<FileRevision>[]));
+    when(() => mockDriveDao.pendingDataFileRevisions())
+        .thenReturn(FakeSelectable(<FileRevision>[]));
+    when(() => mockDriveDao.pendingTransactions())
+        .thenReturn(FakeSelectable(<NetworkTransaction>[]));
+  }
+
+  /// Runs a full sync to exhaustion and returns everything it emitted. Unless
+  /// [stubSuccessfulDriveSync] was called, the drive walk is not mocked, so
+  /// each drive fails inside `_syncDrive` after the phases under test have
+  /// already been announced.
+  Future<List<SyncProgress>> collectProgress({bool syncDeep = false}) async {
+    final emitted = <SyncProgress>[];
+
+    try {
+      await for (final progress in syncRepository.syncAllDrives(
+        wallet: mockWallet,
+        syncDeep: syncDeep,
+      )) {
+        emitted.add(progress);
+      }
+    } catch (_) {}
+
+    // Allow async tasks spawned by syncAllDrives to settle
+    await Future.delayed(const Duration(milliseconds: 100));
+
+    return emitted;
+  }
+
+  Future<List<SyncProgress>> collectSingleDriveProgress(String driveId) async {
+    final emitted = <SyncProgress>[];
+
+    try {
+      await for (final progress in syncRepository.syncSingleDrive(
+        driveId: driveId,
+        wallet: mockWallet,
+      )) {
+        emitted.add(progress);
+      }
+    } catch (_) {}
+
+    await Future.delayed(const Duration(milliseconds: 100));
+
+    return emitted;
+  }
+
+  List<String> statusMessagesOf(List<SyncProgress> emitted) =>
+      emitted.map((p) => p.statusMessage).whereType<String>().toList();
+
+  setUp(() {
+    mockArweave = MockArweaveService();
+    mockDriveDao = MockDriveDao();
+    mockConfigService = MockConfigService();
+    mockBatchProcessor = MockBatchProcessor();
+    mockSnapshotValidation = MockSnapshotValidationService();
+    mockArnsRepository = _MockARNSRepository();
+    mockUserPrefsRepo = MockUserPreferencesRepository();
+    mockWallet = _MockWallet();
+
+    when(() => mockWallet.getAddress()).thenAnswer((_) async => ownerAddress);
+
+    // Mock gateway fallback for snapshot validation service cache sharing
+    final mockGatewayFallback = _MockDataGatewayFallback();
+    when(() => mockArweave.gatewayFallback).thenReturn(mockGatewayFallback);
+    when(() => mockGatewayFallback.cachedGateways).thenReturn([]);
+
+    // Mock ARNS repository
+    when(() => mockArnsRepository.getAntRecordsForWallet(any(),
+        update: any(named: 'update'))).thenAnswer(
+      (_) async => <ANTRecord>[],
+    );
+
+    when(() => mockArweave.getCurrentBlockHeight())
+        .thenAnswer((_) async => 100000);
+
+    buildRepository();
+  });
+
+  group('phase status messages', () {
+    test('names the block height fetch', () async {
+      when(() => mockDriveDao.allDrives()).thenReturn(FakeSelectable([
+        _makeDrive(id: 'a', ownerAddress: ownerAddress, lastBlockHeight: 50000),
+      ]));
+      when(() => mockArweave.probeActiveDriveIds(
+            driveIds: any(named: 'driveIds'),
+            minBlockHeight: any(named: 'minBlockHeight'),
+            ownerAddress: any(named: 'ownerAddress'),
+          )).thenAnswer((_) async => (
+            activeDriveIds: {'a'},
+            isComplete: true,
+          ));
+
+      final messages = statusMessagesOf(await collectProgress());
+
+      expect(messages, contains(connecting));
+    });
+
+    test('the block height message is announced before the probe', () async {
+      when(() => mockDriveDao.allDrives()).thenReturn(FakeSelectable([
+        _makeDrive(id: 'a', ownerAddress: ownerAddress, lastBlockHeight: 50000),
+      ]));
+      when(() => mockArweave.probeActiveDriveIds(
+            driveIds: any(named: 'driveIds'),
+            minBlockHeight: any(named: 'minBlockHeight'),
+            ownerAddress: any(named: 'ownerAddress'),
+          )).thenAnswer((_) async => (
+            activeDriveIds: {'a'},
+            isComplete: true,
+          ));
+
+      final messages = statusMessagesOf(await collectProgress());
+
+      // Both must be present before their order means anything: indexOf
+      // returns -1 for a missing message, and -1 < 0 would pass vacuously.
+      expect(messages, contains(connecting));
+      expect(messages, contains(checking));
+      expect(
+        messages.indexOf(connecting),
+        lessThan(messages.indexOf(checking)),
+      );
+    });
+
+    test('names the snapshot prefetch', () async {
+      buildRepository(enableSyncFromSnapshot: true);
+
+      when(() => mockDriveDao.allDrives()).thenReturn(FakeSelectable([
+        _makeDrive(id: 'a', ownerAddress: ownerAddress, lastBlockHeight: 50000),
+      ]));
+      when(() => mockArweave.probeActiveDriveIds(
+            driveIds: any(named: 'driveIds'),
+            minBlockHeight: any(named: 'minBlockHeight'),
+            ownerAddress: any(named: 'ownerAddress'),
+          )).thenAnswer((_) async => (
+            activeDriveIds: {'a'},
+            isComplete: true,
+          ));
+      when(() => mockArweave.getAllSnapshotsForDrives(
+            any(),
+            any(),
+            ownerAddress: any(named: 'ownerAddress'),
+            onQueryFailure: any(named: 'onQueryFailure'),
+          )).thenAnswer((_) => const Stream.empty());
+
+      final messages = statusMessagesOf(await collectProgress());
+
+      expect(messages, contains(downloading));
+    });
+
+    test('says nothing about snapshots when the prefetch does not run',
+        () async {
+      when(() => mockDriveDao.allDrives()).thenReturn(FakeSelectable([
+        _makeDrive(id: 'a', ownerAddress: ownerAddress, lastBlockHeight: 50000),
+      ]));
+      when(() => mockArweave.probeActiveDriveIds(
+            driveIds: any(named: 'driveIds'),
+            minBlockHeight: any(named: 'minBlockHeight'),
+            ownerAddress: any(named: 'ownerAddress'),
+          )).thenAnswer((_) async => (
+            activeDriveIds: {'a'},
+            isComplete: true,
+          ));
+
+      final messages = statusMessagesOf(await collectProgress());
+
+      expect(messages, isNot(contains(downloading)));
+    });
+
+    test('says nothing during the drive walk, so the percentage stays up',
+        () async {
+      // The dialog renders statusMessage INSTEAD OF the "{n}% complete"
+      // readout (app_shell.dart, `if (statusMessage != null) ... else ...`).
+      // A message set during the walk would blank the only number the user
+      // sees for the whole 0->90% stretch, so the walk must stay silent.
+      final drive = _makeDrive(
+        id: 'a',
+        ownerAddress: ownerAddress,
+        lastBlockHeight: 50000,
+        name: 'Photos',
+      );
+      when(() => mockDriveDao.allDrives()).thenReturn(FakeSelectable([drive]));
+      when(() => mockArweave.probeActiveDriveIds(
+            driveIds: any(named: 'driveIds'),
+            minBlockHeight: any(named: 'minBlockHeight'),
+            ownerAddress: any(named: 'ownerAddress'),
+          )).thenAnswer((_) async => (
+            activeDriveIds: {'a'},
+            isComplete: true,
+          ));
+      stubSuccessfulDriveSync([drive]);
+
+      final emitted = await collectProgress();
+
+      // The walk is everything the drive loop caps at 90%.
+      final walk =
+          emitted.where((p) => p.progress > 0 && p.progress <= 0.9).toList();
+      expect(walk, isNotEmpty);
+      expect(walk.every((p) => p.statusMessage == null), isTrue);
+      expect(
+        statusMessagesOf(emitted).where((m) => m.contains('Photos')),
+        isEmpty,
+      );
+    });
+
+    test('emits exactly the phase messages this sync has, in order', () async {
+      buildRepository(enableSyncFromSnapshot: true);
+
+      when(() => mockDriveDao.allDrives()).thenReturn(FakeSelectable([
+        _makeDrive(
+          id: 'a',
+          ownerAddress: ownerAddress,
+          lastBlockHeight: 50000,
+          name: 'Photos',
+        ),
+      ]));
+      when(() => mockArweave.probeActiveDriveIds(
+            driveIds: any(named: 'driveIds'),
+            minBlockHeight: any(named: 'minBlockHeight'),
+            ownerAddress: any(named: 'ownerAddress'),
+          )).thenAnswer((_) async => (
+            activeDriveIds: {'a'},
+            isComplete: true,
+          ));
+      when(() => mockArweave.getAllSnapshotsForDrives(
+            any(),
+            any(),
+            ownerAddress: any(named: 'ownerAddress'),
+            onQueryFailure: any(named: 'onQueryFailure'),
+          )).thenAnswer((_) => const Stream.empty());
+
+      final messages = statusMessagesOf(await collectProgress());
+
+      // The exact set, not merely "non-empty": this drive fails its walk, so
+      // the three pre-walk phases are the whole of what this sync says.
+      expect(messages, [connecting, checking, downloading]);
+    });
+  });
+
+  group('drive counts on SyncProgress', () {
+    test('reports how many drives need a first-time sync', () async {
+      when(() => mockDriveDao.allDrives()).thenReturn(FakeSelectable([
+        _makeDrive(id: 'a', ownerAddress: ownerAddress, lastBlockHeight: null),
+        _makeDrive(id: 'b', ownerAddress: ownerAddress, lastBlockHeight: 0),
+      ]));
+
+      final emitted = await collectProgress();
+
+      expect(emitted.last.firstTimeSyncDriveCount, 2);
+      expect(emitted.last.skippedDriveCount, 0);
+    });
+
+    test('reports how many unchanged drives the probe skipped', () async {
+      when(() => mockDriveDao.allDrives()).thenReturn(FakeSelectable([
+        _makeDrive(id: 'a', ownerAddress: ownerAddress, lastBlockHeight: 50000),
+        _makeDrive(id: 'b', ownerAddress: ownerAddress, lastBlockHeight: 60000),
+        _makeDrive(id: 'c', ownerAddress: ownerAddress, lastBlockHeight: null),
+      ]));
+      when(() => mockArweave.probeActiveDriveIds(
+            driveIds: any(named: 'driveIds'),
+            minBlockHeight: any(named: 'minBlockHeight'),
+            ownerAddress: any(named: 'ownerAddress'),
+          )).thenAnswer((_) async => (
+            activeDriveIds: <String>{},
+            isComplete: true,
+          ));
+
+      final emitted = await collectProgress();
+
+      // Only the never-synced drive is left to sync.
+      expect(emitted.last.skippedDriveCount, 2);
+      expect(emitted.last.firstTimeSyncDriveCount, 1);
+    });
+
+    test('a sync with nothing to do still reports what it skipped', () async {
+      when(() => mockDriveDao.allDrives()).thenReturn(FakeSelectable([
+        _makeDrive(id: 'a', ownerAddress: ownerAddress, lastBlockHeight: 50000),
+        _makeDrive(id: 'b', ownerAddress: ownerAddress, lastBlockHeight: 60000),
+      ]));
+      when(() => mockArweave.probeActiveDriveIds(
+            driveIds: any(named: 'driveIds'),
+            minBlockHeight: any(named: 'minBlockHeight'),
+            ownerAddress: any(named: 'ownerAddress'),
+          )).thenAnswer((_) async => (
+            activeDriveIds: <String>{},
+            isComplete: true,
+          ));
+
+      final emitted = await collectProgress();
+
+      expect(emitted.last.progress, 1);
+      expect(emitted.last.skippedDriveCount, 2);
+      expect(emitted.last.firstTimeSyncDriveCount, 0);
+    });
+
+    test('a deep sync reads every drive from the start and skips nothing',
+        () async {
+      when(() => mockDriveDao.allDrives()).thenReturn(FakeSelectable([
+        _makeDrive(id: 'a', ownerAddress: ownerAddress, lastBlockHeight: 50000),
+        _makeDrive(id: 'b', ownerAddress: ownerAddress, lastBlockHeight: null),
+      ]));
+
+      final emitted = await collectProgress(syncDeep: true);
+
+      // A deep sync rewinds every drive to block zero, watermark or not, so
+      // both count as first-time walks. Nothing is probed, nothing skipped.
+      expect(emitted.last.firstTimeSyncDriveCount, 2);
+      expect(emitted.last.skippedDriveCount, 0);
+    });
+
+    test('a failed probe still reports the drives read from the start',
+        () async {
+      when(() => mockDriveDao.allDrives()).thenReturn(FakeSelectable([
+        _makeDrive(id: 'a', ownerAddress: ownerAddress, lastBlockHeight: 50000),
+        _makeDrive(id: 'b', ownerAddress: ownerAddress, lastBlockHeight: null),
+        _makeDrive(id: 'c', ownerAddress: ownerAddress, lastBlockHeight: 0),
+      ]));
+      when(() => mockArweave.probeActiveDriveIds(
+            driveIds: any(named: 'driveIds'),
+            minBlockHeight: any(named: 'minBlockHeight'),
+            ownerAddress: any(named: 'ownerAddress'),
+          )).thenThrow(Exception('gateway is down'));
+
+      final emitted = await collectProgress();
+
+      // The probe could not answer, so all three sync and none is skipped -
+      // but only the two never-synced drives walk from the start.
+      expect(emitted.last.firstTimeSyncDriveCount, 2);
+      expect(emitted.last.skippedDriveCount, 0);
+    });
+
+    test('the counts survive to a successful "Sync complete"', () async {
+      final active = _makeDrive(
+          id: 'a', ownerAddress: ownerAddress, lastBlockHeight: 50000);
+      final unchanged = _makeDrive(
+          id: 'b', ownerAddress: ownerAddress, lastBlockHeight: 60000);
+      final neverSynced = _makeDrive(
+          id: 'c', ownerAddress: ownerAddress, lastBlockHeight: null);
+
+      when(() => mockDriveDao.allDrives())
+          .thenReturn(FakeSelectable([active, unchanged, neverSynced]));
+      when(() => mockArweave.probeActiveDriveIds(
+            driveIds: any(named: 'driveIds'),
+            minBlockHeight: any(named: 'minBlockHeight'),
+            ownerAddress: any(named: 'ownerAddress'),
+          )).thenAnswer((_) async => (
+            activeDriveIds: {'a'},
+            isComplete: true,
+          ));
+      stubSuccessfulDriveSync([active, neverSynced]);
+
+      final emitted = await collectProgress();
+      final last = emitted.last;
+
+      // The terminal emission a summary UI reads: not an early return, but the
+      // one the post-sync phase publishes after every drive walked cleanly.
+      expect(last.statusMessage, 'Sync complete');
+      expect(last.progress, 1.0);
+      expect(last.firstTimeSyncDriveCount, 1);
+      expect(last.skippedDriveCount, 1);
+    });
+  });
+
+  group('syncSingleDrive', () {
+    test('announces the block height fetch, then clears it for the walk',
+        () async {
+      final drive = _makeDrive(
+        id: 'a',
+        ownerAddress: ownerAddress,
+        lastBlockHeight: 50000,
+        name: 'Photos',
+      );
+      when(() => mockDriveDao.driveById(driveId: 'a'))
+          .thenReturn(FakeSelectable([drive]));
+
+      final emitted = await collectSingleDriveProgress('a');
+
+      final connectingIndex =
+          emitted.indexWhere((p) => p.statusMessage == connecting);
+      expect(connectingIndex, isNonNegative);
+
+      // Cleared before the walk: from here the dialog shows the percentage,
+      // and its title already names this drive. The drive itself then fails
+      // its walk, so this is the whole of what a single drive sync says.
+      expect(emitted.length, greaterThan(connectingIndex + 1));
+      expect(emitted[connectingIndex + 1].statusMessage, null);
+      expect(statusMessagesOf(emitted), [connecting]);
+    });
+
+    test('reports the drive as first-time when it has never been synced',
+        () async {
+      // The count has to mean the same thing on this path as on the
+      // all-drives one, because the UI reading it cannot tell which sync
+      // produced the number it is holding.
+      final never = _makeDrive(
+        id: 'a',
+        ownerAddress: ownerAddress,
+        lastBlockHeight: 0,
+        name: 'Fresh',
+      );
+      when(() => mockDriveDao.driveById(driveId: 'a'))
+          .thenReturn(FakeSelectable([never]));
+
+      final emitted = await collectSingleDriveProgress('a');
+
+      expect(emitted.first.firstTimeSyncDriveCount, 1);
+    });
+
+    test('reports no first-time drive when it has a watermark', () async {
+      final synced = _makeDrive(
+        id: 'a',
+        ownerAddress: ownerAddress,
+        lastBlockHeight: 50000,
+        name: 'Photos',
+      );
+      when(() => mockDriveDao.driveById(driveId: 'a'))
+          .thenReturn(FakeSelectable([synced]));
+
+      final emitted = await collectSingleDriveProgress('a');
+
+      expect(emitted.first.firstTimeSyncDriveCount, 0);
+    });
+  });
+}


### PR DESCRIPTION
PR 1 of four, from the [sync UX evaluation](https://claude.ai/code/artifact/46918716-c19e-4967-9f9c-581af9a4caad). Purely presentation over values the repository already computes.

## What you see

Two phases that previously ran with the dialog showing a static **"0% complete"** now name themselves:

| Phase | Message |
| --- | --- |
| Fetching the chain head | `Connecting to the network...` |
| Snapshot prefetch | `Downloading drive snapshots...` |

The snapshot prefetch is the **largest download in a sync** — tens of megabytes for a wallet with history — and was the longest stretch of it that said nothing at all.

## Why only two, and not the drive walk

A first pass at this also named the drive being walked. Independent review caught that this is a **regression, not an addition**: `app_shell.dart:378-405` renders

```dart
if (syncProgress.statusMessage != null) Text(statusMessage!) else Text(syncProgressPercentage(...))
```

They are mutually exclusive. A message during the walk would delete the `{n}% complete` readout for the **entire 0→90% phase** — the longest part of a sync and the only place a number is shown. It also thrashed (drives walk concurrently, each overwriting the shared message with its own name) and duplicated the description line above it.

The walk now stays deliberately silent and keeps its percentage. The dialog already says how many drives are done on the line above.

## Counts promoted to state

`firstTimeSyncDriveCount` and `skippedDriveCount` — computed by the probe, previously only reachable via `logger.i`. PR 2 renders them.

Set on **every** path that decides them: the probe, a deep sync, a failed probe, and a single-drive sync. A count that is only correct on one path is worse than an absent one — a caller cannot tell which it is holding. The no-op sync carries them through as well, since "nothing to do" is exactly the sync where the skipped count is the whole story.

## Nothing in the delicate zone

No batching or concurrency arithmetic, no watermark or rewind, no snapshot validation, and **not one additional network request**. Every value surfaced was already computed.

## Tests

`flutter analyze` clean; **1465 passing / 4 skipped**.

Every new test was proved to guard by reverting its implementation line and confirming failure — including the two that previously passed **vacuously**: an ordering assertion where `indexOf` returned `-1` and `-1 < 0` succeeded, and a "messages are non-empty" check satisfied by the pre-existing `Checking for changes...`.

## Known and deliberate

The messages are hardcoded English, matching the existing `syncCheckingForChanges` — also a literal with a registered but unreferenced ARB key. Two more keys are registered here on the same footing. **Non-English users see English for these two short windows** where they previously saw a translated "0% complete".

Wiring localisation needs the repository to emit keys the UI resolves, and should fix all five messages at once rather than half of them. Own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ndA5nwUpt9hGLUx2TAFr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer sync progress updates for network connection, snapshot downloads, first-time drive syncing, and skipped drives.
  * Sync status now reports counts for drives requiring an initial sync and drives skipped during activity checks.
  * Added English messages for connecting to the network and downloading drive snapshots.

* **Bug Fixes**
  * Improved status handling so progress messages are correctly shown and cleared during sync operations.

* **Tests**
  * Expanded coverage for sync progress tracking and phase-specific status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->