### PR TITLE
feat: a sync that finished says what it found

### DIFF
--- a/lib/components/app_top_bar.dart
+++ b/lib/components/app_top_bar.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:ardrive/blocs/drive_detail/drive_detail_cubit.dart';
 import 'package:ardrive/blocs/drives/drives_cubit.dart';
 import 'package:ardrive/blocs/hide/global_hide_bloc.dart';
@@ -9,6 +11,7 @@ import 'package:ardrive/search/search_modal.dart';
 import 'package:ardrive/search/search_text_field.dart';
 import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
 import 'package:ardrive/sync/domain/sync_progress.dart';
+import 'package:ardrive/sync/presentation/sync_summary.dart';
 import 'package:ardrive/user/name/presentation/bloc/profile_name_bloc.dart';
 import 'package:ardrive/utils/app_localizations_wrapper.dart';
 import 'package:ardrive/utils/plausible_event_tracker/plausible_custom_event_properties.dart';
@@ -178,6 +181,28 @@ class SyncButton extends StatelessWidget {
           );
         }
 
+        if (syncState is SyncComplete &&
+            syncState.trigger == SyncTrigger.background &&
+            // A result that has already had its few seconds is not announced
+            // again because the bar was rebuilt - see [syncSummaryIsFresh].
+            syncSummaryIsFresh(syncState)) {
+          // A sync nobody asked for says how it went where it ran, and then
+          // takes it back. Keyed on which result it is so a second one replaces
+          // the first rather than queueing behind it - two zero-change syncs
+          // read identically, and the second one still has to show.
+          return SyncSummaryFlash(
+            key: ValueKey(syncState.sequence),
+            summary: syncCompleteSummaryParts(
+              appLocalizationsOf(context),
+              syncState,
+            ),
+            showFor: syncSummaryRemaining(syncState),
+            child: _SyncButtonMenu(
+              child: ArDriveIcons.refresh(color: colorTokens.textMid),
+            ),
+          );
+        }
+
         if (syncState is! SyncInProgress) {
           return _SyncButtonMenu(
             child: ArDriveIcons.refresh(color: colorTokens.textMid),
@@ -225,6 +250,133 @@ class SyncButton extends StatelessWidget {
             (syncProgress.progress * 100).round().toString(),
           ),
       showElapsed: true,
+    );
+  }
+}
+
+/// What a finished background sync found, beside the indicator that was
+/// turning for it, for [syncSummaryDuration] and no longer.
+///
+/// It hangs off the button in an overlay rather than in the top bar's own row:
+/// a result that arrives while the user is reading something else must not
+/// push the bar's contents sideways, and it has to be able to leave again
+/// without moving them back.
+class SyncSummaryFlash extends StatefulWidget {
+  const SyncSummaryFlash({
+    super.key,
+    required this.summary,
+    required this.showFor,
+    required this.child,
+  });
+
+  /// The finished sync - see [syncCompleteSummaryParts].
+  final SyncSummary summary;
+
+  /// What is left of [syncSummaryDuration] for this result, counted from when
+  /// the sync finished rather than from when this was built.
+  final Duration showFor;
+
+  /// The idle sync button the summary is anchored to.
+  final Widget child;
+
+  @override
+  State<SyncSummaryFlash> createState() => _SyncSummaryFlashState();
+}
+
+class _SyncSummaryFlashState extends State<SyncSummaryFlash> {
+  Timer? _dismiss;
+  bool _showing = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _dismiss = Timer(widget.showFor, () {
+      if (mounted) {
+        setState(() => _showing = false);
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _dismiss?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ArDriveOverlay(
+      visible: _showing,
+      // No barrier: a report is not a question, so it never takes the next
+      // click - the resync menu underneath still opens on the first one.
+      closeOnBarrierTap: false,
+      anchor: const Aligned(
+        follower: Alignment.topRight,
+        target: Alignment.bottomRight,
+        offset: Offset(0, 8),
+        // The button sits at the top bar's trailing edge, so on a phone the
+        // summary is wider than the room left of it.
+        shiftToWithinBound: AxisFlag(x: true),
+      ),
+      content: _SyncSummaryPill(summary: widget.summary),
+      child: widget.child,
+    );
+  }
+}
+
+/// The summary itself: a quiet couple of lines in the surface colours, so a
+/// result that needs nothing from the user does not read like a warning.
+///
+/// The pill is capped at [_syncStatusHeaderWidth], which on a phone is most of
+/// the screen, so what arrived is allowed two lines and then an ellipsis. What
+/// could not be read is not: it goes on its own line underneath, full length.
+/// On one line it was joined last, so a long drive name pushed it past the cap
+/// and the ellipsis ate exactly the clause that says this sync has holes in it.
+class _SyncSummaryPill extends StatelessWidget {
+  const _SyncSummaryPill({required this.summary});
+
+  final SyncSummary summary;
+
+  @override
+  Widget build(BuildContext context) {
+    final typography = ArDriveTypographyNew.of(context);
+    final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
+    final arrived = summary.arrived;
+    final unreadable = summary.unreadable;
+
+    return IgnorePointer(
+      // The margin is what keeps a gutter on the narrowest phone: the anchor's
+      // shiftToWithinBound pulls the follower to x=0, so without it the pill
+      // sits flush against the screen edge while its right side keeps its
+      // inset, and reads as misaligned rather than as a floating card.
+      child: Container(
+        margin: const EdgeInsets.symmetric(horizontal: 8),
+        constraints: const BoxConstraints(maxWidth: _syncStatusHeaderWidth),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          color: colorTokens.containerL1,
+          borderRadius: BorderRadius.circular(6),
+          border: Border.all(color: colorTokens.strokeLow),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (arrived != null)
+              Text(
+                arrived,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: typography.paragraphSmall(color: colorTokens.textHigh),
+              ),
+            if (unreadable != null)
+              Text(
+                unreadable,
+                style: typography.paragraphSmall(color: colorTokens.textHigh),
+              ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2691,6 +2691,61 @@
       }
     }
   },
+  "syncComplete": "Sync Complete",
+  "@syncComplete": {
+    "description": "Title of the summary a finished sync ends on"
+  },
+  "syncSummaryNothingNew": "Up to date — nothing new",
+  "@syncSummaryNothingNew": {
+    "description": "Summary of a sync that found nothing new in any drive"
+  },
+  "syncSummaryNothingNewInDrive": "{driveName} is up to date — nothing new",
+  "@syncSummaryNothingNewInDrive": {
+    "description": "Summary of a single drive sync that found nothing new",
+    "placeholders": {
+      "driveName": {
+        "type": "String",
+        "example": "Photos"
+      }
+    }
+  },
+  "syncSummaryEntities": "{count, plural, =1{1 item changed} other{{count} items changed}}",
+  "@syncSummaryEntities": {
+    "description": "Summary of a sync that changed something. Says \"changed\", not \"new\": a rename, move or new version writes a revision too. Never says how many drives, because the sync only knows how many it walked",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "format": "decimalPattern",
+        "example": "12"
+      }
+    }
+  },
+  "syncSummaryEntitiesInDrive": "{count, plural, =1{1 item changed in {driveName}} other{{count} items changed in {driveName}}}",
+  "@syncSummaryEntitiesInDrive": {
+    "description": "Summary of a single drive sync that changed something",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "format": "decimalPattern",
+        "example": "12"
+      },
+      "driveName": {
+        "type": "String",
+        "example": "Photos"
+      }
+    }
+  },
+  "syncSummarySkippedEntities": "{count, plural, =1{1 update could not be read} other{{count} updates could not be read}}",
+  "@syncSummarySkippedEntities": {
+    "description": "How many updates a sync had to leave out because their metadata could not be read. Counts transactions, not files",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "format": "decimalPattern",
+        "example": "2"
+      }
+    }
+  },
   "syncCompleteWithErrors": "Sync Incomplete - Errors Detected",
   "@syncCompleteWithErrors": {
     "description": "Title when sync completes but some drives failed"

--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -86,6 +86,23 @@ class SyncCubit extends Cubit<SyncState> {
     _lastSyncSkippedEntityTxIdsByDrive = progress.skippedEntityTxIdsByDrive;
   }
 
+  /// What the sync that just finished found, read straight off the progress it
+  /// already reported. Nothing here is recounted: the repository owns these
+  /// numbers, this only carries them out to the two surfaces that say so.
+  /// Counts the results this cubit has reported, so each one is a state of its
+  /// own. See [SyncComplete.sequence] for why a timestamp will not do.
+  int _completedSyncCount = 0;
+
+  SyncComplete _syncComplete(SyncTrigger trigger) => SyncComplete(
+        entitiesSynced: _syncProgress.entitiesSynced,
+        skippedEntityCount: _syncProgress.skippedEntityCount,
+        isSingleDriveSync: _syncProgress.isSingleDriveSync,
+        driveName: _syncProgress.driveName,
+        trigger: trigger,
+        completedAt: DateTime.now(),
+        sequence: ++_completedSyncCount,
+      );
+
   SyncCubit({
     required ProfileCubit profileCubit,
     required ActivityCubit activityCubit,
@@ -286,6 +303,17 @@ class SyncCubit extends Cubit<SyncState> {
 
     _syncProgress = SyncProgress.initial();
 
+    /// Whether this sync actually ran to the end, for a logged-in profile.
+    ///
+    /// The catch below reports the error and falls through to the block that
+    /// decides what to emit, and a sync that threw before any drive query ran
+    /// - `updateUserDrives()` failing, say - records no `failedQueries`. Left
+    /// to itself that block reads "no errors, nothing synced" and announces
+    /// "Up to date - nothing new" beside the snackbar saying the sync failed.
+    /// A sync with no logged-in profile behind it reaches the same place with
+    /// the same nothing to report.
+    var ranToCompletion = false;
+
     // Create a new cancellation token for this sync
     _currentSyncToken?.dispose(); // Clean up any previous token
     _currentSyncToken = SyncCancellationToken();
@@ -379,6 +407,8 @@ class SyncCubit extends Cubit<SyncState> {
         syncProgressController.add(_syncProgress);
       }
 
+      ranToCompletion = profile is ProfileLoggedIn;
+
       // Only refresh balance if drives were actually synced (skip after no-op)
       if (profile is ProfileLoggedIn && _syncProgress.drivesSynced > 0) {
         _profileCubit.refreshBalance();
@@ -437,7 +467,11 @@ class SyncCubit extends Cubit<SyncState> {
         skippedEntityCount: _syncProgress.skippedEntityCount,
         skippedEntityTxIdsByDrive: _syncProgress.skippedEntityTxIdsByDrive,
       ));
+    } else if (ranToCompletion) {
+      emit(_syncComplete(trigger));
     } else {
+      // Nothing to report, so nothing is claimed - exactly what this path
+      // emitted before results existed.
       emit(SyncIdle());
     }
   }
@@ -467,6 +501,10 @@ class SyncCubit extends Cubit<SyncState> {
       isSingleDriveSync: true,
       drivesCount: 1,
     );
+
+    /// See [startSync]: the single-drive path falls through to the same
+    /// decision after the same catch, and must make the same non-claim.
+    var ranToCompletion = false;
 
     // Create a new cancellation token for this sync
     _currentSyncToken?.dispose();
@@ -538,6 +576,8 @@ class SyncCubit extends Cubit<SyncState> {
         syncProgressController.add(_syncProgress);
       }
 
+      ranToCompletion = profile is ProfileLoggedIn;
+
       // Only refresh balance if drives were actually synced
       if (profile is ProfileLoggedIn && _syncProgress.drivesSynced > 0) {
         _profileCubit.refreshBalance();
@@ -589,6 +629,8 @@ class SyncCubit extends Cubit<SyncState> {
         skippedEntityCount: _syncProgress.skippedEntityCount,
         skippedEntityTxIdsByDrive: _syncProgress.skippedEntityTxIdsByDrive,
       ));
+    } else if (ranToCompletion) {
+      emit(_syncComplete(trigger));
     } else {
       emit(SyncIdle());
     }

--- a/lib/sync/domain/cubit/sync_state.dart
+++ b/lib/sync/domain/cubit/sync_state.dart
@@ -88,3 +88,80 @@ class SyncCompleteWithErrors extends SyncState {
         skippedEntityTxIdsByDrive,
       ];
 }
