### PR TITLE
feat: the explorer says what a background sync is doing

### DIFF
--- a/lib/components/app_top_bar.dart
+++ b/lib/components/app_top_bar.dart
@@ -11,6 +11,7 @@ import 'package:ardrive/search/search_modal.dart';
 import 'package:ardrive/search/search_text_field.dart';
 import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
 import 'package:ardrive/sync/domain/sync_progress.dart';
+import 'package:ardrive/sync/presentation/sync_elapsed_time.dart';
 import 'package:ardrive/sync/presentation/sync_summary.dart';
 import 'package:ardrive/user/name/presentation/bloc/profile_name_bloc.dart';
 import 'package:ardrive/utils/app_localizations_wrapper.dart';
@@ -750,47 +751,10 @@ class _SyncStatusHeader extends StatelessWidget {
           if (status.showElapsed)
             const Padding(
               padding: EdgeInsets.only(top: 4),
-              child: _SyncElapsedTime(),
+              child: SyncElapsedTime(),
             ),
         ],
       ),
-    );
-  }
-}
-
-/// Seconds since the running sync started, counted where a phone can read it.
-class _SyncElapsedTime extends StatefulWidget {
-  const _SyncElapsedTime();
-
-  @override
-  State<_SyncElapsedTime> createState() => _SyncElapsedTimeState();
-}
-
-class _SyncElapsedTimeState extends State<_SyncElapsedTime> {
-  // Held in a field, not built in `build`: progress events rebuild this header
-  // often, and a stream rebuilt each time restarts its timer before it fires,
-  // so the counter would tick to the sync's cadence instead of the clock's.
-  final Stream<int> _ticks =
-      Stream.periodic(const Duration(seconds: 1), (i) => i);
-
-  @override
-  Widget build(BuildContext context) {
-    final typography = ArDriveTypographyNew.of(context);
-    final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
-
-    return StreamBuilder<int>(
-      stream: _ticks,
-      builder: (context, _) {
-        final elapsed =
-            DateTime.now().difference(context.read<SyncCubit>().syncStartTime);
-
-        return Text(
-          appLocalizationsOf(context).syncElapsedTime(
-            elapsed.inSeconds.toString(),
-          ),
-          style: typography.paragraphSmall(color: colorTokens.textLow),
-        );
-      },
     );
   }
 }

--- a/lib/components/progress_bar.dart
+++ b/lib/components/progress_bar.dart
@@ -1,4 +1,5 @@
 import 'package:ardrive/sync/domain/sync_progress.dart';
+import 'package:ardrive_ui/ardrive_ui.dart';
 import 'package:flutter/material.dart';
 
 /// The bar the sync modal fills.
