### PR TITLE
feat: a progress bar that keeps moving, and says when it cannot

### DIFF
--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -108,6 +108,9 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
       });
     } else {
       Future.microtask(() async {
+        // No loading state to emit first: the cubit is constructed in
+        // DriveDetailLoadInProgress, so the screen is already saying it is
+        // working before this wait begins.
         // Wait for any current sync to complete before checking drive state
         await _syncCubit.waitCurrentSync();
 
@@ -208,6 +211,10 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
   }
 
   void showEmptyDriveDetail() async {
+    // Nothing to announce before this wait either. This runs when there is no
+    // drive to show, from a state that is already DriveDetailLoadInProgress,
+    // and all it can do afterwards is narrow that to "empty" - so emitting a
+    // loading state here would claim work that is not happening.
     await _syncCubit.waitCurrentSync();
 
     // Check if state has already changed (e.g., drives were loaded during sync)
@@ -227,7 +234,9 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
     // First check current drive state before waiting for sync
     var drive = await _driveDao.driveById(driveId: driveId).getSingleOrNull();
 
-    // If drive doesn't exist locally at all, wait for sync to discover it
+    // If drive doesn't exist locally at all, wait for sync to discover it.
+    // This one already emits before it waits, which is the shape openFolder
+    // now has too.
     if (drive == null) {
       emit(DriveDetailLoadInProgress());
       await _syncCubit.waitCurrentSync();
@@ -271,15 +280,37 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
     // previous folder is stale from here on even when the drive is unchanged.
     final loadGeneration = ++_folderLoadGeneration;
 
+    if (isClosed) {
+      return;
+    }
+
+    // Before the wait, not after it. `changeDrive` has already cancelled the
+    // folder subscription and moved `_driveId` by the time it gets here, so
+    // until this emits, the screen still shows the drive the user just left.
+    // While a sync scrimmed the whole app that was unreachable; now that a
+    // background sync leaves the app usable, a click on a drive - or a
+    // double-click on a folder - would sit there doing nothing at all for as
+    // long as the sync ran, which on a large wallet is minutes.
+    //
+    // The wait itself stays: a folder must not be opened against a
+    // half-written database. What changes is that the app says it heard the
+    // click before it starts waiting.
+    emit(DriveDetailLoadInProgress());
+
     /// always wait for the current sync to finish before opening a new folder
     await _syncCubit.waitCurrentSync();
+
+    // A newer openFolder claimed the generation while this one waited - it
+    // owns the subscription and the state now, so this one stops here rather
+    // than mounting a second listener for a folder nobody is looking at.
+    if (isClosed || loadGeneration != _folderLoadGeneration) {
+      return;
+    }
 
     try {
       _allImagesOfCurrentFolder = null;
 
       String driveId = otherDriveId ?? _driveId;
-
-      emit(DriveDetailLoadInProgress());
 
       await _folderSubscription?.cancel();
 
@@ -311,6 +342,11 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
             return;
           }
 
+          // Left alone deliberately. This fires on every drift tick, so
+          // emitting a loading state here would blank the file list the user
+          // is browsing over and over for the length of a background sync.
+          // Holding the folder that is already on screen until the database
+          // settles is the honest thing for a redraw nobody asked for.
           await _syncCubit.waitCurrentSync();
 
           if (drive == null) {
@@ -370,8 +406,8 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
             }
           }
 
-          final driveIsEmpty = folderContents.files.isEmpty &&
-              folderContents.subfolders.isEmpty;
+          final driveIsEmpty =
+              folderContents.files.isEmpty && folderContents.subfolders.isEmpty;
 
           // A drive that renders with nothing in it is ambiguous: it may be
           // genuinely empty, or its contents may simply never have synced.
@@ -649,7 +685,8 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
   }
 
   Future<void> launchPreview(TxID dataTxId) => openUrl(
-      url: '${_configService.config.arweaveGatewayForDataRequest.url}/$dataTxId');
+      url:
+          '${_configService.config.arweaveGatewayForDataRequest.url}/$dataTxId');
 
   void sortFolder({
     DriveOrder contentOrderBy = DriveOrder.name,
@@ -911,8 +948,7 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
   /// [DriveInitialLoading] was a dead end: no retry, no action, and nothing
   /// that re-triggers it.
   Future<void> _handleFolderNotFound(String driveId) async {
-    final drive =
-        await _driveDao.driveById(driveId: driveId).getSingleOrNull();
+    final drive = await _driveDao.driveById(driveId: driveId).getSingleOrNull();
     // The drive can be switched out from under this query. Emitting after that
     // would put the previous drive's state on the new drive's screen.
     if (isClosed || _driveId != driveId) return;

--- a/lib/components/app_top_bar.dart
+++ b/lib/components/app_top_bar.dart
@@ -222,7 +222,15 @@ class SyncButton extends StatelessWidget {
 
             return _SyncButtonMenu(
               status: _syncStatus(context, syncProgress),
-              child: _SyncProgressRing(progress: syncProgress?.progress),
+              // A phase that cannot measure itself hands the ring no value, so
+              // it sweeps as well as turns - the same honesty the modal's bar
+              // gets. The rotation is its own repeating animation either way,
+              // so the ring never freezes into a static arc.
+              child: _SyncProgressRing(
+                progress: syncProgress != null && syncProgress.isIndeterminate
+                    ? null
+                    : syncProgress?.progress,
+              ),
             );
           },
         );
@@ -245,10 +253,14 @@ class SyncButton extends StatelessWidget {
       title: syncProgress.isSingleDriveSync
           ? appLocalizationsOf(context).syncingSingleDrive
           : appLocalizationsOf(context).syncingAllDrives,
+      // The percentage stands in only when the sync has no phase to name and
+      // a number worth showing; an unmeasurable phase always has a message.
       detail: syncProgress.statusMessage ??
-          appLocalizationsOf(context).syncProgressPercentage(
-            (syncProgress.progress * 100).round().toString(),
-          ),
+          (syncProgress.isIndeterminate
+              ? null
+              : appLocalizationsOf(context).syncProgressPercentage(
+                  (syncProgress.progress * 100).round().toString(),
+                )),
       showElapsed: true,
     );
   }

--- a/lib/components/app_top_bar.dart
+++ b/lib/components/app_top_bar.dart
@@ -133,109 +133,233 @@ const double _syncStatusHeaderHeight = 96;
 /// sync runs.
 const double _syncStatusHeaderWidth = 260;
 
-/// What the sync is doing, in the words the sync modal uses for the same thing.
+/// What the sync indicator has to say, in the words the sync modal uses for the
+/// same thing.
 class _SyncStatus {
   const _SyncStatus({
     required this.title,
     this.detail,
     this.showElapsed = false,
+    this.isError = false,
+    this.detailMaxLines = 1,
   });
 
-  /// What is being synced - the modal's own title.
+  /// What is being synced - the modal's own title - or, for a sync that
+  /// failed, that it did.
   final String title;
 
-  /// The phase the sync names for itself, or the percentage when it names none.
+  /// The phase the sync names for itself, the percentage when it names none,
+  /// or how many drives a failed sync could not read.
   final String? detail;
 
   /// Whether the sync has a start time worth counting from.
   final bool showElapsed;
 
+  /// Whether this is a sync that failed rather than one that is running, so
+  /// the header reads as a problem instead of as progress.
+  final bool isError;
+
+  /// How much room [detail] gets. A running sync's phase is one short line; a
+  /// failure counts drives, which wraps on a phone.
+  final int detailMaxLines;
+
   /// The same two lines, for a pointer that has somewhere to hover.
   String get asTooltip => detail == null ? title : '$title\n$detail';
 }
 
-/// The top bar's sync control: the resync menu, and - while a sync is running -
-/// the only place a background sync reports itself.
+/// What the top bar has to say about a sync that just ended, and for how long.
+class SyncAnnouncement {
+  const SyncAnnouncement({
+    required this.identity,
+    required this.showFor,
+    this.lead,
+    this.trailing,
+    this.isError = false,
+  });
+
+  /// Which announcement this is. A new identity restarts the few seconds it
+  /// gets; the same one arriving again because something rebuilt does not, so
+  /// a result cannot be stretched by a resize - and two syncs that read
+  /// identically are still two results, because their identities differ.
+  final Object identity;
+
+  /// How long it stays, counted from when the sync ended rather than from when
+  /// this was built - see [syncSummaryRemaining].
+  final Duration showFor;
+
+  /// The line that may be shortened when there is not room for everything.
+  final String? lead;
+
+  /// The line that may not: what a sync could not read is the whole reason for
+  /// saying anything, so it never gets ellipsized in favour of a drive name.
+  final String? trailing;
+
+  /// Whether this is a failure. It is drawn as one - a report nobody asked for
+  /// must not be mistaken for a clean result.
+  final bool isError;
+}
+
+/// The top bar's sync control: the resync menu, and - while a sync is running,
+/// or after one that failed - the only place a background sync reports itself.
 ///
 /// A sync the user asked for still gets the modal over the whole app. One that
 /// merely happened gets this: a ring that turns, and the phase, percentage and
 /// elapsed time inside the menu the ring already opens - a tap, not a hover, so
-/// the phone gets them too.
+/// the phone gets them too. A failure it reports here as well, rather than
+/// dropping a scrim over whatever the user had moved on to.
 class SyncButton extends StatelessWidget {
   const SyncButton({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
-
     return BlocBuilder<SyncCubit, SyncState>(
       builder: (context, syncState) {
-        if (syncState is SyncLoadingDrives) {
-          // Loading drive metadata reports no progress at all, so the ring has
-          // nothing to fill and just turns.
-          return _SyncButtonMenu(
-            status: _SyncStatus(
-              title: appLocalizationsOf(context).loadingYourDrives,
-            ),
-            child: const _SyncProgressRing(),
-          );
-        }
-
-        if (syncState is SyncComplete &&
-            syncState.trigger == SyncTrigger.background &&
-            // A result that has already had its few seconds is not announced
-            // again because the bar was rebuilt - see [syncSummaryIsFresh].
-            syncSummaryIsFresh(syncState)) {
-          // A sync nobody asked for says how it went where it ran, and then
-          // takes it back. Keyed on which result it is so a second one replaces
-          // the first rather than queueing behind it - two zero-change syncs
-          // read identically, and the second one still has to show.
-          return SyncSummaryFlash(
-            key: ValueKey(syncState.sequence),
-            summary: syncCompleteSummaryParts(
-              appLocalizationsOf(context),
-              syncState,
-            ),
-            showFor: syncSummaryRemaining(syncState),
-            child: _SyncButtonMenu(
-              child: ArDriveIcons.refresh(color: colorTokens.textMid),
-            ),
-          );
-        }
-
-        if (syncState is! SyncInProgress) {
-          return _SyncButtonMenu(
-            child: ArDriveIcons.refresh(color: colorTokens.textMid),
-          );
-        }
-
         final syncCubit = context.read<SyncCubit>();
 
+        // One shape for every state, and that is the point. This slot used to
+        // hold three structurally different subtrees - the menu on its own
+        // when idle, a StreamBuilder above it while a sync ran, a flash above
+        // that just after one finished - so every transition changed the
+        // widget type at this position and took [ArDriveDropdown]'s element,
+        // and its open/closed flag, down with it. An open menu vanished the
+        // instant a sync started or ended, and a thumb already moving towards
+        // Resync landed on the page behind.
+        //
+        // The stream is subscribed to in every state rather than only while a
+        // sync runs. It is a broadcast controller the cubit already owns, so
+        // listening costs nothing and asks nobody for anything.
         return StreamBuilder<SyncProgress>(
           stream: syncCubit.syncProgressController.stream,
-          // The controller is a broadcast stream that replays nothing, so a
-          // button mounted mid-sync would show an empty ring until the next
-          // event without this.
+          // The controller replays nothing, so a button mounted mid-sync would
+          // show an empty ring until the next event without this.
           initialData: syncCubit.syncProgress,
-          builder: (context, snapshot) {
-            final syncProgress = snapshot.data;
-
-            return _SyncButtonMenu(
-              status: _syncStatus(context, syncProgress),
-              // A phase that cannot measure itself hands the ring no value, so
-              // it sweeps as well as turns - the same honesty the modal's bar
-              // gets. The rotation is its own repeating animation either way,
-              // so the ring never freezes into a static arc.
-              child: _SyncProgressRing(
-                progress: syncProgress != null && syncProgress.isIndeterminate
-                    ? null
-                    : syncProgress?.progress,
-              ),
-            );
-          },
+          builder: (context, snapshot) => _build(
+            context,
+            syncState,
+            snapshot.data,
+          ),
         );
       },
     );
+  }
+
+  Widget _build(
+    BuildContext context,
+    SyncState syncState,
+    SyncProgress? syncProgress,
+  ) {
+    final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
+
+    // Only a sync nobody asked for reports its failure here. One the user
+    // asked for is holding a modal that says all of this already, with the
+    // same retry - see [SyncOverlay].
+    final errors = syncState is SyncCompleteWithErrors &&
+            syncState.trigger != SyncTrigger.userInitiated
+        ? syncState
+        : null;
+
+    final isSyncing = syncState is SyncInProgress;
+
+    final _SyncStatus? status;
+    final Widget indicator;
+
+    if (syncState is SyncLoadingDrives) {
+      // Loading drive metadata reports no progress at all, so the ring has
+      // nothing to fill and just turns.
+      status = _SyncStatus(
+        title: appLocalizationsOf(context).loadingYourDrives,
+      );
+      indicator = const _SyncProgressRing();
+    } else if (isSyncing) {
+      status = _syncStatus(context, syncProgress);
+      // A phase that cannot measure itself hands the ring no value, so it
+      // sweeps as well as turns - the same honesty the modal's bar gets. The
+      // rotation is its own repeating animation either way, so the ring never
+      // freezes into a static arc.
+      indicator = _SyncProgressRing(
+        progress: syncProgress != null && syncProgress.isIndeterminate
+            ? null
+            : syncProgress?.progress,
+      );
+    } else if (errors != null) {
+      status = _SyncStatus(
+        title: appLocalizationsOf(context).syncCompleteWithErrors,
+        detail: appLocalizationsOf(context).syncDrivesFailed(
+          errors.failedDrives,
+          errors.totalDrives,
+        ),
+        isError: true,
+        detailMaxLines: 2,
+      );
+      indicator = ArDriveIcons.triangle(color: colorTokens.strokeRed);
+    } else {
+      status = null;
+      indicator = ArDriveIcons.refresh(color: colorTokens.textMid);
+    }
+
+    return SyncSummaryFlash(
+      announcement: _announcement(context, syncState, errors),
+      child: _SyncButtonMenu(
+        status: status,
+        isSyncing: isSyncing,
+        failedDriveIds: errors?.failedDriveIds,
+        child: indicator,
+      ),
+    );
+  }
+
+  /// What the button has to announce right now, or null when it has nothing.
+  SyncAnnouncement? _announcement(
+    BuildContext context,
+    SyncState syncState,
+    SyncCompleteWithErrors? errors,
+  ) {
+    if (errors != null) {
+      // Gated the same way a result is: SyncCompleteWithErrors stays the
+      // cubit's state until the next sync, so without this the red pill
+      // replayed in full every time the top bar was rebuilt - on every drive
+      // click, for the rest of the session.
+      final remaining = syncSummaryRemainingSince(errors.completedAt);
+      if (remaining == Duration.zero) {
+        return null;
+      }
+
+      return SyncAnnouncement(
+        // The state itself. Two failures that read identically are equal, so
+        // bloc would never deliver the second one anyway - and a failure that
+        // has been cleared and happened again is a different object.
+        identity: errors,
+        showFor: remaining,
+        lead: appLocalizationsOf(context).syncCompleteWithErrors,
+        trailing: appLocalizationsOf(context).syncDrivesFailed(
+          errors.failedDrives,
+          errors.totalDrives,
+        ),
+        isError: true,
+      );
+    }
+
+    if (syncState is SyncComplete &&
+        syncState.trigger != SyncTrigger.userInitiated &&
+        // A result that has already had its few seconds is not announced again
+        // because the bar was rebuilt - see [syncSummaryIsFresh].
+        syncSummaryIsFresh(syncState)) {
+      final summary = syncCompleteSummaryParts(
+        appLocalizationsOf(context),
+        syncState,
+      );
+
+      return SyncAnnouncement(
+        // Which result this is, not what it says: two zero-change syncs read
+        // identically, and the second one still has to show.
+        identity: syncState.sequence,
+        showFor: syncSummaryRemaining(syncState),
+        lead: summary.arrived,
+        trailing: summary.unreadable,
+      );
+    }
+
+    return null;
   }
 
   /// Two lines: what sync is doing, and how far along it is. The phase names
@@ -266,29 +390,28 @@ class SyncButton extends StatelessWidget {
   }
 }
 
-/// What a finished background sync found, beside the indicator that was
-/// turning for it, for [syncSummaryDuration] and no longer.
+/// What a finished background sync found - or could not - beside the indicator
+/// that was turning for it, for [syncSummaryDuration] and no longer.
 ///
 /// It hangs off the button in an overlay rather than in the top bar's own row:
 /// a result that arrives while the user is reading something else must not
 /// push the bar's contents sideways, and it has to be able to leave again
 /// without moving them back.
+///
+/// It is mounted in every state, with nothing to say in most of them, so that
+/// the button's subtree does not change shape when a sync ends - see
+/// [SyncButton].
 class SyncSummaryFlash extends StatefulWidget {
   const SyncSummaryFlash({
     super.key,
-    required this.summary,
-    required this.showFor,
+    required this.announcement,
     required this.child,
   });
 
-  /// The finished sync - see [syncCompleteSummaryParts].
-  final SyncSummary summary;
+  /// What there is to say, or null when there is nothing.
+  final SyncAnnouncement? announcement;
 
-  /// What is left of [syncSummaryDuration] for this result, counted from when
-  /// the sync finished rather than from when this was built.
-  final Duration showFor;
-
-  /// The idle sync button the summary is anchored to.
+  /// The sync button the announcement is anchored to.
   final Widget child;
 
   @override
@@ -297,14 +420,48 @@ class SyncSummaryFlash extends StatefulWidget {
 
 class _SyncSummaryFlashState extends State<SyncSummaryFlash> {
   Timer? _dismiss;
-  bool _showing = true;
+
+  /// The identity of the announcement that has already had its turn. Kept
+  /// after it is hidden: without it, the next rebuild would find the same
+  /// announcement still on the cubit's state and start it over.
+  Object? _announced;
+
+  bool _visible = false;
 
   @override
   void initState() {
     super.initState();
-    _dismiss = Timer(widget.showFor, () {
+    _announce();
+  }
+
+  @override
+  void didUpdateWidget(covariant SyncSummaryFlash oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // No setState: a build follows this immediately.
+    _announce();
+  }
+
+  void _announce() {
+    final announcement = widget.announcement;
+
+    if (announcement == null) {
+      _dismiss?.cancel();
+      _dismiss = null;
+      _announced = null;
+      _visible = false;
+      return;
+    }
+
+    if (announcement.identity == _announced) {
+      return;
+    }
+
+    _announced = announcement.identity;
+    _visible = true;
+    _dismiss?.cancel();
+    _dismiss = Timer(announcement.showFor, () {
       if (mounted) {
-        setState(() => _showing = false);
+        setState(() => _visible = false);
       }
     });
   }
@@ -317,8 +474,10 @@ class _SyncSummaryFlashState extends State<SyncSummaryFlash> {
 
   @override
   Widget build(BuildContext context) {
+    final announcement = widget.announcement;
+
     return ArDriveOverlay(
-      visible: _showing,
+      visible: _visible && announcement != null,
       // No barrier: a report is not a question, so it never takes the next
       // click - the resync menu underneath still opens on the first one.
       closeOnBarrierTap: false,
@@ -330,31 +489,38 @@ class _SyncSummaryFlashState extends State<SyncSummaryFlash> {
         // summary is wider than the room left of it.
         shiftToWithinBound: AxisFlag(x: true),
       ),
-      content: _SyncSummaryPill(summary: widget.summary),
+      content: announcement == null
+          ? const SizedBox.shrink()
+          : _SyncSummaryPill(announcement: announcement),
       child: widget.child,
     );
   }
 }
 
-/// The summary itself: a quiet couple of lines in the surface colours, so a
-/// result that needs nothing from the user does not read like a warning.
+/// The announcement itself: a quiet couple of lines in the surface colours, so
+/// a result that needs nothing from the user does not read like a warning - and
+/// in the red tokens when it is one, so a failure is never mistaken for a
+/// clean result.
 ///
 /// The pill is capped at [_syncStatusHeaderWidth], which on a phone is most of
-/// the screen, so what arrived is allowed two lines and then an ellipsis. What
-/// could not be read is not: it goes on its own line underneath, full length.
-/// On one line it was joined last, so a long drive name pushed it past the cap
-/// and the ellipsis ate exactly the clause that says this sync has holes in it.
+/// the screen, so [SyncAnnouncement.lead] is allowed two lines and then an
+/// ellipsis. [SyncAnnouncement.trailing] is not: it goes on its own line
+/// underneath, full length. On one line it was joined last, so a long drive
+/// name pushed it past the cap and the ellipsis ate exactly the clause that
+/// says this sync has holes in it.
 class _SyncSummaryPill extends StatelessWidget {
-  const _SyncSummaryPill({required this.summary});
+  const _SyncSummaryPill({required this.announcement});
 
-  final SyncSummary summary;
+  final SyncAnnouncement announcement;
 
   @override
   Widget build(BuildContext context) {
     final typography = ArDriveTypographyNew.of(context);
     final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
-    final arrived = summary.arrived;
-    final unreadable = summary.unreadable;
+    final lead = announcement.lead;
+    final trailing = announcement.trailing;
+    final textColor =
+        announcement.isError ? colorTokens.textRed : colorTokens.textHigh;
 
     return IgnorePointer(
       // The margin is what keeps a gutter on the narrowest phone: the anchor's
@@ -368,23 +534,27 @@ class _SyncSummaryPill extends StatelessWidget {
         decoration: BoxDecoration(
           color: colorTokens.containerL1,
           borderRadius: BorderRadius.circular(6),
-          border: Border.all(color: colorTokens.strokeLow),
+          border: Border.all(
+            color: announcement.isError
+                ? colorTokens.strokeRed
+                : colorTokens.strokeLow,
+          ),
         ),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            if (arrived != null)
+            if (lead != null)
               Text(
-                arrived,
+                lead,
                 maxLines: 2,
                 overflow: TextOverflow.ellipsis,
-                style: typography.paragraphSmall(color: colorTokens.textHigh),
+                style: typography.paragraphSmall(color: textColor),
               ),
-            if (unreadable != null)
+            if (trailing != null)
               Text(
-                unreadable,
-                style: typography.paragraphSmall(color: colorTokens.textHigh),
+                trailing,
+                style: typography.paragraphSmall(color: textColor),
               ),
           ],
         ),
@@ -398,20 +568,86 @@ class _SyncSummaryPill extends StatelessWidget {
 ///
 /// While a sync runs the menu also carries a [_SyncStatusHeader], because the
 /// menu is the one surface a phone can reach: [SyncButton] is mounted in
-/// `MobileAppBar` too, where nothing hovers and a tooltip is never seen.
+/// `MobileAppBar` too, where nothing hovers and a tooltip is never seen. After
+/// a background sync fails, the same header carries the failure and the menu
+/// carries the retry.
 class _SyncButtonMenu extends StatelessWidget {
   const _SyncButtonMenu({
     this.status,
+    this.isSyncing = false,
+    this.failedDriveIds,
     required this.child,
   });
 
-  /// The running sync, or null when none is.
+  /// The running sync, the failure it ended in, or null when neither.
   final _SyncStatus? status;
+
+  /// Whether a sync is running. `SyncCubit.startSync` turns a request away
+  /// while one is - a guard written for a world where a running sync scrimmed
+  /// the app, so nobody could ask. Now the menu is fully interactive, and an
+  /// item that looks normal, closes the menu, records a Plausible event and
+  /// drops the request is a lie. These say what they are instead.
+  final bool isSyncing;
+
+  /// The drives a background sync failed on, when it did: the retry has to
+  /// outlive the few seconds the announcement gets.
+  final List<String>? failedDriveIds;
+
   final Widget child;
 
   @override
   Widget build(BuildContext context) {
     final status = this.status;
+    final failedDriveIds = this.failedDriveIds;
+    final iconColor = ArDriveTheme.of(context).themeData.colors.themeFgDefault;
+
+    final items = [
+      ArDriveDropdownItem(
+        // Nothing at all rather than a call that returns immediately: an event
+        // must not be recorded for a sync that never starts.
+        onClick: isSyncing
+            ? null
+            : () {
+                context.read<SyncCubit>().startSync(deepSync: false);
+                context.read<ProfileNameBloc>().add(RefreshProfileName());
+                PlausibleEventTracker.trackResync(type: ResyncType.resync);
+              },
+        content: ArDriveDropdownItemTile(
+          name: appLocalizationsOf(context).resync,
+          isDisabled: isSyncing,
+          icon: ArDriveIcons.refresh(color: iconColor),
+        ),
+      ),
+      ArDriveDropdownItem(
+        onClick: isSyncing
+            ? null
+            : () {
+                context.read<SyncCubit>().startSync(deepSync: true);
+                context.read<ProfileNameBloc>().add(RefreshProfileName());
+                PlausibleEventTracker.trackResync(type: ResyncType.deepResync);
+              },
+        content: ArDriveDropdownItemTile(
+          name: appLocalizationsOf(context).deepResync,
+          isDisabled: isSyncing,
+          icon: ArDriveIcons.cloudSync(color: iconColor),
+        ),
+      ),
+      if (failedDriveIds != null && failedDriveIds.isNotEmpty)
+        ArDriveDropdownItem(
+          onClick: isSyncing
+              ? null
+              : () {
+                  final syncCubit = context.read<SyncCubit>();
+                  syncCubit.clearErrorState();
+                  syncCubit.retryFailedDrives(failedDriveIds);
+                },
+          content: ArDriveDropdownItemTile(
+            name: appLocalizationsOf(context).retryFailedDrives,
+            isDisabled: isSyncing,
+            icon: ArDriveIcons.cloudSync(color: iconColor),
+          ),
+        ),
+    ];
 
     return HoverWidget(
       tooltip: status?.asTooltip ?? appLocalizationsOf(context).resyncTooltip,
@@ -428,38 +664,11 @@ class _SyncButtonMenu extends StatelessWidget {
         // cut the header off.
         maxHeight: status == null
             ? null
-            : _syncStatusHeaderHeight + 2 * _dropdownRowHeight,
+            : _syncStatusHeaderHeight + items.length * _dropdownRowHeight,
         // A header rather than an item: it is there to be read, so it must not
         // light up like an action or close the menu when a thumb lands on it.
         header: status == null ? null : _SyncStatusHeader(status: status),
-        items: [
-          ArDriveDropdownItem(
-            onClick: () {
-              context.read<SyncCubit>().startSync(deepSync: false);
-              context.read<ProfileNameBloc>().add(RefreshProfileName());
-              PlausibleEventTracker.trackResync(type: ResyncType.resync);
-            },
-            content: ArDriveDropdownItemTile(
-              name: appLocalizationsOf(context).resync,
-              icon: ArDriveIcons.refresh(
-                color: ArDriveTheme.of(context).themeData.colors.themeFgDefault,
-              ),
-            ),
-          ),
-          ArDriveDropdownItem(
-            onClick: () {
-              context.read<SyncCubit>().startSync(deepSync: true);
-              context.read<ProfileNameBloc>().add(RefreshProfileName());
-              PlausibleEventTracker.trackResync(type: ResyncType.deepResync);
-            },
-            content: ArDriveDropdownItemTile(
-              name: appLocalizationsOf(context).deepResync,
-              icon: ArDriveIcons.cloudSync(
-                color: ArDriveTheme.of(context).themeData.colors.themeFgDefault,
-              ),
-            ),
-          ),
-        ],
+        items: items,
         child: SizedBox(
           width: _syncIndicatorSize,
           height: _syncIndicatorSize,
@@ -470,8 +679,8 @@ class _SyncButtonMenu extends StatelessWidget {
   }
 }
 
-/// The phase, the percentage and the elapsed time, sitting above the resync
-/// actions in the menu the sync indicator opens.
+/// The phase, the percentage and the elapsed time - or the failure - sitting
+/// above the resync actions in the menu the sync indicator opens.
 ///
 /// This is the mobile half of the indicator. The ring says a sync is running;
 /// this says which one, how far it has got and how long it has been at it,
@@ -501,21 +710,37 @@ class _SyncStatusHeader extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.center,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            status.title,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: typography.paragraphNormal(
-              fontWeight: ArFontWeight.semiBold,
-              color: colorTokens.textHigh,
-            ),
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (status.isError) ...[
+                ArDriveIcons.triangle(
+                  size: 16,
+                  color: colorTokens.strokeRed,
+                ),
+                const SizedBox(width: 8),
+              ],
+              Flexible(
+                child: Text(
+                  status.title,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: typography.paragraphNormal(
+                    fontWeight: ArFontWeight.semiBold,
+                    color: status.isError
+                        ? colorTokens.textRed
+                        : colorTokens.textHigh,
+                  ),
+                ),
+              ),
+            ],
           ),
           if (detail != null)
             Padding(
               padding: const EdgeInsets.only(top: 4),
               child: Text(
                 detail,
-                maxLines: 1,
+                maxLines: status.detailMaxLines,
                 overflow: TextOverflow.ellipsis,
                 style: typography.paragraphSmall(
                   color: colorTokens.textMid,

--- a/lib/components/progress_bar.dart
+++ b/lib/components/progress_bar.dart
@@ -11,6 +11,11 @@ class ProgressBar extends StatefulWidget {
   State<ProgressBar> createState() => _ProgressBarState();
 }
 
+const _barTrack = Color(0xffFAFAFA);
+const _barFill = Color(0xff3C3C3C);
+const _barHeight = 10.0;
+const _barRadius = Radius.circular(5);
+
 class _ProgressBarState extends State<ProgressBar> {
   late double _percentage;
 
@@ -19,6 +24,21 @@ class _ProgressBarState extends State<ProgressBar> {
     return StreamBuilder<LinearProgress>(
       stream: widget.percentage,
       builder: (context, snapshot) {
+        // A phase that cannot know its own length gets a bar that does not
+        // claim to - see [LinearProgress.isIndeterminate]. The alternative is
+        // a number sitting perfectly still for up to half a minute, which is
+        // what a hung app looks like.
+        if (snapshot.hasData && snapshot.data!.isIndeterminate) {
+          return const ClipRRect(
+            borderRadius: BorderRadius.all(_barRadius),
+            child: LinearProgressIndicator(
+              minHeight: _barHeight,
+              backgroundColor: _barTrack,
+              valueColor: AlwaysStoppedAnimation<Color>(_barFill),
+            ),
+          );
+        }
+
         _percentage = snapshot.hasData
             ? ((snapshot.data!.progress * 100)).roundToDouble() / 100
             : 0;
@@ -26,12 +46,12 @@ class _ProgressBarState extends State<ProgressBar> {
         return LinearPercentIndicator(
           animation: true,
           animateFromLastPercent: true,
-          lineHeight: 10.0,
-          barRadius: const Radius.circular(5),
-          backgroundColor: const Color(0xffFAFAFA),
+          lineHeight: _barHeight,
+          barRadius: _barRadius,
+          backgroundColor: _barTrack,
           animationDuration: 1000,
           percent: _percentage,
-          progressColor: const Color(0xff3C3C3C),
+          progressColor: _barFill,
         );
       },
     );

--- a/lib/components/progress_bar.dart
+++ b/lib/components/progress_bar.dart
@@ -1,14 +1,63 @@
 import 'package:ardrive/sync/domain/sync_progress.dart';
 import 'package:flutter/material.dart';
-import 'package:percent_indicator/linear_percent_indicator.dart';
 
-class ProgressBar extends StatefulWidget {
+/// The bar the sync modal fills.
+///
+/// One widget type fills this slot in both phases, and that is the whole
+/// design. The bar used to return a [LinearProgressIndicator] while a phase
+/// could not measure itself and a `LinearPercentIndicator` when it could - two
+/// types in one position, so `Widget.canUpdate` failed on the swap, Flutter
+/// unmounted the element and percent_indicator built a fresh
+/// `Tween(begin: 0.0, end: percent)` in `initState` and animated it. Leaving
+/// the unmeasurable phase at 97% therefore emptied the bar and refilled it over
+/// a full second, which is exactly the backwards-moving bar the sync's
+/// monotonic progress exists to prevent, reintroduced one layer up. It fired
+/// for anyone with pending transactions - anyone who had uploaded recently.
+///
+/// [LinearProgressIndicator] already draws both: it is indeterminate exactly
+/// when its `value` is null. Same distinction, no swap, and the element - with
+/// whatever its fill is currently doing - survives the transition.
+class ProgressBar extends StatelessWidget {
   const ProgressBar({super.key, required this.percentage});
 
   final Stream<LinearProgress> percentage;
 
   @override
-  State<ProgressBar> createState() => _ProgressBarState();
+  Widget build(BuildContext context) {
+    return StreamBuilder<LinearProgress>(
+      stream: percentage,
+      builder: (context, snapshot) {
+        final progress = snapshot.data;
+
+        // A phase that cannot know its own length gets a bar that does not
+        // claim to - see [LinearProgress.isIndeterminate]. The alternative is
+        // a number sitting perfectly still for up to half a minute, which is
+        // what a hung app looks like.
+        final isIndeterminate = progress?.isIndeterminate ?? false;
+        final value = progress == null
+            ? 0.0
+            : ((progress.progress * 100).roundToDouble() / 100).clamp(0.0, 1.0);
+
+        return ClipRRect(
+          borderRadius: const BorderRadius.all(_barRadius),
+          // percent_indicator animated between values for free; a plain
+          // indicator jumps. [TweenAnimationBuilder] restarts from wherever the
+          // fill currently is rather than from zero, so a new value is walked
+          // to and never rewound to the start of the bar.
+          child: TweenAnimationBuilder<double>(
+            tween: Tween<double>(begin: 0, end: value),
+            duration: _barAnimation,
+            builder: (context, animated, _) => LinearProgressIndicator(
+              value: isIndeterminate ? null : animated,
+              minHeight: _barHeight,
+              backgroundColor: _barTrack,
+              valueColor: const AlwaysStoppedAnimation<Color>(_barFill),
+            ),
+          ),
+        );
+      },
+    );
+  }
 }
 
 const _barTrack = Color(0xffFAFAFA);
@@ -16,44 +65,6 @@ const _barFill = Color(0xff3C3C3C);
 const _barHeight = 10.0;
 const _barRadius = Radius.circular(5);
 
-class _ProgressBarState extends State<ProgressBar> {
-  late double _percentage;
-
-  @override
-  Widget build(BuildContext context) {
-    return StreamBuilder<LinearProgress>(
-      stream: widget.percentage,
-      builder: (context, snapshot) {
-        // A phase that cannot know its own length gets a bar that does not
-        // claim to - see [LinearProgress.isIndeterminate]. The alternative is
-        // a number sitting perfectly still for up to half a minute, which is
-        // what a hung app looks like.
-        if (snapshot.hasData && snapshot.data!.isIndeterminate) {
-          return const ClipRRect(
-            borderRadius: BorderRadius.all(_barRadius),
-            child: LinearProgressIndicator(
-              minHeight: _barHeight,
-              backgroundColor: _barTrack,
-              valueColor: AlwaysStoppedAnimation<Color>(_barFill),
-            ),
-          );
-        }
-
-        _percentage = snapshot.hasData
-            ? ((snapshot.data!.progress * 100)).roundToDouble() / 100
-            : 0;
-
-        return LinearPercentIndicator(
-          animation: true,
-          animateFromLastPercent: true,
-          lineHeight: _barHeight,
-          barRadius: _barRadius,
-          backgroundColor: _barTrack,
-          animationDuration: 1000,
-          percent: _percentage,
-          progressColor: _barFill,
-        );
-      },
-    );
-  }
-}
+/// How long the fill takes to travel between two values - percent_indicator's
+/// `animationDuration`, kept so the bar still moves at the speed it did.
+const Duration _barAnimation = Duration(milliseconds: 1000);

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2780,6 +2780,24 @@
   "@retryFailedDrives": {
     "description": "Button to retry syncing only the drives that failed"
   },
+  "syncDrivesFailed": "{failed} of {total} drives could not be synced",
+  "@syncDrivesFailed": {
+    "description": "How a sync nobody asked for reports its failures at the top bar. Short on purpose: the long warning belongs in the modal a user-initiated sync is already holding",
+    "placeholders": {
+      "failed": {
+        "type": "int",
+        "example": "2"
+      },
+      "total": {
+        "type": "int",
+        "example": "5"
+      }
+    }
+  },
+  "multiSelectPausedWhileSyncing": "Selecting several items is paused while syncing",
+  "@multiSelectPausedWhileSyncing": {
+    "description": "Why ctrl-click and ctrl-A do nothing in the file list while a sync is rewriting rows"
+  },
   "syncElapsedTime": "{seconds}s elapsed",
   "@syncElapsedTime": {
     "description": "Elapsed time shown during sync after 5 seconds",

--- a/lib/pages/drive_detail/components/drive_detail_data_list.dart
+++ b/lib/pages/drive_detail/components/drive_detail_data_list.dart
@@ -115,11 +115,15 @@ Widget _buildDataListContent(
           return emptyState;
         }
 
-        return ArDriveDataTable<ArDriveDataTableItem>(
+        final table = ArDriveDataTable<ArDriveDataTableItem>(
           key: ValueKey(
               '${folder.id}-${forceRebuildKey.toString()}${columns.length}-${hideState.toString()}'),
           initialPage: selectedPage,
-          lockMultiSelect: context.watch<SyncCubit>().state is SyncInProgress ||
+          // The sync half of this lock is stated out loud rather than left as
+          // a silent no-op - see [MultiSelectPausedNotice], which is given the
+          // same condition so the two cannot drift apart.
+          lockMultiSelect: MultiSelectPausedNotice.locksMultiSelect(
+                  context.watch<SyncCubit>().state) ||
               !context.watch<ActivityTracker>().isMultiSelectEnabled,
           rowsPerPageText: appLocalizationsOf(context).rowsPerPage,
           maxItemsPerPage: 100,
@@ -231,6 +235,15 @@ Widget _buildDataListContent(
           },
           rows: filteredItems,
           selectedRow: selectedItem,
+        );
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Draws nothing unless a sync is holding multi-select shut.
+            const MultiSelectPausedNotice(),
+            Expanded(child: table),
+          ],
         );
       },
     );

--- a/lib/pages/drive_detail/components/multi_select_paused_notice.dart
+++ b/lib/pages/drive_detail/components/multi_select_paused_notice.dart
@@ -1,0 +1,56 @@
+import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
+import 'package:ardrive/utils/app_localizations_wrapper.dart';
+import 'package:ardrive_ui/ardrive_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+/// Says that selecting several items is off while a sync is running, for as
+/// long as it is, and nothing at all the rest of the time.
+///
+/// The lock itself predates this widget: multi-select is held shut while a sync
+/// runs because the actions behind it would act on rows the sync is rewriting
+/// underneath them, and that is worth keeping. What changed is that a
+/// background sync no longer scrims the app, so the user is browsing for the
+/// whole of it - minutes, on a large wallet - and ctrl/cmd-click and ctrl-A
+/// were hard no-ops with nothing disabled and nothing said. That reads as the
+/// app being broken rather than as the app being busy.
+///
+/// One quiet line above the list, and no dialog: nothing is wrong and nothing
+/// is being asked, the app is briefly not offering something it usually does.
+class MultiSelectPausedNotice extends StatelessWidget {
+  const MultiSelectPausedNotice({super.key});
+
+  /// Whether a running sync is holding multi-select shut.
+  ///
+  /// The single source of truth for both halves of this: the flag the data
+  /// table is locked with, and whether this notice appears. Deriving them
+  /// separately is how the two drift apart and the lock goes quiet again.
+  static bool locksMultiSelect(SyncState state) => state is SyncInProgress;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!locksMultiSelect(context.watch<SyncCubit>().state)) {
+      return const SizedBox.shrink();
+    }
+
+    final typography = ArDriveTypographyNew.of(context);
+    final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ArDriveIcons.info(size: 16, color: colorTokens.textLow),
+          const SizedBox(width: 8),
+          Flexible(
+            child: Text(
+              appLocalizationsOf(context).multiSelectPausedWhileSyncing,
+              style: typography.paragraphSmall(color: colorTokens.textLow),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/drive_detail/drive_detail_page.dart
+++ b/lib/pages/drive_detail/drive_detail_page.dart
@@ -37,6 +37,7 @@ import 'package:ardrive/pages/drive_detail/components/drive_explorer_item_tile.d
 import 'package:ardrive/pages/drive_detail/components/drive_file_drop_zone.dart';
 import 'package:ardrive/pages/drive_detail/components/dropdown_item.dart';
 import 'package:ardrive/pages/drive_detail/components/file_icon.dart';
+import 'package:ardrive/pages/drive_detail/components/multi_select_paused_notice.dart';
 import 'package:ardrive/pages/drive_detail/components/hover_widget.dart';
 import 'package:ardrive/pages/drive_detail/components/unpreviewable_content.dart';
 import 'package:ardrive/pages/drive_detail/components/document_preview_widget.dart';

--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -132,17 +132,25 @@ class SyncCubit extends Cubit<SyncState> {
 
   /// Waits for the current sync to finish.
   /// SyncLoadingDrives is treated as non-blocking (metadata-only loading).
+  /// Whether a sync has finished, by whatever route it got there.
+  ///
+  /// The entry guard and the loop in [waitCurrentSync] have to agree on this.
+  /// They did not: the guard let through every state but two, while the loop
+  /// broke on five - so a wait that BEGAN while the cubit was already sitting
+  /// in `SyncCompleteWithErrors`, `SyncFailure` or `SyncCancelled` blocked on
+  /// an emission that had already happened and was never coming again.
+  static bool _syncHasFinished(SyncState state) =>
+      state is SyncIdle ||
+      state is SyncFailure ||
+      state is SyncCancelled ||
+      state is SyncCompleteWithErrors ||
+      state is SyncLoadingDrives;
+
   Future<void> waitCurrentSync() async {
-    if (state is! SyncIdle && state is! SyncLoadingDrives) {
-      await for (var state in stream) {
-        if (state is SyncIdle ||
-            state is SyncFailure ||
-            state is SyncCancelled ||
-            state is SyncCompleteWithErrors ||
-            state is SyncLoadingDrives) {
-          break;
-        }
-      }
+    if (_syncHasFinished(state)) return;
+
+    await for (final state in stream) {
+      if (_syncHasFinished(state)) break;
     }
   }
 
@@ -466,6 +474,7 @@ class SyncCubit extends Cubit<SyncState> {
         errorMessages: _syncProgress.errorMessages,
         skippedEntityCount: _syncProgress.skippedEntityCount,
         skippedEntityTxIdsByDrive: _syncProgress.skippedEntityTxIdsByDrive,
+        trigger: trigger,
       ));
     } else if (ranToCompletion) {
       emit(_syncComplete(trigger));
@@ -628,6 +637,7 @@ class SyncCubit extends Cubit<SyncState> {
         errorMessages: _syncProgress.errorMessages,
         skippedEntityCount: _syncProgress.skippedEntityCount,
         skippedEntityTxIdsByDrive: _syncProgress.skippedEntityTxIdsByDrive,
+        trigger: trigger,
       ));
     } else if (ranToCompletion) {
       emit(_syncComplete(trigger));

--- a/lib/sync/domain/cubit/sync_state.dart
+++ b/lib/sync/domain/cubit/sync_state.dart
@@ -69,6 +69,25 @@ class SyncCompleteWithErrors extends SyncState {
   final int skippedEntityCount;
   final Map<String, List<String>> skippedEntityTxIdsByDrive;
 
+  /// Who asked for the sync that failed, like every other terminal state.
+  ///
+  /// It was the only one without a trigger, so [SyncOverlay.blocksTheApp]
+  /// returned true for it unconditionally: a login sync that paints nothing
+  /// while it runs would still drop a scrim and a modal over whatever the user
+  /// was doing the moment one drive out of five came back empty. A sync nobody
+  /// asked for reports its failure where it ran - the top bar - and a sync the
+  /// user asked for keeps the modal it was already holding.
+  final SyncTrigger trigger;
+
+  /// When the sync that failed finished.
+  ///
+  /// Deliberately NOT in [props]: it exists so a surface can tell how long ago
+  /// this happened, not to make two otherwise-identical failures distinct. A
+  /// background failure is announced at the top bar for a few seconds, and
+  /// this state stays current until the next sync runs - so without it, every
+  /// rebuild of the top bar replayed the announcement from the beginning.
+  final DateTime completedAt;
+
   SyncCompleteWithErrors({
     required this.failedDrives,
     required this.totalDrives,
@@ -76,7 +95,9 @@ class SyncCompleteWithErrors extends SyncState {
     required this.errorMessages,
     this.skippedEntityCount = 0,
     this.skippedEntityTxIdsByDrive = const {},
-  });
+    this.trigger = SyncTrigger.userInitiated,
+    DateTime? completedAt,
+  }) : completedAt = completedAt ?? DateTime.now();
 
   @override
   List<Object> get props => [
@@ -86,6 +107,7 @@ class SyncCompleteWithErrors extends SyncState {
         errorMessages,
         skippedEntityCount,
         skippedEntityTxIdsByDrive,
+        trigger,
       ];
 }
 

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -61,6 +61,130 @@ const _txConfirmationBatchTimeout = Duration(seconds: 15);
 /// batch can complete; remaining work resumes on the next sync.
 const _txStatusUpdateTimeout = Duration(seconds: 30);
 
+/// Where each phase of a sync ends on the 0..1 progress bar.
+///
+/// The split follows one rule: bar travel goes where progress is real. A phase
+/// that reports what it has actually done gets room to report it; a phase that
+/// cannot report gets almost none, because every point handed to it is a point
+/// the bar crosses without knowing anything.
+///
+/// The walk keeps the large share. It is the only phase whose length grows
+/// with the user's history, and the only one that already reports continuously
+/// - per drive, and per block range inside a drive - so its share is the part
+/// of the bar that genuinely tracks work. The four phases after it split the
+/// remaining sixth between them by the same rule.
+const _progressDriveWalkEnd = 0.85;
+
+/// Ghost folder creation: local database writes over a map already in memory,
+/// usually empty. A phase that flashes past does not get bar real estate it
+/// cannot use, so the share is small - but it is not zero, because a drive
+/// with hundreds of ghosts really does take a moment, and this reports per row
+/// written.
+const _progressGhostFoldersEnd = 0.88;
+
+/// Reading what the snapshots already covered, and the hidden-item preference.
+/// Local queries that already happen, reported per chunk read. Fast for most
+/// wallets and slow for a few, so: a small share, spent granularly.
+const _progressPendingScanEnd = 0.92;
+
+/// The local half of the transaction-status phase: the pinned-data owner
+/// overrides, the per-drive owners, the pending rows, and the date pre-load.
+/// All local reads that were already being made and were counted in nothing
+/// before. They report a step each, which is why this share is the largest of
+/// the tail - it is the last stretch of the bar backed by finished work.
+const _progressTxPrepEnd = 0.97;
+
+/// Asking the gateway which pending transactions confirmed - the one phase in
+/// the tail that leaves the machine, bounded only by [_txStatusUpdateTimeout].
+///
+/// It gets the smallest share of all, which is the opposite of what its
+/// duration would suggest, and deliberate: it reports one step per 5000
+/// pending transactions, so for a real user it reports exactly one step, when
+/// the gateway answers. Points given to it would be points the bar crosses on
+/// no evidence. Instead the bar goes indeterminate for the duration - see
+/// [SyncProgress.isIndeterminate] - and this constant is only where the number
+/// picks back up once the gateway is done with.
+const _progressTxStatusEnd = 0.99;
+
+/// The last hundredth is completion itself - the final writes and the summary
+/// - so a finished sync says so by moving, not by having sat at the end for a
+/// while already. Success lands here exactly.
+const _progressComplete = 1.0;
+
+/// Linear interpolation inside one phase's share of the bar, where [fraction]
+/// is how much of that phase's own work is done.
+double _phaseProgress(double start, double end, double fraction) =>
+    start + (end - start) * fraction.clamp(0.0, 1.0);
+
+/// The one place a sync's progress reaches the outside world.
+///
+/// Every emission passes through here, and `progress` is never published below
+/// the highest value already published. A bar that jumps backwards reads as a
+/// bug even when both numbers are individually defensible, and there is more
+/// than one way to produce one here: drives sync concurrently over a shared
+/// counter, and a single drive's progress is derived from block heights that a
+/// composite history can hand back out of order. Enforcing the guarantee where
+/// progress is published means no future caller can regress it by accident.
+@visibleForTesting
+class MonotonicProgressSink {
+  final StreamController<SyncProgress> _controller =
+      StreamController<SyncProgress>.broadcast();
+
+  double _highWaterMark = 0;
+
+  Stream<SyncProgress> get stream => _controller.stream;
+
+  bool get isClosed => _controller.isClosed;
+
+  /// Bounds and clamps without publishing, for the emissions a sync yields
+  /// directly. Returns what the caller should go on holding as its progress.
+  ///
+  /// The bound to 0..1 is not defensive tidiness: a drive's walk progress is
+  /// `1 - (head - blockHeight) / range`, and `head` is read once at the top of
+  /// a sync that then runs for minutes. A transaction mined after that read
+  /// sits above the head and makes the term negative, so the walk hands up a
+  /// number greater than 1. Un-bounded, that number became the high-water mark
+  /// and pinned every later emission - the whole tail, and "Sync complete"
+  /// itself - to a bar that read 240% and never moved again.
+  SyncProgress raise(SyncProgress progress) {
+    final bounded = progress.progress.clamp(0.0, _progressComplete);
+    if (bounded < _highWaterMark) {
+      return progress.copyWith(progress: _highWaterMark);
+    }
+    _highWaterMark = bounded;
+    return bounded == progress.progress
+        ? progress
+        : progress.copyWith(progress: bounded);
+  }
+
+  /// Clamps and publishes. Returns what was published, so the caller's copy
+  /// and the listener's copy never disagree.
+  ///
+  /// Publishing to a closed controller throws, and this sink is reachable from
+  /// work the sync has already stopped waiting for: `Future.timeout` does not
+  /// cancel its source, so an abandoned `_updateTransactionStatuses` goes on
+  /// issuing confirmation batches while the sync finishes and closes here. A
+  /// throw there would abort the batches it had left, silently - the fired
+  /// timeout swallows the error - and leave transaction statuses unwritten.
+  /// Reporting stops at close; the work does not.
+  SyncProgress add(SyncProgress progress) {
+    final raised = raise(progress);
+    if (!_controller.isClosed) {
+      _controller.add(raised);
+    }
+    return raised;
+  }
+
+  void addError(Object error) {
+    if (_controller.isClosed) {
+      return;
+    }
+    _controller.addError(error);
+  }
+
+  Future<void> close() => _controller.close();
+}
+
 abstract class SyncRepository {
   /// The total transaction-parse budget, shared out across the drives still to
   /// be synced.
@@ -147,6 +271,11 @@ abstract class SyncRepository {
     required DriveDao driveDao,
     required Map<FolderID, GhostFolder> ghostFolders,
     String? ownerAddress,
+
+    /// Called as each ghost row is written, with the fraction of them done.
+    /// Reporting only; it changes nothing about what is written or in what
+    /// order.
+    void Function(double fraction)? onProgress,
   });
 
   Future<int> getCurrentBlockHeight();
@@ -302,6 +431,10 @@ class _SyncRepository implements SyncRepository {
     _skippedEntityTxIdsByDrive.clear();
     _syncedEntityIdsByDrive.clear();
 
+    // Every emission of this sync, from the first to the last, goes out
+    // through one sink, so the number it reports can only ever climb.
+    final syncProgressController = MonotonicProgressSink();
+
     // The address of the currently logged-in wallet. All pending transactions
     // are uploads made by this wallet, so scoping the status query by it lets
     // the gateway prune its search space. Cross-owner txs (e.g. data txs of
@@ -330,7 +463,7 @@ class _SyncRepository implements SyncRepository {
     }
 
     if (drives.isEmpty) {
-      yield SyncProgress.emptySyncCompleted();
+      yield syncProgressController.raise(SyncProgress.emptySyncCompleted());
       _lastSync = DateTime.now();
       return;
     }
@@ -338,7 +471,7 @@ class _SyncRepository implements SyncRepository {
     SyncProgress syncProgress =
         SyncProgress.initial().copyWith(drivesCount: drives.length);
 
-    yield syncProgress;
+    yield syncProgress = syncProgressController.raise(syncProgress);
 
     // The first network call of a sync, and the one that has nothing local to
     // fall back on. Until now the dialog sat at 0% with nothing to say while a
@@ -346,7 +479,7 @@ class _SyncRepository implements SyncRepository {
     syncProgress = syncProgress.copyWith(
       statusMessage: 'Connecting to the network...',
     );
-    yield syncProgress;
+    yield syncProgress = syncProgressController.raise(syncProgress);
 
     final currentBlockHeight = await retry(
       () async => await _arweave.getCurrentBlockHeight(),
@@ -373,7 +506,7 @@ class _SyncRepository implements SyncRepository {
       syncProgress = syncProgress.copyWith(
         statusMessage: 'Checking for changes...',
       );
-      yield syncProgress;
+      yield syncProgress = syncProgressController.raise(syncProgress);
       try {
         final neverSyncedDrives = <Drive>[];
         final previouslySyncedDrives = <Drive>[];
@@ -465,7 +598,7 @@ class _SyncRepository implements SyncRepository {
 
     // Clear the probe status message
     syncProgress = syncProgress.copyWith(statusMessage: null);
-    yield syncProgress;
+    yield syncProgress = syncProgressController.raise(syncProgress);
 
     final numberOfDrivesToSync = drivesToSync.length;
 
@@ -474,16 +607,18 @@ class _SyncRepository implements SyncRepository {
       logger.i('No drives need syncing');
       // Carry the probe's counts through. "Nothing to do" is exactly the sync
       // where the number of drives it skipped is the whole story.
-      yield SyncProgress.emptySyncCompleted().copyWith(
-        firstTimeSyncDriveCount: syncProgress.firstTimeSyncDriveCount,
-        skippedDriveCount: syncProgress.skippedDriveCount,
+      yield syncProgressController.raise(
+        SyncProgress.emptySyncCompleted().copyWith(
+          firstTimeSyncDriveCount: syncProgress.firstTimeSyncDriveCount,
+          skippedDriveCount: syncProgress.skippedDriveCount,
+        ),
       );
       _lastSync = DateTime.now();
       return;
     }
 
     syncProgress = syncProgress.copyWith(drivesCount: numberOfDrivesToSync);
-    yield syncProgress;
+    yield syncProgress = syncProgressController.raise(syncProgress);
 
     // Batch-fetch snapshots for all drives per owner (1 GQL query per owner
     // instead of 1 per drive). Results are grouped by Drive-Id and passed to
@@ -495,7 +630,7 @@ class _SyncRepository implements SyncRepository {
       syncProgress = syncProgress.copyWith(
         statusMessage: 'Downloading drive snapshots...',
       );
-      yield syncProgress;
+      yield syncProgress = syncProgressController.raise(syncProgress);
 
       try {
         // Reuse the drivesByOwner grouping from the probe (or rebuild it)
@@ -569,13 +704,10 @@ class _SyncRepository implements SyncRepository {
 
       // Clear the prefetch status message
       syncProgress = syncProgress.copyWith(statusMessage: null);
-      yield syncProgress;
+      yield syncProgress = syncProgressController.raise(syncProgress);
     }
 
     double totalProgress = 0;
-
-    final StreamController<SyncProgress> syncProgressController =
-        StreamController<SyncProgress>.broadcast();
 
     // Reset the failure simulator for new sync session
     if (SyncFailureSimulator.instance.isEnabled) {
@@ -617,23 +749,31 @@ class _SyncRepository implements SyncRepository {
             // Check for cancellation during sync
             token.checkCancellation();
 
-            // Reserve 10% for post-sync operations (cap drive sync at 90%)
-            currentDriveProgress =
-                (totalProgress + driveProgress) / numberOfDrivesToSync * 0.9;
-            if (currentDriveProgress > syncProgress.progress) {
-              syncProgress = syncProgress.copyWith(
-                progress: currentDriveProgress,
-              );
-            }
-            syncProgressController.add(syncProgress);
+            // The walk's whole share of the bar, divided across the drives
+            // in it. The sink guards the ordering - these drives run
+            // concurrently over a shared counter, and a drive's own progress
+            // is read off block heights a composite history can hand back out
+            // of order - but the ceiling has to be applied here, at the phase
+            // it belongs to. A transaction mined after the head was read
+            // yields a drive progress above 1, and a walk value above the
+            // walk's end would become the high-water mark and pin the whole
+            // tail behind it without ever exceeding 1.0.
+            currentDriveProgress = ((totalProgress + driveProgress) /
+                    numberOfDrivesToSync *
+                    _progressDriveWalkEnd)
+                .clamp(0.0, _progressDriveWalkEnd);
+            syncProgress = syncProgress.copyWith(
+              progress: currentDriveProgress,
+            );
+            syncProgress = syncProgressController.add(syncProgress);
           }
           totalProgress += 1;
           syncProgress = syncProgress.copyWith(
             drivesSynced: syncProgress.drivesSynced + 1,
-            // Cap at 90% for drive syncing
-            progress: (totalProgress / numberOfDrivesToSync) * 0.9,
+            progress:
+                (totalProgress / numberOfDrivesToSync) * _progressDriveWalkEnd,
           );
-          syncProgressController.add(syncProgress);
+          syncProgress = syncProgressController.add(syncProgress);
         } catch (e) {
           // Handle cancellation specially
           if (e is SyncCancelledException) {
@@ -652,16 +792,17 @@ class _SyncRepository implements SyncRepository {
             ..putIfAbsent(
                 drive.id, () => '${drive.name}: ${_extractErrorMessage(e)}');
 
-          // Still increment progress but mark as failed (cap at 90%)
+          // Still increment progress but mark as failed
           totalProgress += 1;
           syncProgress = syncProgress.copyWith(
             drivesSynced: syncProgress.drivesSynced + 1,
-            progress: (totalProgress / numberOfDrivesToSync) * 0.9,
+            progress:
+                (totalProgress / numberOfDrivesToSync) * _progressDriveWalkEnd,
             failedQueries: syncProgress.failedQueries + 1,
             failedDriveIds: updatedFailedDrives,
             errorMessages: updatedErrorMessages,
           );
-          syncProgressController.add(syncProgress);
+          syncProgress = syncProgressController.add(syncProgress);
         }
       }),
       eagerError: false, // Continue processing even if some drives fail
@@ -695,18 +836,37 @@ class _SyncRepository implements SyncRepository {
         // Check for cancellation before ghost creation
         token.checkCancellation();
 
-        // Update progress to 92% for ghost creation
+        // The walk is over, so this phase starts where the walk ended
+        // rather than skipping past it.
         syncProgress = syncProgress.copyWith(
-          progress: 0.92,
+          progress: _progressDriveWalkEnd,
           statusMessage: 'Creating ghost folders...',
         );
-        syncProgressController.add(syncProgress);
+        syncProgress = syncProgressController.add(syncProgress);
 
         await createGhosts(
           driveDao: _driveDao,
           ownerAddress: await wallet?.getAddress(),
           ghostFolders: _ghostFolders,
+          onProgress: (fraction) {
+            syncProgress = syncProgress.copyWith(
+              progress: _phaseProgress(
+                _progressDriveWalkEnd,
+                _progressGhostFoldersEnd,
+                fraction,
+              ),
+            );
+            syncProgress = syncProgressController.add(syncProgress);
+          },
         );
+
+        // Ghosts are done whether there were any to write or not, so the
+        // phase closes on its own boundary instead of leaving the bar
+        // wherever the loop happened to stop.
+        syncProgress = syncProgress.copyWith(
+          progress: _progressGhostFoldersEnd,
+        );
+        syncProgress = syncProgressController.add(syncProgress);
 
         /// Clear the ghost folders after they are created
         _ghostFolders.clear();
@@ -725,17 +885,18 @@ class _SyncRepository implements SyncRepository {
         // Check for cancellation before transaction status updates
         token.checkCancellation();
 
-        // Update progress to 96% for transaction status updates
         syncProgress = syncProgress.copyWith(
-          progress: 0.96,
+          progress: _progressGhostFoldersEnd,
           statusMessage: 'Updating transaction statuses...',
         );
-        syncProgressController.add(syncProgress);
+        syncProgress = syncProgressController.add(syncProgress);
 
         final metadataTxsFromSnapshots =
             await SnapshotItemOnChain.getAllCachedTransactionIds();
         final confirmedFileTxIds = <String>[];
         if (metadataTxsFromSnapshots.isNotEmpty) {
+          final chunkCount = (metadataTxsFromSnapshots.length / 500).ceil();
+          var chunksRead = 0;
           for (var i = 0; i < metadataTxsFromSnapshots.length; i += 500) {
             final chunk = metadataTxsFromSnapshots.sublist(
                 i, min(i + 500, metadataTxsFromSnapshots.length));
@@ -743,6 +904,17 @@ class _SyncRepository implements SyncRepository {
                 .fileRevisionDataTxIdsByMetadataTxIds(metadataTxIds: chunk)
                 .get();
             confirmedFileTxIds.addAll(rows);
+            // One chunk read is one step of this phase - reported off the
+            // query that was already being made, not a new one.
+            chunksRead++;
+            syncProgress = syncProgress.copyWith(
+              progress: _phaseProgress(
+                _progressGhostFoldersEnd,
+                _progressPendingScanEnd,
+                chunksRead / chunkCount,
+              ),
+            );
+            syncProgress = syncProgressController.add(syncProgress);
           }
         }
         // Clear cached transaction IDs now that we've used them
@@ -753,6 +925,14 @@ class _SyncRepository implements SyncRepository {
         final hasHiddenItems = await _driveDao.hasHiddenItems().getSingle();
         await _userPreferencesRepository.saveUserHasHiddenItem(hasHiddenItems);
         await _userPreferencesRepository.load();
+
+        // Everything readable locally has been read; what is left is the
+        // gateway.
+        syncProgress = syncProgress.copyWith(
+          progress: _progressPendingScanEnd,
+        );
+        syncProgress = syncProgressController.add(syncProgress);
+
         // Wrap transaction status update with cancellation check and timeout
         try {
           await Future.wait(
@@ -764,6 +944,30 @@ class _SyncRepository implements SyncRepository {
                 ownerAddress: walletAddress,
                 txsIdsToSkip: confirmedFileTxIds,
                 cancellationToken: token,
+                onLocalProgress: (fraction) {
+                  syncProgress = syncProgress.copyWith(
+                    progress: _phaseProgress(
+                      _progressPendingScanEnd,
+                      _progressTxPrepEnd,
+                      fraction,
+                    ),
+                  );
+                  syncProgress = syncProgressController.add(syncProgress);
+                },
+                onProgress: (fraction) {
+                  syncProgress = syncProgress.copyWith(
+                    progress: _phaseProgress(
+                      _progressTxPrepEnd,
+                      _progressTxStatusEnd,
+                      fraction,
+                    ),
+                  );
+                  syncProgress = syncProgressController.add(syncProgress);
+                },
+                onGatewayPhase: (active) {
+                  syncProgress = syncProgress.copyWith(isIndeterminate: active);
+                  syncProgress = syncProgressController.add(syncProgress);
+                },
               ).timeout(
                 _txStatusUpdateTimeout,
                 onTimeout: () {
@@ -774,8 +978,9 @@ class _SyncRepository implements SyncRepository {
                   // Update status message to indicate timeout but don't treat as error
                   syncProgress = syncProgress.copyWith(
                     statusMessage: 'Completing sync...',
+                    isIndeterminate: false,
                   );
-                  syncProgressController.add(syncProgress);
+                  syncProgress = syncProgressController.add(syncProgress);
                   // Continue without updating transaction statuses
                 },
               ),
@@ -790,20 +995,30 @@ class _SyncRepository implements SyncRepository {
           // Don't fail the entire sync if transaction status update fails
         }
 
+        // The gateway is done with, however that went - answered, failed or
+        // timed out. The phase closes on its boundary either way, because the
+        // work after it is the completion itself, and the bar goes back to
+        // being a number here whatever the loop did or did not manage to say.
+        syncProgress = syncProgress.copyWith(
+          progress: _progressTxStatusEnd,
+          isIndeterminate: false,
+        );
+        syncProgress = syncProgressController.add(syncProgress);
+
         _lastSync = DateTime.now();
         // Invalidate drive caches so next sync re-fetches fresh data
         _userDrivesUpdateFuture = null;
         _arweave.clearUserDriveTxsCache();
 
-        // Update progress to 100% when truly complete
+        // Exactly 1.0, and only here.
         syncProgress = syncProgress.copyWith(
-          progress: 1.0,
+          progress: _progressComplete,
           statusMessage: 'Sync complete',
           entitiesSynced: _syncedEntityCount,
           skippedEntityCount: _skippedEntityCount,
           skippedEntityTxIdsByDrive: _skippedEntityTxIdsByDriveSnapshot,
         );
-        syncProgressController.add(syncProgress);
+        syncProgress = syncProgressController.add(syncProgress);
         _logSkippedEntities();
 
         // Close the controller when everything is done
@@ -907,10 +1122,14 @@ class _SyncRepository implements SyncRepository {
     _skippedEntityTxIdsByDrive.clear();
     _syncedEntityIdsByDrive.clear();
 
+    // Every emission of this sync, from the first to the last, goes out
+    // through one sink, so the number it reports can only ever climb.
+    final syncProgressController = MonotonicProgressSink();
+
     // Get the specific drive
     final drive = await _driveDao.driveById(driveId: driveId).getSingleOrNull();
     if (drive == null) {
-      yield SyncProgress.emptySyncCompleted();
+      yield syncProgressController.raise(SyncProgress.emptySyncCompleted());
       return;
     }
 
@@ -926,13 +1145,13 @@ class _SyncRepository implements SyncRepository {
       firstTimeSyncDriveCount:
           syncDeep || (drive.lastBlockHeight ?? 0) == 0 ? 1 : 0,
     );
-    yield syncProgress;
+    yield syncProgress = syncProgressController.raise(syncProgress);
 
     // Same silent first call as the all-drives path.
     syncProgress = syncProgress.copyWith(
       statusMessage: 'Connecting to the network...',
     );
-    yield syncProgress;
+    yield syncProgress = syncProgressController.raise(syncProgress);
 
     final currentBlockHeight = await retry(
       () async => await _arweave.getCurrentBlockHeight(),
@@ -944,10 +1163,7 @@ class _SyncRepository implements SyncRepository {
     // Clear it again: the drive walk that follows is reported as a percentage,
     // and the dialog already names this drive in its title.
     syncProgress = syncProgress.copyWith(statusMessage: null);
-    yield syncProgress;
-
-    final StreamController<SyncProgress> syncProgressController =
-        StreamController<SyncProgress>.broadcast();
+    yield syncProgress = syncProgressController.raise(syncProgress);
 
     // Store ghost folders for this drive only
     final driveGhostFolders = <String, GhostFolder>{};
@@ -979,19 +1195,24 @@ class _SyncRepository implements SyncRepository {
           // Check for cancellation during sync
           token.checkCancellation();
 
-          // Reserve 10% for post-sync operations (cap drive sync at 90%)
-          final currentProgress = driveProgress * 0.9;
-          if (currentProgress > syncProgress.progress) {
-            syncProgress = syncProgress.copyWith(progress: currentProgress);
-          }
-          syncProgressController.add(syncProgress);
+          // The walk's whole share of the bar. The sink guards the ordering
+          // - a drive's progress is read off block heights a composite
+          // history can hand back out of order - but the ceiling belongs
+          // here: a transaction mined after the head was read yields a drive
+          // progress above 1, and a walk value above the walk's end would
+          // pin every phase after it without ever exceeding 1.0.
+          syncProgress = syncProgress.copyWith(
+            progress: (driveProgress * _progressDriveWalkEnd)
+                .clamp(0.0, _progressDriveWalkEnd),
+          );
+          syncProgress = syncProgressController.add(syncProgress);
         }
 
         syncProgress = syncProgress.copyWith(
           drivesSynced: 1,
-          progress: 0.9,
+          progress: _progressDriveWalkEnd,
         );
-        syncProgressController.add(syncProgress);
+        syncProgress = syncProgressController.add(syncProgress);
 
         // Copy ghost folders for this drive only
         for (final entry in _ghostFolders.entries) {
@@ -1003,12 +1224,13 @@ class _SyncRepository implements SyncRepository {
         // Check for cancellation before ghost creation
         token.checkCancellation();
 
-        // Update progress to 92% for ghost creation
+        // The walk is over, so this phase starts where the walk ended
+        // rather than skipping past it.
         syncProgress = syncProgress.copyWith(
-          progress: 0.92,
+          progress: _progressDriveWalkEnd,
           statusMessage: 'Creating ghost folders...',
         );
-        syncProgressController.add(syncProgress);
+        syncProgress = syncProgressController.add(syncProgress);
 
         logger.i('Creating ghosts for single drive sync...');
 
@@ -1016,7 +1238,24 @@ class _SyncRepository implements SyncRepository {
           driveDao: _driveDao,
           ownerAddress: await wallet?.getAddress(),
           ghostFolders: driveGhostFolders,
+          onProgress: (fraction) {
+            syncProgress = syncProgress.copyWith(
+              progress: _phaseProgress(
+                _progressDriveWalkEnd,
+                _progressGhostFoldersEnd,
+                fraction,
+              ),
+            );
+            syncProgress = syncProgressController.add(syncProgress);
+          },
         );
+
+        // Ghosts are done whether there were any to write or not, so the
+        // phase closes on its own boundary.
+        syncProgress = syncProgress.copyWith(
+          progress: _progressGhostFoldersEnd,
+        );
+        syncProgress = syncProgressController.add(syncProgress);
 
         // Remove processed ghost folders from the main map
         for (final key in driveGhostFolders.keys) {
@@ -1033,18 +1272,36 @@ class _SyncRepository implements SyncRepository {
         // Check for cancellation before transaction status updates
         token.checkCancellation();
 
-        // Update progress to 96% for transaction status updates
         syncProgress = syncProgress.copyWith(
-          progress: 0.96,
+          progress: _progressGhostFoldersEnd,
           statusMessage: 'Updating transaction statuses...',
         );
-        syncProgressController.add(syncProgress);
+        syncProgress = syncProgressController.add(syncProgress);
 
         logger.i('Updating transaction statuses for single drive...');
+
+        // This phase's local reads: the drive's revisions, the transaction ids
+        // the snapshots already covered, then the hidden-item preference.
+        // Three steps, reported as each one lands. All three reads already
+        // happened; only the reporting is new.
+        const localReadCount = 3;
+        var localReadsDone = 0;
+        void reportLocalRead() {
+          localReadsDone++;
+          syncProgress = syncProgress.copyWith(
+            progress: _phaseProgress(
+              _progressGhostFoldersEnd,
+              _progressPendingScanEnd,
+              localReadsDone / localReadCount,
+            ),
+          );
+          syncProgress = syncProgressController.add(syncProgress);
+        }
 
         // Get file revisions for this specific drive to scope transaction updates
         final driveFileRevisions =
             await _driveDao.db.fileRevisions.select().get();
+        reportLocalRead();
         final driveDataTxIds = driveFileRevisions
             .where((r) => r.driveId == driveId)
             .map((r) => r.dataTxId)
@@ -1052,6 +1309,7 @@ class _SyncRepository implements SyncRepository {
 
         final metadataTxsFromSnapshots =
             await SnapshotItemOnChain.getAllCachedTransactionIds();
+        reportLocalRead();
         final confirmedFileTxIds = driveFileRevisions
             .where((file) =>
                 file.driveId == driveId &&
@@ -1066,6 +1324,7 @@ class _SyncRepository implements SyncRepository {
         final hasHiddenItems = await _driveDao.hasHiddenItems().getSingle();
         await _userPreferencesRepository.saveUserHasHiddenItem(hasHiddenItems);
         await _userPreferencesRepository.load();
+        reportLocalRead();
 
         try {
           await _updateTransactionStatusesForDrive(
@@ -1076,6 +1335,30 @@ class _SyncRepository implements SyncRepository {
             ownerAddress: drive.ownerAddress,
             txsIdsToSkip: confirmedFileTxIds,
             cancellationToken: token,
+            onLocalProgress: (fraction) {
+              syncProgress = syncProgress.copyWith(
+                progress: _phaseProgress(
+                  _progressPendingScanEnd,
+                  _progressTxPrepEnd,
+                  fraction,
+                ),
+              );
+              syncProgress = syncProgressController.add(syncProgress);
+            },
+            onProgress: (fraction) {
+              syncProgress = syncProgress.copyWith(
+                progress: _phaseProgress(
+                  _progressTxPrepEnd,
+                  _progressTxStatusEnd,
+                  fraction,
+                ),
+              );
+              syncProgress = syncProgressController.add(syncProgress);
+            },
+            onGatewayPhase: (active) {
+              syncProgress = syncProgress.copyWith(isIndeterminate: active);
+              syncProgress = syncProgressController.add(syncProgress);
+            },
           ).timeout(
             _txStatusUpdateTimeout,
             onTimeout: () {
@@ -1084,8 +1367,9 @@ class _SyncRepository implements SyncRepository {
                   '${_txStatusUpdateTimeout.inSeconds}s for single drive');
               syncProgress = syncProgress.copyWith(
                 statusMessage: 'Completing sync...',
+                isIndeterminate: false,
               );
-              syncProgressController.add(syncProgress);
+              syncProgress = syncProgressController.add(syncProgress);
             },
           );
         } catch (e) {
@@ -1096,20 +1380,29 @@ class _SyncRepository implements SyncRepository {
               'Failed to update transaction statuses for single drive, continuing: $e');
         }
 
+        // The gateway is done with, however that went. The phase closes on its
+        // boundary either way, because the work after it is the completion,
+        // and the bar goes back to being a number here regardless.
+        syncProgress = syncProgress.copyWith(
+          progress: _progressTxStatusEnd,
+          isIndeterminate: false,
+        );
+        syncProgress = syncProgressController.add(syncProgress);
+
         _lastSync = DateTime.now();
         // Invalidate drive caches so next sync re-fetches fresh data
         _userDrivesUpdateFuture = null;
         _arweave.clearUserDriveTxsCache();
 
-        // Update progress to 100% when truly complete
+        // Exactly 1.0, and only here.
         syncProgress = syncProgress.copyWith(
-          progress: 1.0,
+          progress: _progressComplete,
           statusMessage: 'Sync complete',
           entitiesSynced: _syncedEntityCount,
           skippedEntityCount: _skippedEntityCount,
           skippedEntityTxIdsByDrive: _skippedEntityTxIdsByDriveSnapshot,
         );
-        syncProgressController.add(syncProgress);
+        syncProgress = syncProgressController.add(syncProgress);
         _logSkippedEntities();
 
         logger
@@ -1144,12 +1437,12 @@ class _SyncRepository implements SyncRepository {
 
         syncProgress = syncProgress.copyWith(
           drivesSynced: 1,
-          progress: 1.0,
+          progress: _progressComplete,
           failedQueries: 1,
           failedDriveIds: [driveId],
           errorMessages: updatedErrorMessages,
         );
-        syncProgressController.add(syncProgress);
+        syncProgress = syncProgressController.add(syncProgress);
         await syncProgressController.close();
       }
     }).catchError((error) async {
@@ -1178,13 +1471,37 @@ class _SyncRepository implements SyncRepository {
     String? ownerAddress,
     List<TxID> txsIdsToSkip = const [],
     SyncCancellationToken? cancellationToken,
+
+    /// Called as this phase's local database reads land, with the fraction of
+    /// them done. Both already happened; only the reporting is new.
+    void Function(double fraction)? onLocalProgress,
+
+    /// Called as the rest of the phase lands - the date pre-load chunks and
+    /// each gateway confirmation batch - with the fraction of it done.
+    /// Reporting only.
+    void Function(double fraction)? onProgress,
+
+    /// Called with true when the gateway confirmation loop begins and false
+    /// when it is over. See [_updateTransactionStatuses].
+    void Function(bool active)? onGatewayPhase,
   }) async {
     cancellationToken?.checkCancellation();
 
+    // The two local reads this phase makes before it touches the gateway,
+    // reported as each lands. Both were already being made.
+    const localReadCount = 2;
+    var localReadsDone = 0;
+    void reportLocalRead() {
+      localReadsDone++;
+      onLocalProgress?.call(localReadsDone / localReadCount);
+    }
+
     final ownerOverrides = await _buildPinnedDataTxOwnerOverrides(driveDao);
+    reportLocalRead();
 
     // Load all pending transactions and filter to this drive
     final allPendingTxs = await driveDao.pendingTransactions().get();
+    reportLocalRead();
     final drivePendingTxs =
         allPendingTxs.where((tx) => driveDataTxIds.contains(tx.id)).toList();
 
@@ -1206,6 +1523,23 @@ class _SyncRepository implements SyncRepository {
         .map((e) => e.key)
         .toList();
 
+    // What is left of the phase after the local reads above, counted off the
+    // work it already does: one step per date pre-load chunk, one per
+    // confirmation batch. No extra query, and no invented ramp - a phase with
+    // a single batch reports a single step, because a single step is what it
+    // has. Finer detail than this lives inside the gateway call itself and
+    // would mean changing ArweaveService, which is why the gateway stretch is
+    // drawn as indeterminate rather than as a number.
+    const page = 5000;
+    final totalSteps = (txIdsNeedingDates.length / 500).ceil() +
+        (pendingTxMap.length / page).ceil();
+    var stepsDone = 0;
+    void reportStep() {
+      if (totalSteps == 0) return;
+      stepsDone++;
+      onProgress?.call(stepsDone / totalSteps);
+    }
+
     final dateCreatedCache = <String, DateTime?>{};
     if (txIdsNeedingDates.isNotEmpty) {
       for (var i = 0; i < txIdsNeedingDates.length; i += 500) {
@@ -1217,12 +1551,21 @@ class _SyncRepository implements SyncRepository {
         for (final row in rows) {
           dateCreatedCache[row.dataTxId] = row.dateCreated;
         }
+        reportStep();
       }
     }
 
     final length = pendingTxMap.length;
     final list = pendingTxMap.keys.toList();
-    const page = 5000;
+
+    // From here the phase belongs to the gateway, and how long it takes is
+    // the gateway's to know. Rather than cross points of the bar on no
+    // evidence, the bar goes indeterminate for the duration and picks the
+    // number back up on the far side - however that side is reached.
+    final batchCount = (length / page).ceil();
+    if (batchCount > 0) {
+      onGatewayPhase?.call(true);
+    }
 
     for (var i = 0; i < length / page; i++) {
       cancellationToken?.checkCancellation();
@@ -1309,6 +1652,11 @@ class _SyncRepository implements SyncRepository {
       if (updates.isNotEmpty) {
         await driveDao.insertNewNetworkTransactions(updates);
       }
+      reportStep();
+    }
+
+    if (batchCount > 0) {
+      onGatewayPhase?.call(false);
     }
 
     // Mark skipped transactions as confirmed
@@ -1329,6 +1677,7 @@ class _SyncRepository implements SyncRepository {
     required DriveDao driveDao,
     required Map<FolderID, GhostFolder> ghostFolders,
     String? ownerAddress,
+    void Function(double fraction)? onProgress,
   }) async {
     final ghostFoldersByDrive =
         <DriveID, Map<FolderID, FolderEntriesCompanion>>{};
@@ -1388,8 +1737,13 @@ class _SyncRepository implements SyncRepository {
     // Insert all ghost folders in a single transaction
     if (ghostFoldersToCreate.isNotEmpty) {
       await driveDao.transaction(() async {
+        var inserted = 0;
         for (final folderEntry in ghostFoldersToCreate) {
           await driveDao.into(driveDao.folderEntries).insert(folderEntry);
+          // The same single transaction over the same rows in the same order.
+          // The only new thing is that each row is reported as it lands.
+          inserted++;
+          onProgress?.call(inserted / ghostFoldersToCreate.length);
         }
       });
     }
@@ -1509,20 +1863,50 @@ class _SyncRepository implements SyncRepository {
     String? ownerAddress,
     List<TxID> txsIdsToSkip = const [],
     SyncCancellationToken? cancellationToken,
+
+    /// Called as this phase's local database reads land, with the fraction of
+    /// them done. Every one of them already happened; only the reporting is
+    /// new.
+    void Function(double fraction)? onLocalProgress,
+
+    /// Called as the rest of the phase lands - the date pre-load chunks and
+    /// each gateway confirmation batch - with the fraction of it done.
+    /// Reporting only.
+    void Function(double fraction)? onProgress,
+
+    /// Called with true when the gateway confirmation loop begins and false
+    /// when it is over. Nothing in here can measure that loop, so the bar is
+    /// told to stop pretending to for its duration.
+    void Function(bool active)? onGatewayPhase,
   }) async {
     // Check for cancellation at the start
     cancellationToken?.checkCancellation();
 
+    // Three local database reads happen before the gateway is touched, and
+    // were counted in nothing: the bar rested on the number the phase started
+    // from until the gateway answered. A step each costs nothing - the reads
+    // were already being made - and is the only granularity in this phase that
+    // is real.
+    const localReadCount = 3;
+    var localReadsDone = 0;
+    void reportLocalRead() {
+      localReadsDone++;
+      onLocalProgress?.call(localReadsDone / localReadCount);
+    }
+
     final ownerOverrides = await _buildPinnedDataTxOwnerOverrides(driveDao);
+    reportLocalRead();
     // Scope each pending tx by the owner of its own drive rather than assuming
     // the logged-in wallet owns everything (which is wrong for attached drives
     // owned by other wallets, and null when browsing without a wallet).
     final ownersByTxId = await _buildPendingTxDriveOwners(driveDao);
+    reportLocalRead();
 
     // Load all pending transactions
     // Note: We load all at once here, but the memory impact is acceptable
     // since we're just building a map. The original code did the same.
     final allPendingTxs = await driveDao.pendingTransactions().get();
+    reportLocalRead();
 
     logger.i('Loaded ${allPendingTxs.length} pending transactions');
 
@@ -1547,6 +1931,23 @@ class _SyncRepository implements SyncRepository {
         .map((e) => e.key)
         .toList();
 
+    // What is left of the phase after the local reads above, counted off the
+    // work it already does: one step per date pre-load chunk, one per
+    // confirmation batch. No extra query, and no invented ramp - a phase with
+    // a single batch reports a single step, because a single step is what it
+    // has. Finer detail than this lives inside the gateway call itself and
+    // would mean changing ArweaveService, which is why the gateway stretch is
+    // drawn as indeterminate rather than as a number.
+    const page = 5000;
+    final totalSteps = (txIdsNeedingDates.length / 500).ceil() +
+        (pendingTxMap.length / page).ceil();
+    var stepsDone = 0;
+    void reportStep() {
+      if (totalSteps == 0) return;
+      stepsDone++;
+      onProgress?.call(stepsDone / totalSteps);
+    }
+
     final dateCreatedCache = <String, DateTime?>{};
     if (txIdsNeedingDates.isNotEmpty) {
       for (var i = 0; i < txIdsNeedingDates.length; i += 500) {
@@ -1558,13 +1959,21 @@ class _SyncRepository implements SyncRepository {
         for (final row in rows) {
           dateCreatedCache[row.dataTxId] = row.dateCreated;
         }
+        reportStep();
       }
     }
 
     final length = pendingTxMap.length;
     final list = pendingTxMap.keys.toList();
 
-    const page = 5000;
+    // From here the phase belongs to the gateway, and how long it takes is
+    // the gateway's to know. Rather than cross points of the bar on no
+    // evidence, the bar goes indeterminate for the duration and picks the
+    // number back up on the far side - however that side is reached.
+    final batchCount = (length / page).ceil();
+    if (batchCount > 0) {
+      onGatewayPhase?.call(true);
+    }
 
     for (var i = 0; i < length / page; i++) {
       // Check for cancellation before each batch
@@ -1665,7 +2074,13 @@ class _SyncRepository implements SyncRepository {
       if (updates.isNotEmpty) {
         await driveDao.insertNewNetworkTransactions(updates);
       }
+      reportStep();
     }
+
+    if (batchCount > 0) {
+      onGatewayPhase?.call(false);
+    }
+
     if (txsIdsToSkip.isNotEmpty) {
       await driveDao.insertNewNetworkTransactions(
         txsIdsToSkip

--- a/lib/sync/domain/sync_progress.dart
+++ b/lib/sync/domain/sync_progress.dart
@@ -1,5 +1,10 @@
 abstract class LinearProgress {
   double get progress;
+
+  /// Whether [progress] is a real measurement right now, or a number standing
+  /// in for work whose length nothing here can know. A bar reading an
+  /// indeterminate progress should animate rather than draw [progress].
+  bool get isIndeterminate => false;
 }
 
 /// Sentinel used by copyWith to distinguish "not provided" from "explicitly null".
@@ -23,6 +28,7 @@ class SyncProgress extends LinearProgress {
     this.skippedEntityTxIdsByDrive = const {},
     this.firstTimeSyncDriveCount = 0,
     this.skippedDriveCount = 0,
+    this.isIndeterminate = false,
   });
 
   factory SyncProgress.initial() {
@@ -75,7 +81,8 @@ class SyncProgress extends LinearProgress {
 
   // Fields for distinguishing sync type
   final bool isSingleDriveSync; // true if syncing a single drive
-  final String? driveName; // name of the drive being synced (for single drive sync)
+  final String?
+      driveName; // name of the drive being synced (for single drive sync)
 
   /// Number of entities left out of this sync because their metadata could not
   /// be read from the configured gateway.
@@ -96,6 +103,19 @@ class SyncProgress extends LinearProgress {
   /// sync. Zero for a deep sync, and zero when the probe could not answer -
   /// in both of those cases nothing was skipped.
   final int skippedDriveCount;
+
+  /// True while the sync is inside a phase whose length it cannot know and
+  /// whose progress it cannot measure - today, the gateway round trip that
+  /// asks which pending transactions confirmed. That phase reports one step
+  /// per 5000 pending transactions, which for almost every user is one step,
+  /// landing only when the gateway answers.
+  ///
+  /// No weighting makes a determinate bar move through that honestly, so it
+  /// does not pretend to: [progress] holds where the phase began and the UI
+  /// draws an indeterminate bar instead. Cleared as soon as the gateway is
+  /// done with, however that went.
+  @override
+  final bool isIndeterminate;
 
   /// Flat list of every skipped transaction id, drive association discarded.
   List<String> get skippedEntityTxIds =>
@@ -125,6 +145,7 @@ class SyncProgress extends LinearProgress {
     Map<String, List<String>>? skippedEntityTxIdsByDrive,
     int? firstTimeSyncDriveCount,
     int? skippedDriveCount,
+    bool? isIndeterminate,
   }) {
     return SyncProgress(
       numberOfEntities: numberOfEntities ?? this.numberOfEntities,
@@ -141,14 +162,14 @@ class SyncProgress extends LinearProgress {
           ? this.statusMessage
           : statusMessage as String?,
       isSingleDriveSync: isSingleDriveSync ?? this.isSingleDriveSync,
-      driveName:
-          driveName == _absent ? this.driveName : driveName as String?,
+      driveName: driveName == _absent ? this.driveName : driveName as String?,
       skippedEntityCount: skippedEntityCount ?? this.skippedEntityCount,
       skippedEntityTxIdsByDrive:
           skippedEntityTxIdsByDrive ?? this.skippedEntityTxIdsByDrive,
       firstTimeSyncDriveCount:
           firstTimeSyncDriveCount ?? this.firstTimeSyncDriveCount,
       skippedDriveCount: skippedDriveCount ?? this.skippedDriveCount,
+      isIndeterminate: isIndeterminate ?? this.isIndeterminate,
     );
   }
 }

--- a/lib/sync/presentation/sync_overlay.dart
+++ b/lib/sync/presentation/sync_overlay.dart
@@ -20,10 +20,11 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 /// opening drives and uploading while it runs; the top bar's [SyncButton] is
 /// the only place it shows up.
 ///
-/// Errors are the exception to that. [SyncCompleteWithErrors] blocks whatever
-/// asked for it, because it is the one sync outcome that asks a question - the
-/// modal offers a retry - and a question nobody sees is a question nobody
-/// answers.
+/// Errors follow the same rule. A failure the user was waiting on keeps the
+/// modal it was already holding, retry button and all. A failure from a sync
+/// nobody asked for does not seize the screen to ask a question the user has
+/// no context for - it reports at the top bar's [SyncButton], where the sync
+/// was running, and keeps Retry reachable in that button's menu.
 class SyncOverlay extends StatelessWidget {
   const SyncOverlay({
     super.key,
@@ -46,8 +47,12 @@ class SyncOverlay extends StatelessWidget {
     if (state is SyncComplete) {
       return false;
     }
+    // Errors used to be the one terminal state with no trigger to honour, so
+    // a login sync that painted nothing while it ran would still drop a scrim
+    // and "Sync Incomplete" over whatever the user was in the middle of the
+    // moment one drive out of several failed. It reports at the top bar now.
     if (state is SyncCompleteWithErrors) {
-      return true;
+      return state.trigger == SyncTrigger.userInitiated;
     }
     if (state is SyncInProgress) {
       return state.trigger == SyncTrigger.userInitiated;

--- a/lib/sync/presentation/sync_summary.dart
+++ b/lib/sync/presentation/sync_summary.dart
@@ -29,8 +29,13 @@ bool syncSummaryIsFresh(SyncComplete state, {DateTime? now}) =>
 /// the freshness boundary would run almost twice the intended time. The timer
 /// is counted from when the sync finished, not from when something happened to
 /// draw it.
-Duration syncSummaryRemaining(SyncComplete state, {DateTime? now}) {
-  final elapsed = (now ?? DateTime.now()).difference(state.completedAt);
+Duration syncSummaryRemaining(SyncComplete state, {DateTime? now}) =>
+    syncSummaryRemainingSince(state.completedAt, now: now);
+
+/// [syncSummaryRemaining] for anything that carries a finish time - a failure
+/// announces itself on the same terms a result does.
+Duration syncSummaryRemainingSince(DateTime completedAt, {DateTime? now}) {
+  final elapsed = (now ?? DateTime.now()).difference(completedAt);
   final remaining = syncSummaryDuration - elapsed;
   return remaining.isNegative ? Duration.zero : remaining;
 }

--- a/test/blocs/drive_detail/drive_detail_cubit_test.dart
+++ b/test/blocs/drive_detail/drive_detail_cubit_test.dart
@@ -371,4 +371,114 @@ void main() {
       },
     );
   });
+
+  group('DriveDetailCubit during a background sync', () {
+    const otherDriveId = 'other-drive-id';
+    const otherRootFolderId = 'other-root-folder-id';
+
+    /// A second drive, fully readable: the one the user clicks over to.
+    Future<void> insertOtherDrive() async {
+      await db.into(db.drives).insert(
+            DrivesCompanion.insert(
+              id: otherDriveId,
+              name: 'Other Drive',
+              ownerAddress: ownerAddress,
+              rootFolderId: otherRootFolderId,
+              privacy: DrivePrivacyTag.public,
+              lastBlockHeight: const Value(100),
+            ),
+          );
+
+      await db.into(db.folderEntries).insert(
+            FolderEntriesCompanion.insert(
+              id: otherRootFolderId,
+              driveId: otherDriveId,
+              name: 'Other Drive',
+              path: '',
+            ),
+          );
+
+      await driveDao.insertFolderRevision(
+        FolderRevisionsCompanion.insert(
+          folderId: otherRootFolderId,
+          driveId: otherDriveId,
+          name: 'Other Drive',
+          metadataTxId: 'other-metadata-tx-id',
+          action: RevisionAction.create,
+        ),
+      );
+    }
+
+    /// Clicking a drive while the login sync is still running used to produce
+    /// nothing at all - no navigation, no spinner, no error, the drive the
+    /// user had just left still on screen - for as long as the sync ran, which
+    /// on a large wallet is minutes. `openFolder` awaited the sync as its
+    /// first statement, and `changeDrive` had already cancelled the folder
+    /// subscription and moved the drive id by then, so the screen was showing
+    /// something the cubit had already stopped maintaining.
+    ///
+    /// While a sync scrimmed the whole app the click was impossible. Now that
+    /// a background sync leaves the app usable, it is the first thing a tester
+    /// does.
+    test('a drive clicked during a background sync answers straight away',
+        () async {
+      await insertDrive(lastBlockHeight: 100);
+      await insertRootFolderRevision();
+      await insertSubfolder('subfolder-1');
+      await insertOtherDrive();
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      expect(cubit.state, isA<DriveDetailLoadSuccess>(),
+          reason: 'precondition: the first drive is on screen');
+
+      // A sync that is running and has not finished. Deliberately never
+      // completed: the point is what the app does *during* it.
+      final syncing = Completer<void>();
+      when(() => syncCubit.waitCurrentSync()).thenAnswer((_) => syncing.future);
+
+      unawaited(cubit.changeDrive(otherDriveId));
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      expect(
+        cubit.state,
+        isA<DriveDetailLoadInProgress>(),
+        reason: 'the click has to be answered before the wait, not after it - '
+            'otherwise the drive the user left stays on screen, with nothing '
+            'to say the app heard them, for the whole sync',
+      );
+    });
+
+    /// The wait itself is not the bug and must survive: a folder opened
+    /// against a half-written database is the reason it is there.
+    test('the folder still waits for the sync before it is read', () async {
+      await insertDrive(lastBlockHeight: 100);
+      await insertRootFolderRevision();
+      await insertSubfolder('subfolder-1');
+      await insertOtherDrive();
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      final syncing = Completer<void>();
+      when(() => syncCubit.waitCurrentSync()).thenAnswer((_) => syncing.future);
+
+      unawaited(cubit.changeDrive(otherDriveId));
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      expect(cubit.state, isA<DriveDetailLoadInProgress>(),
+          reason: 'precondition: the click was answered');
+
+      syncing.complete();
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      final state = cubit.state;
+      expect(state, isA<DriveDetailLoadSuccess>());
+      expect((state as DriveDetailLoadSuccess).currentDrive.id, otherDriveId);
+    });
+  });
 }

--- a/test/components/progress_bar_test.dart
+++ b/test/components/progress_bar_test.dart
@@ -1,0 +1,71 @@
+import 'dart:async';
+
+import 'package:ardrive/components/progress_bar.dart';
+import 'package:ardrive/sync/domain/sync_progress.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:percent_indicator/linear_percent_indicator.dart';
+
+void main() {
+  late StreamController<LinearProgress> progress;
+
+  setUp(() => progress = StreamController<LinearProgress>.broadcast());
+  tearDown(() async => progress.close());
+
+  Widget wrap() => MaterialApp(
+        home: Scaffold(body: ProgressBar(percentage: progress.stream)),
+      );
+
+  SyncProgress at(double value, {bool indeterminate = false}) =>
+      SyncProgress.initial().copyWith(
+        progress: value,
+        isIndeterminate: indeterminate,
+      );
+
+  testWidgets('a measurable phase draws the bar at its percentage',
+      (tester) async {
+    await tester.pumpWidget(wrap());
+    progress.add(at(0.42));
+    await tester.pump(const Duration(milliseconds: 10));
+
+    expect(find.byType(LinearPercentIndicator), findsOneWidget);
+    expect(find.byType(LinearProgressIndicator), findsNothing);
+    expect(
+      tester
+          .widget<LinearPercentIndicator>(find.byType(LinearPercentIndicator))
+          .percent,
+      0.42,
+    );
+  });
+
+  testWidgets('a phase that cannot measure itself draws a bar with no value',
+      (tester) async {
+    await tester.pumpWidget(wrap());
+    progress.add(at(0.97, indeterminate: true));
+    await tester.pump(const Duration(milliseconds: 10));
+
+    // Indeterminate means value == null: the bar sweeps instead of sitting at
+    // a number it has no evidence for.
+    final bar = tester.widget<LinearProgressIndicator>(
+      find.byType(LinearProgressIndicator),
+    );
+    expect(bar.value, isNull);
+    expect(find.byType(LinearPercentIndicator), findsNothing);
+
+    await tester.pump(const Duration(milliseconds: 300));
+  });
+
+  testWidgets('the bar goes back to a number once the phase can measure again',
+      (tester) async {
+    await tester.pumpWidget(wrap());
+    progress.add(at(0.97, indeterminate: true));
+    await tester.pump(const Duration(milliseconds: 10));
+    expect(find.byType(LinearProgressIndicator), findsOneWidget);
+
+    progress.add(at(1.0));
+    await tester.pump(const Duration(milliseconds: 10));
+
+    expect(find.byType(LinearProgressIndicator), findsNothing);
+    expect(find.byType(LinearPercentIndicator), findsOneWidget);
+  });
+}

--- a/test/components/progress_bar_test.dart
+++ b/test/components/progress_bar_test.dart
@@ -4,7 +4,6 @@ import 'package:ardrive/components/progress_bar.dart';
 import 'package:ardrive/sync/domain/sync_progress.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:percent_indicator/linear_percent_indicator.dart';
 
 void main() {
   late StreamController<LinearProgress> progress;
@@ -22,20 +21,23 @@ void main() {
         isIndeterminate: indeterminate,
       );
 
+  double? drawnValue(WidgetTester tester) => tester
+      .widget<LinearProgressIndicator>(find.byType(LinearProgressIndicator))
+      .value;
+
+  /// Long enough for the fill to finish travelling to a new value.
+  const settle = Duration(milliseconds: 1100);
+
   testWidgets('a measurable phase draws the bar at its percentage',
       (tester) async {
     await tester.pumpWidget(wrap());
     progress.add(at(0.42));
     await tester.pump(const Duration(milliseconds: 10));
+    await tester.pump(settle);
 
-    expect(find.byType(LinearPercentIndicator), findsOneWidget);
-    expect(find.byType(LinearProgressIndicator), findsNothing);
-    expect(
-      tester
-          .widget<LinearPercentIndicator>(find.byType(LinearPercentIndicator))
-          .percent,
-      0.42,
-    );
+    expect(drawnValue(tester), closeTo(0.42, 0.001));
+
+    await tester.pumpWidget(const SizedBox());
   });
 
   testWidgets('a phase that cannot measure itself draws a bar with no value',
@@ -46,13 +48,9 @@ void main() {
 
     // Indeterminate means value == null: the bar sweeps instead of sitting at
     // a number it has no evidence for.
-    final bar = tester.widget<LinearProgressIndicator>(
-      find.byType(LinearProgressIndicator),
-    );
-    expect(bar.value, isNull);
-    expect(find.byType(LinearPercentIndicator), findsNothing);
+    expect(drawnValue(tester), isNull);
 
-    await tester.pump(const Duration(milliseconds: 300));
+    await tester.pumpWidget(const SizedBox());
   });
 
   testWidgets('the bar goes back to a number once the phase can measure again',
@@ -60,12 +58,89 @@ void main() {
     await tester.pumpWidget(wrap());
     progress.add(at(0.97, indeterminate: true));
     await tester.pump(const Duration(milliseconds: 10));
-    expect(find.byType(LinearProgressIndicator), findsOneWidget);
+    expect(drawnValue(tester), isNull);
 
     progress.add(at(1.0));
     await tester.pump(const Duration(milliseconds: 10));
+    await tester.pump(settle);
 
-    expect(find.byType(LinearProgressIndicator), findsNothing);
-    expect(find.byType(LinearPercentIndicator), findsOneWidget);
+    expect(drawnValue(tester), closeTo(1.0, 0.001));
+
+    await tester.pumpWidget(const SizedBox());
+  });
+
+  testWidgets('leaving an unmeasurable phase never draws less than it showed',
+      (tester) async {
+    // The regression this bar was rebuilt for. Two widget types used to share
+    // this slot - a LinearProgressIndicator while a phase could not measure
+    // itself, a LinearPercentIndicator when it could - so `Widget.canUpdate`
+    // failed on the swap, Flutter destroyed the element, and percent_indicator
+    // built a fresh `Tween(begin: 0.0, end: percent)` in initState and ran it
+    // over a second. The bar emptied and refilled: 0.97 -> 0.0 -> 1.0. It fired
+    // for anyone with pending transactions, which is anyone who had uploaded
+    // recently.
+    await tester.pumpWidget(wrap());
+
+    progress.add(at(0.97));
+    await tester.pump(const Duration(milliseconds: 10));
+    await tester.pump(settle);
+
+    // One widget type serves both phases, and that is not incidental: two
+    // types in this slot is exactly what destroys the element and replays the
+    // fill from zero.
+    expect(
+      find.byType(LinearProgressIndicator),
+      findsOneWidget,
+      reason: 'a measurable phase must draw the same widget an unmeasurable '
+          'one does, or the swap destroys the element',
+    );
+    expect(drawnValue(tester), closeTo(0.97, 0.001));
+
+    progress.add(at(0.97, indeterminate: true));
+    await tester.pump(const Duration(milliseconds: 10));
+    expect(drawnValue(tester), isNull,
+        reason: 'precondition: the bar is in the unmeasurable phase');
+
+    progress.add(at(1.0));
+
+    // Every frame of the way back, not just where it lands.
+    final drawn = <double>[];
+    for (var i = 0; i < 30; i++) {
+      await tester.pump(const Duration(milliseconds: 50));
+      final value = drawnValue(tester);
+      if (value != null) {
+        drawn.add(value);
+      }
+    }
+
+    expect(drawn, isNotEmpty);
+    expect(
+      drawn.where((value) => value < 0.97 - 0.001),
+      isEmpty,
+      reason: 'the bar must never render below where it already stood: $drawn',
+    );
+    expect(drawn.last, closeTo(1.0, 0.001));
+
+    await tester.pumpWidget(const SizedBox());
+  });
+
+  testWidgets('the same element draws both phases', (tester) async {
+    // The mechanism behind the test above: one widget type in the slot, so
+    // there is no unmount to replay an animation from zero.
+    await tester.pumpWidget(wrap());
+
+    progress.add(at(0.97));
+    await tester.pump(const Duration(milliseconds: 10));
+    final before = tester.element(find.byType(LinearProgressIndicator));
+
+    progress.add(at(0.97, indeterminate: true));
+    await tester.pump(const Duration(milliseconds: 10));
+    expect(tester.element(find.byType(LinearProgressIndicator)), same(before));
+
+    progress.add(at(1.0));
+    await tester.pump(const Duration(milliseconds: 10));
+    expect(tester.element(find.byType(LinearProgressIndicator)), same(before));
+
+    await tester.pumpWidget(const SizedBox());
   });
 }

--- a/test/components/sync_button_test.dart
+++ b/test/components/sync_button_test.dart
@@ -178,6 +178,36 @@ void main() {
     expect(ring().value, 0.5);
   });
 
+  testWidgets('a phase that cannot measure itself empties the ring',
+      (tester) async {
+    await tester.pumpWidget(wrap());
+    await tester.pump();
+
+    await startSyncing(tester);
+
+    CircularProgressIndicator ring() =>
+        tester.widget<CircularProgressIndicator>(
+          find.byType(CircularProgressIndicator),
+        );
+
+    progressController.add(SyncProgress.initial().copyWith(progress: 0.97));
+    await tester.pump(const Duration(milliseconds: 10));
+    expect(ring().value, 0.97);
+
+    // The gateway phase cannot know its own length, so the ring stops
+    // claiming a fraction and sweeps instead of sitting at 97%.
+    progressController.add(SyncProgress.initial().copyWith(
+      progress: 0.97,
+      isIndeterminate: true,
+      statusMessage: 'Updating transaction statuses...',
+    ));
+    await tester.pump(const Duration(milliseconds: 10));
+
+    expect(ring().value, isNull);
+
+    await tester.pumpWidget(const SizedBox());
+  });
+
   testWidgets('the ring keeps moving while progress stands still',
       (tester) async {
     await tester.pumpWidget(wrap());

--- a/test/components/sync_button_test.dart
+++ b/test/components/sync_button_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:ardrive/components/app_top_bar.dart';
+import 'package:ardrive/pages/drive_detail/components/dropdown_item.dart';
 import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
 import 'package:ardrive/sync/domain/sync_progress.dart';
 import 'package:ardrive/sync/presentation/sync_summary.dart';
@@ -40,6 +41,8 @@ void main() {
     when(() => syncCubit.syncProgressController).thenReturn(progressController);
     when(() => syncCubit.syncProgress).thenReturn(SyncProgress.initial());
     when(() => syncCubit.syncStartTime).thenReturn(DateTime.now());
+    when(() => syncCubit.clearErrorState()).thenReturn(null);
+    when(() => syncCubit.retryFailedDrives(any())).thenAnswer((_) async {});
   });
 
   tearDown(() async {
@@ -577,5 +580,253 @@ void main() {
 
     expect(find.byType(CircularProgressIndicator), findsOneWidget);
     expect(find.byType(ArDriveDropdown), findsOneWidget);
+  });
+
+  /// A sync that ended with drives it could not read, as the cubit reports it.
+  SyncCompleteWithErrors failed({
+    SyncTrigger trigger = SyncTrigger.background,
+    DateTime? completedAt,
+  }) =>
+      SyncCompleteWithErrors(
+        completedAt: completedAt,
+        failedDrives: 2,
+        totalDrives: 5,
+        failedDriveIds: const ['drive-a', 'drive-b'],
+        errorMessages: const {'drive-a': 'the gateway said no'},
+        trigger: trigger,
+      );
+
+  /// Opens the resync menu and waits for it to finish expanding.
+  Future<void> openMenu(WidgetTester tester) async {
+    await tester.tap(find.byType(SyncButton));
+    await tester.pump(const Duration(milliseconds: 300));
+  }
+
+  ArDriveDropdownItemTile itemNamed(WidgetTester tester, String name) =>
+      tester.widget<ArDriveDropdownItemTile>(
+        find.widgetWithText(ArDriveDropdownItemTile, name),
+      );
+
+  /// The menu entry behind an item, so a test can ask whether it has anything
+  /// to run. The items live in the portal's overlay, where a synthesised tap
+  /// lands on the dropdown's own dismiss barrier rather than on the row, so
+  /// what the row would do is read off the item instead of mimed at it.
+  ArDriveDropdownItem entryNamed(WidgetTester tester, String name) =>
+      tester.widget<ArDriveDropdownItem>(
+        find.ancestor(
+          of: find.widgetWithText(ArDriveDropdownItemTile, name),
+          matching: find.byType(ArDriveDropdownItem),
+        ),
+      );
+
+  group('the menu while a sync runs', () {
+    testWidgets('resync says it is unavailable rather than doing nothing',
+        (tester) async {
+      // `SyncCubit.startSync` returns immediately while a sync is in progress -
+      // a guard written when a running sync scrimmed the app and nobody could
+      // ask. Now the menu is fully interactive, so an item that looks normal,
+      // closes the menu and drops the request is a lie.
+      await tester.pumpWidget(wrap());
+      await tester.pump();
+
+      await openMenu(tester);
+      expect(itemNamed(tester, 'Resync').isDisabled, isFalse,
+          reason: 'precondition: an idle menu offers the actions');
+      expect(itemNamed(tester, 'Deep Resync').isDisabled, isFalse);
+      expect(entryNamed(tester, 'Resync').onClick, isNotNull);
+
+      await tester.pumpWidget(const SizedBox());
+      await tester.pumpWidget(wrap());
+      await tester.pump();
+      await startSyncing(tester);
+      await openMenu(tester);
+
+      expect(itemNamed(tester, 'Resync').isDisabled, isTrue);
+      expect(itemNamed(tester, 'Deep Resync').isDisabled, isTrue);
+
+      await tester.pumpWidget(const SizedBox());
+    });
+
+    testWidgets('a resync that cannot start is never recorded as one',
+        (tester) async {
+      // The dropped request used to take a Plausible event and a profile-name
+      // refresh with it. Both live in the same closure as the startSync call,
+      // and a disabled item has no closure at all.
+      await tester.pumpWidget(wrap());
+      await tester.pump();
+      await startSyncing(tester);
+      await openMenu(tester);
+
+      // Nothing to run at all, which is what keeps the event out: the
+      // Plausible call and the profile-name refresh sat in the same closure as
+      // the startSync that would have been dropped.
+      expect(entryNamed(tester, 'Resync').onClick, isNull);
+      expect(entryNamed(tester, 'Deep Resync').onClick, isNull);
+
+      verifyNever(() => syncCubit.startSync(deepSync: false));
+      verifyNever(() => syncCubit.startSync(deepSync: true));
+
+      await tester.pumpWidget(const SizedBox());
+    });
+  });
+
+  group('a background sync that failed', () {
+    testWidgets('says so at the top bar rather than over the app',
+        (tester) async {
+      await tester.pumpWidget(wrap());
+      await tester.pump();
+
+      await startSyncing(tester);
+      stateController.add(failed());
+      await tester.pump(const Duration(milliseconds: 10));
+
+      // Beside the indicator that was turning for it - the same surface a
+      // successful background sync reports at, and clearly not a success.
+      expect(find.text('Sync Incomplete - Errors Detected'), findsOneWidget);
+      expect(find.text('2 of 5 drives could not be synced'), findsOneWidget);
+
+      await tester.pumpWidget(const SizedBox());
+    });
+
+    testWidgets('is drawn as a failure, not as a result', (tester) async {
+      await tester.pumpWidget(wrap());
+      await tester.pump();
+
+      stateController.add(failed());
+      await tester.pump(const Duration(milliseconds: 10));
+
+      final colorTokens = lightTheme().colorTokens;
+
+      final pill = tester.widget<Container>(
+        find
+            .ancestor(
+              of: find.text('Sync Incomplete - Errors Detected'),
+              matching: find.byType(Container),
+            )
+            .first,
+      );
+      expect(
+        (pill.decoration! as BoxDecoration).border,
+        Border.all(color: colorTokens.strokeRed),
+      );
+
+      await tester.pumpWidget(const SizedBox());
+    });
+
+    testWidgets('leaves retry reachable after the announcement has gone',
+        (tester) async {
+      // The announcement takes itself away like every other one. The failure
+      // does not: the question it asks - retry these drives? - is still open,
+      // and the modal that used to ask it is no longer allowed to.
+      await tester.pumpWidget(wrap());
+      await tester.pump();
+
+      stateController.add(failed());
+      await tester.pump(const Duration(milliseconds: 10));
+      await tester.pump(syncSummaryDuration + const Duration(seconds: 1));
+
+      expect(find.text('Sync Incomplete - Errors Detected'), findsNothing,
+          reason: 'precondition: the announcement has had its few seconds');
+
+      await openMenu(tester);
+
+      expect(find.text('Sync Incomplete - Errors Detected'), findsOneWidget);
+      expect(find.text('Retry Failed'), findsOneWidget);
+
+      entryNamed(tester, 'Retry Failed').onClick!();
+      await tester.pump(const Duration(milliseconds: 10));
+
+      verify(() => syncCubit.clearErrorState()).called(1);
+      verify(() => syncCubit.retryFailedDrives(['drive-a', 'drive-b']))
+          .called(1);
+
+      await tester.pumpWidget(const SizedBox());
+    });
+
+    testWidgets('a failure the user asked for is left to its own modal',
+        (tester) async {
+      // It has been holding a modal the whole time, and that modal has the
+      // same retry in it - see SyncOverlay.
+      await tester.pumpWidget(wrap());
+      await tester.pump();
+
+      stateController.add(failed(trigger: SyncTrigger.userInitiated));
+      await tester.pump(const Duration(milliseconds: 10));
+
+      expect(find.text('Sync Incomplete - Errors Detected'), findsNothing);
+      expect(find.text('2 of 5 drives could not be synced'), findsNothing);
+
+      await openMenu(tester);
+      expect(find.text('Retry Failed'), findsNothing);
+
+      await tester.pumpWidget(const SizedBox());
+    });
+  });
+
+  group('the menu survives what the sync does', () {
+    testWidgets('a menu open when a sync starts is still open after it starts',
+        (tester) async {
+      // Three structurally different subtrees used to occupy this slot, so
+      // every transition changed the widget type at that position and took the
+      // dropdown's element - and its open flag - with it. A thumb already
+      // moving towards Resync landed on the page behind.
+      await tester.pumpWidget(wrap());
+      await tester.pump();
+
+      await openMenu(tester);
+      expect(find.text('Resync'), findsOneWidget,
+          reason: 'precondition: the menu is open');
+
+      await startSyncing(tester);
+
+      expect(
+        find.text('Resync'),
+        findsOneWidget,
+        reason: 'a sync starting must not close a menu the user has open',
+      );
+
+      await tester.pumpWidget(const SizedBox());
+    });
+
+    testWidgets('a menu open when a sync ends is still open after it ends',
+        (tester) async {
+      await tester.pumpWidget(wrap());
+      await tester.pump();
+
+      await startSyncing(tester);
+      await openMenu(tester);
+      expect(find.text('Resync'), findsOneWidget,
+          reason: 'precondition: the menu is open during the sync');
+
+      stateController.add(finished(entitiesSynced: 12));
+      await tester.pump(const Duration(milliseconds: 10));
+
+      expect(
+        find.text('Resync'),
+        findsOneWidget,
+        reason: 'a sync finishing must not close a menu the user has open',
+      );
+      // And the result still lands, beside the menu rather than instead of it.
+      expect(find.text('12 items changed'), findsOneWidget);
+
+      await tester.pumpWidget(const SizedBox());
+    });
+  });
+  testWidgets('a failure that has had its moment is not announced again',
+      (tester) async {
+    await tester.pumpWidget(wrap());
+    await tester.pump();
+
+    // SyncCompleteWithErrors stays the cubit's state until the next sync runs.
+    // Without a freshness gate the red pill replayed in full on every rebuild
+    // of the top bar - i.e. on every drive click, for the rest of the session.
+    stateController.add(failed(
+      completedAt: DateTime.now().subtract(const Duration(minutes: 5)),
+    ));
+    await tester.pump(const Duration(milliseconds: 10));
+
+    expect(find.text('Sync Incomplete - Errors Detected'), findsNothing);
+
+    await tester.pumpWidget(const SizedBox());
   });
 }

--- a/test/pages/drive_detail/components/multi_select_paused_notice_test.dart
+++ b/test/pages/drive_detail/components/multi_select_paused_notice_test.dart
@@ -1,0 +1,128 @@
+import 'dart:async';
+
+import 'package:ardrive/pages/drive_detail/components/multi_select_paused_notice.dart';
+import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
+import 'package:ardrive_ui/ardrive_ui.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../test_utils/mocks.dart';
+
+void main() {
+  late MockSyncBloc syncCubit;
+  late StreamController<SyncState> stateController;
+
+  setUp(() {
+    syncCubit = MockSyncBloc();
+    stateController = StreamController<SyncState>.broadcast();
+    whenListen(syncCubit, stateController.stream, initialState: SyncIdle());
+  });
+
+  tearDown(() async => stateController.close());
+
+  Widget wrap({ArDriveThemeData? theme}) => ArDriveTheme(
+        themeData: theme ?? lightTheme(),
+        child: MaterialApp(
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: const [Locale('en', '')],
+          home: Scaffold(
+            body: BlocProvider<SyncCubit>.value(
+              value: syncCubit,
+              child: const MultiSelectPausedNotice(),
+            ),
+          ),
+        ),
+      );
+
+  const line = 'Selecting several items is paused while syncing';
+
+  testWidgets('a running sync says why several items cannot be selected',
+      (tester) async {
+    // The lock is old; the silence is what a background sync made reachable.
+    // With the app usable for the whole login sync, ctrl/cmd-click and ctrl-A
+    // were hard no-ops with nothing disabled and no explanation, which reads
+    // as the app being broken rather than busy.
+    await tester.pumpWidget(wrap());
+    await tester.pump(const Duration(milliseconds: 10));
+
+    expect(find.text(line), findsNothing,
+        reason: 'precondition: nothing is said when nothing is locked');
+
+    stateController.add(SyncInProgress(trigger: SyncTrigger.background));
+    await tester.pump(const Duration(milliseconds: 10));
+
+    expect(find.text(line), findsOneWidget);
+  });
+
+  testWidgets('it says nothing once the sync is over', (tester) async {
+    await tester.pumpWidget(wrap());
+    stateController.add(SyncInProgress(trigger: SyncTrigger.background));
+    await tester.pump(const Duration(milliseconds: 10));
+    expect(find.text(line), findsOneWidget);
+
+    stateController.add(SyncComplete(
+      entitiesSynced: 0,
+      completedAt: DateTime.now(),
+      sequence: 1,
+    ));
+    await tester.pump(const Duration(milliseconds: 10));
+
+    expect(find.text(line), findsNothing);
+    // And it leaves nothing behind in the layout it was sharing.
+    expect(tester.getSize(find.byType(MultiSelectPausedNotice)), Size.zero);
+  });
+
+  test('the notice and the lock read the same condition', () {
+    // The data table is locked with this exact predicate. Deriving the two
+    // separately is how the notice goes quiet while the lock stays on.
+    expect(
+      MultiSelectPausedNotice.locksMultiSelect(
+        SyncInProgress(trigger: SyncTrigger.background),
+      ),
+      isTrue,
+    );
+    expect(
+      MultiSelectPausedNotice.locksMultiSelect(
+        SyncInProgress(trigger: SyncTrigger.userInitiated),
+      ),
+      isTrue,
+    );
+    expect(MultiSelectPausedNotice.locksMultiSelect(SyncIdle()), isFalse);
+    expect(
+      MultiSelectPausedNotice.locksMultiSelect(SyncLoadingDrives()),
+      isFalse,
+      reason: 'loading the drives list rewrites no rows in the open folder',
+    );
+  });
+
+  testWidgets('it is drawn in the theme it lands in', (tester) async {
+    Future<Color> textColourUnder(ArDriveThemeData theme) async {
+      await tester.pumpWidget(wrap(theme: theme));
+      stateController.add(SyncInProgress(trigger: SyncTrigger.background));
+      await tester.pump(const Duration(milliseconds: 10));
+
+      final text = tester.widget<Text>(find.text(line));
+      await tester.pumpWidget(const SizedBox());
+
+      return text.style!.color!;
+    }
+
+    final light = await textColourUnder(lightTheme());
+    final dark = await textColourUnder(
+      ArDriveThemeData(colorTokens: ArDriveColorTokens.darkMode()),
+    );
+
+    expect(light, lightTheme().colorTokens.textLow);
+    expect(dark, ArDriveColorTokens.darkMode().textLow);
+    expect(light, isNot(dark));
+  });
+}

--- a/test/sync/domain/cubit/sync_trigger_test.dart
+++ b/test/sync/domain/cubit/sync_trigger_test.dart
@@ -179,4 +179,51 @@ void main() {
 
     expect(triggers, [SyncTrigger.userInitiated]);
   });
+  group('waiting for a sync that has already finished', () {
+    // The entry guard and the loop have to agree on what "finished" means.
+    // They did not: the guard let every state but two through, so a wait that
+    // BEGAN in one of the terminal states blocked on an emission that had
+    // already happened. openFolder() awaits this, so the symptom was a folder
+    // that never opened for the rest of the session.
+    for (final terminal in <SyncState Function()>[
+      () => SyncCompleteWithErrors(
+            failedDrives: 1,
+            totalDrives: 2,
+            failedDriveIds: const ['drive-a'],
+            errorMessages: const {'drive-a': 'boom'},
+            trigger: SyncTrigger.background,
+          ),
+      () => SyncFailure(error: 'boom', stackTrace: StackTrace.empty),
+      () => SyncCancelled(
+            drivesCompleted: 1,
+            totalDrives: 2,
+            cancelledAt: DateTime(2026),
+            trigger: SyncTrigger.background,
+          ),
+    ]) {
+      final state = terminal();
+
+      test('returns straight away in ${state.runtimeType}', () async {
+        final cubit = buildCubit(syncAllDrivesOnLogin: false);
+        addTearDown(cubit.close);
+
+        // Let the login path finish first. Its own emission would otherwise
+        // break the wait's loop and hide the bug: the point here is that
+        // NOTHING more is coming after the terminal state.
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        cubit.emit(state);
+
+        // No further emission is coming, so a wait that does not check the
+        // state it starts in never returns.
+        await cubit.waitCurrentSync().timeout(
+              const Duration(seconds: 2),
+              onTimeout: () => fail(
+                'waitCurrentSync hung in ${state.runtimeType}: a folder opened '
+                'from here would spin forever',
+              ),
+            );
+      });
+    }
+  });
 }

--- a/test/sync/domain/sync_repository_phase_messages_test.dart
+++ b/test/sync/domain/sync_repository_phase_messages_test.dart
@@ -329,7 +329,7 @@ void main() {
       // The dialog renders statusMessage INSTEAD OF the "{n}% complete"
       // readout (app_shell.dart, `if (statusMessage != null) ... else ...`).
       // A message set during the walk would blank the only number the user
-      // sees for the whole 0->90% stretch, so the walk must stay silent.
+      // sees for the whole length of the walk, so the walk must stay silent.
       final drive = _makeDrive(
         id: 'a',
         ownerAddress: ownerAddress,
@@ -349,9 +349,16 @@ void main() {
 
       final emitted = await collectProgress();
 
-      // The walk is everything the drive loop caps at 90%.
-      final walk =
-          emitted.where((p) => p.progress > 0 && p.progress <= 0.9).toList();
+      // The walk is the stretch before the post-sync phases announce
+      // themselves - it ends where ghost folder creation begins. Bounding it
+      // by a progress value instead would pin this test to whatever share of
+      // the bar the walk currently owns, which is not what it is about.
+      final tailStart = emitted
+          .indexWhere((p) => p.statusMessage == 'Creating ghost folders...');
+      final walk = emitted
+          .sublist(0, tailStart == -1 ? emitted.length : tailStart)
+          .where((p) => p.progress > 0)
+          .toList();
       expect(walk, isNotEmpty);
       expect(walk.every((p) => p.statusMessage == null), isTrue);
       expect(

--- a/test/sync/domain/sync_repository_progress_test.dart
+++ b/test/sync/domain/sync_repository_progress_test.dart
@@ -1,0 +1,680 @@
+import 'package:ardrive/arns/domain/arns_repository.dart';
+import 'package:ardrive/entities/entities.dart';
+import 'package:ardrive/models/database/database.dart';
+import 'package:ardrive/services/arweave/arweave_service.dart';
+import 'package:ardrive/services/arweave/graphql/graphql_api.graphql.dart';
+import 'package:ardrive/services/config/app_config.dart';
+import 'package:ardrive/sync/data/snapshot_validation_service.dart';
+import 'package:ardrive/sync/domain/models/drive_entity_history.dart';
+import 'package:ardrive/sync/domain/repositories/sync_repository.dart';
+import 'package:ardrive/sync/domain/sync_progress.dart';
+import 'package:ardrive/sync/utils/batch_processor.dart';
+import 'package:ardrive/user/repositories/user_preferences_repository.dart';
+import 'package:ardrive/user/user_preferences.dart';
+import 'package:ardrive_ui/ardrive_ui.dart';
+import 'package:ardrive_utils/ardrive_utils.dart';
+import 'package:ario_sdk/ario_sdk.dart';
+import 'package:arweave/arweave.dart';
+import 'package:drift/drift.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../test_utils/utils.dart';
+
+class _MockSnapshotValidationService extends Mock
+    implements SnapshotValidationService {}
+
+class _MockARNSRepository extends Mock implements ARNSRepository {}
+
+class _MockUserPreferencesRepository extends Mock
+    implements UserPreferencesRepository {}
+
+class _MockWallet extends Mock implements Wallet {}
+
+/// The progress number a sync reports, driven through the real repository.
+///
+/// The bar used to give the drive walk 0.0-0.9 and then jump: 0.92 for ghost
+/// folders, 0.96 for transaction statuses, 1.0 for done. Two phases of unknown
+/// length - one of them a gateway round trip - passed with the bar perfectly
+/// still, which reads as hung.
+///
+/// These are the guarantees that replaced it, and they are asserted off a real
+/// `SyncRepository` over a real in-memory database with only the gateway
+/// mocked. A test that builds a `SyncProgress` by hand cannot catch a wrong
+/// number in the repository; that gap is how a fake count shipped once already.
+///
+/// Two rules run through them. Bar travel belongs to phases that can report
+/// what they have done, so the phase assertions look for distinct values
+/// strictly inside a phase's open interval - a count over the whole tail is
+/// satisfied by the fixed boundaries alone and guards nothing. And a phase
+/// that cannot report does not get a number at all: it says so, and the tests
+/// check both that it says so and that it stops.
+void main() {
+  // The contract, restated here rather than imported: these tests are supposed
+  // to fail if the implementation's constants move.
+  const driveWalkEnd = 0.85;
+  const ghostFoldersEnd = 0.88;
+  const pendingScanEnd = 0.92;
+  const txPrepEnd = 0.97;
+  const txStatusEnd = 0.99;
+
+  const tailMessages = {
+    'Creating ghost folders...',
+    'Updating transaction statuses...',
+    // The timeout handler's message. Without it here, a sync whose gateway
+    // call timed out would have its tail emissions counted as pre-tail and
+    // fail the walk-share assertion for a reason that has nothing to do with
+    // the walk.
+    'Completing sync...',
+    'Sync complete',
+  };
+
+  const driveId = 'drive-id';
+  const rootFolderId = 'root-folder-id';
+  const ownerAddress = 'owner-address';
+
+  late Database db;
+  late MockArweaveService arweave;
+  late MockConfigService configService;
+  late _MockSnapshotValidationService snapshotValidation;
+  late _MockARNSRepository arnsRepository;
+  late _MockUserPreferencesRepository userPreferences;
+  late _MockWallet wallet;
+  late SyncRepository syncRepository;
+
+  DriveEntityHistoryTransactionModel transactionAt(int height) {
+    return DriveEntityHistoryTransactionModel(
+      transactionCommonMixin:
+          DriveEntityHistory$Query$TransactionConnection$TransactionEdge$Transaction
+              .fromJson({
+        'id': 'tx-$height',
+        'owner': {'address': ownerAddress},
+        'tags': <dynamic>[],
+        'block': {'height': height, 'timestamp': height * 100},
+      }),
+      cursor: 'cursor-$height',
+    );
+  }
+
+  FolderEntity folder(String id, {String? parentFolderId}) => FolderEntity(
+        id: id,
+        driveId: driveId,
+        parentFolderId: parentFolderId,
+        name: id,
+      )
+        ..txId = 'metadata-$id'
+        ..ownerAddress = ownerAddress
+        ..createdAt = DateTime(2026, 8, 29);
+
+  FileEntity file(String id, {String parentFolderId = rootFolderId}) =>
+      FileEntity(
+        id: id,
+        driveId: driveId,
+        parentFolderId: parentFolderId,
+        name: id,
+        size: 1024,
+        lastModifiedDate: DateTime(2026, 8, 29),
+        dataTxId: 'data-$id',
+        dataContentType: 'text/plain',
+      )
+        ..txId = 'metadata-$id'
+        ..ownerAddress = ownerAddress
+        ..createdAt = DateTime(2026, 8, 29);
+
+  /// What the gateway returns for this drive: one transaction per entity at
+  /// [blockHeights] (ascending by default), and those entities when the sync
+  /// asks what the transactions were.
+  void gatewayReturns(List<Entity> entities, {List<int>? blockHeights}) {
+    final heights =
+        blockHeights ?? [for (var i = 0; i < entities.length; i++) 10 + i];
+
+    when(() => arweave.getSegmentedTransactionsFromDrive(
+              any(),
+              ownerAddress: any(named: 'ownerAddress'),
+              minBlockHeight: any(named: 'minBlockHeight'),
+              maxBlockHeight: any(named: 'maxBlockHeight'),
+              strategy: any(named: 'strategy'),
+            ))
+        .thenAnswer(
+            (_) => Stream.value([for (final h in heights) transactionAt(h)]));
+
+    when(() => arweave.createDriveEntityHistoryFromTransactions(
+          any(),
+          any(),
+          any(),
+          driveId: any(named: 'driveId'),
+          ownerAddress: any(named: 'ownerAddress'),
+          currentBlockHeight: any(named: 'currentBlockHeight'),
+        )).thenAnswer((_) async {
+      final block = BlockEntities(10)..entities = [...entities];
+      return DriveEntityHistory(10, [block]);
+    });
+  }
+
+  Future<void> insertDrive({int? lastBlockHeight}) async {
+    await db.into(db.drives).insert(
+          DrivesCompanion.insert(
+            id: driveId,
+            name: 'Test Drive',
+            ownerAddress: ownerAddress,
+            rootFolderId: rootFolderId,
+            privacy: DrivePrivacyTag.public,
+            lastBlockHeight: Value(lastBlockHeight),
+          ),
+        );
+  }
+
+  Future<List<SyncProgress>> collectSingleDrive(
+      {bool withWallet = false}) async {
+    final emitted = <SyncProgress>[];
+    await for (final progress in syncRepository.syncSingleDrive(
+      driveId: driveId,
+      wallet: withWallet ? wallet : null,
+    )) {
+      emitted.add(progress);
+    }
+    await Future.delayed(const Duration(milliseconds: 20));
+    return emitted;
+  }
+
+  Future<List<SyncProgress>> collectAllDrives() async {
+    final emitted = <SyncProgress>[];
+    await for (final progress in syncRepository.syncAllDrives(wallet: wallet)) {
+      emitted.add(progress);
+    }
+    await Future.delayed(const Duration(milliseconds: 20));
+    return emitted;
+  }
+
+  /// Every consecutive pair, so a decrease anywhere in the run is named with
+  /// the pair that caused it.
+  void expectMonotonic(List<SyncProgress> emitted) {
+    expect(emitted, isNotEmpty);
+    for (var i = 1; i < emitted.length; i++) {
+      expect(
+        emitted[i].progress,
+        greaterThanOrEqualTo(emitted[i - 1].progress),
+        reason: 'emission $i (${emitted[i].progress}) went backwards from '
+            'emission ${i - 1} (${emitted[i - 1].progress})',
+      );
+    }
+  }
+
+  /// The distinct values reported strictly inside one phase's own share of
+  /// the bar - its open interval, so neither boundary counts.
+  ///
+  /// Counting the whole stretch from the walk to 1.0 does not work as a guard:
+  /// the fixed phase boundaries alone put three values in it, so a test on
+  /// that range stays green with every intra-phase report deleted. Only
+  /// reporting from inside a phase can put a value strictly between that
+  /// phase's own two ends.
+  List<double> insidePhase(
+    List<SyncProgress> emitted,
+    double start,
+    double end,
+  ) =>
+      (emitted
+          .map((p) => p.progress)
+          .where((v) => v > start && v < end)
+          .toSet()
+          .toList()
+        ..sort());
+
+  setUp(() {
+    db = getTestDb();
+    arweave = MockArweaveService();
+    configService = MockConfigService();
+    snapshotValidation = _MockSnapshotValidationService();
+    arnsRepository = _MockARNSRepository();
+    userPreferences = _MockUserPreferencesRepository();
+    wallet = _MockWallet();
+
+    when(() => wallet.getAddress()).thenAnswer((_) async => ownerAddress);
+
+    when(() => configService.config).thenReturn(AppConfig(
+      allowedDataItemSizeForTurbo: 0,
+      stripePublishableKey: '',
+      enableSyncFromSnapshot: false,
+      autoSync: true,
+    ));
+
+    when(() => arweave.getCurrentBlockHeight()).thenAnswer((_) async => 100);
+    when(() => arweave.clearUserDriveTxsCache()).thenReturn(null);
+    when(() => arweave.snapshotMetadataHits).thenReturn(<String, int>{});
+    when(() => arweave.snapshotMetadataMisses).thenReturn(<String, int>{});
+    when(() => arweave.probeActiveDriveIds(
+          driveIds: any(named: 'driveIds'),
+          minBlockHeight: any(named: 'minBlockHeight'),
+          ownerAddress: any(named: 'ownerAddress'),
+        )).thenAnswer((_) async => (
+          activeDriveIds: {driveId},
+          isComplete: true,
+        ));
+    when(() => arweave.getTransactionConfirmations(
+          any(),
+          owner: any(named: 'owner'),
+          ownersByTxId: any(named: 'ownersByTxId'),
+          ownerOverrides: any(named: 'ownerOverrides'),
+          verifiedSink: any(named: 'verifiedSink'),
+        )).thenAnswer((_) async => <String?, int>{});
+    when(() => arnsRepository.getAntRecordsForWallet(any(),
+        update: any(named: 'update'))).thenAnswer((_) async => <ANTRecord>[]);
+    when(() => arnsRepository.waitForARNSRecordsToUpdate())
+        .thenAnswer((_) async {});
+    when(() => arnsRepository.saveAllFilesWithAssignedNames())
+        .thenAnswer((_) async {});
+    when(() => userPreferences.load()).thenAnswer(
+      (_) async => const UserPreferences(
+        currentTheme: ArDriveThemes.light,
+        lastSelectedDriveId: null,
+      ),
+    );
+    when(() => userPreferences.saveUserHasHiddenItem(any()))
+        .thenAnswer((_) async {});
+
+    gatewayReturns([]);
+
+    syncRepository = SyncRepository(
+      arweave: arweave,
+      driveDao: db.driveDao,
+      configService: configService,
+      batchProcessor: BatchProcessor(),
+      snapshotValidationService: snapshotValidation,
+      arnsRepository: arnsRepository,
+      userPreferencesRepository: userPreferences,
+    );
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  group('all drives', () {
+    setUp(() async {
+      await insertDrive(lastBlockHeight: 50);
+      gatewayReturns([folder(rootFolderId), file('file-a'), file('file-b')]);
+    });
+
+    test('progress never goes backwards', () async {
+      expectMonotonic(await collectAllDrives());
+    });
+
+    test('a successful sync ends on exactly 1.0', () async {
+      final emitted = await collectAllDrives();
+
+      expect(emitted.last.progress, 1.0);
+      expect(emitted.last.statusMessage, 'Sync complete');
+      // Not 0.999, and not a value that only rounds to 100%.
+      expect(emitted.last.progress == 1.0, isTrue);
+    });
+
+    test('the drive walk stays inside its share of the bar', () async {
+      final emitted = await collectAllDrives();
+
+      final beforeTheTail =
+          emitted.where((p) => !tailMessages.contains(p.statusMessage));
+
+      expect(beforeTheTail, isNotEmpty);
+      for (final progress in beforeTheTail) {
+        expect(progress.progress, lessThanOrEqualTo(driveWalkEnd),
+            reason: 'the walk took more than its share');
+      }
+    });
+
+    test('each tail phase stays inside its own share', () async {
+      final emitted = await collectAllDrives();
+
+      for (final progress in emitted) {
+        switch (progress.statusMessage) {
+          case 'Creating ghost folders...':
+            expect(progress.progress,
+                inInclusiveRange(driveWalkEnd, ghostFoldersEnd));
+            break;
+          case 'Updating transaction statuses...':
+            expect(progress.progress,
+                inInclusiveRange(ghostFoldersEnd, txStatusEnd));
+            break;
+          case 'Sync complete':
+            expect(progress.progress, 1.0);
+            break;
+        }
+      }
+    });
+
+    test('the transaction-status phase advances off its own local reads',
+        () async {
+      // The three database reads that run before the gateway is touched -
+      // owner overrides, per-drive owners, pending rows - each report a step.
+      // Strictly inside the phase, so only reporting from inside it can
+      // satisfy this: the phase's own boundaries sit on the excluded ends.
+      final inside =
+          insidePhase(await collectAllDrives(), pendingScanEnd, txPrepEnd);
+
+      expect(inside.length, greaterThanOrEqualTo(2),
+          reason: 'the phase reported $inside');
+      for (var i = 1; i < inside.length; i++) {
+        expect(inside[i], greaterThan(inside[i - 1]));
+      }
+    });
+  });
+
+  group('single drive', () {
+    setUp(() async {
+      await insertDrive(lastBlockHeight: 50);
+      gatewayReturns([folder(rootFolderId), file('file-a'), file('file-b')]);
+    });
+
+    test('progress never goes backwards', () async {
+      expectMonotonic(await collectSingleDrive());
+    });
+
+    test('a successful sync ends on exactly 1.0', () async {
+      final emitted = await collectSingleDrive();
+
+      expect(emitted.last.progress, 1.0);
+      expect(emitted.last.statusMessage, 'Sync complete');
+    });
+
+    test('the drive walk stays inside its share of the bar', () async {
+      final emitted = await collectSingleDrive();
+
+      final beforeTheTail =
+          emitted.where((p) => !tailMessages.contains(p.statusMessage));
+
+      expect(beforeTheTail, isNotEmpty);
+      for (final progress in beforeTheTail) {
+        expect(progress.progress, lessThanOrEqualTo(driveWalkEnd));
+      }
+    });
+
+    test('each tail phase stays inside its own share', () async {
+      final emitted = await collectSingleDrive();
+
+      for (final progress in emitted) {
+        switch (progress.statusMessage) {
+          case 'Creating ghost folders...':
+            expect(progress.progress,
+                inInclusiveRange(driveWalkEnd, ghostFoldersEnd));
+            break;
+          case 'Updating transaction statuses...':
+            expect(progress.progress,
+                inInclusiveRange(ghostFoldersEnd, txStatusEnd));
+            break;
+          case 'Sync complete':
+            expect(progress.progress, 1.0);
+            break;
+        }
+      }
+    });
+
+    test('the pending-scan phase advances off its own local reads', () async {
+      // The drive's revisions, the snapshot-covered transaction ids, and the
+      // hidden-item preference: three reads that were already being made,
+      // reported as each lands. Strictly inside the phase, so the phase's own
+      // boundaries cannot satisfy it.
+      final inside = insidePhase(
+          await collectSingleDrive(), ghostFoldersEnd, pendingScanEnd);
+
+      expect(inside.length, greaterThanOrEqualTo(2),
+          reason: 'the phase reported $inside');
+      for (var i = 1; i < inside.length; i++) {
+        expect(inside[i], greaterThan(inside[i - 1]));
+      }
+    });
+
+    test(
+        'the gateway phase says it cannot be measured, and then stops saying it',
+        () async {
+      // Same guarantee as the all-drives path, through a different callee:
+      // the single-drive sync sets and clears the flag in
+      // _updateTransactionStatusesForDrive, with its own call sites. The
+      // group's setUp already inserted the drive.
+      await db.into(db.networkTransactions).insert(
+            NetworkTransactionsCompanion.insert(id: 'pending-tx'),
+          );
+
+      // The confirmation loop is only reached with a wallet.
+      final emitted = await collectSingleDrive(withWallet: true);
+
+      final indeterminate = emitted.where((p) => p.isIndeterminate).toList();
+      expect(indeterminate, isNotEmpty,
+          reason: 'the gateway phase pretended to have a number');
+      for (final progress in indeterminate) {
+        expect(progress.statusMessage, 'Updating transaction statuses...');
+      }
+      expect(emitted.last.isIndeterminate, isFalse);
+      expect(emitted.last.progress, 1.0);
+    });
+  });
+
+  group('the arithmetic behind the bar', () {
+    test('block heights that arrive out of order cannot push the bar back',
+        () async {
+      // A drive's own progress is 1 - (head - blockHeight) / range, so a
+      // history that hands back a lower block than the one before it computes
+      // a smaller - here negative - number. Composite histories can do exactly
+      // that. Nothing downstream may see the bar move backwards because of it.
+      await insertDrive(lastBlockHeight: 50);
+      gatewayReturns(
+        [folder(rootFolderId), file('file-a'), file('file-b')],
+        blockHeights: [95, 85, 75],
+      );
+
+      final emitted = await collectSingleDrive();
+
+      expectMonotonic(emitted);
+      for (final progress in emitted) {
+        expect(progress.progress, greaterThanOrEqualTo(0.0),
+            reason: 'a negative progress reached the bar');
+      }
+      expect(emitted.last.progress, 1.0);
+    });
+
+    test('all drives: out-of-order block heights cannot push the bar back',
+        () async {
+      await insertDrive(lastBlockHeight: 50);
+      gatewayReturns(
+        [folder(rootFolderId), file('file-a'), file('file-b')],
+        blockHeights: [95, 85, 75],
+      );
+
+      final emitted = await collectAllDrives();
+
+      expectMonotonic(emitted);
+      for (final progress in emitted) {
+        expect(progress.progress, greaterThanOrEqualTo(0.0));
+      }
+      expect(emitted.last.progress, 1.0);
+    });
+
+    test('ghost folder creation moves the bar as it writes the rows', () async {
+      // Three files whose parent folders were never found: three ghost rows,
+      // written one at a time inside the phase that used to be a single jump.
+      await insertDrive(lastBlockHeight: 50);
+      gatewayReturns([
+        folder(rootFolderId),
+        file('file-a', parentFolderId: 'ghost-one'),
+        file('file-b', parentFolderId: 'ghost-two'),
+        file('file-c', parentFolderId: 'ghost-three'),
+      ]);
+
+      final emitted = await collectSingleDrive(withWallet: true);
+
+      expect(await db.select(db.folderEntries).get(),
+          hasLength(greaterThanOrEqualTo(3)));
+
+      final duringGhosts = emitted
+          .where(
+              (p) => p.progress > driveWalkEnd && p.progress < ghostFoldersEnd)
+          .map((p) => p.progress)
+          .toSet();
+
+      expect(duringGhosts, hasLength(greaterThanOrEqualTo(2)),
+          reason: 'ghost creation reported $duringGhosts');
+      expectMonotonic(emitted);
+    });
+
+    test('a transaction mined above the head block cannot break the bar',
+        () async {
+      // The head block height is read once, at the top of a sync that then
+      // runs for minutes. A transaction mined after that read sits above it,
+      // and the walk's own number - 1 - (head - height) / range - goes above
+      // 1: head 100 with transactions at 99, 101 and 103 computes 1.6 and 3.2.
+      // Unbounded, the first of those became the high-water mark and every
+      // later emission, "Sync complete" included, was pinned to it: a bar
+      // reading 240% that never moved again.
+      await insertDrive(lastBlockHeight: 50);
+      gatewayReturns(
+        [folder(rootFolderId), file('file-a'), file('file-b')],
+        blockHeights: [99, 101, 103],
+      );
+
+      final emitted = await collectSingleDrive();
+
+      for (final progress in emitted) {
+        expect(progress.progress, inInclusiveRange(0.0, 1.0),
+            reason: 'a progress outside 0..1 reached the bar');
+      }
+      for (final progress
+          in emitted.where((p) => !tailMessages.contains(p.statusMessage))) {
+        expect(progress.progress, lessThanOrEqualTo(driveWalkEnd),
+            reason: 'the overshoot leaked out of the walk');
+      }
+      // The tail is not pinned behind the overshoot: each phase still closes
+      // on its own boundary, exactly.
+      expect(emitted.map((p) => p.progress), contains(ghostFoldersEnd));
+      expect(emitted.last.progress, 1.0);
+      expect(emitted.last.statusMessage, 'Sync complete');
+      expectMonotonic(emitted);
+    });
+
+    test('all drives: a transaction above the head cannot break the bar',
+        () async {
+      // The same overshoot, through the other path: here the walk's value is
+      // divided across the drives in the sync before it is scaled, and the cap
+      // has to be applied at that site too.
+      await insertDrive(lastBlockHeight: 50);
+      gatewayReturns(
+        [folder(rootFolderId), file('file-a'), file('file-b')],
+        blockHeights: [99, 101, 103],
+      );
+
+      final emitted = await collectAllDrives();
+
+      for (final progress in emitted) {
+        expect(progress.progress, inInclusiveRange(0.0, 1.0));
+      }
+      for (final progress
+          in emitted.where((p) => !tailMessages.contains(p.statusMessage))) {
+        expect(progress.progress, lessThanOrEqualTo(driveWalkEnd),
+            reason: 'the overshoot leaked out of the walk');
+      }
+      expect(emitted.map((p) => p.progress), contains(ghostFoldersEnd));
+      expect(emitted.last.progress, 1.0);
+      expectMonotonic(emitted);
+    });
+
+    test('a walk value over its phase end cannot pin the tail behind it',
+        () async {
+      // The overshoot does not have to reach 1.0 to do damage. First block 90
+      // against a head of 100 makes the range 10, so a transaction at 103
+      // computes 1.3, and the walk hands up 1.3 * its share = 0.884 - inside
+      // 0..1, and past the end of the walk's own phase. Left uncapped that
+      // becomes the high-water mark and swallows the ghost phase whole.
+      await insertDrive(lastBlockHeight: 50);
+      gatewayReturns(
+        [folder(rootFolderId), file('file-a'), file('file-b')],
+        blockHeights: [90, 95, 103],
+      );
+
+      final emitted = await collectSingleDrive();
+
+      for (final progress
+          in emitted.where((p) => !tailMessages.contains(p.statusMessage))) {
+        expect(progress.progress, lessThanOrEqualTo(driveWalkEnd),
+            reason: 'the walk reported ${progress.progress}, past its share');
+      }
+      expect(emitted.map((p) => p.progress), contains(ghostFoldersEnd),
+          reason: 'the ghost phase closed above its own boundary');
+      expect(emitted.last.progress, 1.0);
+      expectMonotonic(emitted);
+    });
+
+    test(
+        'the gateway phase says it cannot be measured, and then stops saying it',
+        () async {
+      // A pending transaction gives the confirmation loop a batch to run, and
+      // the loop is the one stretch of a sync nothing here can measure. The
+      // bar is told so rather than handed a number to sit on.
+      await insertDrive(lastBlockHeight: 50);
+      gatewayReturns([folder(rootFolderId), file('file-a')]);
+      await db.into(db.networkTransactions).insert(
+            NetworkTransactionsCompanion.insert(id: 'pending-tx'),
+          );
+
+      final emitted = await collectAllDrives();
+
+      final indeterminate = emitted.where((p) => p.isIndeterminate).toList();
+      expect(indeterminate, isNotEmpty,
+          reason: 'the gateway phase pretended to have a number');
+      for (final progress in indeterminate) {
+        // It says which phase it is in while it says it cannot measure it -
+        // an animated bar with no words is worse than a still one.
+        expect(progress.statusMessage, 'Updating transaction statuses...');
+      }
+      // And it is over by the time the sync is.
+      expect(emitted.last.isIndeterminate, isFalse);
+      expect(emitted.last.progress, 1.0);
+    });
+  });
+
+  group('the sink every emission passes through', () {
+    SyncProgress at(double progress) => SyncProgress(
+          numberOfEntities: 0,
+          progress: progress,
+          entitiesSynced: 0,
+          drivesCount: 1,
+          drivesSynced: 0,
+          numberOfDrivesAtGetMetadataPhase: 0,
+        );
+
+    test('a progress above 1.0 never becomes the high-water mark', () {
+      final sink = MonotonicProgressSink();
+
+      // What the walk hands up when a transaction is newer than the head.
+      expect(sink.raise(at(2.4)).progress, 1.0);
+      // And the mark it left behind is 1.0, not 2.4 - so the next emission is
+      // a bar at 100%, not a bar at 240%.
+      expect(sink.raise(at(0.5)).progress, 1.0);
+    });
+
+    test('work still running when the stream closes is not aborted by it',
+        () async {
+      // `Future.timeout` does not cancel its source: after the transaction
+      // status update times out, the abandoned loop goes on issuing its
+      // remaining confirmation batches while the sync finishes and closes this
+      // sink. Reporting from that loop must not throw, or the batches it had
+      // left are silently dropped and those uploads stay "pending" for another
+      // whole cycle.
+      final sink = MonotonicProgressSink();
+      final seen = <double>[];
+      final subscription = sink.stream.listen((p) => seen.add(p.progress));
+
+      sink.add(at(0.9));
+      await Future.delayed(Duration.zero);
+      await sink.close();
+
+      var batchesIssued = 0;
+      for (var batch = 0; batch < 4; batch++) {
+        batchesIssued++;
+        sink.add(at(0.95));
+      }
+      sink.addError(StateError('a late failure nobody is listening for'));
+
+      expect(batchesIssued, 4,
+          reason: 'reporting after the close aborted the remaining batches');
+      expect(seen, [0.9]);
+      await subscription.cancel();
+    });
+  });
+}

--- a/test/sync/presentation/sync_overlay_test.dart
+++ b/test/sync/presentation/sync_overlay_test.dart
@@ -99,22 +99,52 @@ void main() {
     await tester.pumpWidget(const SizedBox());
   });
 
-  testWidgets('errors block even when nobody asked for the sync',
-      (tester) async {
-    await tester.pumpWidget(
-      wrap(
-        SyncCompleteWithErrors(
-          failedDrives: 1,
-          totalDrives: 3,
-          failedDriveIds: const ['drive-id'],
-          errorMessages: const {'drive-id': 'the gateway said no'},
-        ),
-      ),
-    );
+  SyncCompleteWithErrors failed({
+    SyncTrigger trigger = SyncTrigger.userInitiated,
+  }) =>
+      SyncCompleteWithErrors(
+        failedDrives: 1,
+        totalDrives: 3,
+        failedDriveIds: const ['drive-id'],
+        errorMessages: const {'drive-id': 'the gateway said no'},
+        trigger: trigger,
+      );
+
+  testWidgets('a failure the user waited for keeps its modal', (tester) async {
+    // They are looking at the sync; the answer belongs where the question was
+    // asked, retry and all.
+    await tester.pumpWidget(wrap(failed()));
     await tester.pump();
 
     expect(find.byType(SyncScrim), findsOneWidget);
     expect(find.text('Retry Failed'), findsOneWidget);
+  });
+
+  testWidgets('a failure nobody asked for does not take the screen',
+      (tester) async {
+    // The login sync paints nothing while it runs, so the user is in the
+    // middle of something else. One drive out of several failing used to drop
+    // a full-screen scrim and "Sync Incomplete - Errors Detected" over it -
+    // SyncCompleteWithErrors was the only terminal state with no trigger to
+    // honour. It reports at the top bar's sync button instead.
+    await tester.pumpWidget(wrap(failed(trigger: SyncTrigger.background)));
+    await tester.pump();
+
+    expect(find.byType(SyncScrim), findsNothing);
+    expect(find.byType(ArDriveStandardModalNew), findsNothing);
+    expect(find.text('Sync Incomplete - Errors Detected'), findsNothing);
+  });
+
+  testWidgets('every terminal state follows the sync it came from',
+      (tester) async {
+    for (final trigger in SyncTrigger.values) {
+      expect(
+        SyncOverlay.blocksTheApp(failed(trigger: trigger)),
+        trigger == SyncTrigger.userInitiated,
+        reason: 'a $trigger sync that failed must block exactly as much as a '
+            '$trigger sync that is running',
+      );
+    }
   });
 
   testWidgets('cancelling follows the sync it came from', (tester) async {

--- a/test/sync/presentation/sync_summary_test.dart
+++ b/test/sync/presentation/sync_summary_test.dart
@@ -9,20 +9,26 @@ import 'package:flutter_test/flutter_test.dart';
 /// which is the sync the user most needs to learn they can ignore next time.
 void main() {
   group('how long a result is entitled to', () {
+    // A fixed clock, not the wall clock: these assert durations to the
+    // millisecond, and a GC pause between constructing the state and reading
+    // the remainder would otherwise fail them for a reason unrelated to the
+    // code. syncSummaryRemaining takes `now` precisely so it can be pinned.
+    final now = DateTime(2026, 8, 29, 12);
+
     SyncComplete completedAgo(Duration ago) => SyncComplete(
           entitiesSynced: 0,
           skippedEntityCount: 0,
           isSingleDriveSync: false,
           driveName: null,
           trigger: SyncTrigger.background,
-          completedAt: DateTime.now().subtract(ago),
+          completedAt: now.subtract(ago),
           sequence: 1,
         );
 
     test('a fresh result gets the whole window', () {
-      final remaining = syncSummaryRemaining(completedAgo(Duration.zero));
-      expect(remaining.inMilliseconds,
-          closeTo(syncSummaryDuration.inMilliseconds, 100));
+      final remaining =
+          syncSummaryRemaining(completedAgo(Duration.zero), now: now);
+      expect(remaining, syncSummaryDuration);
     });
 
     test('a result built near the boundary gets only what is left', () {
@@ -31,14 +37,14 @@ void main() {
       // its entitlement.
       final remaining = syncSummaryRemaining(
         completedAgo(syncSummaryDuration - const Duration(milliseconds: 200)),
+        now: now,
       );
-      expect(remaining, lessThan(const Duration(milliseconds: 400)));
-      expect(remaining, greaterThan(Duration.zero));
+      expect(remaining, const Duration(milliseconds: 200));
     });
 
     test('an expired result gets nothing, never a negative', () {
       expect(
-        syncSummaryRemaining(completedAgo(const Duration(hours: 1))),
+        syncSummaryRemaining(completedAgo(const Duration(hours: 1)), now: now),
         Duration.zero,
       );
     });


### PR DESCRIPTION
Last of four. Stacked on #2209 → #2208 → #2207, so **this PR's preview build contains the whole series** — it is the one link to test.

This is the only PR in the series that changes a number sync computes rather than adding one, so it is briefed and reviewed harder than the others.

## The problem

The drive walk ran 0 → 0.90, and then the entire tail was three fixed jumps: `0.92` for ghost folders, `0.96` for transaction statuses, `1.0` for completion. So the bar climbed fast and then sat perfectly still through phases of unknown length — transaction status updates go to the gateway and are bounded only by a 30s timeout. A bar that has not moved in half a minute is what a hung app looks like.

## Where the bar's travel goes now, and why

| phase | share | why |
|---|---|---|
| drive walk | 0 → 0.85 | The only phase whose length grows with the user's history, and the only one already reporting continuously. Travel belongs where progress is measured. |
| ghost folders | 0.85 → 0.88 | Local writes over an in-memory map, usually empty. Reports per row. |
| snapshot / preference reads | 0.88 → 0.92 | Local queries, reported per chunk. |
| pending-tx local reads | 0.92 → 0.97 | Largest tail share — the last stretch backed by work that has actually finished. |
| gateway confirmations | 0.97 → 0.99 | **Smallest share, deliberately the inverse of its duration.** Points here would be crossed on no evidence. |
| completion | 1.0 | Reached exactly, and only on success. |

## The honest part

No weighting makes a determinate bar move through a phase with no measurable progress. An earlier cut of this PR gave that phase the *largest* share and produced the biggest jump in the bar's history — freeze at 84% for up to 30s, then leap 15 points, which reads worse than the 96%-then-4-points it replaced.

So the gateway phase now says it cannot be measured. `SyncProgress.isIndeterminate` is set for its duration; the modal renders an indeterminate bar and the top-bar ring drops its value so it sweeps as well as turns. The user sees motion and a phase name instead of a number sitting still. No ETA, and no invented time-based ramp — an estimate that lies is worse than the stopwatch already there.

## Two regressions caught in review, both fixed

**The high-water mark had no ceiling.** Progress is now clamped monotonically at the point of publication, but the walk's value is unbounded above: it derives from block heights against a head read *once* at the start of a sync that can run for minutes, so a transaction in a newer block pushes it past 1. Reproduced at 1.2 then 2.4 — after which *every* later emission, "Sync complete" included, was pinned at 2.4. A bar reading 240% that never moved again, and a successful sync that never reported 1.0. Fixed by bounding to `[0,1]` before the value can become the mark, and by capping the walk at its own phase end so an overshoot below 1.0 cannot pin the tail either. Both cases are tested.

**The new reporting aborted real work.** `Future.timeout` does not cancel its source, so after the 30s status-update timeout the abandoned loop kept running while the controller closed; the new progress callback then threw into it and killed the remaining confirmation batches — invisibly, because a fired timeout drops late errors. Confirmed with 15001 pending transactions and a slow gateway: 3 of 4 batches issued instead of 4, leaving uploads "pending" for another cycle. The sink now no-ops once closed, and a test drives that exact scenario.

## Verification

`flutter analyze` clean. Full suite **1559 passed, 4 skipped, 0 failed**.

Tests run through a real `SyncRepository` over a real in-memory `DriveDao` with only `ArweaveService` mocked. Every guarantee is asserted on **both** the all-drives and single-drive paths, which are separate code with separate callees.

Two rounds of review found tests that passed without guarding anything — the original "tail advances" assertions counted the three fixed phase boundaries, so deleting every intra-phase callback left them green. They now count distinct values **strictly inside one phase's open interval**, which only intra-phase reporting can satisfy, and each was proved by deleting only the callback and observing the failure.

## Known, not fixed

Swapping widget types across the indeterminate branch destroys `LinearPercentIndicator`'s state, so the determinate bar returns from empty. It is at most a frame or two at the very end of a sync and no visible duration could be demonstrated; the obvious fix (`animateToInitialPercent`) does not exist in percent_indicator 4.2.3.

Cancelling inside the gateway phase leaves `isIndeterminate` set on the stream's final event. Harmless today — the cubit emits `SyncCancelled`, the overlay swaps to the cancelled modal, and the next sync resets before emitting. Clearing it would mean touching the cancellation path, which this PR's constraints put off limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ndA5nwUpt9hGLUx2TAFr