+
+/// A sync that finished, and what it found.
+///
+/// It extends [SyncIdle] deliberately. `DriveDetailCubit` refreshes the open
+/// drive on `syncState is SyncIdle`, and `SharingFileListener` hands a shared
+/// file over on the same test; a sibling state would leave both waiting,
+/// silently, for a sync that had already finished. Subclassing keeps every
+/// existing `is SyncIdle` true while letting the two surfaces that report the
+/// result match `is SyncComplete`.
+///
+/// Only a sync that ran and got to the end emits this. A sync that was turned
+/// away before it started - a hidden tab, an upload in progress - still emits a
+/// plain [SyncIdle], because it has nothing to report.
+class SyncComplete extends SyncIdle {
+  SyncComplete({
+    required this.entitiesSynced,
+    required this.sequence,
+    required this.completedAt,
+    this.skippedEntityCount = 0,
+    this.isSingleDriveSync = false,
+    this.driveName,
+    this.trigger = SyncTrigger.userInitiated,
+  });
+
+  /// File and folder revisions this sync wrote, straight off [SyncProgress].
+  ///
+  /// Deliberately not accompanied by a count of drives. `drivesSynced` counts
+  /// drives *walked*, failures included, so "12 new items across 3 drives"
+  /// sent a user whose twelve files all landed in one drive looking through
+  /// three - and "1 new item across 3 drives" is not a thing that can happen.
+  /// The two numbers do not belong in one sentence, and the number of drives
+  /// a sync looked at is not a result worth reporting on its own.
+  final int entitiesSynced;
+
+  /// Entities dropped because their metadata could not be read - files the
+  /// user will not see, so the summary says so rather than claiming a clean
+  /// result. See [SyncCubit.lastSyncSkippedEntityTxIdsByDrive].
+  final int skippedEntityCount;
+
+  /// Whether this was a sync of one named drive rather than all of them, and
+  /// which drive it was, so the summary can name it.
+  final bool isSingleDriveSync;
+  final String? driveName;
+
+  /// Who asked for the sync that produced this. It decides which surface
+  /// reports it: the top bar for a sync nobody asked for, the modal it is
+  /// already showing for one the user did.
+  final SyncTrigger trigger;
+
+  /// When it finished, so a surface can refuse to announce a result that has
+  /// been sitting in the cubit's state for an hour - see `syncSummaryIsFresh`.
+  /// Never the discriminator: see [sequence].
+  final DateTime completedAt;
+
+  /// Which result this is, counted up by the cubit that emitted it.
+  ///
+  /// Bloc drops a state equal to the one it is already in, and two zero-change
+  /// syncs carry identical counts - so a result needs something that tells it
+  /// apart from the one before, or the second one goes unreported. A timestamp
+  /// cannot be that thing: `DateTime.now()` is only millisecond-grained here,
+  /// and two syncs with no I/O between them land inside the same millisecond
+  /// often enough to drop a result in the app and to fail a test at random.
+  final int sequence;
+
+  @override
+  List<Object> get props => [
+        entitiesSynced,
+        skippedEntityCount,
+        isSingleDriveSync,
+        // Equatable rejects a nullable member here. Collapsing null and '' is
+        // safe for identity only - the summary itself distinguishes them, and
+        // treats an empty name as no name.
+        driveName ?? '',
+        trigger,
+        sequence,
+      ];
+}

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -212,6 +212,36 @@ class _SyncRepository implements SyncRepository {
         .addAll(txIds);
   }
 