@@ -18,14 +19,30 @@ import 'package:flutter/material.dart';
 /// when its `value` is null. Same distinction, no swap, and the element - with
 /// whatever its fill is currently doing - survives the transition.
 class ProgressBar extends StatelessWidget {
-  const ProgressBar({super.key, required this.percentage});
+  const ProgressBar({
+    super.key,
+    required this.percentage,
+    this.initialPercentage,
+  });
 
   final Stream<LinearProgress> percentage;
 
+  /// What the bar reads before [percentage] delivers anything.
+  ///
+  /// The sync modal mounts when a sync starts, so an empty bar is the truth
+  /// for it and it passes nothing. A bar that mounts *during* a sync - the
+  /// explorer's, when a drive is clicked while one runs - would otherwise sit
+  /// at zero until the next progress event, which in the unmeasurable phase
+  /// is up to half a minute of a bar claiming a number that is already wrong.
+  final LinearProgress? initialPercentage;
+
   @override
   Widget build(BuildContext context) {
+    final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
+
     return StreamBuilder<LinearProgress>(
       stream: percentage,
+      initialData: initialPercentage,
       builder: (context, snapshot) {
         final progress = snapshot.data;
 
@@ -50,8 +67,8 @@ class ProgressBar extends StatelessWidget {
             builder: (context, animated, _) => LinearProgressIndicator(
               value: isIndeterminate ? null : animated,
               minHeight: _barHeight,
-              backgroundColor: _barTrack,
-              valueColor: const AlwaysStoppedAnimation<Color>(_barFill),
+              backgroundColor: colorTokens.strokeHigh,
+              valueColor: AlwaysStoppedAnimation<Color>(colorTokens.textHigh),
             ),
           ),
         );
@@ -60,8 +77,6 @@ class ProgressBar extends StatelessWidget {
   }
 }
 
-const _barTrack = Color(0xffFAFAFA);
-const _barFill = Color(0xff3C3C3C);
 const _barHeight = 10.0;
 const _barRadius = Radius.circular(5);
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -641,6 +641,16 @@
   "@driveNotSyncedDescription": {
     "description": "Description shown when a drive has not been synced yet"
   },
+  "driveWillOpenWhenSyncFinishes": "{driveName} will open when the sync finishes",
+  "@driveWillOpenWhenSyncFinishes": {
+    "description": "Shown in the explorer while a background sync is running and a drive is waiting on it, so the wait says which drive it is for and that nothing needs to be clicked again",
+    "placeholders": {
+      "driveName": {
+        "type": "String",
+        "example": "Photos"
+      }
+    }
+  },
   "syncThisDriveDescription": "Fetch the latest files and folders from this drive.",
   "@syncThisDriveDescription": {
     "description": "Description for the sync drive action card"
@@ -1783,6 +1793,20 @@
   "onboarding3Title": "Total Privacy Control",
   "@onboarding3Title": {
     "description": "Title of 4th page of onboarding"
+  },
+  "openingDrive": "Opening drive",
+  "@openingDrive": {
+    "description": "Shown in the explorer while a drive is being opened and no sync is running, when the drive's name is not known"
+  },
+  "openingDriveNamed": "Opening {driveName}",
+  "@openingDriveNamed": {
+    "description": "Shown in the explorer while a named drive is being opened and no sync is running",
+    "placeholders": {
+      "driveName": {
+        "type": "String",
+        "example": "Photos"
+      }
+    }
   },
   "onceUploadedCantBeRemoved": "Once uploaded, your data can’t be removed.",
   "@onceUploadedCantBeRemoved": {

--- a/lib/pages/drive_detail/components/drive_detail_syncing_card.dart
+++ b/lib/pages/drive_detail/components/drive_detail_syncing_card.dart
@@ -1,0 +1,323 @@
+import 'dart:async';
+
+import 'package:ardrive/blocs/drives/drives_cubit.dart';
+import 'package:ardrive/components/progress_bar.dart';
+import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
+import 'package:ardrive/sync/domain/sync_progress.dart';
+import 'package:ardrive/sync/presentation/sync_elapsed_time.dart';
+import 'package:ardrive/utils/app_localizations_wrapper.dart';
+import 'package:ardrive_ui/ardrive_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:responsive_builder/responsive_builder.dart';
+
+/// How wide the wait is allowed to get. Past this the phase line and the bar
+/// drift apart on a wide monitor and stop reading as one thing.
+const double _syncingContentMaxWidth = 420;
+
+/// What the explorer draws while it is waiting to show a folder -
+/// `DriveDetailLoadInProgress`.
+///
+/// This slot used to be a bare [CircularProgressIndicator]: no words, no
+/// progress, no drive name, no time bound. That was survivable while a sync
+/// held a scrim over the whole app, because nobody could reach this screen
+/// during one. Now that a background sync leaves the app usable, and now that
+/// opening a folder says it heard the click *before* it waits for the sync, a
+/// drive clicked mid-sync lands here for the length of that sync - minutes, on
+/// a large wallet - on a featureless spinner. A silent failure traded for a
+/// blank wait.
+///
+/// So the explorer reports the sync, since the explorer is where the user is
+/// looking: what is running, which drive they are waiting for, the phase the
+/// sync names for itself, the same bar the modal fills, and a count of seconds
+/// so a long wait reads as working rather than hung. Nothing here scrims, takes
+/// focus or blocks navigation - it is one panel in a page the user can still
+/// leave.
+///
+/// It is deliberately quieter than [DriveDetailUnsyncedCard], which occupies
+/// the same slot for a drive that has *not* been synced: that one is a decision
+/// the user has to make and is drawn as one, with headline type and two action
+/// cards. This is a wait, and asks for nothing.
+class DriveDetailSyncingCard extends StatefulWidget {
+  const DriveDetailSyncingCard({super.key});
+
+  @override
+  State<DriveDetailSyncingCard> createState() => _DriveDetailSyncingCardState();
+}
+
+class _DriveDetailSyncingCardState extends State<DriveDetailSyncingCard> {
+  /// The cubit's own broadcast stream of progress, read but never driven -
+  /// this panel adds no request of any kind.
+  ///
+  /// Held in a field rather than read in `build`: [StreamBuilder] resubscribes
+  /// and falls back to its initial data whenever the stream identity changes,
+  /// so a stream fetched per build would reset the bar to where it was when
+  /// this panel mounted every time a progress event arrived.
+  late final Stream<SyncProgress> _progress;
+
+  /// Where the bar starts.
+  ///
+  /// This panel mounts *during* a sync - that is the case it exists for - and
+  /// the cubit replays nothing, so without a seed the bar would read empty
+  /// until the next progress event, which in the unmeasurable phase can be
+  /// half a minute away. A wait that is not a sync has no number to start
+  /// from and gets a bar that says so.
+  ///
+  /// Decided once, here, because that is exactly when [StreamBuilder] reads
+  /// it. Deciding it per build would mean handing the bar a different stream
+  /// depending on the sync state, and a bar whose stream identity changes
+  /// resubscribes and keeps whatever it was last showing - the seed would
+  /// never be applied at all.
+  late final LinearProgress _initialProgress;
+
+  /// What the sync was reporting when this panel appeared, or null when no
+  /// sync was running to report anything.
+  late final SyncProgress? _progressAtMount;
+
+  @override
+  void initState() {
+    super.initState();
+
+    final syncCubit = context.read<SyncCubit>();
+    _progress = syncCubit.syncProgressController.stream;
+    _progressAtMount =
+        _reportsProgress(syncCubit.state) ? syncCubit.syncProgress : null;
+    _initialProgress = _progressAtMount ?? _indeterminate;
+  }
+
+  /// Whether this screen is waiting on a sync at all.
+  static bool _isSyncing(SyncState state) =>
+      state is SyncInProgress || state is SyncLoadingDrives;
+
+  /// Whether there is an elapsed time worth showing.
+  ///
+  /// Only [SyncInProgress] sets a start time. `syncMetadataOnly` never does,
+  /// so counting during [SyncLoadingDrives] counts from whenever the cubit was
+  /// built - which reads "420s elapsed" under "Loading your drives...". The
+  /// top bar withholds it in exactly this state for the same reason.
+  static bool _hasElapsedWorthShowing(SyncState state) =>
+      state is SyncInProgress;
+
+  /// Whether the sync is far enough along to have progress to publish.
+  /// Collecting drive metadata reports none at all - the top bar's ring has
+  /// nothing to fill during it either - so this panel does not invent a nought
+  /// to put on screen.
+  static bool _reportsProgress(SyncState state) => state is SyncInProgress;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<SyncCubit, SyncState>(
+      builder: (context, syncState) {
+        final isSyncing = _isSyncing(syncState);
+        final reportsProgress = _reportsProgress(syncState);
+
+        return StreamBuilder<SyncProgress>(
+          stream: _progress,
+          initialData: _progressAtMount,
+          builder: (context, snapshot) {
+            return BlocBuilder<DrivesCubit, DrivesState>(
+              builder: (context, drivesState) {
+                final content = _content(
+                  context,
+                  isSyncing: isSyncing,
+                  showElapsed: _hasElapsedWorthShowing(syncState),
+                  isLoadingDrives: syncState is SyncLoadingDrives,
+                  progress: reportsProgress ? snapshot.data : null,
+                  driveName: _driveName(drivesState, snapshot.data),
+                );
+
+                return ScreenTypeLayout.builder(
+                  mobile: (context) => content,
+                  // The card the explorer's other full-panel states use on a
+                  // wide screen, so the frame does not change shape when this
+                  // becomes a folder listing or an unsynced drive.
+                  desktop: (context) => Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 20),
+                    child: SizedBox(
+                      height: MediaQuery.of(context).size.height * 0.8,
+                      child: ArDriveCard(
+                        width: double.infinity,
+                        backgroundColor: ArDriveTheme.of(context)
+                            .themeData
+                            .colorTokens
+                            .containerL1,
+                        content: content,
+                      ),
+                    ),
+                  ),
+                );
+              },
+            );
+          },
+        );
+      },
+    );
+  }
+
+  /// The drive the user is waiting for, when anything on screen already knows
+  /// it. The drive they selected is the one that will open, so it wins; a
+  /// single-drive sync names its own drive and stands in when there is no
+  /// selection to read yet.
+  String? _driveName(DrivesState drivesState, SyncProgress? progress) {
+    if (drivesState is DrivesLoadSuccess) {
+      final selectedDriveId = drivesState.selectedDriveId;
+
+      if (selectedDriveId != null) {
+        for (final drive in [
+          ...drivesState.userDrives,
+          ...drivesState.sharedDrives,
+        ]) {
+          if (drive.id == selectedDriveId) {
+            return drive.name;
+          }
+        }
+      }
+    }
+
+    if (progress != null && progress.isSingleDriveSync) {
+      return progress.driveName;
+    }
+
+    return null;
+  }
+
+  Widget _content(
+    BuildContext context, {
+    required bool isSyncing,
+    required bool showElapsed,
+    required bool isLoadingDrives,
+    required SyncProgress? progress,
+    required String? driveName,
+  }) {
+    final typography = ArDriveTypographyNew.of(context);
+    final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
+
+    final String title;
+    final String? subtitle;
+
+    if (isSyncing) {
+      // The same words the top bar uses for the same moment: the two report
+      // one sync between them and must never name it differently.
+      title = isLoadingDrives
+          ? appLocalizationsOf(context).loadingYourDrives
+          : progress != null && progress.isSingleDriveSync
+              ? appLocalizationsOf(context).syncingSingleDrive
+              : appLocalizationsOf(context).syncingAllDrives;
+      // Says what the wait is for as well as what it is: this folder opens on
+      // its own when the sync is done, and nothing has to be clicked again.
+      subtitle = driveName == null
+          ? null
+          : appLocalizationsOf(context)
+              .driveWillOpenWhenSyncFinishes(driveName);
+    } else {
+      title = driveName == null
+          ? appLocalizationsOf(context).openingDrive
+          : appLocalizationsOf(context).openingDriveNamed(driveName);
+      subtitle = null;
+    }
+
+    // The phase names itself whenever the sync has one to give. The percentage
+    // stands in only when it does not *and* the number means something: an
+    // unmeasurable phase must not leave a figure sitting still on screen, which
+    // is the one thing this panel exists to stop.
+    final String? detail;
+    if (progress == null) {
+      detail = null;
+    } else {
+      detail = progress.statusMessage ??
+          (progress.isIndeterminate
+              ? null
+              : appLocalizationsOf(context).syncProgressPercentage(
+                  (progress.progress * 100).round().toString(),
+                ));
+    }
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return SingleChildScrollView(
+          child: ConstrainedBox(
+            constraints: BoxConstraints(minHeight: constraints.maxHeight),
+            child: Center(
+              child: Padding(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(
+                    maxWidth: _syncingContentMaxWidth,
+                  ),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        title,
+                        style: typography.heading4(
+                          fontWeight: ArFontWeight.bold,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                      if (subtitle != null) ...[
+                        const SizedBox(height: 8),
+                        Text(
+                          subtitle,
+                          style: typography.paragraphLarge(
+                            color: colorTokens.textLow,
+                            fontWeight: ArFontWeight.semiBold,
+                          ),
+                          textAlign: TextAlign.center,
+                        ),
+                      ],
+                      const SizedBox(height: 24),
+                      // The modal's bar, not a second one: it already knows
+                      // not to claim a number during a phase that cannot
+                      // measure itself, and not to rewind when one ends.
+                      ProgressBar(
+                        // Keyed so the Column matches it by identity, not by
+                        // position. When the sync ends, subtitle, detail and
+                        // the elapsed line all disappear at once and the
+                        // children list shrinks; an unkeyed bar would be
+                        // matched against a different widget, destroyed, and
+                        // remounted at its mount-time seed - a bar animating
+                        // backwards from 99%, which is the exact thing the
+                        // sink beneath it exists to prevent.
+                        key: const ValueKey('driveDetailSyncProgress'),
+                        percentage: _progress,
+                        initialPercentage: _initialProgress,
+                      ),
+                      if (detail != null) ...[
+                        const SizedBox(height: 12),
+                        Text(
+                          detail,
+                          style: typography.paragraphNormal(
+                            color: colorTokens.textMid,
+                          ),
+                          textAlign: TextAlign.center,
+                        ),
+                      ],
+                      if (showElapsed) ...[
+                        const SizedBox(height: 4),
+                        const SyncElapsedTime(),
+                      ],
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// A bar with nothing to report: it moves, and claims nothing. What a wait on
+/// the local database gets, since it is over in well under a second and has no
+/// progress to publish.
+final LinearProgress _indeterminate = _IndeterminateProgress();
+
+class _IndeterminateProgress extends LinearProgress {
+  @override
+  double get progress => 0;
+
+  @override
+  bool get isIndeterminate => true;
+}

--- a/lib/pages/drive_detail/drive_detail_page.dart
+++ b/lib/pages/drive_detail/drive_detail_page.dart
@@ -34,6 +34,7 @@ import 'package:ardrive/l11n/l11n.dart';
 import 'package:ardrive/misc/resources.dart';
 import 'package:ardrive/models/models.dart';
 import 'package:ardrive/pages/drive_detail/components/drive_explorer_item_tile.dart';
+import 'package:ardrive/pages/drive_detail/components/drive_detail_syncing_card.dart';
 import 'package:ardrive/pages/drive_detail/components/drive_file_drop_zone.dart';
 import 'package:ardrive/pages/drive_detail/components/dropdown_item.dart';
 import 'package:ardrive/pages/drive_detail/components/file_icon.dart';
@@ -188,19 +189,22 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
                             widget.anonymouslyShowDriveDetail,
                       );
                     } else if (driveDetailState is DriveDetailLoadInProgress) {
+                      // Same chrome as before - only the middle of the panel
+                      // changes, so nothing around it moves when the wait ends
+                      // - and the same widget on both, because the surface with
+                      // less room and no hover is the last one that should be
+                      // told less.
                       return ScreenTypeLayout.builder(
                         mobile: (context) => const Scaffold(
                           drawerScrimColor: Colors.transparent,
                           drawer: AppSideBar(),
                           appBar: MobileAppBar(),
-                          body: Center(child: CircularProgressIndicator()),
+                          body: DriveDetailSyncingCard(),
                         ),
                         desktop: (context) => const Column(
                           children: [
                             AppTopBar(),
-                            Expanded(
-                              child: Center(child: CircularProgressIndicator()),
-                            ),
+                            Expanded(child: DriveDetailSyncingCard()),
                           ],
                         ),
                       );

--- a/lib/sync/presentation/sync_elapsed_time.dart
+++ b/lib/sync/presentation/sync_elapsed_time.dart
@@ -1,0 +1,53 @@
+import 'dart:async';
+
+import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
+import 'package:ardrive/utils/app_localizations_wrapper.dart';
+import 'package:ardrive_ui/ardrive_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+/// Seconds since the running sync started.
+///
+/// Shown wherever a background sync reports itself - the top bar's status
+/// header and the explorer panel a drive click lands on - because a wait that
+/// counts is a wait that is working, and one that does not is a hang. Both read
+/// [SyncCubit.syncStartTime], so they can never disagree about how long this
+/// has been going on.
+///
+/// Only mount this while a sync is actually running: `syncStartTime` keeps the
+/// last sync's start, so an idle surface counting from it would report minutes.
+class SyncElapsedTime extends StatefulWidget {
+  const SyncElapsedTime({super.key});
+
+  @override
+  State<SyncElapsedTime> createState() => _SyncElapsedTimeState();
+}
+
+class _SyncElapsedTimeState extends State<SyncElapsedTime> {
+  // Held in a field, not built in `build`: progress events rebuild this widget
+  // often, and a stream rebuilt each time restarts its timer before it fires,
+  // so the counter would tick to the sync's cadence instead of the clock's.
+  final Stream<int> _ticks =
+      Stream.periodic(const Duration(seconds: 1), (i) => i);
+
+  @override
+  Widget build(BuildContext context) {
+    final typography = ArDriveTypographyNew.of(context);
+    final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
+
+    return StreamBuilder<int>(
+      stream: _ticks,
+      builder: (context, _) {
+        final elapsed =
+            DateTime.now().difference(context.read<SyncCubit>().syncStartTime);
+
+        return Text(
+          appLocalizationsOf(context).syncElapsedTime(
+            elapsed.inSeconds.toString(),
+          ),
+          style: typography.paragraphSmall(color: colorTokens.textLow),
+        );
+      },
+    );
+  }
+}

--- a/test/components/progress_bar_test.dart
+++ b/test/components/progress_bar_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:ardrive/components/progress_bar.dart';
 import 'package:ardrive/sync/domain/sync_progress.dart';
+import 'package:ardrive_ui/ardrive_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -11,8 +12,11 @@ void main() {
   setUp(() => progress = StreamController<LinearProgress>.broadcast());
   tearDown(() async => progress.close());
 
-  Widget wrap() => MaterialApp(
-        home: Scaffold(body: ProgressBar(percentage: progress.stream)),
+  Widget wrap() => ArDriveTheme(
+        themeData: lightTheme(),
+        child: MaterialApp(
+          home: Scaffold(body: ProgressBar(percentage: progress.stream)),
+        ),
       );
 
   SyncProgress at(double value, {bool indeterminate = false}) =>

--- a/test/pages/drive_detail/components/drive_detail_syncing_card_test.dart
+++ b/test/pages/drive_detail/components/drive_detail_syncing_card_test.dart
@@ -1,0 +1,456 @@
+import 'dart:async';
+
+import 'package:ardrive/blocs/drives/drives_cubit.dart';
+import 'package:ardrive/models/models.dart';
+import 'package:ardrive/pages/drive_detail/components/drive_detail_syncing_card.dart';
+import 'package:ardrive/pages/drive_detail/drive_detail_page.dart';
+import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
+import 'package:ardrive/sync/domain/sync_progress.dart';
+import 'package:ardrive_ui/ardrive_ui.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../test_utils/mocks.dart';
+
+/// What the explorer draws while it waits for a folder.
+///
+/// Every test here disposes the tree itself before finishing: the elapsed
+/// counter owns a periodic timer for as long as it is mounted, and a test that
+/// walks away from one fails on the pending timer instead of on its subject.
+void main() {
+  late MockSyncBloc syncCubit;
+  late MockDrivesCubit drivesCubit;
+  late StreamController<SyncState> syncStates;
+  late StreamController<SyncProgress> progress;
+
+  const phoneSize = Size(320, 640);
+  const desktopSize = Size(1200, 900);
+
+  setUp(() {
+    syncCubit = MockSyncBloc();
+    drivesCubit = MockDrivesCubit();
+    // Broadcast on purpose - see the same note in sync_button_test.dart.
+    syncStates = StreamController<SyncState>.broadcast();
+    progress = StreamController<SyncProgress>.broadcast();
+
+    whenListen(syncCubit, syncStates.stream, initialState: SyncIdle());
+    when(() => syncCubit.syncProgressController).thenReturn(progress);
+    when(() => syncCubit.syncProgress).thenReturn(SyncProgress.initial());
+    when(() => syncCubit.syncStartTime).thenReturn(DateTime.now());
+
+    whenListen(
+      drivesCubit,
+      const Stream<DrivesState>.empty(),
+      initialState: DrivesLoadInProgress(),
+    );
+  });
+
+  tearDown(() async {
+    await syncStates.close();
+    await progress.close();
+  });
+
+  Drive drive({required String id, required String name}) => Drive(
+        id: id,
+        rootFolderId: '$id-root',
+        ownerAddress: 'owner',
+        name: name,
+        privacy: 'public',
+        isHidden: false,
+        dateCreated: DateTime(2026),
+        lastUpdated: DateTime(2026),
+      );
+
+  Widget host(
+    Widget body, {
+    ArDriveThemeData? theme,
+    Size size = phoneSize,
+  }) {
+    return ArDriveTheme(
+      themeData: theme ?? lightTheme(),
+      child: MaterialApp(
+        localizationsDelegates: const [
+          AppLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: const [Locale('en', '')],
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => MediaQuery(
+              // `setSurfaceSize` changes the box the tree is laid out in but
+              // not what MediaQuery reports, and responsive_builder chooses a
+              // layout from MediaQuery. Without this the desktop branch is
+              // unreachable from a test and both "platforms" would silently
+              // prove the same widget - which is exactly what happened here
+              // before a deliberate break said so.
+              data: MediaQuery.of(context).copyWith(size: size),
+              child: MultiBlocProvider(
+                providers: [
+                  BlocProvider<SyncCubit>.value(value: syncCubit),
+                  BlocProvider<DrivesCubit>.value(value: drivesCubit),
+                ],
+                child: body,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget wrap({ArDriveThemeData? theme, Size size = phoneSize}) =>
+      host(const DriveDetailSyncingCard(), theme: theme, size: size);
+
+  /// Renders the panel at [size] with a background sync already under way -
+  /// the case it exists for. A drive clicked mid-sync lands here, so the panel
+  /// mounts into a sync rather than watching one start.
+  Future<void> pumpSyncing(
+    WidgetTester tester, {
+    Size size = phoneSize,
+    SyncProgress? reporting,
+    ArDriveThemeData? theme,
+  }) async {
+    await tester.binding.setSurfaceSize(size);
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    whenListen(
+      syncCubit,
+      syncStates.stream,
+      initialState: SyncInProgress(trigger: SyncTrigger.background),
+    );
+
+    await tester.pumpWidget(wrap(theme: theme, size: size));
+    await tester.pump();
+
+    if (reporting != null) {
+      progress.add(reporting);
+      await tester.pump(const Duration(milliseconds: 10));
+    }
+  }
+
+  /// The bar the panel is filling.
+  LinearProgressIndicator bar(WidgetTester tester) =>
+      tester.widget<LinearProgressIndicator>(
+        find.byType(LinearProgressIndicator),
+      );
+
+  /// Selects the drive the user is waiting for.
+  void selectDrive(String name) {
+    whenListen(
+      drivesCubit,
+      const Stream<DrivesState>.empty(),
+      initialState: DrivesLoadSuccess(
+        selectedDriveId: 'drive-1',
+        userDrives: [drive(id: 'drive-1', name: name)],
+        sharedDrives: const [],
+        drivesWithAlerts: const [],
+        canCreateNewDrive: true,
+      ),
+    );
+  }
+
+  testWidgets('a background sync is named, not spun at', (tester) async {
+    await pumpSyncing(
+      tester,
+      reporting: SyncProgress.initial().copyWith(
+        progress: 0.42,
+        statusMessage: 'Downloading drive snapshots...',
+      ),
+    );
+
+    // What the wait is, in words - the same words the top bar and the modal
+    // use for it.
+    expect(find.text('Syncing All Drives'), findsOneWidget);
+    expect(find.text('Downloading drive snapshots...'), findsOneWidget);
+    // How long it has been going on.
+    expect(find.textContaining('s elapsed'), findsOneWidget);
+
+    // And a bar that is actually filling, in place of the bare indicator this
+    // slot used to hold.
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+    await tester.pump(const Duration(milliseconds: 1100));
+    expect(bar(tester).value, closeTo(0.42, 0.001));
+
+    await tester.pumpWidget(const SizedBox());
+  });
+
+  testWidgets('the bar starts where the sync already is', (tester) async {
+    // The panel mounts mid-sync by definition, and the cubit replays nothing.
+    // Without the seed the bar reads empty until the next progress event -
+    // which in the unmeasurable phase is up to half a minute away. No event is
+    // published here at all: everything on screen came from the seed.
+    when(() => syncCubit.syncProgress).thenReturn(
+      SyncProgress.initial().copyWith(
+        progress: 0.6,
+        statusMessage: 'Downloading drive snapshots...',
+      ),
+    );
+
+    await pumpSyncing(tester);
+    await tester.pump(const Duration(milliseconds: 1100));
+
+    expect(bar(tester).value, closeTo(0.6, 0.001));
+    expect(find.text('Downloading drive snapshots...'), findsOneWidget);
+
+    await tester.pumpWidget(const SizedBox());
+  });
+
+  testWidgets('the drive being waited for is named', (tester) async {
+    selectDrive('Photos');
+
+    await pumpSyncing(
+      tester,
+      reporting: SyncProgress.initial().copyWith(
+        progress: 0.42,
+        statusMessage: 'Downloading drive snapshots...',
+      ),
+    );
+
+    expect(
+      find.text('Photos will open when the sync finishes'),
+      findsOneWidget,
+    );
+
+    await tester.pumpWidget(const SizedBox());
+  });
+
+  testWidgets('a single drive sync names its own drive', (tester) async {
+    await pumpSyncing(
+      tester,
+      reporting: SyncProgress.initial().copyWith(
+        progress: 0.42,
+        isSingleDriveSync: true,
+        driveName: 'Invoices',
+        statusMessage: 'Downloading drive snapshots...',
+      ),
+    );
+
+    expect(find.text('Syncing Drive'), findsOneWidget);
+    expect(
+      find.text('Invoices will open when the sync finishes'),
+      findsOneWidget,
+    );
+
+    await tester.pumpWidget(const SizedBox());
+  });
+
+  testWidgets('a phase that cannot measure itself shows no frozen number',
+      (tester) async {
+    await pumpSyncing(
+      tester,
+      reporting: SyncProgress.initial().copyWith(progress: 0.97),
+    );
+    await tester.pump(const Duration(milliseconds: 1100));
+
+    expect(bar(tester).value, closeTo(0.97, 0.001));
+    expect(find.text('97% complete'), findsOneWidget);
+
+    // The gateway round trip cannot know its own length, so the bar stops
+    // claiming one rather than sitting at 97% until it answers.
+    progress.add(SyncProgress.initial().copyWith(
+      progress: 0.97,
+      isIndeterminate: true,
+      statusMessage: 'Updating transaction statuses...',
+    ));
+    await tester.pump(const Duration(milliseconds: 1100));
+
+    expect(bar(tester).value, isNull);
+    expect(find.text('97% complete'), findsNothing);
+    expect(find.text('Updating transaction statuses...'), findsOneWidget);
+
+    await tester.pumpWidget(const SizedBox());
+  });
+
+  testWidgets('collecting drive metadata is named, and invents no number',
+      (tester) async {
+    // The phase before a sync has anything to measure. The top bar calls it
+    // "Loading your drives..." and leaves its ring empty; this panel has to
+    // agree with it rather than announce a sync at 0%.
+    await tester.binding.setSurfaceSize(phoneSize);
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    whenListen(
+      syncCubit,
+      syncStates.stream,
+      initialState: SyncLoadingDrives(),
+    );
+
+    await tester.pumpWidget(wrap());
+    await tester.pump(const Duration(milliseconds: 1100));
+
+    expect(find.text('Loading your drives...'), findsOneWidget);
+    expect(find.text('0% complete'), findsNothing);
+    expect(bar(tester).value, isNull);
+    // And no stopwatch: only a real sync sets a start time, so counting here
+    // counts from whenever the cubit was built - "420s elapsed" under
+    // "Loading your drives...". The top bar withholds it for the same reason.
+    expect(find.textContaining('s elapsed'), findsNothing);
+
+    await tester.pumpWidget(const SizedBox());
+  });
+
+  testWidgets('a wait that is not a sync still says what it is',
+      (tester) async {
+    selectDrive('Photos');
+
+    await tester.binding.setSurfaceSize(phoneSize);
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(wrap());
+    await tester.pump();
+
+    expect(find.text('Opening Photos'), findsOneWidget);
+    // Nothing to measure, so nothing is claimed - and no elapsed time, which
+    // would be counted from a sync that ended long ago.
+    expect(bar(tester).value, isNull);
+    expect(find.textContaining('s elapsed'), findsNothing);
+
+    await tester.pumpWidget(const SizedBox());
+  });
+
+  for (final layout in [
+    ('a phone', phoneSize),
+    ('a desktop', desktopSize),
+  ]) {
+    testWidgets('${layout.$1} is told the phase and the progress',
+        (tester) async {
+      selectDrive('Photos');
+
+      await pumpSyncing(
+        tester,
+        size: layout.$2,
+        reporting: SyncProgress.initial().copyWith(
+          progress: 0.42,
+          statusMessage: 'Downloading drive snapshots...',
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 1100));
+
+      expect(find.text('Syncing All Drives'), findsOneWidget);
+      expect(
+        find.text('Photos will open when the sync finishes'),
+        findsOneWidget,
+      );
+      expect(find.text('Downloading drive snapshots...'), findsOneWidget);
+      expect(find.textContaining('s elapsed'), findsOneWidget);
+      expect(bar(tester).value, closeTo(0.42, 0.001));
+
+      await tester.pumpWidget(const SizedBox());
+    });
+  }
+
+  for (final theme in [
+    ('light', lightTheme()),
+    ('dark', ArDriveThemeData(colorTokens: ArDriveColorTokens.darkMode())),
+  ]) {
+    testWidgets('nothing overflows a 320px phone in ${theme.$1}',
+        (tester) async {
+      selectDrive('Family Photos And Videos Nineteen Ninety Nine To Today');
+
+      await pumpSyncing(
+        tester,
+        theme: theme.$2,
+        reporting: SyncProgress.initial().copyWith(
+          progress: 0.42,
+          statusMessage: 'Updating transaction statuses for pending uploads...',
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 1100));
+
+      expect(tester.takeException(), isNull);
+
+      // Rendered, not merely present: every line has to start on screen and
+      // end on screen.
+      for (final text in [
+        'Syncing All Drives',
+        'Family Photos And Videos Nineteen Ninety Nine To Today '
+            'will open when the sync finishes',
+        'Updating transaction statuses for pending uploads...',
+      ]) {
+        final finder = find.text(text);
+        expect(finder, findsOneWidget, reason: text);
+        expect(tester.getTopLeft(finder).dx, greaterThanOrEqualTo(0));
+        expect(tester.getBottomRight(finder).dx, lessThanOrEqualTo(320.0));
+        expect(
+          tester.renderObject<RenderParagraph>(finder).didExceedMaxLines,
+          isFalse,
+          reason: text,
+        );
+      }
+
+      await tester.pumpWidget(const SizedBox());
+    });
+  }
+
+  testWidgets('a drive that was never synced still asks, rather than waits',
+      (tester) async {
+    // The other half of this slot, left exactly as it was: a decision the user
+    // has to make reads as one, and must not be confused with a wait.
+    await tester.binding.setSurfaceSize(phoneSize);
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      host(
+        DriveDetailUnsyncedCard(drive: drive(id: 'drive-1', name: 'Photos')),
+      ),
+    );
+    await tester.pump();
+
+    // The card's two 283x283 action tiles do not fit their own contents under
+    // the test font's square glyphs. That predates this work, is not what this
+    // test is about, and the card is left exactly as it was found.
+    while (tester.takeException() != null) {}
+
+    expect(find.text('Drive Not Synced'), findsOneWidget);
+    expect(find.text('Sync Now'), findsOneWidget);
+
+    // Nothing about it reads as work in progress.
+    expect(find.byType(LinearProgressIndicator), findsNothing);
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+    expect(find.text('Syncing All Drives'), findsNothing);
+    expect(find.textContaining('s elapsed'), findsNothing);
+
+    await tester.pumpWidget(const SizedBox());
+  });
+  testWidgets('the bar does not rewind when the sync ends', (tester) async {
+    // When the sync finishes, the subtitle, the phase line and the elapsed
+    // counter all disappear at once and the Column's children shrink. An
+    // unkeyed bar is then matched by POSITION against a different widget,
+    // destroyed, and remounted at its mount-time seed - so a bar live at 99%
+    // animates backwards. That is the backwards-moving bar the monotonic sink
+    // underneath exists to prevent, reintroduced a layer up.
+    selectDrive('Photos');
+    await pumpSyncing(
+      tester,
+      reporting: SyncProgress.initial().copyWith(
+        progress: 0.99,
+        statusMessage: 'Updating transaction statuses...',
+      ),
+    );
+
+    // Let the fill animation reach the value before reading it.
+    await tester.pump(const Duration(milliseconds: 1200));
+    expect(bar(tester).value, closeTo(0.99, 0.01));
+
+    // The sync ends; the panel stays up while the folder opens.
+    syncStates.add(SyncIdle());
+    await tester.pump(const Duration(milliseconds: 10));
+
+    final after = bar(tester).value;
+    expect(
+      after == null || after >= 0.99,
+      isTrue,
+      reason: 'the bar fell back to $after after reading 0.99',
+    );
+
+    await tester.pumpWidget(const SizedBox());
+  });
+}


### PR DESCRIPTION
Stacked on #2211. Sixth of the sync-UX series.

## The problem

Once a background sync stopped taking the screen, the explorer had no story for the wait it left behind. `drive_detail_page.dart:190` drew `DriveDetailLoadInProgress` as `Center(child: CircularProgressIndicator())` — no words, no progress, no drive name, no time bound.

That barely mattered while a scrim covered everything. Then PR #2210 fixed "clicking a drive during a sync does nothing" by emitting the loading state *before* awaiting `waitCurrentSync()` — which means a user who clicks a drive mid-sync now sits on that featureless spinner for the whole sync. A silent failure was traded for a blank wait.

## What the panel says now

| state | title | second line | bar | detail | elapsed |
|---|---|---|---|---|---|
| syncing all drives | Syncing All Drives | `{drive} will open when the sync finishes` | follows progress | `Downloading drive snapshots…` | `{n}s elapsed` |
| single drive | Syncing Drive | same | same | same | `{n}s elapsed` |
| unmeasurable phase | as above | as above | **indeterminate** | `Updating transaction statuses…` | `{n}s elapsed` |
| no phase message | as above | as above | determinate | `{n}% complete` | `{n}s elapsed` |
| loading drive metadata | Loading your drives… | — | indeterminate | — (no number invented) | — |
| no sync running | `Opening {drive}` | — | indeterminate | — | — |

**Identical on mobile and desktop.** Mobile previously got strictly less than desktop, which is backwards for the surface with less room and no hover. Desktop wraps it in the same `ArDriveCard` frame the explorer's other full-panel states use, so the frame does not change shape between states.

It reuses the modal's `ProgressBar` rather than inventing a second one, so it inherits PR #2210's indeterminate treatment: during the gateway phase it does not claim a number it cannot stand behind.

`DriveDetailUnsyncedCard` is untouched — a drive that is *not synced* already had a good story with a Sync Now button. The bug was only that a *wait* looked like nothing, and the two now read as different things: something in progress, versus something waiting for you to act.

## Three defects review caught, all fixed

**The bar rewound when the sync ended.** As the sync finishes, the subtitle, phase line and elapsed counter all disappear at once and the Column's children shrink. An unkeyed bar is then matched by *position* against a different widget, destroyed, and remounted at its mount-time seed — a bar live at 99% animating backwards, or a sweeping indeterminate bar snapping to a static number. That is the backwards-moving bar PR #2210's monotonic sink exists to prevent, reintroduced a layer above it. The bar is now keyed so it is matched by identity. Test: without the key, *"the bar fell back to 0.0 after reading 0.99"*.

**The bar read inverted in dark mode.** Track `#FAFAFA`, fill `#3C3C3C`, both hardcoded — so on a dark panel the *unfilled* remainder was the brightest object on screen and the filled portion nearly vanished. It was equally wrong in the modal, which is why it survived; matching a broken surface is not a reason to keep it. Both now come from `colorTokens` (`strokeHigh` track, `textHigh` fill) and adapt correctly. **This changes the sync modal's bar too**, and fixes it there as well.

**The elapsed counter ran on a stale clock.** It was shown during `SyncLoadingDrives`, but only `startSync` sets a start time — `syncMetadataOnly` never does — so it counted from whenever the cubit was built and could print "420s elapsed" under "Loading your drives…". The top bar deliberately withholds it in exactly that state; this now matches.

## Verification

`flutter analyze` clean. Full suite **1612 passed, 4 skipped, 0 failed**.

Every test proved by reverting its implementation line. One mutation exposed a broken *test* rather than broken code: `setSurfaceSize` does not change what `MediaQuery` reports, and `responsive_builder` picks its layout from `MediaQuery` — so both "platform" tests were rendering the mobile branch and the desktop one passed with its content stubbed out. The harness now overrides `MediaQuery.size` too, and the mutation fails exactly one test.

## Known

`DriveDetailUnsyncedCard` cannot be rendered in a widget test without a 38px `RenderFlex` overflow — its fixed 283×283 tiles do not fit their contents under the test font. Pre-existing and unrelated; the test drains that exception with a comment rather than touching the card.

Three surfaces still format elapsed time under two rules (the modal gates it to 5s; the top bar and this panel do not). Cosmetic, and worth one pass across all three rather than a fourth variation here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ndA5nwUpt9hGLUx2TAFr