+  /// Number of file and folder revisions this sync actually wrote to the
+  /// database, keyed by drive id. Accumulated here for the same reason the
+  /// skipped tx ids are: the write is the only place that knows what was
+  /// written, and `SyncProgress.entitiesSynced` is otherwise a number nothing
+  /// ever sets - it stayed 0 through a sync that pulled in five hundred files,
+  /// and every surface built on it reported "nothing new".
+  ///
+  /// Taken from the revisions actually inserted, not from the lists the batch
+  /// hands back. Those also carry revisions read from the cache for entities
+  /// that turned out not to have changed, and every sync re-walks the last
+  /// [kBlockHeightLookBack] blocks - so counting them would report a drive
+  /// full of new items on a sync that wrote none.
+  ///
+  /// Ids, not revisions: one file arriving with three historical versions
+  /// writes three revisions but is one item to the person reading the summary,
+  /// and a first sync walks a drive's whole history.
+  ///
+  /// In-memory only - cleared at the start of each sync.
+  final Map<String, Set<String>> _syncedEntityIdsByDrive = {};
+
+  int get _syncedEntityCount =>
+      _syncedEntityIdsByDrive.values.fold(0, (sum, ids) => sum + ids.length);
+
+  void _recordSyncedEntities(String driveId, Iterable<String> entityIds) {
+    if (entityIds.isEmpty) return;
+    _syncedEntityIdsByDrive
+        .putIfAbsent(driveId, () => <String>{})
+        .addAll(entityIds);
+  }
+
   void _logSkippedEntities() {
     if (_skippedEntityTxIdsByDrive.isEmpty) return;
     logger.w(
@@ -270,6 +300,7 @@ class _SyncRepository implements SyncRepository {
     _ghostFolders.clear();
     _folderIds.clear();
     _skippedEntityTxIdsByDrive.clear();
+    _syncedEntityIdsByDrive.clear();
 
     // The address of the currently logged-in wallet. All pending transactions
     // are uploads made by this wallet, so scoping the status query by it lets
@@ -768,6 +799,7 @@ class _SyncRepository implements SyncRepository {
         syncProgress = syncProgress.copyWith(
           progress: 1.0,
           statusMessage: 'Sync complete',
+          entitiesSynced: _syncedEntityCount,
           skippedEntityCount: _skippedEntityCount,
           skippedEntityTxIdsByDrive: _skippedEntityTxIdsByDriveSnapshot,
         );
@@ -873,6 +905,7 @@ class _SyncRepository implements SyncRepository {
     _ghostFolders.clear();
     _folderIds.clear();
     _skippedEntityTxIdsByDrive.clear();
+    _syncedEntityIdsByDrive.clear();
 
     // Get the specific drive
     final drive = await _driveDao.driveById(driveId: driveId).getSingleOrNull();
@@ -1072,6 +1105,7 @@ class _SyncRepository implements SyncRepository {
         syncProgress = syncProgress.copyWith(
           progress: 1.0,
           statusMessage: 'Sync complete',
+          entitiesSynced: _syncedEntityCount,
           skippedEntityCount: _skippedEntityCount,
           skippedEntityTxIdsByDrive: _skippedEntityTxIdsByDriveSnapshot,
         );
@@ -2337,6 +2371,8 @@ class _SyncRepository implements SyncRepository {
     await _driveDao.insertNewFileRevisions(newRevisions);
     await _driveDao.insertNewNetworkTransactions(newNetworkTransactions);
 
+    _recordSyncedEntities(driveId, newRevisions.map((r) => r.fileId.value));
+
     return latestRevisions.values.toList();
   }
 
@@ -2383,6 +2419,8 @@ class _SyncRepository implements SyncRepository {
     );
     await _driveDao.insertNewFolderRevisions(newRevisions);
     await _driveDao.insertNewNetworkTransactions(newNetworkTransactions);
+
+    _recordSyncedEntities(driveId, newRevisions.map((r) => r.folderId.value));
 
     return latestRevisions.values.toList();
   }

--- a/lib/sync/presentation/sync_overlay.dart
+++ b/lib/sync/presentation/sync_overlay.dart
@@ -1,9 +1,12 @@
+import 'dart:async';
+
 import 'package:ardrive/blocs/blocs.dart';
 import 'package:ardrive/components/components.dart';
 import 'package:ardrive/components/progress_bar.dart';
 import 'package:ardrive/services/config/config_service.dart';
 import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
 import 'package:ardrive/sync/domain/sync_progress.dart';
+import 'package:ardrive/sync/presentation/sync_summary.dart';
 import 'package:ardrive/utils/app_localizations_wrapper.dart';
 import 'package:ardrive_ui/ardrive_ui.dart';
 import 'package:flutter/material.dart';
@@ -36,6 +39,13 @@ class SyncOverlay extends StatelessWidget {
   /// and the drives list they refresh is already on screen from the local
   /// database. The top bar's indicator says it is happening.
   static bool blocksTheApp(SyncState state) {
+    // A finished sync reports itself and gets out of the way, whoever asked
+    // for it. The summary the user-initiated one ends on is drawn without a
+    // scrim and dismisses itself, so a sync that used to end in silence never
+    // starts costing a click.
+    if (state is SyncComplete) {
+      return false;
+    }
     if (state is SyncCompleteWithErrors) {
       return true;
     }
@@ -53,6 +63,24 @@ class SyncOverlay extends StatelessWidget {
   Widget build(BuildContext context) {
     // Read into a local so the `is` checks below promote it.
     final syncState = this.syncState;
+
+    if (syncState is SyncComplete) {
+      // The sync the user asked for is already holding a modal; it ends on its
+      // result rather than vanishing. A sync nobody asked for was never here,
+      // and reports at the top bar's indicator instead.
+      if (syncState.trigger != SyncTrigger.userInitiated) {
+        return const SizedBox.shrink();
+      }
+
+      // A result the user has already been shown, or missed entirely, is not
+      // announced again just because this widget was rebuilt - see
+      // [syncSummaryIsFresh].
+      if (!syncSummaryIsFresh(syncState)) {
+        return const SizedBox.shrink();
+      }
+
+      return SyncCompleteSummary(state: syncState);
+    }
 
     if (!blocksTheApp(syncState)) {
       return const SizedBox.shrink();
@@ -454,6 +482,86 @@ class SyncOverlay extends StatelessWidget {
       // drivesCount == 0, initial state
       return '';
     }
+  }
+}
+
+/// The last thing a sync the user asked for shows: what it found, and then
+/// nothing.
+///
+/// It reuses the modal the sync was already in so the wait ends where it
+/// happened, but drops the scrim: there is no question to answer here, so the
+/// app is usable underneath from the moment the result appears, and the
+/// summary takes itself away after [syncSummaryDuration].
+class SyncCompleteSummary extends StatefulWidget {
+  const SyncCompleteSummary({super.key, required this.state});
+
+  final SyncComplete state;
+
+  @override
+  State<SyncCompleteSummary> createState() => _SyncCompleteSummaryState();
+}
+
+class _SyncCompleteSummaryState extends State<SyncCompleteSummary> {
+  Timer? _dismiss;
+  bool _showing = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _countDown();
+  }
+
+  @override
+  void didUpdateWidget(covariant SyncCompleteSummary oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // A second sync finishing is a second result, even when it reads the same
+    // as the first one - so it gets shown again, and its own few seconds.
+    if (widget.state.sequence != oldWidget.state.sequence) {
+      setState(() => _showing = true);
+      _countDown();
+    }
+  }
+
+  void _countDown() {
+    _dismiss?.cancel();
+    _dismiss = Timer(syncSummaryRemaining(widget.state), () {
+      if (mounted) {
+        setState(() => _showing = false);
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _dismiss?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_showing) {
+      return const SizedBox.shrink();
+    }
+
+    final typography = ArDriveTypographyNew.of(context);
+
+    // Nothing here is clickable, and the app behind it is: the summary must
+    // not eat a click aimed at the drive the user came back to.
+    return IgnorePointer(
+      child: Align(
+        alignment: Alignment.center,
+        child: Material(
+          borderRadius: BorderRadius.circular(8),
+          child: ArDriveStandardModalNew(
+            title: appLocalizationsOf(context).syncComplete,
+            content: Text(
+              syncCompleteSummary(appLocalizationsOf(context), widget.state),
+              style: typography.paragraphNormal(),
+            ),
+          ),
+        ),
+      ),
+    );
   }
 }
 

--- a/lib/sync/presentation/sync_summary.dart
+++ b/lib/sync/presentation/sync_summary.dart
@@ -1,0 +1,108 @@
+import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+/// How long a finished sync's summary stays on screen before it takes itself
+/// away. Long enough to read a line, short enough that nobody has to dismiss
+/// it: neither surface asks for a click.
+const Duration syncSummaryDuration = Duration(seconds: 4);
+
+/// The separator between the two halves of a summary that has both - what
+/// arrived, and what could not be read.
+const String _summaryJoin = ' · ';
+
+/// Whether a finished sync is still worth announcing.
+///
+/// [SyncComplete] stays the cubit's state until the next sync runs, and both
+/// surfaces start their countdown when they are first built rather than when
+/// the sync finished. `app_shell` builds its stack separately in the desktop
+/// and mobile branches of `ScreenTypeLayout`, so crossing the breakpoint an
+/// hour after login rebuilds one from scratch - and would pop a fresh "Sync
+/// Complete" for a sync that ended long ago. A result that has already had its
+/// [syncSummaryDuration] does not get another one.
+bool syncSummaryIsFresh(SyncComplete state, {DateTime? now}) =>
+    syncSummaryRemaining(state, now: now) > Duration.zero;
+
+/// How much of [syncSummaryDuration] a result has left.
+///
+/// A surface that starts a fresh [syncSummaryDuration] timer when it is built
+/// shows a result for longer than it is entitled to: one built a moment before
+/// the freshness boundary would run almost twice the intended time. The timer
+/// is counted from when the sync finished, not from when something happened to
+/// draw it.
+Duration syncSummaryRemaining(SyncComplete state, {DateTime? now}) {
+  final elapsed = (now ?? DateTime.now()).difference(state.completedAt);
+  final remaining = syncSummaryDuration - elapsed;
+  return remaining.isNegative ? Duration.zero : remaining;
+}
+
+/// What a finished sync found, in the two parts it can be broken into.
+///
+/// They are kept apart because they shorten differently. Joined into one line
+/// the unreadable clause comes last, so on a narrow screen a long drive name
+/// is what survives and "3 items could not be read" is what gets ellipsized -
+/// exactly backwards, since the whole point of that clause is that a sync with
+/// holes in it must not read as a clean one. A surface with a width limit lays
+/// the two out as separate lines and lets only [arrived] shorten.
+class SyncSummary {
+  const SyncSummary({this.arrived, this.unreadable});
+
+  /// What the sync brought in, or that it brought in nothing. Absent only when
+  /// nothing arrived and something could not be read, where "up to date" would
+  /// be a claim this sync cannot make.
+  final String? arrived;
+
+  /// How many entities were left out because their metadata could not be read.
+  /// Absent when there were none.
+  final String? unreadable;
+
+  /// Both parts, in order, for a surface that can lay them out itself.
+  List<String> get lines =>
+      [if (arrived != null) arrived!, if (unreadable != null) unreadable!];
+
+  /// Both parts on one line, for a surface with room for it.
+  String get oneLine => lines.join(_summaryJoin);
+}
+
+/// What a finished sync found.
+///
+/// Every case has to say something. A sync that changed nothing is the case
+/// that matters most: told "up to date - nothing new", the user learns that the
+/// next sync is one they can ignore, which is the whole point of reporting a
+/// result at all.
+///
+/// No case counts drives. `drivesSynced` counts drives walked, failures
+/// included, so "across 3 drives" was two facts joined by a word that does not
+/// hold between them. And no case says "new": a rename, a move or a new
+/// version writes a revision too, so the count is what changed, not what
+/// arrived - see [SyncComplete.entitiesSynced].
+SyncSummary syncCompleteSummaryParts(
+    AppLocalizations l10n, SyncComplete state) {
+  final synced = state.entitiesSynced;
+  final skipped = state.skippedEntityCount;
+  final driveName = state.driveName;
+  // Non-empty, not just non-null: an empty name renders " is up to date"
+  // with a leading space, where a null one correctly falls back.
+  final namesADrive =
+      state.isSingleDriveSync && driveName != null && driveName.isNotEmpty;
+
+  if (synced == 0 && skipped == 0) {
+    return SyncSummary(
+      arrived: namesADrive
+          ? l10n.syncSummaryNothingNewInDrive(driveName)
+          : l10n.syncSummaryNothingNew,
+    );
+  }
+
+  return SyncSummary(
+    arrived: synced > 0
+        ? (namesADrive
+            ? l10n.syncSummaryEntitiesInDrive(synced, driveName)
+            : l10n.syncSummaryEntities(synced))
+        : null,
+    unreadable: skipped > 0 ? l10n.syncSummarySkippedEntities(skipped) : null,
+  );
+}
+
+/// The whole summary on one line, for a surface that has the room.
+String syncCompleteSummary(AppLocalizations l10n, SyncComplete state) =>
+    syncCompleteSummaryParts(l10n, state).oneLine;

--- a/test/blocs/drive_detail/drive_detail_cubit_test.dart
+++ b/test/blocs/drive_detail/drive_detail_cubit_test.dart
@@ -293,6 +293,62 @@ void main() {
       expect(cubit.state, isA<DriveDetailLoadSuccess>());
     });
 
+    /// `SyncComplete` extends `SyncIdle` precisely so this handler keeps
+    /// firing: it gates on `syncState is SyncIdle`, and a sibling state would
+    /// leave a drive sitting on "Drive Not Synced" after the sync that fixed
+    /// it. Nothing fed a `SyncComplete` through this consumer until now.
+    ///
+    /// The drive stream is frozen first, so the recovery cannot come from
+    /// anywhere else. `watchDrive` is the only thing here that watches the
+    /// drives table; pinned to a single emission, the writes below reach the
+    /// database without reaching the cubit, and the sync-completion handler is
+    /// the only path left that can move it off the unsynced screen.
+    test('a finished sync that reports a result still refreshes the drive',
+        () async {
+      await insertDrive(lastBlockHeight: 0);
+
+      final frozenDrive =
+          await driveDao.driveById(driveId: driveId).getSingle();
+      when(() => driveRepository.watchDrive(driveId: any(named: 'driveId')))
+          .thenAnswer((_) => Stream.value(frozenDrive));
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      expect(cubit.state, isA<DriveDetailLoadUnsynced>(),
+          reason: 'precondition: the drive starts out unsynced');
+
+      // The sync writes the root revision. Straight into the table rather
+      // than through `insertRootFolderRevision`, which also writes the
+      // metadata's network transaction - and the folder listing joins that
+      // table, so going through the DAO would re-fire the folder stream and
+      // repair the state on its own, leaving nothing for this test to prove.
+      await db.into(db.folderRevisions).insert(
+            FolderRevisionsCompanion.insert(
+              folderId: rootFolderId,
+              driveId: driveId,
+              name: 'Test Drive',
+              metadataTxId: 'metadata-tx-id',
+              action: RevisionAction.create,
+            ),
+          );
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      expect(cubit.state, isA<DriveDetailLoadUnsynced>(),
+          reason: 'precondition: nothing the cubit watches has fired, so only '
+              'the sync result can recover this drive');
+
+      syncStates.add(SyncComplete(
+        entitiesSynced: 3,
+        completedAt: DateTime.now(),
+        sequence: 1,
+      ));
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      expect(cubit.state, isA<DriveDetailLoadSuccess>());
+    });
+
     blocTest<DriveDetailCubit, DriveDetailState>(
       'stays unsynced while the root metadata is still missing',
       setUp: () => insertDrive(lastBlockHeight: 0),
@@ -300,7 +356,13 @@ void main() {
       act: (cubit) async {
         await Future<void>.delayed(const Duration(milliseconds: 100));
 
-        syncStates.add(SyncIdle());
+        // A result, not a bare idle: a sync that finished having found
+        // nothing must not be mistaken for metadata arriving.
+        syncStates.add(SyncComplete(
+          entitiesSynced: 0,
+          completedAt: DateTime.now(),
+          sequence: 1,
+        ));
 
         await Future<void>.delayed(const Duration(milliseconds: 200));
       },

--- a/test/components/sync_button_test.dart
+++ b/test/components/sync_button_test.dart
@@ -3,9 +3,11 @@ import 'dart:async';
 import 'package:ardrive/components/app_top_bar.dart';
 import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
 import 'package:ardrive/sync/domain/sync_progress.dart';
+import 'package:ardrive/sync/presentation/sync_summary.dart';
 import 'package:ardrive_ui/ardrive_ui.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -45,10 +47,10 @@ void main() {
     await progressController.close();
   });
 
-  Widget host(Widget body) {
+  Widget host(Widget body, {ArDriveThemeData? theme}) {
     return Portal(
       child: ArDriveTheme(
-        themeData: lightTheme(),
+        themeData: theme ?? lightTheme(),
         child: MaterialApp(
           localizationsDelegates: const [
             AppLocalizations.delegate,
@@ -68,7 +70,8 @@ void main() {
     );
   }
 
-  Widget wrap() => host(const Row(children: [SyncButton()]));
+  Widget wrap({ArDriveThemeData? theme}) =>
+      host(const Row(children: [SyncButton()]), theme: theme);
 
   /// The button as `MobileAppBar` places it: against the trailing edge, with
   /// the rest of the bar's chrome to its right.
@@ -98,6 +101,28 @@ void main() {
       await tester.pump(const Duration(milliseconds: 10));
     }
   }
+
+  /// A finished sync, as the cubit reports it. [sequence] is what tells two
+  /// results apart - see [SyncComplete.sequence] - so each call gets its own.
+  var nextSequence = 0;
+  SyncComplete finished({
+    int entitiesSynced = 0,
+    int skippedEntityCount = 0,
+    bool isSingleDriveSync = false,
+    String? driveName,
+    SyncTrigger trigger = SyncTrigger.background,
+    DateTime? completedAt,
+    int? sequence,
+  }) =>
+      SyncComplete(
+        entitiesSynced: entitiesSynced,
+        skippedEntityCount: skippedEntityCount,
+        isSingleDriveSync: isSingleDriveSync,
+        driveName: driveName,
+        trigger: trigger,
+        completedAt: completedAt ?? DateTime.now(),
+        sequence: sequence ?? ++nextSequence,
+      );
 
   testWidgets('an idle sync leaves the plain refresh icon alone',
       (tester) async {
@@ -299,6 +324,217 @@ void main() {
 
     expect(find.byType(CircularProgressIndicator), findsNothing);
     expect(tester.getSize(find.byType(SyncButton)), idleSize);
+  });
+
+  testWidgets('a finished background sync says what it found', (tester) async {
+    await tester.pumpWidget(wrap());
+    await tester.pump();
+
+    await startSyncing(tester);
+    stateController.add(finished(entitiesSynced: 12));
+    await tester.pump(const Duration(milliseconds: 10));
+
+    // Beside the indicator that was turning for it - no hover, no click.
+    expect(find.text('12 items changed'), findsOneWidget);
+    // And the sync is over, so the ring is gone.
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+
+    await tester.pumpWidget(const SizedBox());
+  });
+
+  testWidgets('a sync that changed nothing still says so', (tester) async {
+    // The case the whole summary exists for: told nothing changed, the user
+    // learns the next one is safe to ignore.
+    await tester.pumpWidget(wrap());
+    await tester.pump();
+
+    stateController.add(finished());
+    await tester.pump(const Duration(milliseconds: 10));
+
+    expect(find.text('Up to date — nothing new'), findsOneWidget);
+
+    await tester.pumpWidget(const SizedBox());
+  });
+
+  testWidgets('the result takes itself away', (tester) async {
+    await tester.pumpWidget(wrap());
+    await tester.pump();
+
+    stateController.add(finished());
+    await tester.pump(const Duration(milliseconds: 10));
+
+    expect(find.text('Up to date — nothing new'), findsOneWidget);
+
+    await tester.pump(syncSummaryDuration + const Duration(seconds: 1));
+
+    expect(find.text('Up to date — nothing new'), findsNothing);
+  });
+
+  testWidgets('a second result that reads the same is shown again',
+      (tester) async {
+    await tester.pumpWidget(wrap());
+    await tester.pump();
+
+    stateController.add(finished());
+    await tester.pump(const Duration(milliseconds: 10));
+    await tester.pump(syncSummaryDuration + const Duration(seconds: 1));
+
+    expect(find.text('Up to date — nothing new'), findsNothing);
+
+    // Two zero-change syncs read identically, and land in the same
+    // millisecond when nothing does any I/O between them. The second one is
+    // still a result, and reporting the first must not have used the summary
+    // up - so they are told apart by sequence, not by a timestamp.
+    stateController.add(finished());
+    await tester.pump(const Duration(milliseconds: 10));
+
+    expect(find.text('Up to date — nothing new'), findsOneWidget);
+
+    await tester.pumpWidget(const SizedBox());
+  });
+
+  testWidgets('results never stack up', (tester) async {
+    await tester.pumpWidget(wrap());
+    await tester.pump();
+
+    stateController.add(finished());
+    await tester.pump(const Duration(milliseconds: 10));
+    stateController.add(finished());
+    await tester.pump(const Duration(milliseconds: 10));
+
+    expect(find.text('Up to date — nothing new'), findsOneWidget);
+
+    await tester.pumpWidget(const SizedBox());
+  });
+
+  testWidgets('reporting a result does not move the top bar', (tester) async {
+    await tester.pumpWidget(wrap());
+    await tester.pump();
+
+    final idleSize = tester.getSize(find.byType(SyncButton));
+
+    stateController.add(finished(entitiesSynced: 12));
+    await tester.pump(const Duration(milliseconds: 10));
+
+    expect(find.text('12 items changed'), findsOneWidget);
+    expect(tester.getSize(find.byType(SyncButton)), idleSize);
+
+    // And nothing moves back when it leaves either.
+    await tester.pump(syncSummaryDuration + const Duration(seconds: 1));
+
+    expect(tester.getSize(find.byType(SyncButton)), idleSize);
+  });
+
+  testWidgets(
+      'what could not be read survives a long drive name on a narrow phone',
+      (tester) async {
+    // The pill is capped at the status header's width and the arrival clause
+    // is allowed to ellipsize. Joined into one string the unreadable clause
+    // came last, so a long drive name pushed it past the cap and the ellipsis
+    // ate the one clause that says this sync has holes in it - inverting the
+    // rule the summary exists to state.
+    await tester.binding.setSurfaceSize(const Size(320, 640));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(wrapNarrow(trailingChrome: 120));
+    await tester.pump();
+
+    stateController.add(finished(
+      entitiesSynced: 12,
+      skippedEntityCount: 3,
+      isSingleDriveSync: true,
+      driveName: 'Family Photos And Videos Nineteen Ninety Nine To Today',
+    ));
+    await tester.pump(const Duration(milliseconds: 10));
+
+    const unreadable = '3 updates could not be read';
+    expect(find.text(unreadable), findsOneWidget);
+
+    // Rendered, not merely present: the clause has to fit the lines it was
+    // given, and start on screen.
+    final paragraph =
+        tester.renderObject<RenderParagraph>(find.text(unreadable));
+    expect(
+      paragraph.didExceedMaxLines,
+      isFalse,
+      reason: 'the unreadable count must never be the part that gets cut',
+    );
+    expect(
+        tester.getTopLeft(find.text(unreadable)).dx, greaterThanOrEqualTo(0));
+
+    await tester.pumpWidget(const SizedBox());
+  });
+
+  testWidgets('a result from an hour ago is not flashed again', (tester) async {
+    // SyncComplete is still the cubit's state long after the sync. The shell
+    // builds the top bar afresh when the layout crosses its breakpoint, which
+    // used to pop the summary for a sync that finished an hour earlier.
+    await tester.pumpWidget(wrap());
+    await tester.pump();
+
+    stateController.add(finished(
+      entitiesSynced: 12,
+      completedAt: DateTime.now().subtract(const Duration(hours: 1)),
+    ));
+    await tester.pump(const Duration(milliseconds: 10));
+
+    expect(find.text('12 items changed'), findsNothing);
+    // And the button is its idle self, not a flash with nothing in it.
+    expect(find.byType(ArDriveIcon), findsOneWidget);
+  });
+
+  testWidgets('a sync the user asked for is left to its own modal',
+      (tester) async {
+    // It has been holding a modal the whole time; the result belongs there,
+    // and saying it twice would be twice as much to dismiss.
+    await tester.pumpWidget(wrap());
+    await tester.pump();
+
+    stateController.add(
+      finished(
+        entitiesSynced: 12,
+        trigger: SyncTrigger.userInitiated,
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 10));
+
+    expect(find.text('12 items changed'), findsNothing);
+    // The button is back to its idle self.
+    expect(find.byType(ArDriveIcon), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+  });
+
+  testWidgets('the summary is drawn in the theme it lands in', (tester) async {
+    Future<Color> pillColourUnder(ArDriveThemeData theme) async {
+      await tester.pumpWidget(wrap(theme: theme));
+      await tester.pump();
+
+      stateController.add(finished());
+      await tester.pump(const Duration(milliseconds: 10));
+
+      final pill = tester.widget<Container>(
+        find
+            .ancestor(
+              of: find.text('Up to date — nothing new'),
+              matching: find.byType(Container),
+            )
+            .first,
+      );
+      await tester.pumpWidget(const SizedBox());
+
+      return (pill.decoration! as BoxDecoration).color!;
+    }
+
+    final light = await pillColourUnder(lightTheme());
+    final dark = await pillColourUnder(
+      ArDriveThemeData(colorTokens: ArDriveColorTokens.darkMode()),
+    );
+
+    expect(light, lightTheme().colorTokens.containerL1);
+    expect(dark, ArDriveColorTokens.darkMode().containerL1);
+    // Which is the point: a colour written into the widget would be the same
+    // one in both, and unreadable in one of them.
+    expect(light, isNot(dark));
   });
 
   testWidgets('the resync menu survives a running sync', (tester) async {

--- a/test/sync/domain/cubit/sync_complete_test.dart
+++ b/test/sync/domain/cubit/sync_complete_test.dart
@@ -1,0 +1,373 @@
+import 'package:ardrive/blocs/activity/activity_cubit.dart';
+import 'package:ardrive/blocs/blocs.dart';
+import 'package:ardrive/core/activity_tracker.dart';
+import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
+import 'package:ardrive/sync/domain/repositories/sync_repository.dart';
+import 'package:ardrive/sync/domain/sync_progress.dart';
+import 'package:ardrive/user/repositories/user_preferences_repository.dart';
+import 'package:ardrive/user/user_preferences.dart';
+import 'package:ardrive_ui/ardrive_ui.dart';
+import 'package:arweave/arweave.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:cryptography/cryptography.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../test_utils/utils.dart';
+
+class MockSyncRepository extends Mock implements SyncRepository {}
+
+class MockUserPreferencesRepository extends Mock
+    implements UserPreferencesRepository {}
+
+class MockActivityCubit extends MockCubit<ActivityState>
+    implements ActivityCubit {}
+
+class MockActivityTracker extends Mock implements ActivityTracker {}
+
+class _FakeWallet extends Fake implements Wallet {}
+
+class _FakeSecretKey extends Fake implements SecretKey {}
+
+void main() {
+  late MockProfileCubit profileCubit;
+  late MockActivityCubit activityCubit;
+  late MockPromptToSnapshotBloc promptToSnapshotBloc;
+  late MockTabVisibilitySingleton tabVisibility;
+  late MockConfigService configService;
+  late MockConfig config;
+  late MockActivityTracker activityTracker;
+  late MockSyncRepository syncRepository;
+  late MockUserPreferencesRepository userPreferencesRepository;
+
+  setUpAll(() {
+    registerFallbackValue(false);
+    registerFallbackValue(_FakeWallet());
+    registerFallbackValue(_FakeSecretKey());
+  });
+
+  /// What the repository reports for the sync under test. The cubit only ever
+  /// carries these numbers out; it must not arrive at any of its own.
+  void repositoryReports(SyncProgress progress) {
+    when(() => syncRepository.syncAllDrives(
+          wallet: any(named: 'wallet'),
+          password: any(named: 'password'),
+          cipherKey: any(named: 'cipherKey'),
+          syncDeep: any(named: 'syncDeep'),
+          driveIdsToRetry: any(named: 'driveIdsToRetry'),
+          cancellationToken: any(named: 'cancellationToken'),
+          txFechedCallback: any(named: 'txFechedCallback'),
+        )).thenAnswer((_) => Stream.value(progress));
+  }
+
+  void repositoryReportsForOneDrive(SyncProgress progress) {
+    when(() => syncRepository.syncSingleDrive(
+          driveId: any(named: 'driveId'),
+          wallet: any(named: 'wallet'),
+          password: any(named: 'password'),
+          cipherKey: any(named: 'cipherKey'),
+          syncDeep: any(named: 'syncDeep'),
+          cancellationToken: any(named: 'cancellationToken'),
+          txFechedCallback: any(named: 'txFechedCallback'),
+        )).thenAnswer((_) => Stream.value(progress));
+  }
+
+  setUp(() {
+    profileCubit = MockProfileCubit();
+    activityCubit = MockActivityCubit();
+    promptToSnapshotBloc = MockPromptToSnapshotBloc();
+    tabVisibility = MockTabVisibilitySingleton();
+    configService = MockConfigService();
+    config = MockConfig();
+    activityTracker = MockActivityTracker();
+    syncRepository = MockSyncRepository();
+    userPreferencesRepository = MockUserPreferencesRepository();
+
+    // Logged in, because that is the only profile a sync has a result for -
+    // see `loggedOut()` below.
+    when(() => profileCubit.state).thenReturn(
+      ProfileLoggedIn(user: getTestUser(), useTurbo: false),
+    );
+    when(() => profileCubit.isCurrentProfileArConnect())
+        .thenAnswer((_) async => false);
+    when(() => profileCubit.refreshBalance()).thenAnswer((_) async {});
+    when(() => activityCubit.state).thenReturn(ActivityNotRunning());
+    when(() => syncRepository.updateUserDrives(
+          wallet: any(named: 'wallet'),
+          password: any(named: 'password'),
+          cipherKey: any(named: 'cipherKey'),
+        )).thenAnswer((_) async {});
+    when(() => tabVisibility.isTabFocused()).thenReturn(true);
+    when(() => tabVisibility.onTabGetsFocused(any()))
+        .thenAnswer((_) => const Stream<void>.empty().listen((_) {}));
+    when(() => configService.config).thenReturn(config);
+    // Nothing here may fire a second sync of its own.
+    when(() => config.autoSync).thenReturn(false);
+    when(() => config.autoSyncIntervalInSeconds).thenReturn(3600);
+    when(() => syncRepository.numberOfFilesInWallet())
+        .thenAnswer((_) async => 0);
+    when(() => syncRepository.numberOfFoldersInWallet())
+        .thenAnswer((_) async => 0);
+    repositoryReports(SyncProgress.emptySyncCompleted());
+  });
+
+  /// A cubit whose login does nothing but load drive metadata, so the only
+  /// full syncs in a test are the ones the test starts.
+  SyncCubit buildCubit() {
+    when(() => userPreferencesRepository.load()).thenAnswer(
+      (_) async => const UserPreferences(
+        currentTheme: ArDriveThemes.dark,
+        lastSelectedDriveId: null,
+        syncAllDrivesOnLogin: false,
+      ),
+    );
+
+    return SyncCubit(
+      profileCubit: profileCubit,
+      activityCubit: activityCubit,
+      promptToSnapshotBloc: promptToSnapshotBloc,
+      tabVisibility: tabVisibility,
+      configService: configService,
+      activityTracker: activityTracker,
+      syncRepository: syncRepository,
+      userPreferencesRepository: userPreferencesRepository,
+    );
+  }
+
+  /// No profile behind the sync. Nothing was read, so there is nothing to
+  /// report - and 'up to date' would be a claim about drives never looked at.
+  void loggedOut() {
+    when(() => profileCubit.state).thenReturn(ProfileCheckingAvailability());
+  }
+
+  /// Every result the cubit reported while [act] ran.
+  Future<List<SyncComplete>> resultsOf(
+    SyncCubit cubit,
+    Future<void> Function() act,
+  ) async {
+    final results = <SyncComplete>[];
+    final subscription = cubit.stream.listen((state) {
+      if (state is SyncComplete) {
+        results.add(state);
+      }
+    });
+
+    await act();
+    // The cubit hands its states to listeners on a later microtask, so the
+    // last result of the run is still in flight when act() returns.
+    await Future<void>.delayed(Duration.zero);
+    await subscription.cancel();
+
+    return results;
+  }
+
+  test('a finished sync is still an idle sync', () {
+    // The contract this whole state hangs on. DriveDetailCubit refreshes the
+    // open drive on `syncState is SyncIdle`, and SharingFileListener hands a
+    // shared file over on the same test. A sibling state would leave both
+    // waiting on a sync that had already finished, with nothing to show for
+    // it - so the result is a kind of idle, not an alternative to it.
+    final result = SyncComplete(
+      entitiesSynced: 0,
+      completedAt: DateTime.now(),
+      sequence: 1,
+    );
+
+    expect(result, isA<SyncIdle>());
+  });
+
+  test('two results that read the same are still two results', () {
+    // Bloc drops a state equal to the one it is already in. Two syncs that
+    // both found nothing carry identical counts, so without something that
+    // tells them apart the second result could go unreported - and the sync
+    // that changed nothing is the one most worth hearing about.
+    //
+    // Deliberately at the same instant: two mocked syncs with no I/O between
+    // them land in the same millisecond, and a millisecond-grained timestamp
+    // is therefore not something that tells them apart.
+    final sameInstant = DateTime(2026, 8, 29, 10);
+    final first = SyncComplete(
+      entitiesSynced: 0,
+      completedAt: sameInstant,
+      sequence: 1,
+    );
+    final second = SyncComplete(
+      entitiesSynced: 0,
+      completedAt: sameInstant,
+      sequence: 2,
+    );
+
+    expect(second, isNot(equals(first)));
+  });
+
+  test('a finished sync carries the counts the repository reported', () async {
+    repositoryReports(
+      SyncProgress.initial().copyWith(
+        progress: 1,
+        entitiesSynced: 12,
+        drivesSynced: 3,
+        drivesCount: 3,
+        skippedEntityCount: 2,
+        skippedEntityTxIdsByDrive: const {
+          'drive-id': ['tx-one', 'tx-two'],
+        },
+      ),
+    );
+
+    final cubit = buildCubit();
+    final results = await resultsOf(cubit, () => cubit.startSync());
+    await cubit.close();
+
+    expect(results, hasLength(1));
+    expect(results.single.entitiesSynced, 12);
+    expect(results.single.skippedEntityCount, 2);
+    expect(results.single.trigger, SyncTrigger.userInitiated);
+  });
+
+  test('a sync of one drive reports the drive it was', () async {
+    repositoryReportsForOneDrive(
+      SyncProgress.initial().copyWith(
+        progress: 1,
+        entitiesSynced: 4,
+        drivesSynced: 1,
+        drivesCount: 1,
+        isSingleDriveSync: true,
+        driveName: 'Photos',
+      ),
+    );
+
+    final cubit = buildCubit();
+    final results = await resultsOf(
+      cubit,
+      () => cubit.startSyncForDrive(driveId: 'drive-id'),
+    );
+    await cubit.close();
+
+    expect(results, hasLength(1));
+    expect(results.single.isSingleDriveSync, isTrue);
+    expect(results.single.driveName, 'Photos');
+    expect(results.single.entitiesSynced, 4);
+  });
+
+  test('a background sync reports itself as one nobody asked for', () async {
+    final cubit = buildCubit();
+    final results = await resultsOf(
+      cubit,
+      () => cubit.startSync(trigger: SyncTrigger.background),
+    );
+    await cubit.close();
+
+    expect(results.single.trigger, SyncTrigger.background);
+  });
+
+  test('two zero-change syncs in a row both report', () async {
+    final cubit = buildCubit();
+
+    final results = await resultsOf(cubit, () async {
+      await cubit.startSync();
+      await cubit.startSync();
+    });
+    await cubit.close();
+
+    expect(results, hasLength(2));
+    expect(results.first.entitiesSynced, 0);
+    expect(results.last.entitiesSynced, 0);
+    // And they are two states, not one reported twice: a UI that keys on the
+    // result cannot show the second one otherwise. Nothing here does any I/O,
+    // so the two land in the same millisecond often enough that a timestamp
+    // would drop one at random - the sequence is what separates them.
+    expect(results.last, isNot(equals(results.first)));
+    expect(results.first.sequence, 1);
+    expect(results.last.sequence, 2);
+  });
+
+  group('a sync that did not finish claims nothing', () {
+    // The catch reports the error and falls through to the block that decides
+    // what to emit. A sync that threw before any drive query ran records no
+    // failedQueries, so that block used to read "no errors, nothing synced"
+    // and announce "Up to date - nothing new" next to the snackbar saying the
+    // sync failed.
+
+    test('the all-drives path reports no result when it throws', () async {
+      when(() => syncRepository.updateUserDrives(
+            wallet: any(named: 'wallet'),
+            password: any(named: 'password'),
+            cipherKey: any(named: 'cipherKey'),
+          )).thenThrow(Exception('the gateway said no'));
+
+      final cubit = buildCubit();
+      final states = <SyncState>[];
+      final subscription = cubit.stream.listen(states.add);
+
+      await cubit.startSync();
+      await Future<void>.delayed(Duration.zero);
+      await subscription.cancel();
+      await cubit.close();
+
+      expect(states.whereType<SyncComplete>(), isEmpty);
+      expect(states.whereType<SyncFailure>(), isNotEmpty,
+          reason: 'the failure is still reported as a failure');
+      expect(cubit.state, isA<SyncIdle>());
+      expect(cubit.state, isNot(isA<SyncComplete>()));
+    });
+
+    test('the single-drive path reports no result when it throws', () async {
+      when(() => syncRepository.syncSingleDrive(
+            driveId: any(named: 'driveId'),
+            wallet: any(named: 'wallet'),
+            password: any(named: 'password'),
+            cipherKey: any(named: 'cipherKey'),
+            syncDeep: any(named: 'syncDeep'),
+            cancellationToken: any(named: 'cancellationToken'),
+            txFechedCallback: any(named: 'txFechedCallback'),
+          )).thenAnswer(
+        (_) => Stream<SyncProgress>.error(Exception('the gateway said no')),
+      );
+
+      final cubit = buildCubit();
+      final results = await resultsOf(
+        cubit,
+        () => cubit.startSyncForDrive(driveId: 'drive-id'),
+      );
+
+      expect(results, isEmpty);
+      expect(cubit.state, isA<SyncIdle>());
+      expect(cubit.state, isNot(isA<SyncComplete>()));
+
+      await cubit.close();
+    });
+
+    test('a sync with nobody logged in reports no result', () async {
+      loggedOut();
+
+      final cubit = buildCubit();
+      final results = await resultsOf(cubit, () => cubit.startSync());
+
+      expect(results, isEmpty);
+      expect(cubit.state, isA<SyncIdle>());
+      expect(cubit.state, isNot(isA<SyncComplete>()));
+
+      await cubit.close();
+    });
+
+    test('a single drive sync with nobody logged in reports no result',
+        () async {
+      loggedOut();
+      repositoryReportsForOneDrive(
+        SyncProgress.initial().copyWith(progress: 1, drivesCount: 1),
+      );
+
+      final cubit = buildCubit();
+      final results = await resultsOf(
+        cubit,
+        () => cubit.startSyncForDrive(driveId: 'drive-id'),
+      );
+
+      expect(results, isEmpty);
+      expect(cubit.state, isA<SyncIdle>());
+      expect(cubit.state, isNot(isA<SyncComplete>()));
+
+      await cubit.close();
+    });
+  });
+}

--- a/test/sync/domain/sync_repository_entities_synced_test.dart
+++ b/test/sync/domain/sync_repository_entities_synced_test.dart
@@ -1,0 +1,301 @@
+import 'package:ardrive/arns/domain/arns_repository.dart';
+import 'package:ardrive/entities/entities.dart';
+import 'package:ardrive/models/database/database.dart';
+import 'package:ardrive/services/arweave/arweave_service.dart';
+import 'package:ardrive/services/arweave/graphql/graphql_api.graphql.dart';
+import 'package:ardrive/services/config/app_config.dart';
+import 'package:ardrive/sync/data/snapshot_validation_service.dart';
+import 'package:ardrive/sync/domain/models/drive_entity_history.dart';
+import 'package:ardrive/sync/domain/repositories/sync_repository.dart';
+import 'package:ardrive/sync/domain/sync_progress.dart';
+import 'package:ardrive/sync/utils/batch_processor.dart';
+import 'package:ardrive/user/repositories/user_preferences_repository.dart';
+import 'package:ardrive/user/user_preferences.dart';
+import 'package:ardrive_ui/ardrive_ui.dart';
+import 'package:ardrive_utils/ardrive_utils.dart';
+import 'package:ario_sdk/ario_sdk.dart';
+import 'package:drift/drift.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../test_utils/utils.dart';
+
+class _MockSnapshotValidationService extends Mock
+    implements SnapshotValidationService {}
+
+class _MockARNSRepository extends Mock implements ARNSRepository {}
+
+class _MockUserPreferencesRepository extends Mock
+    implements UserPreferencesRepository {}
+
+/// A sync that writes N entities has to report N.
+///
+/// `SyncProgress.entitiesSynced` shipped as a number nothing in `lib/` ever
+/// set: it was 0 in `initial()`, 0 in `emptySyncCompleted()`, and no `copyWith`
+/// gave it a value - so a sync that pulled in five hundred files still told the
+/// user "up to date, nothing new". Every test of the summary built its state by
+/// hand, which is exactly how that got through, so this one drives the real
+/// repository against a real database and reads the number off the far end.
+void main() {
+  const driveId = 'drive-id';
+  const rootFolderId = 'root-folder-id';
+  const ownerAddress = 'owner-address';
+
+  late Database db;
+  late MockArweaveService arweave;
+  late MockConfigService configService;
+  late _MockSnapshotValidationService snapshotValidation;
+  late _MockARNSRepository arnsRepository;
+  late _MockUserPreferencesRepository userPreferences;
+  late SyncRepository syncRepository;
+
+  /// The transactions the gateway hands back. Their contents do not matter:
+  /// what they parse into is stubbed below, entity by entity.
+  DriveEntityHistoryTransactionModel transactionAt(int height) {
+    return DriveEntityHistoryTransactionModel(
+      transactionCommonMixin:
+          DriveEntityHistory$Query$TransactionConnection$TransactionEdge$Transaction
+              .fromJson({
+        'id': 'tx-$height',
+        'owner': {'address': ownerAddress},
+        'tags': <dynamic>[],
+        'block': {'height': height, 'timestamp': height * 100},
+      }),
+      cursor: 'cursor-$height',
+    );
+  }
+
+  FolderEntity folder(String id, {String? parentFolderId}) => FolderEntity(
+        id: id,
+        driveId: driveId,
+        parentFolderId: parentFolderId,
+        name: id,
+      )
+        ..txId = 'metadata-$id'
+        ..ownerAddress = ownerAddress
+        ..createdAt = DateTime(2026, 8, 29);
+
+  FileEntity file(String id, {String parentFolderId = rootFolderId}) =>
+      FileEntity(
+        id: id,
+        driveId: driveId,
+        parentFolderId: parentFolderId,
+        name: id,
+        size: 1024,
+        lastModifiedDate: DateTime(2026, 8, 29),
+        dataTxId: 'data-$id',
+        dataContentType: 'text/plain',
+      )
+        ..txId = 'metadata-$id'
+        ..ownerAddress = ownerAddress
+        ..createdAt = DateTime(2026, 8, 29);
+
+  /// What the gateway returns for this drive: one transaction per entity, and
+  /// those entities when the sync asks what the transactions were.
+  void gatewayReturns(List<Entity> entities) {
+    when(() => arweave.getSegmentedTransactionsFromDrive(
+          any(),
+          ownerAddress: any(named: 'ownerAddress'),
+          minBlockHeight: any(named: 'minBlockHeight'),
+          maxBlockHeight: any(named: 'maxBlockHeight'),
+          strategy: any(named: 'strategy'),
+        )).thenAnswer((_) => Stream.value([
+          for (var i = 0; i < entities.length; i++) transactionAt(10 + i),
+        ]));
+
+    when(() => arweave.createDriveEntityHistoryFromTransactions(
+          any(),
+          any(),
+          any(),
+          driveId: any(named: 'driveId'),
+          ownerAddress: any(named: 'ownerAddress'),
+          currentBlockHeight: any(named: 'currentBlockHeight'),
+        )).thenAnswer((_) async {
+      final block = BlockEntities(10)..entities = [...entities];
+      return DriveEntityHistory(10, [block]);
+    });
+  }
+
+  Future<void> insertDrive({int? lastBlockHeight}) async {
+    await db.into(db.drives).insert(
+          DrivesCompanion.insert(
+            id: driveId,
+            name: 'Test Drive',
+            ownerAddress: ownerAddress,
+            rootFolderId: rootFolderId,
+            privacy: DrivePrivacyTag.public,
+            lastBlockHeight: Value(lastBlockHeight),
+          ),
+        );
+  }
+
+  /// Runs a real single-drive sync to exhaustion and hands back the last
+  /// thing it reported - the progress the cubit turns into a result.
+  Future<SyncProgress> syncToCompletion() async {
+    final emitted = <SyncProgress>[];
+    await for (final progress in syncRepository.syncSingleDrive(
+      driveId: driveId,
+    )) {
+      emitted.add(progress);
+    }
+    return emitted.last;
+  }
+
+  setUp(() {
+    db = getTestDb();
+    arweave = MockArweaveService();
+    configService = MockConfigService();
+    snapshotValidation = _MockSnapshotValidationService();
+    arnsRepository = _MockARNSRepository();
+    userPreferences = _MockUserPreferencesRepository();
+
+    when(() => configService.config).thenReturn(AppConfig(
+      allowedDataItemSizeForTurbo: 0,
+      stripePublishableKey: '',
+      enableSyncFromSnapshot: false,
+      autoSync: true,
+    ));
+
+    when(() => arweave.getCurrentBlockHeight()).thenAnswer((_) async => 100);
+    when(() => arweave.clearUserDriveTxsCache()).thenReturn(null);
+    when(() => arweave.snapshotMetadataHits).thenReturn(<String, int>{});
+    when(() => arweave.snapshotMetadataMisses).thenReturn(<String, int>{});
+    when(() => arweave.getTransactionConfirmations(
+          any(),
+          owner: any(named: 'owner'),
+          ownersByTxId: any(named: 'ownersByTxId'),
+          ownerOverrides: any(named: 'ownerOverrides'),
+          verifiedSink: any(named: 'verifiedSink'),
+        )).thenAnswer((_) async => <String?, int>{});
+    when(() => arnsRepository.getAntRecordsForWallet(any(),
+        update: any(named: 'update'))).thenAnswer((_) async => <ANTRecord>[]);
+    when(() => userPreferences.load()).thenAnswer(
+      (_) async => const UserPreferences(
+        currentTheme: ArDriveThemes.light,
+        lastSelectedDriveId: null,
+      ),
+    );
+    when(() => userPreferences.saveUserHasHiddenItem(any()))
+        .thenAnswer((_) async {});
+
+    gatewayReturns([]);
+
+    syncRepository = SyncRepository(
+      arweave: arweave,
+      driveDao: db.driveDao,
+      configService: configService,
+      batchProcessor: BatchProcessor(),
+      snapshotValidationService: snapshotValidation,
+      arnsRepository: arnsRepository,
+      userPreferencesRepository: userPreferences,
+    );
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  test('a sync that wrote nothing reports nothing', () async {
+    await insertDrive();
+
+    final result = await syncToCompletion();
+
+    expect(result.entitiesSynced, 0);
+    expect(await db.select(db.fileRevisions).get(), isEmpty);
+  });
+
+  test('a sync reports every file and folder revision it wrote', () async {
+    await insertDrive();
+    gatewayReturns([
+      folder(rootFolderId),
+      folder('subfolder', parentFolderId: rootFolderId),
+      file('file-a'),
+      file('file-b'),
+      file('file-c'),
+    ]);
+
+    final result = await syncToCompletion();
+
+    // What the database actually holds, so the reported number is checked
+    // against the writes rather than against another count of the same guess.
+    final folderRevisions = await db.select(db.folderRevisions).get();
+    final fileRevisions = await db.select(db.fileRevisions).get();
+    expect(folderRevisions, hasLength(2));
+    expect(fileRevisions, hasLength(3));
+
+    expect(result.entitiesSynced, 5);
+  });
+
+  test('a second sync over the same entities reports nothing new', () async {
+    // Every sync rewinds its watermark and re-walks the last blocks, so the
+    // same entities come back around unchanged. They were already written;
+    // reporting them again would announce a drive full of new items on a sync
+    // that wrote none.
+    await insertDrive();
+    gatewayReturns([folder(rootFolderId), file('file-a')]);
+
+    expect((await syncToCompletion()).entitiesSynced, 2);
+
+    final second = await syncToCompletion();
+
+    expect(second.entitiesSynced, 0);
+    expect(await db.select(db.fileRevisions).get(), hasLength(1));
+  });
+
+  test('a sync counts only what it wrote, not what came before it', () async {
+    await insertDrive();
+    gatewayReturns([folder(rootFolderId), file('file-a')]);
+    await syncToCompletion();
+
+    // One more file arrives on top of the two entities already in the drive.
+    gatewayReturns([folder(rootFolderId), file('file-a'), file('file-b')]);
+
+    final result = await syncToCompletion();
+
+    expect(await db.select(db.fileRevisions).get(), hasLength(2));
+    expect(result.entitiesSynced, 1);
+  });
+
+  test('a file that arrives with its history is one item, not one per version',
+      () async {
+    await insertDrive();
+
+    // A first sync walks a drive's whole history, so one file can arrive with
+    // several versions at once. That writes several revisions, but it is one
+    // item to the person reading the summary - the difference between
+    // counting revisions and counting entities.
+    gatewayReturns([
+      folder(rootFolderId),
+      file('file-a'),
+      file('file-a')
+        ..name = 'file-a-v2'
+        ..txId = 'metadata-file-a-v2'
+        ..createdAt = DateTime(2026, 8, 30),
+    ]);
+
+    final result = await syncToCompletion();
+
+    expect(await db.select(db.fileRevisions).get(), hasLength(2));
+    // The root folder and the file. Counting revisions would say 3.
+    expect(result.entitiesSynced, 2);
+  });
+
+  test('a changed file is a revision the sync reports', () async {
+    await insertDrive();
+    gatewayReturns([folder(rootFolderId), file('file-a')]);
+    await syncToCompletion();
+
+    gatewayReturns([
+      folder(rootFolderId),
+      file('file-a')
+        ..name = 'file-a-renamed'
+        ..txId = 'metadata-file-a-v2'
+        ..createdAt = DateTime(2026, 8, 30),
+    ]);
+
+    final result = await syncToCompletion();
+
+    expect(await db.select(db.fileRevisions).get(), hasLength(2));
+    expect(result.entitiesSynced, 1);
+  });
+}

--- a/test/sync/presentation/sync_overlay_test.dart
+++ b/test/sync/presentation/sync_overlay_test.dart
@@ -6,6 +6,7 @@ import 'package:ardrive/services/config/config_service.dart';
 import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
 import 'package:ardrive/sync/domain/sync_progress.dart';
 import 'package:ardrive/sync/presentation/sync_overlay.dart';
+import 'package:ardrive/sync/presentation/sync_summary.dart';
 import 'package:ardrive_ui/ardrive_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -156,6 +157,113 @@ void main() {
 
     expect(find.byType(SyncScrim), findsNothing);
     expect(find.byType(ProgressDialog), findsNothing);
+  });
+
+  testWidgets('a finished sync never holds the app', (tester) async {
+    // Whoever asked for it. The summary is drawn without a scrim and leaves on
+    // its own, so a sync that used to end in silence never starts costing a
+    // click to get rid of.
+    for (final trigger in SyncTrigger.values) {
+      expect(
+        SyncOverlay.blocksTheApp(
+          SyncComplete(
+            entitiesSynced: 0,
+            completedAt: DateTime.now(),
+            sequence: 1,
+            trigger: trigger,
+          ),
+        ),
+        isFalse,
+        reason: 'a $trigger sync that finished must not block the app',
+      );
+    }
+  });
+
+  testWidgets('the modal the user waited on ends on what the sync found',
+      (tester) async {
+    await tester.pumpWidget(
+      wrap(
+        SyncComplete(
+          entitiesSynced: 0,
+          completedAt: DateTime.now(),
+          sequence: 1,
+          trigger: SyncTrigger.userInitiated,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Sync Complete'), findsOneWidget);
+    expect(find.text('Up to date — nothing new'), findsOneWidget);
+    // The wait is over, so the app underneath is free again.
+    expect(find.byType(SyncScrim), findsNothing);
+
+    await tester.pumpWidget(const SizedBox());
+  });
+
+  testWidgets('the summary sees itself out', (tester) async {
+    await tester.pumpWidget(
+      wrap(
+        SyncComplete(
+          entitiesSynced: 12,
+          completedAt: DateTime.now(),
+          sequence: 1,
+          trigger: SyncTrigger.userInitiated,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('12 items changed'), findsOneWidget);
+
+    // Nobody clicks anything here: the modal is gone a few seconds later.
+    await tester.pump(syncSummaryDuration + const Duration(seconds: 1));
+
+    expect(find.text('12 items changed'), findsNothing);
+    expect(find.byType(ArDriveStandardModalNew), findsNothing);
+  });
+
+  testWidgets('a finished background sync is not painted over the app',
+      (tester) async {
+    // It reports at the top bar's indicator, where it was running - the app
+    // was never interrupted for it and must not be interrupted by its result.
+    await tester.pumpWidget(
+      wrap(
+        SyncComplete(
+          entitiesSynced: 12,
+          completedAt: DateTime.now(),
+          sequence: 1,
+          trigger: SyncTrigger.background,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byType(SyncScrim), findsNothing);
+    expect(find.byType(ArDriveStandardModalNew), findsNothing);
+    expect(find.text('12 items changed'), findsNothing);
+  });
+
+  testWidgets('a result from an hour ago is not announced again',
+      (tester) async {
+    // SyncComplete is still the cubit's state long after the sync. The shell
+    // builds this stack separately in its desktop and mobile branches, so
+    // crossing the breakpoint builds a fresh one - which used to pop a "Sync
+    // Complete" modal for a sync that finished an hour earlier.
+    await tester.pumpWidget(
+      wrap(
+        SyncComplete(
+          entitiesSynced: 12,
+          completedAt: DateTime.now().subtract(const Duration(hours: 1)),
+          sequence: 1,
+          trigger: SyncTrigger.userInitiated,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Sync Complete'), findsNothing);
+    expect(find.text('12 items changed'), findsNothing);
   });
 
   testWidgets('the modal counts whole percent', (tester) async {

--- a/test/sync/presentation/sync_summary_test.dart
+++ b/test/sync/presentation/sync_summary_test.dart
@@ -1,0 +1,215 @@
+import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
+import 'package:ardrive/sync/presentation/sync_summary.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The line a finished sync gets to say for itself. Every case has to read as
+/// a sentence someone would write - most of all the one where nothing changed,
+/// which is the sync the user most needs to learn they can ignore next time.
+void main() {
+  group('how long a result is entitled to', () {
+    SyncComplete completedAgo(Duration ago) => SyncComplete(
+          entitiesSynced: 0,
+          skippedEntityCount: 0,
+          isSingleDriveSync: false,
+          driveName: null,
+          trigger: SyncTrigger.background,
+          completedAt: DateTime.now().subtract(ago),
+          sequence: 1,
+        );
+
+    test('a fresh result gets the whole window', () {
+      final remaining = syncSummaryRemaining(completedAgo(Duration.zero));
+      expect(remaining.inMilliseconds,
+          closeTo(syncSummaryDuration.inMilliseconds, 100));
+    });
+
+    test('a result built near the boundary gets only what is left', () {
+      // The defect this guards: a surface that started a fresh
+      // syncSummaryDuration timer here would show the result for nearly twice
+      // its entitlement.
+      final remaining = syncSummaryRemaining(
+        completedAgo(syncSummaryDuration - const Duration(milliseconds: 200)),
+      );
+      expect(remaining, lessThan(const Duration(milliseconds: 400)));
+      expect(remaining, greaterThan(Duration.zero));
+    });
+
+    test('an expired result gets nothing, never a negative', () {
+      expect(
+        syncSummaryRemaining(completedAgo(const Duration(hours: 1))),
+        Duration.zero,
+      );
+    });
+  });
+
+  late AppLocalizations l10n;
+
+  setUpAll(() async {
+    l10n = await AppLocalizations.delegate.load(const Locale('en'));
+  });
+
+  SyncComplete finished({
+    int entitiesSynced = 0,
+    int skippedEntityCount = 0,
+    bool isSingleDriveSync = false,
+    String? driveName,
+  }) =>
+      SyncComplete(
+        entitiesSynced: entitiesSynced,
+        skippedEntityCount: skippedEntityCount,
+        isSingleDriveSync: isSingleDriveSync,
+        driveName: driveName,
+        completedAt: DateTime(2026, 8, 29),
+        sequence: 1,
+      );
+
+  String summaryOf(SyncComplete state) => syncCompleteSummary(l10n, state);
+
+  SyncSummary partsOf(SyncComplete state) =>
+      syncCompleteSummaryParts(l10n, state);
+
+  test('a sync that changed nothing says so', () {
+    expect(summaryOf(finished()), 'Up to date — nothing new');
+  });
+
+  test('a sync of one named drive that changed nothing names it', () {
+    expect(
+      summaryOf(finished(isSingleDriveSync: true, driveName: 'Photos')),
+      'Photos is up to date — nothing new',
+    );
+  });
+
+  test('a single drive sync with no name to give still says nothing is new',
+      () {
+    expect(
+      summaryOf(finished(isSingleDriveSync: true)),
+      'Up to date — nothing new',
+    );
+  });
+
+  test('the count of what arrived is the whole claim', () {
+    expect(summaryOf(finished(entitiesSynced: 12)), '12 items changed');
+  });
+
+  test('a single new item is not "1 items changed"', () {
+    expect(summaryOf(finished(entitiesSynced: 1)), '1 item changed');
+  });
+
+  test('a sync of every drive does not say how many drives it walked', () {
+    // It used to say "12 items changed across 3 drives". That number counted
+    // drives *walked*, failures included: twelve files that all landed in one
+    // drive sent the user looking through three, and "1 item changed across 3
+    // drives" is not a thing that can happen. The sync does not know the
+    // number that sentence implied, so it stopped implying it.
+    expect(summaryOf(finished(entitiesSynced: 12)), '12 items changed');
+    expect(summaryOf(finished(entitiesSynced: 12)), isNot(contains('across')));
+    expect(summaryOf(finished(entitiesSynced: 12)), isNot(contains('drive')));
+  });
+
+  test('a sync of one named drive names it', () {
+    expect(
+      summaryOf(finished(
+        entitiesSynced: 12,
+        isSingleDriveSync: true,
+        driveName: 'Photos',
+      )),
+      '12 items changed in Photos',
+    );
+  });
+
+  test('items that could not be read are said out loud', () {
+    // These are files the user will not see. A summary that counted only what
+    // arrived would report a clean sync over a drive with holes in it.
+    expect(
+      summaryOf(finished(entitiesSynced: 12, skippedEntityCount: 2)),
+      '12 items changed · 2 updates could not be read',
+    );
+  });
+
+  test('one item that could not be read is not "1 items"', () {
+    expect(
+      summaryOf(finished(entitiesSynced: 12, skippedEntityCount: 1)),
+      '12 items changed · 1 update could not be read',
+    );
+  });
+
+  test('nothing arrived and something was unreadable is not "up to date"', () {
+    // Nothing was written, but the sync cannot claim the drive is current:
+    // what it could not read is exactly what is missing.
+    expect(
+      summaryOf(finished(skippedEntityCount: 2)),
+      '2 updates could not be read',
+    );
+  });
+
+  group('the two halves stay separable', () {
+    // A surface with a width limit has to be able to shorten what arrived
+    // without shortening what could not be read - joined into one string the
+    // unreadable clause comes last, and is the first thing an ellipsis eats.
+    test('what could not be read is a part of its own', () {
+      final parts =
+          partsOf(finished(entitiesSynced: 12, skippedEntityCount: 2));
+
+      expect(parts.arrived, '12 items changed');
+      expect(parts.unreadable, '2 updates could not be read');
+      expect(parts.lines, ['12 items changed', '2 updates could not be read']);
+    });
+
+    test('a clean sync has nothing unreadable to say', () {
+      final parts = partsOf(finished(entitiesSynced: 12));
+
+      expect(parts.arrived, '12 items changed');
+      expect(parts.unreadable, isNull);
+      expect(parts.lines, ['12 items changed']);
+    });
+
+    test('nothing arrived leaves only the unreadable line', () {
+      final parts = partsOf(finished(skippedEntityCount: 2));
+
+      expect(parts.arrived, isNull);
+      expect(parts.lines, ['2 updates could not be read']);
+    });
+  });
+
+  group('a stale result is not a result', () {
+    // SyncComplete stays the cubit's state until the next sync runs, and both
+    // surfaces start their countdown when they are built. Rebuilding one an
+    // hour later must not announce a sync that finished an hour ago.
+    final finishedAt = DateTime(2026, 8, 29, 12);
+    final result = SyncComplete(
+      entitiesSynced: 3,
+      completedAt: finishedAt,
+      sequence: 1,
+    );
+
+    test('a result that just landed is fresh', () {
+      expect(syncSummaryIsFresh(result, now: finishedAt), isTrue);
+    });
+
+    test('a result is fresh right up to the end of its few seconds', () {
+      expect(
+        syncSummaryIsFresh(
+          result,
+          now: finishedAt.add(syncSummaryDuration - const Duration(seconds: 1)),
+        ),
+        isTrue,
+      );
+    });
+
+    test('a result that has had its time is not shown again', () {
+      expect(
+        syncSummaryIsFresh(result, now: finishedAt.add(syncSummaryDuration)),
+        isFalse,
+      );
+      expect(
+        syncSummaryIsFresh(
+          result,
+          now: finishedAt.add(const Duration(hours: 1)),
+        ),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Stacked on #2208 (which is stacked on #2207). Review those first — this PR's base is `sync-ui-2-non-blocking`, so the diff here is only the third commit.

## The problem

A finished sync told the user nothing. On success the cubit emitted `SyncIdle()` and the modal simply vanished, so a sync that pulled in nothing looked exactly like one that pulled in five hundred files. The zero-change case is the one that matters most: a sync that says "nothing new" teaches people the next one is safe to ignore.

## What changes

`SyncComplete` carries what the sync found, and two surfaces report it — a pill at the sync button for a background sync, the modal ending on the result for one the user asked for. Both take themselves away after four seconds. Neither asks for a click.

| case | reads |
|---|---|
| nothing changed | `Up to date — nothing new` |
| nothing changed, named drive | `Photos is up to date — nothing new` |
| changes | `1 item changed` / `12 items changed` |
| changes, named drive | `12 items changed in Photos` |
| unreadable only | `2 updates could not be read` |
| both | `12 items changed · 2 updates could not be read` |

## Three things worth a reviewer's attention

**`SyncComplete extends SyncIdle`, deliberately.** `drive_detail_cubit.dart:144` and `sharing/sharing_file_listener.dart:40` both gate on `is SyncIdle` — the post-sync drive refresh and the shared-file handoff. A sibling state would have broken both silently. There is now a test feeding a `SyncComplete` through the drive-detail stream.

**It carries a `sequence`, not just a timestamp.** `SyncState` extends `Equatable` and bloc skips a state equal to the current one, so two "nothing new" syncs in a row would have been identical objects and the second would never have emitted — the exact case this PR exists for. `completedAt` alone was not enough: two mocked syncs run back-to-back land in the same millisecond and the test went intermittently red.

**A sync that failed says nothing.** The `catch` in `startSync` called `addError` without returning, so a sync that threw before any drive was queried fell through into the completion block with `hasErrors` false. That would have shown the "Failed to sync drive" snackbar and a "Sync Complete — nothing new" card at the same time. Both paths now carry `ranToCompletion`, and anything else emits a plain `SyncIdle()` — making no claim, exactly as before.

## The count is real, and it counts entities

`SyncProgress.entitiesSynced` was set nowhere in `lib/` — 0 in both factories, no `copyWith` anywhere. So every "N new items" string was dead and the app would have said "Up to date — nothing new" after syncing five hundred files.

It is now accumulated in `sync_repository.dart` beside the existing `_skippedEntityTxIdsByDrive`, from the revisions actually inserted. Two details that are easy to get wrong, both pinned by tests:

- **Not from the lists the batch hands back.** `_addNew*EntityRevisions` seed their return lists from the cache before testing whether anything changed, and every sync re-walks the last `kBlockHeightLookBack` blocks — so counting those reports a drive full of new items on a sync that wrote none. Test: a second sync over unchanged entities reports `0`; counting the returned lists gives `2`.
- **Entity ids, not revisions.** One file arriving with three historical versions writes three revisions but is one item to the reader, and a first sync walks a drive's whole history. Test: `Expected: <2> Actual: <3>` if revisions are counted.

Counting only — no change to control flow, batch sizes, transaction boundaries, the watermark, snapshot validation, progress arithmetic, or any query.

## Why the strings say "changed" and "updates"

A revision is written for a rename, move, hide, new version, thumbnail or licence — so "new items" would be false in the common case of a sync that picked up renames from another device. And the skipped count is a set of **transaction** ids, so three unreadable revisions of one file are three of them; calling those "items" would send someone hunting for three missing files.

## Verification

`flutter analyze` clean. Full suite **1535 passed, 4 skipped, 0 failed**.

Every new test was mutation-tested — implementation line reverted, failure observed, restored. The end-to-end count test drives a real `SyncRepository` over a real in-memory `DriveDao` with only `ArweaveService` mocked, and asserts the reported number against actual database row counts, because building the state by hand is exactly how the fake count got through the first review.

## Known, not fixed

The summary's `Material` has no colour, so it paints `canvasColor` at the corners — but the pre-existing `SyncCancelled` modal does the same thing. Worth one pass across all of them rather than making the new one the odd one out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ndA5nwUpt9hGLUx2TAFr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added completion summaries for syncs, showing newly synced items and updates that could not be read.
  * Added distinct messaging for up-to-date syncs and single-drive syncs.
  * Added non-blocking summary notifications that automatically dismiss and refresh for each completed sync.
  * Added localized text for sync results.

* **Bug Fixes**
  * Completed syncs now refresh drive details correctly, even when metadata updates are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->