### PR TITLE
feat: say "we don't know yet" and "we couldn't find out"

### DIFF
--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -86,7 +86,13 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
         _driveRepository = driveRepository,
         _driveId = driveId,
         super(DriveDetailLoadInProgress()) {
+    _listenForSyncCompletion();
+
     if (driveId.isEmpty) {
+      // No drive to open, but this cubit still shows the drive-list screens -
+      // "loading", "none" and "could not be loaded" - so it has to keep
+      // hearing about syncs. The subscription used to be registered below
+      // this return, which meant a login at the root URL never heard one.
       return;
     }
 
@@ -141,8 +147,22 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
       });
     }
 
-    // Listen for sync completion to auto-refresh if we're in an unsynced/loading state
+    // (registered by _listenForSyncCompletion, above)
+  }
+
+  void _listenForSyncCompletion() {
     _syncSubscription = _syncCubit.stream.listen((syncState) {
+      // A drive list that has since been read means the failure screen is out
+      // of date, wherever the retry came from. The top bar has its own Try
+      // Again, and without this the body would go on saying the drives could
+      // not be loaded while the bar above it reported everything was fine.
+      if (state is DriveDetailDrivesUnavailable &&
+          syncState is SyncIdle &&
+          !_syncCubit.driveListRefreshFailed) {
+        showEmptyDriveDetail();
+        return;
+      }
+
       if (_initialLoadComplete &&
           (syncState is SyncIdle || syncState is SyncCompleteWithErrors)) {
         _onSyncCompleted();
@@ -210,12 +230,32 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
     }
   }
 
-  void showEmptyDriveDetail() async {
+  /// Decides which of the three things an empty drive list means.
+  ///
+  /// It used to mean one: "Getting Started", two create-a-drive buttons and an
+  /// empty sidebar, shown on EVERY login with an empty local database for the
+  /// whole length of the drive-list fetch - because `DrivesCubit` reports the
+  /// empty table the instant Drift reads it, and the wait here did not cover
+  /// the fetch. [SyncCubit.waitCurrentSync] treats `SyncLoadingDrives` as
+  /// finished on purpose, so folder opens do not hang behind a refresh, and
+  /// that is precisely the state a metadata-only login sits in.
+  ///
+  /// So this waits on the drive list specifically - see
+  /// [SyncCubit.waitForDriveListRefresh] - and then separates the three:
+  /// still looking (the caller's [DriveDetailLoadInProgress] stands, and the
+  /// explorer says the drives are loading), looked and found nothing
+  /// ([DriveDetailLoadEmpty]), and could not look at all
+  /// ([DriveDetailDrivesUnavailable]).
+  Future<void> showEmptyDriveDetail() async {
     // Nothing to announce before this wait either. This runs when there is no
     // drive to show, from a state that is already DriveDetailLoadInProgress,
     // and all it can do afterwards is narrow that to "empty" - so emitting a
     // loading state here would claim work that is not happening.
-    await _syncCubit.waitCurrentSync();
+    await _syncCubit.waitForDriveListRefresh();
+
+    if (isClosed) {
+      return;
+    }
 
     // Check if state has already changed (e.g., drives were loaded during sync)
     // Don't overwrite a more specific state with the empty state.
@@ -227,7 +267,53 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
       return;
     }
 
+    // We asked and could not find out. Saying "you have no drives" here is the
+    // one answer that is certainly wrong.
+    if (_syncCubit.driveListRefreshFailed) {
+      emit(DriveDetailDrivesUnavailable());
+      return;
+    }
+
+    // And check, rather than infer. The login path only reaches here when
+    // DrivesCubit already said the list was empty, but `retryLoadingDrives`
+    // reaches it after a refresh that may well have found drives - and
+    // claiming emptiness there would show "Getting Started" to a user who has
+    // just been told their drives could not be loaded, which is the exact
+    // thing this whole change exists to stop.
+    final drives = await _driveDao.allDrives().get();
+    if (isClosed) return;
+
+    if (drives.isNotEmpty) {
+      // Somebody else owns the next state: DrivesCubit will select one and the
+      // page listener opens it.
+      return;
+    }
+
     emit(DriveDetailLoadEmpty());
+  }
+
+  /// Runs the drive-list refresh again after one failed, for the screen that
+  /// told the user it had.
+  ///
+  /// [SyncCubit.syncMetadataOnly] and nothing more: it is the same request
+  /// that failed, it is what the login path runs, and it leaves the user's
+  /// syncAllDrivesOnLogin preference alone. The explorer goes back to saying
+  /// the drives are loading while it runs, and lands on whichever of the three
+  /// answers is true afterwards.
+  Future<void> retryLoadingDrives() async {
+    if (state is! DriveDetailDrivesUnavailable) {
+      return;
+    }
+
+    emit(DriveDetailLoadInProgress());
+
+    await _syncCubit.syncMetadataOnly();
+
+    if (isClosed) {
+      return;
+    }
+
+    await showEmptyDriveDetail();
   }
 
   Future<void> changeDrive(String driveId) async {
@@ -850,7 +936,9 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
       if (hasRootFolderMetadata) {
         openFolder(folderId: rootFolderId, otherDriveId: driveId);
       } else {
-        emit(DriveDetailLoadUnsynced(drive: drive));
+        // Same as syncCurrentDrive: a sync has looked, so the card says so
+        // rather than repeating itself.
+        emit(DriveDetailLoadUnsynced(drive: drive, syncFoundNothing: true));
       }
     }
   }
@@ -911,8 +999,11 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
       if (isClosed || _driveId != driveId) return;
 
       if (!hasRootFolderMetadata) {
-        // Sync reported success but the drive's root metadata never arrived
-        emit(DriveDetailLoadUnsynced(drive: drive));
+        // The sync ran, finished, and the drive's root metadata still is not
+        // there. Re-emitting the plain unsynced card would put the user back
+        // on the screen they just pressed Sync Now on, with nothing to say the
+        // press did anything - so the card is told a sync has already looked.
+        emit(DriveDetailLoadUnsynced(drive: drive, syncFoundNothing: true));
         return;
       }
 

--- a/lib/blocs/drive_detail/drive_detail_state.dart
+++ b/lib/blocs/drive_detail/drive_detail_state.dart
@@ -151,20 +151,33 @@ class DriveDetailLoadUnsynced extends DriveDetailState {
   final bool showDriveInfo;
   final ArDriveDataTableItem? selectedItem;
 
+  /// Whether a sync has already been run against this drive and came back with
+  /// nothing.
+  ///
+  /// Without it the card the user pressed Sync Now on is re-rendered exactly
+  /// as it was, which reads as a button that did nothing - when what actually
+  /// happened is that the sync ran, finished, and found no root metadata on
+  /// chain to open. The card says that instead, so the user is not sent round
+  /// the same loop expecting a different answer.
+  final bool syncFoundNothing;
+
   DriveDetailLoadUnsynced({
     required this.drive,
     this.showDriveInfo = false,
     this.selectedItem,
+    this.syncFoundNothing = false,
   });
 
   DriveDetailLoadUnsynced copyWith({
     Drive? drive,
     bool? showDriveInfo,
     Object? selectedItem = _driveDetailAbsent,
+    bool? syncFoundNothing,
   }) {
     return DriveDetailLoadUnsynced(
       drive: drive ?? this.drive,
       showDriveInfo: showDriveInfo ?? this.showDriveInfo,
+      syncFoundNothing: syncFoundNothing ?? this.syncFoundNothing,
       selectedItem: identical(selectedItem, _driveDetailAbsent)
           ? this.selectedItem
           : selectedItem as ArDriveDataTableItem?,
@@ -172,9 +185,24 @@ class DriveDetailLoadUnsynced extends DriveDetailState {
   }
 
   @override
-  List<Object?> get props => [drive, showDriveInfo, selectedItem];
+  List<Object?> get props =>
+      [drive, showDriveInfo, selectedItem, syncFoundNothing];
 }
 
+/// The user genuinely has no drives - we looked, and there were none.
+///
+/// Only ever emitted after the drive list has actually been refreshed. It is
+/// the "Getting Started" screen, and getting here off an empty local database
+/// that nobody has filled in yet tells a user with drives that they have none.
 class DriveDetailLoadEmpty extends DriveDetailState {}
+
+/// The drive list could not be read at all.
+///
+/// The third thing an empty database can mean, and the one the app used to
+/// render as the second: we asked, and could not find out. It is not
+/// [DriveDetailLoadEmpty] - the user is not told they have no drives, and is
+/// not offered a drive to create - and it is not
+/// [DriveDetailLoadInProgress], because nothing is still running.
+class DriveDetailDrivesUnavailable extends DriveDetailState {}
 
 class DriveInitialLoading extends DriveDetailState {}

--- a/lib/blocs/drives/drives_cubit.dart
+++ b/lib/blocs/drives/drives_cubit.dart
@@ -6,7 +6,9 @@ import 'package:ardrive/blocs/prompt_to_snapshot/prompt_to_snapshot_bloc.dart';
 import 'package:ardrive/blocs/prompt_to_snapshot/prompt_to_snapshot_event.dart';
 import 'package:ardrive/core/activity_tracker.dart';
 import 'package:ardrive/models/models.dart';
+import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
 import 'package:ardrive/user/repositories/user_preferences_repository.dart';
+import 'package:ardrive/utils/logger.dart';
 import 'package:ardrive/utils/user_utils.dart';
 import 'package:ardrive_utils/ardrive_utils.dart';
 import 'package:drift/drift.dart';
@@ -24,6 +26,7 @@ class DrivesCubit extends Cubit<DrivesState> {
   final DriveDao _driveDao;
   final ArDriveAuth _auth;
   final UserPreferencesRepository _userPreferencesRepository;
+  final SyncCubit _syncCubit;
 
   late StreamSubscription _drivesSubscription;
   String? initialSelectedDriveId;
@@ -35,11 +38,13 @@ class DrivesCubit extends Cubit<DrivesState> {
     required DriveDao driveDao,
     required ActivityTracker activityTracker,
     required UserPreferencesRepository userPreferencesRepository,
+    required SyncCubit syncCubit,
   })  : _profileCubit = profileCubit,
         _promptToSnapshotBloc = promptToSnapshotBloc,
         _driveDao = driveDao,
         _auth = auth,
         _userPreferencesRepository = userPreferencesRepository,
+        _syncCubit = syncCubit,
         super(DrivesLoadInProgress()) {
     _auth.onAuthStateChanged().listen((user) {
       if (user == null) {
@@ -66,6 +71,43 @@ class DrivesCubit extends Cubit<DrivesState> {
       if (profileState is ProfileLoggingIn) {
         emit(DrivesLoadInProgress());
         return;
+      }
+
+      // An empty table is not the same as an empty account.
+      //
+      // Drift answers the instant it is asked, and on a login with an empty
+      // local database that answer lands long before `updateUserDrives` has
+      // said whether the user owns anything. Emitting it as
+      // `DrivesLoadSuccess` told the sidebar, the router and the explorer that
+      // the user has no drives - as a fact, not as a guess - for the whole
+      // length of the fetch. So when the table is empty, wait until the drive
+      // list has actually been looked at before answering.
+      //
+      // Only when it is empty. A returning user whose drives are already local
+      // gets the same immediate answer they always did, and never waits.
+      if (drives.isEmpty) {
+        try {
+          await _waitForDriveListRefresh();
+        } catch (e, stackTrace) {
+          // A wait that could not be completed is no reason to say nothing at
+          // all: fall through and answer with what the table holds, which is
+          // what this listener did before the wait existed.
+          logger.e('Could not wait for the drive list refresh', e, stackTrace);
+        }
+
+        if (isClosed) {
+          return;
+        }
+
+        // The refresh may have written the drives it found. If it did, the
+        // watch above has already re-fired with them and that firing owns the
+        // answer - this one is holding a snapshot that is now stale, and would
+        // report "none found" over the top of it.
+        final drivesAfterRefresh = await _driveDao.allDrives().get();
+
+        if (isClosed || drivesAfterRefresh.isNotEmpty) {
+          return;
+        }
       }
 
       String? selectedDriveId;
@@ -123,6 +165,20 @@ class DrivesCubit extends Cubit<DrivesState> {
       );
     });
   }
+
+  /// The single in-flight wait on the drive-list refresh.
+  ///
+  /// The watch feeding the listener can fire several times while the refresh
+  /// is still running - a ghost-folder write or a profile emission is enough -
+  /// and every firing runs the listener again without waiting for the last
+  /// one, because `Stream.listen` does not await an asynchronous callback.
+  /// Left alone each would open its own wait. One shared future keeps that
+  /// bounded; and because it stays completed once it completes, a later sync
+  /// cannot silence the sidebar again for a user whose drives are now known.
+  Future<void>? _driveListRefreshWait;
+
+  Future<void> _waitForDriveListRefresh() =>
+      _driveListRefreshWait ??= _syncCubit.waitForDriveListRefresh();
 
   void selectDrive(String driveId) {
     final profileIsLoggedIn = _profileCubit.state is ProfileLoggedIn;

--- a/lib/components/app_top_bar.dart
+++ b/lib/components/app_top_bar.dart
@@ -259,6 +259,15 @@ class SyncButton extends StatelessWidget {
         ? syncState
         : null;
 
+    // A sync that could not be done at all, as against one that got through
+    // some drives and not others. `syncMetadataOnly` is the only place this is
+    // terminal, and it is the whole of a default login - so without a branch
+    // for it the button fell through to the idle refresh icon and the app
+    // looked fully synced while showing nothing, permanently, with only a
+    // snackbar that had already gone. `autoSync` is false in all three
+    // flavours, so nothing was going to retry it either.
+    final failure = syncState is SyncFailure ? syncState : null;
+
     final isSyncing = syncState is SyncInProgress;
 
     final _SyncStatus? status;
@@ -293,17 +302,28 @@ class SyncButton extends StatelessWidget {
         detailMaxLines: 2,
       );
       indicator = ArDriveIcons.triangle(color: colorTokens.strokeRed);
+    } else if (failure != null) {
+      // The same surface, the same tokens and the same red triangle a partial
+      // failure gets: two ways of failing, reported one way.
+      status = _SyncStatus(
+        title: appLocalizationsOf(context).syncFailed,
+        detail: appLocalizationsOf(context).syncFailedDetail,
+        isError: true,
+        detailMaxLines: 2,
+      );
+      indicator = ArDriveIcons.triangle(color: colorTokens.strokeRed);
     } else {
       status = null;
       indicator = ArDriveIcons.refresh(color: colorTokens.textMid);
     }
 
     return SyncSummaryFlash(
-      announcement: _announcement(context, syncState, errors),
+      announcement: _announcement(context, syncState, errors, failure),
       child: _SyncButtonMenu(
         status: status,
         isSyncing: isSyncing,
         failedDriveIds: errors?.failedDriveIds,
+        refreshFailed: failure != null,
         child: indicator,
       ),
     );
@@ -314,6 +334,7 @@ class SyncButton extends StatelessWidget {
     BuildContext context,
     SyncState syncState,
     SyncCompleteWithErrors? errors,
+    SyncFailure? failure,
   ) {
     if (errors != null) {
       // Gated the same way a result is: SyncCompleteWithErrors stays the
@@ -336,6 +357,29 @@ class SyncButton extends StatelessWidget {
           errors.failedDrives,
           errors.totalDrives,
         ),
+        isError: true,
+      );
+    }
+
+    if (failure != null) {
+      // Gated off the moment of the failure, exactly like a partial one: the
+      // state stays current until something refreshes the drive list, so an
+      // announcement counted from build time would replay on every rebuild for
+      // the rest of the session. The indicator and the menu are what carry it
+      // after the few seconds are up.
+      final remaining = syncSummaryRemainingSince(failure.failedAt);
+      if (remaining == Duration.zero) {
+        return null;
+      }
+
+      return SyncAnnouncement(
+        // The timestamp, not the state: SyncFailure has no props, so every
+        // failure is equal to every other one and using the state itself would
+        // silence a second failure after an intervening SyncIdle.
+        identity: failure.failedAt,
+        showFor: remaining,
+        lead: appLocalizationsOf(context).syncFailed,
+        trailing: appLocalizationsOf(context).syncFailedDetail,
         isError: true,
       );
     }
@@ -577,6 +621,7 @@ class _SyncButtonMenu extends StatelessWidget {
     this.status,
     this.isSyncing = false,
     this.failedDriveIds,
+    this.refreshFailed = false,
     required this.child,
   });
 
@@ -593,6 +638,11 @@ class _SyncButtonMenu extends StatelessWidget {
   /// The drives a background sync failed on, when it did: the retry has to
   /// outlive the few seconds the announcement gets.
   final List<String>? failedDriveIds;
+
+  /// Whether the drive-list refresh itself failed, so the menu carries a way
+  /// to run it again. There are no failed drive ids to retry in this case -
+  /// the sync never got as far as a drive.
+  final bool refreshFailed;
 
   final Widget child;
 
@@ -646,6 +696,20 @@ class _SyncButtonMenu extends StatelessWidget {
             name: appLocalizationsOf(context).retryFailedDrives,
             isDisabled: isSyncing,
             icon: ArDriveIcons.cloudSync(color: iconColor),
+          ),
+        ),
+      if (refreshFailed)
+        ArDriveDropdownItem(
+          // `syncMetadataOnly` and nothing more: it is the request that
+          // failed, and it leaves the user's syncAllDrivesOnLogin preference
+          // alone. Resync, one row up, is still there for a full one.
+          onClick: isSyncing
+              ? null
+              : () => context.read<SyncCubit>().syncMetadataOnly(),
+          content: ArDriveDropdownItemTile(
+            name: appLocalizationsOf(context).tryAgain,
+            isDisabled: isSyncing,
+            icon: ArDriveIcons.refresh(color: iconColor),
           ),
         ),
     ];

--- a/lib/components/side_bar.dart
+++ b/lib/components/side_bar.dart
@@ -110,6 +110,9 @@ class _AppSideBarState extends State<AppSideBar> {
                             ),
                           );
                         }
+                        if (state is DrivesLoadInProgress) {
+                          return const _DrivesStillLoading();
+                        }
                         return const SizedBox();
                       },
                     ),
@@ -208,6 +211,11 @@ class _AppSideBarState extends State<AppSideBar> {
                                               state: state,
                                             ),
                                           ),
+                                        );
+                                      }
+                                      if (state is DrivesLoadInProgress) {
+                                        return const _DrivesStillLoading(
+                                          leftPadding: 43,
                                         );
                                       }
                                       return const SizedBox();
@@ -848,3 +856,45 @@ class _Accordion extends StatelessWidget {
   }
 }
 //
+
+/// What the drive list shows before it knows what is in it.
+///
+/// The nav used to render nothing here, which is indistinguishable from a
+/// wallet with no drives - and that is exactly what a returning user sees on a
+/// device the app has not read yet. It says which it is now.
+class _DrivesStillLoading extends StatelessWidget {
+  const _DrivesStillLoading({this.leftPadding = 0});
+
+  final double leftPadding;
+
+  @override
+  Widget build(BuildContext context) {
+    final typography = ArDriveTypographyNew.of(context);
+    final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
+
+    return Padding(
+      padding: EdgeInsets.only(left: leftPadding, top: 8, bottom: 8),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SizedBox(
+            width: 12,
+            height: 12,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              valueColor: AlwaysStoppedAnimation<Color>(colorTokens.textLow),
+            ),
+          ),
+          const SizedBox(width: 10),
+          Flexible(
+            child: Text(
+              appLocalizationsOf(context).loadingYourDrives,
+              style: typography.paragraphSmall(color: colorTokens.textLow),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -641,6 +641,26 @@
   "@driveNotSyncedDescription": {
     "description": "Description shown when a drive has not been synced yet"
   },
+  "driveSyncFoundNothing": "Nothing Found Yet",
+  "@driveSyncFoundNothing": {
+    "description": "Title of the unsynced drive card after a sync has already run against it and found no root metadata, so the card does not repeat the screen the user just pressed Sync Now on"
+  },
+  "driveSyncFoundNothingDescription": "The sync finished, but nothing for this drive has appeared on Arweave yet. A drive created moments ago can take a few minutes to show up.",
+  "@driveSyncFoundNothingDescription": {
+    "description": "Says what the sync actually did, so a second identical card does not read as a button that did nothing"
+  },
+  "checkAgain": "Check Again",
+  "@checkAgain": {
+    "description": "Action on the unsynced drive card once a sync has already looked and found nothing. Deliberately not Sync Now, which was the button that was already pressed"
+  },
+  "driveListUnavailable": "Your Drives Could Not Be Loaded",
+  "@driveListUnavailable": {
+    "description": "Shown when the drive list could not be read at all. Never says the user has no drives - we do not know whether they do"
+  },
+  "driveListUnavailableDescription": "We could not reach the network to read your drive list. Your drives are safe and nothing has been lost.",
+  "@driveListUnavailableDescription": {
+    "description": "Explains that a drive list that could not be loaded is a network problem, not a missing drive"
+  },
   "driveWillOpenWhenSyncFinishes": "{driveName} will open when the sync finishes",
   "@driveWillOpenWhenSyncFinishes": {
     "description": "Shown in the explorer while a background sync is running and a drive is waiting on it, so the wait says which drive it is for and that nothing needs to be clicked again",
@@ -652,6 +672,10 @@
     }
   },
   "syncThisDriveDescription": "Fetch the latest files and folders from this drive.",
+  "syncThisDriveCheckAgainDescription": "Look again for this drive's files and folders on Arweave.",
+  "@syncThisDriveCheckAgainDescription": {
+    "description": "Action tile description on the card shown after a sync found nothing for this drive"
+  },
   "@syncThisDriveDescription": {
     "description": "Description for the sync drive action card"
   },
@@ -2803,6 +2827,14 @@
   "retryFailedDrives": "Retry Failed",
   "@retryFailedDrives": {
     "description": "Button to retry syncing only the drives that failed"
+  },
+  "syncFailed": "Drives Could Not Be Loaded",
+  "@syncFailed": {
+    "description": "Top bar title for a sync that could not be done at all, as against one that got through some drives and not others"
+  },
+  "syncFailedDetail": "We could not reach the network to read your drive list.",
+  "@syncFailedDetail": {
+    "description": "What a failed sync means for what is on screen: the drive list is whatever was last read, not what is out there"
   },
   "syncDrivesFailed": "{failed} of {total} drives could not be synced",
   "@syncDrivesFailed": {

--- a/lib/pages/app_router_delegate.dart
+++ b/lib/pages/app_router_delegate.dart
@@ -376,6 +376,7 @@ class AppRouterDelegate extends RouterDelegate<AppRoutePath>
                             context.read<PromptToSnapshotBloc>(),
                         userPreferencesRepository:
                             context.read<UserPreferencesRepository>(),
+                        syncCubit: context.read<SyncCubit>(),
                       ),
                     ),
                     BlocProvider<PrivateDriveMigrationBloc>(

--- a/lib/pages/drive_detail/components/drive_detail_syncing_card.dart
+++ b/lib/pages/drive_detail/components/drive_detail_syncing_card.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:ardrive/blocs/drive_detail/drive_detail_cubit.dart';
 import 'package:ardrive/blocs/drives/drives_cubit.dart';
 import 'package:ardrive/components/progress_bar.dart';
 import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
@@ -38,8 +39,24 @@ const double _syncingContentMaxWidth = 420;
 /// the same slot for a drive that has *not* been synced: that one is a decision
 /// the user has to make and is drawn as one, with headline type and two action
 /// cards. This is a wait, and asks for nothing.
+///
+/// It has a second job, in the same frame: the drive list could not be read at
+/// all - `DriveDetailDrivesUnavailable`. That is the third thing an empty
+/// local database can mean, and until now the app rendered it as the second
+/// ("Getting Started", two create-a-drive buttons). It belongs here rather
+/// than in a screen of its own because it is the same sentence at the end of
+/// the same wait, in the same panel, and it must not offer to create a drive
+/// or claim the user has none.
 class DriveDetailSyncingCard extends StatefulWidget {
-  const DriveDetailSyncingCard({super.key});
+  const DriveDetailSyncingCard({super.key}) : driveListUnavailable = false;
+
+  /// The drive list could not be loaded: no progress, no phase, no elapsed
+  /// time - nothing is running - just what happened and a way to try again.
+  const DriveDetailSyncingCard.driveListUnavailable({super.key})
+      : driveListUnavailable = true;
+
+  /// Which of the panel's two jobs this is.
+  final bool driveListUnavailable;
 
   @override
   State<DriveDetailSyncingCard> createState() => _DriveDetailSyncingCardState();
@@ -106,6 +123,10 @@ class _DriveDetailSyncingCardState extends State<DriveDetailSyncingCard> {
 
   @override
   Widget build(BuildContext context) {
+    if (widget.driveListUnavailable) {
+      return _frame(context, _unavailableContent(context));
+    }
+
     return BlocBuilder<SyncCubit, SyncState>(
       builder: (context, syncState) {
         final isSyncing = _isSyncing(syncState);
@@ -126,32 +147,100 @@ class _DriveDetailSyncingCardState extends State<DriveDetailSyncingCard> {
                   driveName: _driveName(drivesState, snapshot.data),
                 );
 
-                return ScreenTypeLayout.builder(
-                  mobile: (context) => content,
-                  // The card the explorer's other full-panel states use on a
-                  // wide screen, so the frame does not change shape when this
-                  // becomes a folder listing or an unsynced drive.
-                  desktop: (context) => Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 20),
-                    child: SizedBox(
-                      height: MediaQuery.of(context).size.height * 0.8,
-                      child: ArDriveCard(
-                        width: double.infinity,
-                        backgroundColor: ArDriveTheme.of(context)
-                            .themeData
-                            .colorTokens
-                            .containerL1,
-                        content: content,
-                      ),
-                    ),
-                  ),
-                );
+                return _frame(context, content);
               },
             );
           },
         );
       },
     );
+  }
+
+  /// The shape every state of this panel is drawn in.
+  ///
+  /// The card the explorer's other full-panel states use on a wide screen, so
+  /// the frame does not change shape when this becomes a folder listing, an
+  /// unsynced drive, or the report that the drive list could not be read.
+  Widget _frame(BuildContext context, Widget content) {
+    return ScreenTypeLayout.builder(
+      mobile: (context) => content,
+      desktop: (context) => Padding(
+        padding: const EdgeInsets.symmetric(vertical: 20),
+        child: SizedBox(
+          height: MediaQuery.of(context).size.height * 0.8,
+          child: ArDriveCard(
+            width: double.infinity,
+            backgroundColor:
+                ArDriveTheme.of(context).themeData.colorTokens.containerL1,
+            content: content,
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// The centred, width-capped, scrollable column both states lay themselves
+  /// out in, so a 320px phone and a large text scale scroll rather than
+  /// overflow.
+  Widget _panel(List<Widget> children) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return SingleChildScrollView(
+          child: ConstrainedBox(
+            constraints: BoxConstraints(minHeight: constraints.maxHeight),
+            child: Center(
+              child: Padding(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(
+                    maxWidth: _syncingContentMaxWidth,
+                  ),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: children,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  /// What the panel says when the drive list could not be read.
+  ///
+  /// Three things it deliberately does not do: claim the user has no drives,
+  /// offer to create one, and show a bar. Nothing is running, so there is
+  /// nothing to fill.
+  Widget _unavailableContent(BuildContext context) {
+    final typography = ArDriveTypographyNew.of(context);
+    final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
+
+    return _panel([
+      Text(
+        appLocalizationsOf(context).driveListUnavailable,
+        style: typography.heading4(fontWeight: ArFontWeight.bold),
+        textAlign: TextAlign.center,
+      ),
+      const SizedBox(height: 8),
+      Text(
+        appLocalizationsOf(context).driveListUnavailableDescription,
+        style: typography.paragraphLarge(
+          color: colorTokens.textLow,
+          fontWeight: ArFontWeight.semiBold,
+        ),
+        textAlign: TextAlign.center,
+      ),
+      const SizedBox(height: 24),
+      ArDriveButtonNew(
+        text: appLocalizationsOf(context).tryAgain,
+        typography: typography,
+        variant: ButtonVariant.primary,
+        onPressed: () => context.read<DriveDetailCubit>().retryLoadingDrives(),
+      ),
+    ]);
   }
 
   /// The drive the user is waiting for, when anything on screen already knows
@@ -232,80 +321,55 @@ class _DriveDetailSyncingCardState extends State<DriveDetailSyncingCard> {
                 ));
     }
 
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        return SingleChildScrollView(
-          child: ConstrainedBox(
-            constraints: BoxConstraints(minHeight: constraints.maxHeight),
-            child: Center(
-              child: Padding(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
-                child: ConstrainedBox(
-                  constraints: const BoxConstraints(
-                    maxWidth: _syncingContentMaxWidth,
-                  ),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(
-                        title,
-                        style: typography.heading4(
-                          fontWeight: ArFontWeight.bold,
-                        ),
-                        textAlign: TextAlign.center,
-                      ),
-                      if (subtitle != null) ...[
-                        const SizedBox(height: 8),
-                        Text(
-                          subtitle,
-                          style: typography.paragraphLarge(
-                            color: colorTokens.textLow,
-                            fontWeight: ArFontWeight.semiBold,
-                          ),
-                          textAlign: TextAlign.center,
-                        ),
-                      ],
-                      const SizedBox(height: 24),
-                      // The modal's bar, not a second one: it already knows
-                      // not to claim a number during a phase that cannot
-                      // measure itself, and not to rewind when one ends.
-                      ProgressBar(
-                        // Keyed so the Column matches it by identity, not by
-                        // position. When the sync ends, subtitle, detail and
-                        // the elapsed line all disappear at once and the
-                        // children list shrinks; an unkeyed bar would be
-                        // matched against a different widget, destroyed, and
-                        // remounted at its mount-time seed - a bar animating
-                        // backwards from 99%, which is the exact thing the
-                        // sink beneath it exists to prevent.
-                        key: const ValueKey('driveDetailSyncProgress'),
-                        percentage: _progress,
-                        initialPercentage: _initialProgress,
-                      ),
-                      if (detail != null) ...[
-                        const SizedBox(height: 12),
-                        Text(
-                          detail,
-                          style: typography.paragraphNormal(
-                            color: colorTokens.textMid,
-                          ),
-                          textAlign: TextAlign.center,
-                        ),
-                      ],
-                      if (showElapsed) ...[
-                        const SizedBox(height: 4),
-                        const SyncElapsedTime(),
-                      ],
-                    ],
-                  ),
-                ),
-              ),
-            ),
+    return _panel([
+      Text(
+        title,
+        style: typography.heading4(
+          fontWeight: ArFontWeight.bold,
+        ),
+        textAlign: TextAlign.center,
+      ),
+      if (subtitle != null) ...[
+        const SizedBox(height: 8),
+        Text(
+          subtitle,
+          style: typography.paragraphLarge(
+            color: colorTokens.textLow,
+            fontWeight: ArFontWeight.semiBold,
           ),
-        );
-      },
-    );
+          textAlign: TextAlign.center,
+        ),
+      ],
+      const SizedBox(height: 24),
+      // The modal's bar, not a second one: it already knows not to claim a
+      // number during a phase that cannot measure itself, and not to rewind
+      // when one ends.
+      ProgressBar(
+        // Keyed so the Column matches it by identity, not by position. When
+        // the sync ends, subtitle, detail and the elapsed line all disappear
+        // at once and the children list shrinks; an unkeyed bar would be
+        // matched against a different widget, destroyed, and remounted at its
+        // mount-time seed - a bar animating backwards from 99%, which is the
+        // exact thing the sink beneath it exists to prevent.
+        key: const ValueKey('driveDetailSyncProgress'),
+        percentage: _progress,
+        initialPercentage: _initialProgress,
+      ),
+      if (detail != null) ...[
+        const SizedBox(height: 12),
+        Text(
+          detail,
+          style: typography.paragraphNormal(
+            color: colorTokens.textMid,
+          ),
+          textAlign: TextAlign.center,
+        ),
+      ],
+      if (showElapsed) ...[
+        const SizedBox(height: 4),
+        const SyncElapsedTime(),
+      ],
+    ]);
   }
 }
 

--- a/lib/pages/drive_detail/components/drive_detail_unsynced_card.dart
+++ b/lib/pages/drive_detail/components/drive_detail_unsynced_card.dart
@@ -164,9 +164,13 @@ class _UnsyncedDriveMobileView extends StatelessWidget {
   final Drive drive;
   final bool isOwner;
 
+  /// See [DriveDetailUnsyncedCard.syncFoundNothing].
+  final bool syncFoundNothing;
+
   const _UnsyncedDriveMobileView({
     required this.drive,
     required this.isOwner,
+    this.syncFoundNothing = false,
   });
 
   @override
@@ -209,7 +213,10 @@ class _UnsyncedDriveMobileView extends StatelessWidget {
         ),
         // Content area
         Expanded(
-          child: DriveDetailUnsyncedCard(drive: drive),
+          child: DriveDetailUnsyncedCard(
+            drive: drive,
+            syncFoundNothing: syncFoundNothing,
+          ),
         ),
       ],
     );
@@ -305,10 +312,32 @@ class _UnsyncedDriveMobileView extends StatelessWidget {
 class DriveDetailUnsyncedCard extends StatelessWidget {
   final Drive drive;
 
+  /// Whether a sync has already run against this drive and come back with
+  /// nothing.
+  ///
+  /// The card is the same card either way - same frame, same two actions - but
+  /// it does not repeat itself. Before a sync it says the drive needs one;
+  /// after one that found no root metadata it says the sync ran and what it
+  /// found, and the primary action stops being the button that was already
+  /// pressed. Rendering the identical card twice reads as a Sync Now that did
+  /// nothing.
+  final bool syncFoundNothing;
+
   const DriveDetailUnsyncedCard({
     super.key,
     required this.drive,
+    this.syncFoundNothing = false,
   });
+
+  /// What this drive's situation is, in a headline.
+  String _title(BuildContext context) => syncFoundNothing
+      ? appLocalizationsOf(context).driveSyncFoundNothing
+      : appLocalizationsOf(context).driveNotSynced;
+
+  /// And what to do about it.
+  String _description(BuildContext context) => syncFoundNothing
+      ? appLocalizationsOf(context).driveSyncFoundNothingDescription
+      : appLocalizationsOf(context).driveNotSyncedDescription;
 
   @override
   Widget build(BuildContext context) {
@@ -327,7 +356,7 @@ class DriveDetailUnsyncedCard extends StatelessWidget {
         children: [
           const SizedBox(height: 40),
           Text(
-            appLocalizationsOf(context).driveNotSynced,
+            _title(context),
             style: typography.heading4(fontWeight: ArFontWeight.bold),
             textAlign: TextAlign.center,
           ),
@@ -335,7 +364,7 @@ class DriveDetailUnsyncedCard extends StatelessWidget {
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),
             child: Text(
-              appLocalizationsOf(context).driveNotSyncedDescription,
+              _description(context),
               style: typography.paragraphLarge(
                 color: colorTokens.textLow,
                 fontWeight: ArFontWeight.semiBold,
@@ -372,14 +401,15 @@ class DriveDetailUnsyncedCard extends StatelessWidget {
                 child: Column(
                   children: [
                     Text(
-                      appLocalizationsOf(context).driveNotSynced,
+                      _title(context),
                       style: typography.display(
                         fontWeight: ArFontWeight.bold,
                       ),
+                      textAlign: TextAlign.center,
                     ),
                     const SizedBox(height: 10),
                     Text(
-                      appLocalizationsOf(context).driveNotSyncedDescription,
+                      _description(context),
                       style: typography.heading5(
                         color: colorTokens.textLow,
                         fontWeight: ArFontWeight.semiBold,
@@ -424,7 +454,9 @@ class DriveDetailUnsyncedCard extends StatelessWidget {
           ),
           const SizedBox(height: 10),
           Text(
-            appLocalizationsOf(context).syncThisDriveDescription,
+            syncFoundNothing
+                ? appLocalizationsOf(context).syncThisDriveCheckAgainDescription
+                : appLocalizationsOf(context).syncThisDriveDescription,
             style: typography.paragraphNormal(
               color: colorTokens.textMid,
               fontWeight: ArFontWeight.semiBold,
@@ -433,7 +465,13 @@ class DriveDetailUnsyncedCard extends StatelessWidget {
           ),
           const SizedBox(height: 20),
           ArDriveButtonNew(
-            text: appLocalizationsOf(context).syncNow,
+            // Not "Sync Now" a second time: that button has been pressed, and
+            // offering it again unchanged is what made the screen read as a
+            // loop. Checking again is worth doing - a drive created moments
+            // ago does turn up - so the action stays, under its real name.
+            text: syncFoundNothing
+                ? appLocalizationsOf(context).checkAgain
+                : appLocalizationsOf(context).syncNow,
             typography: typography,
             onPressed: () {
               context.read<DriveDetailCubit>().syncCurrentDrive();

--- a/lib/pages/drive_detail/drive_detail_page.dart
+++ b/lib/pages/drive_detail/drive_detail_page.dart
@@ -208,6 +208,31 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
                           ],
                         ),
                       );
+                    } else if (driveDetailState
+                        is DriveDetailDrivesUnavailable) {
+                      // The same chrome and the same panel as the wait above,
+                      // because it is the end of that wait - only the words
+                      // change. Notably NOT NoDrivesPage: we do not know that
+                      // the user has no drives, so we do not say so and do not
+                      // put two create-a-drive buttons where the answer should
+                      // be.
+                      return ScreenTypeLayout.builder(
+                        mobile: (context) => const Scaffold(
+                          drawerScrimColor: Colors.transparent,
+                          drawer: AppSideBar(),
+                          appBar: MobileAppBar(),
+                          body: DriveDetailSyncingCard.driveListUnavailable(),
+                        ),
+                        desktop: (context) => const Column(
+                          children: [
+                            AppTopBar(),
+                            Expanded(
+                              child:
+                                  DriveDetailSyncingCard.driveListUnavailable(),
+                            ),
+                          ],
+                        ),
+                      );
                     } else if (driveDetailState is DriveInitialLoading) {
                       return ArDriveDevToolsShortcuts(
                         customShortcuts: [
@@ -304,6 +329,8 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
                               body: _UnsyncedDriveMobileView(
                                 drive: driveDetailState.drive,
                                 isOwner: isOwner,
+                                syncFoundNothing:
+                                    driveDetailState.syncFoundNothing,
                               ),
                             );
                           },
@@ -330,6 +357,9 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
                                             Expanded(
                                               child: DriveDetailUnsyncedCard(
                                                 drive: driveDetailState.drive,
+                                                syncFoundNothing:
+                                                    driveDetailState
+                                                        .syncFoundNothing,
                                               ),
                                             ),
                                           ],

--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -154,15 +154,63 @@ class SyncCubit extends Cubit<SyncState> {
     }
   }
 
+  /// Whether the drive list itself has been refreshed.
+  ///
+  /// A different question from [_syncHasFinished], and deliberately so.
+  /// `SyncLoadingDrives` counts as finished there because a folder open must
+  /// not hang behind a metadata refresh - but that is exactly the state a
+  /// login sync sits in while `updateUserDrives` is still running, so anything
+  /// asking "does this user have drives?" gets its answer from an empty table
+  /// nobody has filled in yet. `SyncInProgress` blocks too: a full sync
+  /// refreshes the list on its way through, so a wait that returned during one
+  /// would be reading the same half-written table.
+  static bool _driveListRefreshHasFinished(SyncState state) =>
+      state is! SyncLoadingDrives && state is! SyncInProgress;
+
+  /// Waits for the drive list to have actually been looked at.
+  ///
+  /// For the one caller that needs it: the screen that would otherwise tell a
+  /// user with drives that they have none. Everything else still waits on
+  /// [waitCurrentSync], which stays non-blocking during a metadata refresh.
+  Future<void> waitForDriveListRefresh() async {
+    if (_driveListRefreshHasFinished(state)) return;
+
+    await for (final state in stream) {
+      if (_driveListRefreshHasFinished(state)) break;
+    }
+  }
+
+  /// Whether the last thing this cubit did to the drive list failed.
+  ///
+  /// [SyncFailure] is the only terminal failure state - `onError` emits it and
+  /// then `SyncIdle` in the same turn - so it means precisely "the drive-list
+  /// refresh could not be done", which is what the explorer needs to know
+  /// before it claims the user has no drives.
+  bool get driveListRefreshFailed => state is SyncFailure;
+
   void createSyncStream() async {
     logger.d('Creating sync stream to periodically call sync automatically');
 
     // Note: Initial state is already SyncLoadingDrives (set in constructor)
     // to prevent race conditions with waitCurrentSync()
 
-    // Check if syncAllDrivesOnLogin preference is enabled before initial sync
-    final preferences = await _userPreferencesRepository.load();
-    if (preferences.syncAllDrivesOnLogin) {
+    // Check if syncAllDrivesOnLogin preference is enabled before initial sync.
+    //
+    // A local read that throws must not strand the app: the cubit starts in
+    // SyncLoadingDrives, and anything waiting on the drive-list refresh waits
+    // on leaving that state - so a throw here would pin the explorer on
+    // "Loading your drives..." with nothing to end it. Falling back to the
+    // shipped default keeps the login moving.
+    bool syncAllDrivesOnLogin;
+    try {
+      syncAllDrivesOnLogin =
+          (await _userPreferencesRepository.load()).syncAllDrivesOnLogin;
+    } catch (e, stackTrace) {
+      logger.e('Could not read preferences on login', e, stackTrace);
+      syncAllDrivesOnLogin = false;
+    }
+
+    if (syncAllDrivesOnLogin) {
       // Start initial sync immediately without waiting for async operations.
       // Skip tab visibility check for initial sync because the user just logged in
       // (which requires wallet interaction, proving they're active). The wallet popup

--- a/lib/sync/domain/cubit/sync_state.dart
+++ b/lib/sync/domain/cubit/sync_state.dart
@@ -24,11 +24,25 @@ class SyncInProgress extends SyncState {
   List<Object> get props => [trigger];
 }
 
+/// A sync that could not be done at all, as against one that got through some
+/// drives and not others - see [SyncCompleteWithErrors].
+///
+/// `syncMetadataOnly` is the only place this is terminal: everywhere else
+/// `onError` emits it and `SyncIdle` in the same turn, so it flashes past.
+/// Terminal is what makes it worth reporting - it means the drive list itself
+/// could not be read, and stays true until something refreshes it.
 class SyncFailure extends SyncState {
   final Object? error;
   final StackTrace? stackTrace;
 
-  SyncFailure({this.error, this.stackTrace});
+  /// When it failed, on the same terms as [SyncCompleteWithErrors.completedAt]
+  /// and deliberately out of [props] for the same reason: the top bar's
+  /// announcement is entitled to a few seconds from the moment of the failure,
+  /// not a fresh few seconds every time something rebuilds the bar.
+  final DateTime failedAt;
+
+  SyncFailure({this.error, this.stackTrace, DateTime? failedAt})
+      : failedAt = failedAt ?? DateTime.now();
 }
 
 class SyncEmpty extends SyncState {}

--- a/test/blocs/drive_detail/drive_detail_cubit_test.dart
+++ b/test/blocs/drive_detail/drive_detail_cubit_test.dart
@@ -495,4 +495,229 @@ void main() {
       expect((state as DriveDetailLoadSuccess).currentDrive.id, otherDriveId);
     });
   });
+
+  /// What an empty local database means, which is three different things.
+  ///
+  /// The app used to render all three as one: "Getting Started", two
+  /// create-a-drive buttons and an empty sidebar, on EVERY login with an empty
+  /// database, for the whole length of the drive-list fetch, on the success
+  /// path. `DrivesCubit` reports Drift's immediate empty-table read before
+  /// `updateUserDrives` has returned anything, and the wait in
+  /// `showEmptyDriveDetail` did not cover that fetch.
+  group('DriveDetailCubit and an empty drive list', () {
+    /// The cubit as the explorer builds it when there is no drive to show at
+    /// all - the state a fresh login lands in before the drive list arrives.
+    DriveDetailCubit buildCubitWithNoDrive() => DriveDetailCubit(
+          driveId: '',
+          profileCubit: profileCubit,
+          driveDao: driveDao,
+          configService: configService,
+          activityTracker: activityTracker,
+          auth: auth,
+          breadcrumbBuilder: breadcrumbBuilder,
+          syncCubit: syncCubit,
+          driveRepository: driveRepository,
+        );
+
+    /// The drive-list refresh, under the test's control: it finishes when the
+    /// test says it has, and not before.
+    late Completer<void> driveListRead;
+
+    setUp(() {
+      driveListRead = Completer<void>();
+      when(() => syncCubit.waitForDriveListRefresh())
+          .thenAnswer((_) => driveListRead.future);
+      when(() => syncCubit.driveListRefreshFailed).thenReturn(false);
+      when(() => syncCubit.syncMetadataOnly()).thenAnswer((_) async {});
+    });
+
+    test('does not say the user has no drives while the list is still loading',
+        () async {
+      final cubit = buildCubitWithNoDrive();
+      addTearDown(cubit.close);
+
+      final emitted = <DriveDetailState>[];
+      final subscription = cubit.stream.listen(emitted.add);
+      addTearDown(subscription.cancel);
+
+      unawaited(cubit.showEmptyDriveDetail());
+      await pumpEventQueue(times: 100);
+
+      // Nothing has read the drive list, so nothing may claim it is empty.
+      // The explorer stays on the panel that says the drives are loading.
+      expect(cubit.state, isA<DriveDetailLoadInProgress>());
+      expect(
+        emitted.whereType<DriveDetailLoadEmpty>(),
+        isEmpty,
+        reason: '"Getting Started" is a claim about a list nobody has read',
+      );
+    });
+
+    test('says the user has no drives once the list has actually been read',
+        () async {
+      final cubit = buildCubitWithNoDrive();
+      addTearDown(cubit.close);
+
+      unawaited(cubit.showEmptyDriveDetail());
+      await pumpEventQueue(times: 100);
+      expect(cubit.state, isA<DriveDetailLoadInProgress>(),
+          reason: 'precondition: the refresh has not finished yet');
+
+      driveListRead.complete();
+      await pumpEventQueue(times: 100);
+
+      // The screen is still right for the user it was written for.
+      expect(cubit.state, isA<DriveDetailLoadEmpty>());
+    });
+
+    test('a refresh that failed is not a user with no drives', () async {
+      when(() => syncCubit.driveListRefreshFailed).thenReturn(true);
+
+      final cubit = buildCubitWithNoDrive();
+      addTearDown(cubit.close);
+
+      final emitted = <DriveDetailState>[];
+      final subscription = cubit.stream.listen(emitted.add);
+      addTearDown(subscription.cancel);
+
+      driveListRead.complete();
+      await cubit.showEmptyDriveDetail();
+      await pumpEventQueue(times: 100);
+
+      expect(cubit.state, isA<DriveDetailDrivesUnavailable>());
+      expect(
+        emitted.whereType<DriveDetailLoadEmpty>(),
+        isEmpty,
+        reason: 'we could not find out, so we must not answer',
+      );
+    });
+
+    test('a retry that succeeds gets the user off the failure screen',
+        () async {
+      when(() => syncCubit.driveListRefreshFailed).thenReturn(true);
+
+      final cubit = buildCubitWithNoDrive();
+      addTearDown(cubit.close);
+
+      driveListRead.complete();
+      await cubit.showEmptyDriveDetail();
+      await pumpEventQueue(times: 100);
+      expect(cubit.state, isA<DriveDetailDrivesUnavailable>(),
+          reason: 'precondition: the refresh failed');
+
+      // The retry runs the request that failed, and this time it works.
+      when(() => syncCubit.syncMetadataOnly()).thenAnswer((_) async {
+        when(() => syncCubit.driveListRefreshFailed).thenReturn(false);
+      });
+
+      final emitted = <DriveDetailState>[];
+      final subscription = cubit.stream.listen(emitted.add);
+      addTearDown(subscription.cancel);
+
+      await cubit.retryLoadingDrives();
+      await pumpEventQueue(times: 100);
+
+      verify(() => syncCubit.syncMetadataOnly()).called(1);
+      // It says it is working again before it lands anywhere.
+      expect(emitted.first, isA<DriveDetailLoadInProgress>());
+      expect(cubit.state, isA<DriveDetailLoadEmpty>());
+    });
+
+    test('a retry that finds drives does not claim the user has none',
+        () async {
+      // The bug this pins: showEmptyDriveDetail claimed emptiness from the
+      // cubit's own state and never asked whether drives existed. On the
+      // login path DrivesCubit had already established that; on the retry
+      // path nothing had - so a Try Again that WORKED showed "Getting
+      // Started / Create a new drive" to a user who had just been told their
+      // drives could not be loaded.
+      when(() => syncCubit.driveListRefreshFailed).thenReturn(true);
+
+      final cubit = buildCubitWithNoDrive();
+      addTearDown(cubit.close);
+
+      driveListRead.complete();
+      await cubit.showEmptyDriveDetail();
+      await pumpEventQueue(times: 100);
+      expect(cubit.state, isA<DriveDetailDrivesUnavailable>(),
+          reason: 'precondition: the refresh failed');
+
+      // This time the retry succeeds AND the drive list turns out to have
+      // drives in it.
+      when(() => syncCubit.syncMetadataOnly()).thenAnswer((_) async {
+        await insertDrive(lastBlockHeight: 0);
+        when(() => syncCubit.driveListRefreshFailed).thenReturn(false);
+      });
+
+      await cubit.retryLoadingDrives();
+      await pumpEventQueue(times: 100);
+
+      expect(cubit.state, isNot(isA<DriveDetailLoadEmpty>()),
+          reason: 'told a user with drives that they have none');
+    });
+
+    test('a refresh that succeeds anywhere clears the failure screen',
+        () async {
+      // The top bar has its own Try Again, which calls syncMetadataOnly
+      // directly. Without this the body went on saying the drives could not
+      // be loaded while the bar above it reported everything was fine.
+      when(() => syncCubit.driveListRefreshFailed).thenReturn(true);
+
+      final cubit = buildCubitWithNoDrive();
+      addTearDown(cubit.close);
+
+      driveListRead.complete();
+      await cubit.showEmptyDriveDetail();
+      await pumpEventQueue(times: 100);
+      expect(cubit.state, isA<DriveDetailDrivesUnavailable>());
+
+      // The refresh succeeds somewhere else entirely.
+      when(() => syncCubit.driveListRefreshFailed).thenReturn(false);
+      syncStates.add(SyncIdle());
+      await pumpEventQueue(times: 100);
+
+      expect(cubit.state, isNot(isA<DriveDetailDrivesUnavailable>()),
+          reason: 'the failure screen outlived the failure');
+    });
+  });
+
+  /// A sync that ran, finished and found nothing must not be rendered as a
+  /// sync that never happened.
+  group('DriveDetailCubit after a sync that found nothing', () {
+    test('says the sync looked, rather than re-offering the same card',
+        () async {
+      await insertDrive(lastBlockHeight: 0);
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      final before = cubit.state;
+      expect(before, isA<DriveDetailLoadUnsynced>(),
+          reason: 'precondition: the drive starts out unsynced');
+      expect((before as DriveDetailLoadUnsynced).syncFoundNothing, isFalse,
+          reason: 'precondition: nothing has been synced yet');
+
+      // The sync runs to the end and writes no root revision - the drive's
+      // metadata simply is not out there yet.
+      when(() => syncCubit.startSyncForDrive(
+            driveId: any(named: 'driveId'),
+            deepSync: any(named: 'deepSync'),
+            trigger: any(named: 'trigger'),
+          )).thenAnswer((_) async {});
+      when(() => syncCubit.state).thenReturn(SyncIdle());
+
+      await cubit.syncCurrentDrive();
+      await pumpEventQueue(times: 100);
+
+      final after = cubit.state;
+      expect(after, isA<DriveDetailLoadUnsynced>());
+      expect(
+        (after as DriveDetailLoadUnsynced).syncFoundNothing,
+        isTrue,
+        reason: 'the card the user pressed Sync Now on must not come back '
+            'word for word, as though the press did nothing',
+      );
+    });
+  });
 }

--- a/test/blocs/drives_cubit_test.dart
+++ b/test/blocs/drives_cubit_test.dart
@@ -1,15 +1,20 @@
-@Tags(['broken'])
+import 'dart:async';
 
 import 'package:ardrive/blocs/blocs.dart';
-import 'package:ardrive/blocs/prompt_to_snapshot/prompt_to_snapshot_bloc.dart';
 import 'package:ardrive/core/activity_tracker.dart';
 import 'package:ardrive/models/models.dart';
+import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
 import 'package:ardrive/user/repositories/user_preferences_repository.dart';
+import 'package:ardrive/user/user.dart';
+import 'package:ardrive/user/user_preferences.dart';
+import 'package:ardrive_ui/ardrive_ui.dart';
+import 'package:ardrive_utils/ardrive_utils.dart';
 import 'package:bloc_test/bloc_test.dart';
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:test/test.dart';
 
-import '../test_utils/fakes.dart';
+import '../test_utils/fake_user.dart';
 import '../test_utils/utils.dart';
 
 class MockActivityTracker extends Mock implements ActivityTracker {}
@@ -18,45 +23,260 @@ class MockUserPreferencesRepository extends Mock
     implements UserPreferencesRepository {}
 
 void main() {
-  group('DrivesCubit', () {
-    late Database db;
-    late DriveDao driveDao;
+  late Database db;
+  late DriveDao driveDao;
+  late MockProfileCubit profileCubit;
+  late MockPromptToSnapshotBloc promptToSnapshotBloc;
+  late MockUserPreferencesRepository userPreferencesRepository;
+  late MockArDriveAuth auth;
+  late MockSyncBloc syncCubit;
+  late StreamController<SyncState> syncStates;
 
-    late ProfileCubit profileCubit;
-    late DrivesCubit drivesCubit;
-    late PromptToSnapshotBloc promptToSnapshotBloc;
-    late UserPreferencesRepository userPreferencesRepository;
+  const ownerAddress = 'address';
 
-    setUp(() {
-      registerFallbackValue(SyncStateFake());
-      registerFallbackValue(ProfileStateFake());
-      db = getTestDb();
-      driveDao = db.driveDao;
+  Future<void> insertDrive(String id) async {
+    await db.into(db.drives).insert(
+          DrivesCompanion.insert(
+            id: id,
+            name: id,
+            ownerAddress: ownerAddress,
+            rootFolderId: '$id-root',
+            privacy: DrivePrivacyTag.public,
+          ),
+        );
+  }
 
-      profileCubit = MockProfileCubit();
-      promptToSnapshotBloc = MockPromptToSnapshotBloc();
-      userPreferencesRepository = MockUserPreferencesRepository();
-      drivesCubit = DrivesCubit(
+  DrivesCubit buildCubit() => DrivesCubit(
         activityTracker: MockActivityTracker(),
-        auth: MockArDriveAuth(),
+        auth: auth,
         profileCubit: profileCubit,
         driveDao: driveDao,
         promptToSnapshotBloc: promptToSnapshotBloc,
         userPreferencesRepository: userPreferencesRepository,
+        syncCubit: syncCubit,
       );
-    });
 
-    tearDown(() async {
-      await db.close();
-    });
+  /// Holds the drive-list refresh open until the test says otherwise, the way
+  /// a login sync holds it open while `updateUserDrives` is still running.
+  Completer<void> holdRefreshOpen() {
+    final gate = Completer<void>();
+    when(() => syncCubit.waitForDriveListRefresh())
+        .thenAnswer((_) => gate.future);
+    return gate;
+  }
 
-    blocTest<DrivesCubit, DrivesState>(
-      'create public drive',
-      build: () => drivesCubit,
-      act: (bloc) async {},
-      expect: () => [
-        DrivesLoadInProgress(),
-      ],
+  setUp(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+
+    db = getTestDb();
+    driveDao = db.driveDao;
+
+    auth = MockArDriveAuth();
+    when(() => auth.onAuthStateChanged())
+        .thenAnswer((_) => const Stream<User?>.empty());
+    when(() => auth.currentUser).thenReturn(fakeUserJson);
+
+    profileCubit = MockProfileCubit();
+    whenListen(
+      profileCubit,
+      const Stream<ProfileState>.empty(),
+      initialState: ProfileLoggedIn(user: fakeUserJson, useTurbo: false),
     );
+
+    promptToSnapshotBloc = MockPromptToSnapshotBloc();
+
+    userPreferencesRepository = MockUserPreferencesRepository();
+    when(() => userPreferencesRepository.load()).thenAnswer(
+      (_) async => const UserPreferences(
+        currentTheme: ArDriveThemes.dark,
+        lastSelectedDriveId: null,
+      ),
+    );
+    when(() => userPreferencesRepository.saveUserHasHiddenItem(any()))
+        .thenAnswer((_) async {});
+    when(() => userPreferencesRepository.saveLastSelectedDriveId(any()))
+        .thenAnswer((_) async {});
+
+    syncCubit = MockSyncBloc();
+    syncStates = StreamController<SyncState>.broadcast();
+    whenListen(syncCubit, syncStates.stream, initialState: SyncIdle());
+    when(() => syncCubit.waitForDriveListRefresh()).thenAnswer((_) async {});
+  });
+
+  tearDown(() async {
+    await syncStates.close();
+    await db.close();
+  });
+
+  test('HARNESS PROOF: reports the drives that are already in the table',
+      () async {
+    await insertDrive('drive-a');
+
+    final cubit = buildCubit();
+    final emitted = <DrivesState>[];
+    final sub = cubit.stream.listen(emitted.add);
+
+    await pumpEventQueue();
+
+    expect(cubit.state, isA<DrivesLoadSuccess>());
+    final state = cubit.state as DrivesLoadSuccess;
+    expect(state.userDrives.map((d) => d.id), ['drive-a']);
+    expect(emitted, isNotEmpty);
+
+    await sub.cancel();
+    await cubit.close();
+  });
+
+  group('an empty table before the drive list has been looked at', () {
+    /// The bug, stated as a test: on a login with an empty local database the
+    /// cubit announced "no drives" as a fact, and the sidebar, the router and
+    /// the explorer all believed it - for the whole length of the fetch.
+    test('says nothing at all while the refresh is still running', () async {
+      holdRefreshOpen();
+
+      final cubit = buildCubit();
+      final emitted = <DrivesState>[];
+      final sub = cubit.stream.listen(emitted.add);
+
+      await pumpEventQueue();
+
+      expect(
+        emitted.whereType<DrivesLoadSuccess>(),
+        isEmpty,
+        reason: 'an unanswered drive list must not be reported as success',
+      );
+      expect(cubit.state, isA<DrivesLoadInProgress>());
+
+      await sub.cancel();
+      await cubit.close();
+    });
+
+    /// The other half of the same coin: a genuinely new user still has to be
+    /// told, or the fix trades one wrong screen for a permanent blank one.
+    test('reports the empty account once the refresh has finished', () async {
+      final gate = holdRefreshOpen();
+
+      final cubit = buildCubit();
+      final emitted = <DrivesState>[];
+      final sub = cubit.stream.listen(emitted.add);
+
+      await pumpEventQueue();
+      expect(emitted.whereType<DrivesLoadSuccess>(), isEmpty);
+
+      gate.complete();
+      await pumpEventQueue();
+
+      expect(cubit.state, isA<DrivesLoadSuccess>());
+      expect((cubit.state as DrivesLoadSuccess).hasNoDrives, isTrue);
+
+      await sub.cancel();
+      await cubit.close();
+    });
+
+    /// The case the whole change exists for: the refresh found drives. What
+    /// the user must never see is "none found" landing on top of them.
+    test('reports the drives the refresh wrote, not "none found"', () async {
+      final gate = holdRefreshOpen();
+
+      final cubit = buildCubit();
+      final emitted = <DrivesState>[];
+      final sub = cubit.stream.listen(emitted.add);
+
+      await pumpEventQueue();
+
+      await insertDrive('drive-a');
+      gate.complete();
+      await pumpEventQueue();
+
+      expect(cubit.state, isA<DrivesLoadSuccess>());
+      final state = cubit.state as DrivesLoadSuccess;
+      expect(state.userDrives.map((d) => d.id), ['drive-a']);
+      expect(
+        emitted.whereType<DrivesLoadSuccess>().where((s) => s.hasNoDrives),
+        isEmpty,
+        reason: 'the stale empty snapshot must not be reported after the fact',
+      );
+
+      await sub.cancel();
+      await cubit.close();
+    });
+
+    /// A wait nobody ends must not pin the sidebar shut for good.
+    test('answers anyway when the refresh itself fails', () async {
+      when(() => syncCubit.waitForDriveListRefresh())
+          .thenAnswer((_) async => throw Exception('gateway said no'));
+
+      final cubit = buildCubit();
+      await pumpEventQueue();
+
+      expect(cubit.state, isA<DrivesLoadSuccess>());
+      expect((cubit.state as DrivesLoadSuccess).hasNoDrives, isTrue);
+
+      await cubit.close();
+    });
+
+    /// Closing mid-wait is the ordinary way this ends - the user logs out, or
+    /// the route is torn down - and an emit after close throws.
+    test('does not emit after being closed mid-wait', () async {
+      final gate = holdRefreshOpen();
+
+      final cubit = buildCubit();
+      final emitted = <DrivesState>[];
+      final sub = cubit.stream.listen(emitted.add);
+
+      await pumpEventQueue();
+      await cubit.close();
+
+      gate.complete();
+      await pumpEventQueue();
+
+      expect(emitted.whereType<DrivesLoadSuccess>(), isEmpty);
+
+      await sub.cancel();
+    });
+
+    /// The wait is opened once, however many times the watch fires.
+    test('opens a single wait however often the watch re-fires', () async {
+      final gate = holdRefreshOpen();
+
+      final cubit = buildCubit();
+      await pumpEventQueue();
+
+      // A ghost folder is enough to re-fire the combined stream without
+      // putting a drive in the table.
+      await db.into(db.folderEntries).insert(
+            FolderEntriesCompanion.insert(
+              id: 'ghost-folder',
+              driveId: 'drive-a',
+              name: 'ghost',
+              path: '',
+              isGhost: const Value(true),
+            ),
+          );
+      await pumpEventQueue();
+
+      verify(() => syncCubit.waitForDriveListRefresh()).called(1);
+
+      gate.complete();
+      await cubit.close();
+    });
+  });
+
+  group('a returning user whose drives are already local', () {
+    /// The common case, and the one that must not regress into a wait.
+    test('never waits on the drive list refresh', () async {
+      holdRefreshOpen();
+      await insertDrive('drive-a');
+
+      final cubit = buildCubit();
+      await pumpEventQueue();
+
+      expect(cubit.state, isA<DrivesLoadSuccess>());
+      expect((cubit.state as DrivesLoadSuccess).userDrives.map((d) => d.id),
+          ['drive-a']);
+      verifyNever(() => syncCubit.waitForDriveListRefresh());
+
+      await cubit.close();
+    });
   });
 }

--- a/test/components/side_bar_loading_test.dart
+++ b/test/components/side_bar_loading_test.dart
@@ -1,0 +1,92 @@
+import 'dart:async';
+
+import 'package:ardrive/blocs/blocs.dart';
+import 'package:ardrive/blocs/hide/global_hide_bloc.dart';
+import 'package:ardrive/components/side_bar.dart';
+import 'package:ardrive_ui/ardrive_ui.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../test_utils/mocks.dart';
+
+class _MockGlobalHideBloc extends MockBloc<GlobalHideEvent, GlobalHideState>
+    implements GlobalHideBloc {}
+
+/// An empty nav is indistinguishable from a wallet that has no drives - and
+/// that is exactly what a returning user sees on a device the app has not read
+/// yet. The real sidebar is mounted here, not a copy of its logic.
+void main() {
+  late MockDrivesCubit drivesCubit;
+  late MockProfileCubit profileCubit;
+  late MockDriveDetailCubit driveDetailCubit;
+  late _MockGlobalHideBloc hideBloc;
+
+  setUp(() {
+    drivesCubit = MockDrivesCubit();
+    profileCubit = MockProfileCubit();
+    driveDetailCubit = MockDriveDetailCubit();
+    hideBloc = _MockGlobalHideBloc();
+
+    whenListen(profileCubit, const Stream<ProfileState>.empty(),
+        initialState: ProfileCheckingAvailability());
+    whenListen(driveDetailCubit, const Stream<DriveDetailState>.empty(),
+        initialState: DriveDetailLoadInProgress());
+    whenListen(hideBloc, const Stream<GlobalHideState>.empty(),
+        initialState: const HiddingItems(userHasHiddenDrive: false));
+  });
+
+  Widget wrap(DrivesState drivesState) {
+    whenListen(drivesCubit, const Stream<DrivesState>.empty(),
+        initialState: drivesState);
+
+    return ArDriveTheme(
+      themeData: lightTheme(),
+      child: MaterialApp(
+        localizationsDelegates: const [
+          AppLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: const [Locale('en', '')],
+        home: MultiBlocProvider(
+          providers: [
+            BlocProvider<DrivesCubit>.value(value: drivesCubit),
+            BlocProvider<ProfileCubit>.value(value: profileCubit),
+            BlocProvider<DriveDetailCubit>.value(value: driveDetailCubit),
+            BlocProvider<GlobalHideBloc>.value(value: hideBloc),
+          ],
+          child: const Scaffold(body: AppSideBar()),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('says it is still looking rather than showing nothing',
+      (tester) async {
+    await tester.pumpWidget(wrap(DrivesLoadInProgress()));
+    await tester.pump();
+
+    expect(find.text('Loading your drives...'), findsOneWidget);
+
+    await tester.pumpWidget(const SizedBox());
+  });
+
+  testWidgets('says nothing once the list has actually been read',
+      (tester) async {
+    await tester.pumpWidget(
+      wrap(DrivesLoadedWithNoDrivesFound(canCreateNewDrive: true)),
+    );
+    await tester.pump();
+
+    // A genuinely empty account is the one case where silence is right: the
+    // main panel carries the Getting Started story.
+    expect(find.text('Loading your drives...'), findsNothing);
+
+    await tester.pumpWidget(const SizedBox());
+  });
+}

--- a/test/components/sync_button_test.dart
+++ b/test/components/sync_button_test.dart
@@ -43,6 +43,7 @@ void main() {
     when(() => syncCubit.syncStartTime).thenReturn(DateTime.now());
     when(() => syncCubit.clearErrorState()).thenReturn(null);
     when(() => syncCubit.retryFailedDrives(any())).thenAnswer((_) async {});
+    when(() => syncCubit.syncMetadataOnly()).thenAnswer((_) async {});
   });
 
   tearDown(() async {
@@ -758,6 +759,110 @@ void main() {
 
       await openMenu(tester);
       expect(find.text('Retry Failed'), findsNothing);
+
+      await tester.pumpWidget(const SizedBox());
+    });
+  });
+
+  /// The other way a sync fails: not "some drives could not be read" but "this
+  /// could not be done at all". `syncMetadataOnly` is the only place that
+  /// emits it terminally - everywhere else `onError` emits it and `SyncIdle`
+  /// in the same turn - and it is the whole of a default login, so it is
+  /// exactly the failure a user is most likely to hit.
+  group('a drive-list refresh that failed', () {
+    testWidgets('is visible at the top bar instead of the idle refresh icon',
+        (tester) async {
+      // The bug: no branch for SyncFailure, so it fell through to the final
+      // `else` and drew the ordinary refresh icon. With autoSync false in all
+      // three flavours nothing was going to retry it either - so the app
+      // looked fully synced while showing nothing, permanently.
+      await tester.pumpWidget(wrap());
+      await tester.pump();
+
+      stateController.add(SyncFailure(error: Exception('the gateway said no')));
+      await tester.pump(const Duration(milliseconds: 10));
+
+      expect(find.text('Drives Could Not Be Loaded'), findsOneWidget);
+      expect(find.text('We could not reach the network to read your drive list.'), findsOneWidget);
+
+      await tester.pumpWidget(const SizedBox());
+    });
+
+    testWidgets('stays reachable after the announcement has gone',
+        (tester) async {
+      await tester.pumpWidget(wrap());
+      await tester.pump();
+
+      stateController.add(SyncFailure(error: Exception('the gateway said no')));
+      await tester.pump(const Duration(milliseconds: 10));
+      await tester.pump(syncSummaryDuration + const Duration(seconds: 1));
+
+      expect(find.text('Drives Could Not Be Loaded'), findsNothing,
+          reason: 'precondition: the announcement has had its few seconds');
+
+      // The failure outlives it, in the surface a partial failure uses: the
+      // menu the indicator opens.
+      await openMenu(tester);
+
+      expect(find.text('Drives Could Not Be Loaded'), findsOneWidget);
+      expect(find.text('Try Again'), findsOneWidget);
+
+      entryNamed(tester, 'Try Again').onClick!();
+      await tester.pump(const Duration(milliseconds: 10));
+
+      // The request that failed, and not a full sync the user did not ask for.
+      verify(() => syncCubit.syncMetadataOnly()).called(1);
+
+      await tester.pumpWidget(const SizedBox());
+    });
+
+    testWidgets('a retry that succeeds clears it', (tester) async {
+      await tester.pumpWidget(wrap());
+      await tester.pump();
+
+      stateController.add(SyncFailure(error: Exception('the gateway said no')));
+      await tester.pump(const Duration(milliseconds: 10));
+      expect(find.text('Drives Could Not Be Loaded'), findsOneWidget,
+          reason: 'precondition: the failure is on screen');
+
+      // The retry runs and this time the drive list arrives.
+      stateController.add(SyncLoadingDrives());
+      await tester.pump(const Duration(milliseconds: 10));
+      stateController.add(SyncIdle());
+      await tester.pump(const Duration(milliseconds: 10));
+
+      expect(find.text('Drives Could Not Be Loaded'), findsNothing);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+
+      // And the retry goes with it - there is nothing left to retry.
+      await openMenu(tester);
+      expect(find.text('Try Again'), findsNothing);
+      expect(find.text('Resync'), findsOneWidget,
+          reason: 'precondition: the menu really did open');
+
+      await tester.pumpWidget(const SizedBox());
+    });
+
+    testWidgets('a failure that has had its moment is not announced again',
+        (tester) async {
+      // SyncFailure stays the cubit's state until something refreshes the
+      // drive list, so an announcement counted from build time would replay on
+      // every rebuild of the top bar for the rest of the session.
+      await tester.pumpWidget(wrap());
+      await tester.pump();
+
+      stateController.add(SyncFailure(
+        error: Exception('the gateway said no'),
+        failedAt: DateTime.now().subtract(const Duration(minutes: 5)),
+      ));
+      await tester.pump(const Duration(milliseconds: 10));
+
+      // Gone from the announcement, still in the menu: the indicator is what
+      // carries a failure that is no longer news.
+      expect(find.text('We could not reach the network to read your drive list.'), findsNothing);
+
+      await openMenu(tester);
+      expect(find.text('Try Again'), findsOneWidget);
 
       await tester.pumpWidget(const SizedBox());
     });

--- a/test/pages/drive_detail/components/drive_detail_syncing_card_test.dart
+++ b/test/pages/drive_detail/components/drive_detail_syncing_card_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:ardrive/blocs/drive_detail/drive_detail_cubit.dart';
 import 'package:ardrive/blocs/drives/drives_cubit.dart';
 import 'package:ardrive/models/models.dart';
 import 'package:ardrive/pages/drive_detail/components/drive_detail_syncing_card.dart';
@@ -420,6 +421,100 @@ void main() {
 
     await tester.pumpWidget(const SizedBox());
   });
+
+  /// A sync that ran, finished and found nothing must not be drawn as a sync
+  /// that never happened. Before this the card came back word for word -
+  /// "Drive Not Synced", "Sync now to see your files and folders", the same
+  /// Sync Now button - so pressing it read as a button that did nothing.
+  group('the unsynced card after a sync that found nothing', () {
+    /// How many layout overflows the card produces, drained so they do not
+    /// leak into the next test. The two 283x283 action tiles do not fit their
+    /// own contents under the test font's square glyphs; that predates this
+    /// work, so what matters is that the new copy does not add to it.
+    int overflowsRendering(WidgetTester tester) {
+      var count = 0;
+      while (tester.takeException() != null) {
+        count++;
+      }
+      return count;
+    }
+
+    Future<int> pumpCard(
+      WidgetTester tester, {
+      required bool syncFoundNothing,
+      Size size = phoneSize,
+    }) async {
+      await tester.binding.setSurfaceSize(size);
+      await tester.pumpWidget(
+        host(
+          DriveDetailUnsyncedCard(
+            drive: drive(id: 'drive-1', name: 'Photos'),
+            syncFoundNothing: syncFoundNothing,
+          ),
+          size: size,
+        ),
+      );
+      await tester.pump();
+      return overflowsRendering(tester);
+    }
+
+    testWidgets('says the sync looked and found nothing', (tester) async {
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await pumpCard(tester, syncFoundNothing: true);
+
+      expect(find.text('Nothing Found Yet'), findsOneWidget);
+      expect(
+        find.textContaining('The sync finished, but nothing for this drive'),
+        findsOneWidget,
+      );
+
+      // Not the card that was already acted on, and not the button that was
+      // already pressed.
+      expect(find.text('Drive Not Synced'), findsNothing);
+      expect(find.text('Sync Now'), findsNothing);
+      expect(find.text('Check Again'), findsOneWidget);
+
+      await tester.pumpWidget(const SizedBox());
+    });
+
+    testWidgets('leaves the first-time card alone', (tester) async {
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await pumpCard(tester, syncFoundNothing: false);
+
+      expect(find.text('Drive Not Synced'), findsOneWidget);
+      expect(find.text('Sync Now'), findsOneWidget);
+      expect(find.text('Nothing Found Yet'), findsNothing);
+
+      await tester.pumpWidget(const SizedBox());
+    });
+
+    testWidgets('adds no overflow at 320px, on either wording', (tester) async {
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final before = await pumpCard(tester, syncFoundNothing: false);
+      await tester.pumpWidget(const SizedBox());
+      final after = await pumpCard(tester, syncFoundNothing: true);
+      await tester.pumpWidget(const SizedBox());
+
+      expect(after, lessThanOrEqualTo(before),
+          reason: 'the longer wording must not push the card off a phone');
+    });
+
+    testWidgets('reads the same on a desktop', (tester) async {
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await pumpCard(tester, syncFoundNothing: true, size: desktopSize);
+
+      expect(find.text('Nothing Found Yet'), findsOneWidget);
+      expect(find.text('Check Again'), findsOneWidget);
+      expect(find.text('Drive Not Synced'), findsNothing);
+
+      await tester.pumpWidget(const SizedBox());
+    });
+  });
+
   testWidgets('the bar does not rewind when the sync ends', (tester) async {
     // When the sync finishes, the subtitle, the phase line and the elapsed
     // counter all disappear at once and the Column's children shrink. An
@@ -452,5 +547,87 @@ void main() {
     );
 
     await tester.pumpWidget(const SizedBox());
+  });
+
+  group('when the drive list could not be read at all', () {
+    late MockDriveDetailCubit driveDetailCubit;
+
+    setUp(() {
+      driveDetailCubit = MockDriveDetailCubit();
+      whenListen(
+        driveDetailCubit,
+        const Stream<DriveDetailState>.empty(),
+        initialState: DriveDetailDrivesUnavailable(),
+      );
+      when(() => driveDetailCubit.retryLoadingDrives())
+          .thenAnswer((_) async {});
+    });
+
+    Widget unavailable({ArDriveThemeData? theme, Size size = phoneSize}) =>
+        host(
+          BlocProvider<DriveDetailCubit>.value(
+            value: driveDetailCubit,
+            child: const DriveDetailSyncingCard.driveListUnavailable(),
+          ),
+          theme: theme,
+          size: size,
+        );
+
+    testWidgets('says what happened, and never that the user has no drives',
+        (tester) async {
+      await tester.binding.setSurfaceSize(phoneSize);
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(unavailable());
+      await tester.pump();
+
+      expect(find.text('Your Drives Could Not Be Loaded'), findsOneWidget);
+      expect(
+        find.textContaining('Your drives are safe'),
+        findsOneWidget,
+      );
+
+      // The three things the old screen did that this one may not: claim the
+      // list is empty, offer a drive to create, and pretend work is still
+      // going on.
+      expect(find.textContaining('Getting Started'), findsNothing);
+      expect(find.textContaining('Create new'), findsNothing);
+      expect(find.byType(LinearProgressIndicator), findsNothing);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+    });
+
+    testWidgets('offers a retry that actually runs one', (tester) async {
+      await tester.binding.setSurfaceSize(phoneSize);
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(unavailable());
+      await tester.pump();
+
+      await tester.tap(find.text('Try Again'));
+      await tester.pump();
+
+      verify(() => driveDetailCubit.retryLoadingDrives()).called(1);
+    });
+
+    testWidgets('fits a 320px phone and a wide desktop, in both themes',
+        (tester) async {
+      for (final theme in [
+        lightTheme(),
+        ArDriveThemeData(colorTokens: ArDriveColorTokens.darkMode()),
+      ]) {
+        for (final size in [phoneSize, desktopSize]) {
+          await tester.binding.setSurfaceSize(size);
+          await tester.pumpWidget(unavailable(theme: theme, size: size));
+          await tester.pump();
+
+          expect(find.text('Your Drives Could Not Be Loaded'), findsOneWidget);
+          expect(tester.takeException(), isNull);
+
+          await tester.pumpWidget(const SizedBox());
+        }
+      }
+
+      await tester.binding.setSurfaceSize(null);
+    });
   });
 }

--- a/test/sync/domain/cubit/sync_only_when_needed_test.dart
+++ b/test/sync/domain/cubit/sync_only_when_needed_test.dart
@@ -306,4 +306,96 @@ void main() {
           txFechedCallback: any(named: 'txFechedCallback'),
         ));
   });
+
+  /// The login path refreshes the drive list, and something has to be able to
+  /// ask whether that has happened. [SyncCubit.waitCurrentSync] cannot: it
+  /// treats `SyncLoadingDrives` as finished on purpose, so that opening a
+  /// folder does not hang behind a metadata refresh - which is exactly why an
+  /// empty local database used to be reported as "this user has no drives"
+  /// before anyone had looked.
+  group('waiting for the drive list itself', () {
+    /// Holds `updateUserDrives` open so a test can ask both questions while
+    /// the refresh is genuinely still running.
+    ({Completer<void> started, Completer<void> finish}) blockTheRefresh() {
+      final started = Completer<void>();
+      final finish = Completer<void>();
+
+      when(() => syncRepository.updateUserDrives(
+            wallet: any(named: 'wallet'),
+            password: any(named: 'password'),
+            cipherKey: any(named: 'cipherKey'),
+          )).thenAnswer((_) async {
+        if (!started.isCompleted) started.complete();
+        await finish.future;
+      });
+
+      return (started: started, finish: finish);
+    }
+
+    test('the drive-list wait covers the refresh waitCurrentSync lets through',
+        () async {
+      nothingIsPending();
+      final refresh = blockTheRefresh();
+
+      final cubit = buildCubit(syncAllDrivesOnLogin: false);
+      addTearDown(cubit.close);
+
+      await refresh.started.future.timeout(
+        const Duration(seconds: 10),
+        onTimeout: () => fail('the login never refreshed the drive list'),
+      );
+
+      expect(cubit.state, isA<SyncLoadingDrives>(),
+          reason: 'precondition: the drive list is being read right now');
+
+      // Deliberately non-blocking, and left that way: a folder open must not
+      // wait on a metadata refresh. This is the hole the empty screen fell
+      // through, not a bug to fix here.
+      await cubit.waitCurrentSync().timeout(
+            const Duration(seconds: 5),
+            onTimeout: () =>
+                fail('waitCurrentSync must stay non-blocking during a refresh'),
+          );
+
+      var driveListWasRead = false;
+      unawaited(
+        cubit.waitForDriveListRefresh().then((_) => driveListWasRead = true),
+      );
+      await pumpEventQueue(times: 100);
+
+      expect(driveListWasRead, isFalse,
+          reason: 'nothing has read the drive list yet, so nothing may claim '
+              'to know what is in it');
+
+      refresh.finish.complete();
+      await pumpEventQueue(times: 100);
+
+      expect(driveListWasRead, isTrue);
+      expect(cubit.driveListRefreshFailed, isFalse);
+    });
+
+    test('a refresh that could not be done says so, and keeps saying it',
+        () async {
+      nothingIsPending();
+      when(() => syncRepository.updateUserDrives(
+            wallet: any(named: 'wallet'),
+            password: any(named: 'password'),
+            cipherKey: any(named: 'cipherKey'),
+          )).thenAnswer((_) async => throw Exception('the gateway said no'));
+
+      final cubit = buildCubit(syncAllDrivesOnLogin: false);
+      addTearDown(cubit.close);
+
+      await cubit.waitForDriveListRefresh().timeout(
+            const Duration(seconds: 10),
+            onTimeout: () => fail('the drive-list wait never returned'),
+          );
+
+      // Terminal, unlike the SyncFailure `onError` emits and immediately
+      // replaces - which is what makes it worth reporting at all.
+      await pumpEventQueue(times: 100);
+      expect(cubit.state, isA<SyncFailure>());
+      expect(cubit.driveListRefreshFailed, isTrue);
+    });
+  });
 }


### PR DESCRIPTION
Stacked on #2212. Seventh of the sync-UX series, and the first from the login-story audit.

## The pattern

**The app rendered "we don't know yet" and "we couldn't find out" as "there is nothing".** Three different situations produced one screen with one message:

- we haven't looked yet
- we looked, there is genuinely nothing
- we tried to look and failed

Only the middle one is safe to act on, and it was the one the app always claimed.

## What a user saw before this

On **every** empty-database login — a fresh browser, a new device, or the state after a logout — the app rendered `NoDrivesPage`: *"Getting Started / Create a new drive to start uploading your files"*, with two create-a-drive buttons and an empty sidebar, for the whole duration of the drive-list fetch. **On the success path.**

`DrivesCubit` emits `hasNoDrives: true` off Drift's immediate empty-table read, before `updateUserDrives` returns; `drive_detail_page.dart` calls `showEmptyDriveDetail()`; and its `waitCurrentSync()` guard is a no-op, because `_syncHasFinished` counts `SyncLoadingDrives` as finished and that is exactly where the metadata-only login sync sits.

This window existed on `dev` too — it was invisible because the login sync scrimmed the app over it. Making sync quiet is what exposed it.

## What changes

**A separate wait for the drive-list refresh.** `waitCurrentSync` / `_syncHasFinished` are untouched — treating `SyncLoadingDrives` as finished there is deliberate and stops folder opens hanging behind the refresh. The new `waitForDriveListRefresh()` blocks on exactly the states the refresh occupies, so "there is nothing" is only ever claimed once we have actually looked.

**Three screens instead of one.** *Loading* reuses `DriveDetailSyncingCard` from the PR beneath this. *Nothing* keeps today's `NoDrivesPage`, which is correct for a genuinely new user. *Could not load* is a new state, `DriveDetailDrivesUnavailable`, saying so with a **Try Again** — and no create-a-drive action.

**A failed refresh stays visible.** `syncMetadataOnly` is the only place that emits `SyncFailure` terminally — everywhere else `onError` emits it and then `SyncIdle` in the same turn, so it is a one-frame flash. `SyncButton` had no branch for it, so it rendered the ordinary idle refresh icon, and `autoSync` is `false` in all three flavours so neither automatic retry route can fire. The app looked fully synced while showing nothing, permanently. It now has a persistent top-bar surface and a Try Again, following the error pattern the PR beneath already established.

**A sync that finds nothing says so.** Pressing Sync Now on a drive whose root revision never arrives used to re-render the identical "Drive Not Synced" card, with nothing to say a sync had just run and found nothing.

## Two defects review caught in this PR's own fix

**The retry reintroduced the bug it was fixing.** `retryLoadingDrives()` ended in `showEmptyDriveDetail()`, which claimed emptiness from the cubit's own state and **never asked whether drives existed**. On the login path `DrivesCubit` had already established that; on the retry path nothing had — so a Try Again that *succeeded* showed "Getting Started" to a user who had just been told their drives could not be loaded. It now checks the drive list before claiming it is empty.

**The two retries disagreed.** The top bar's Try Again calls `syncMetadataOnly()` directly, and nothing re-decided the explorer — so the body went on saying the drives could not be loaded while the bar directly above it reported everything was fine. Any successful refresh now clears the failure screen, wherever the retry came from.

Fixing the second exposed a third: `DriveDetailCubit` returned before registering its sync subscription when built with an empty drive id — so the cubit that shows these very screens never heard about a sync at all. The subscription is now registered first.

## Also

- A preferences read that throws no longer strands the app on "Loading your drives…" forever. The cubit starts in `SyncLoadingDrives` and the new wait blocks on leaving it, so a throw in `createSyncStream` had nothing to end it.
- One failure, one name: the top bar and the panel described the same event in two vocabularies while both were on screen.
- The em dash is gone from the new copy — none of the four Wavehaus weights contains U+2014, so it renders as tofu or breaks typeface mid-line.
- The found-nothing card's action tile no longer promises to "fetch the latest files and folders" on the one screen whose message is that there are none yet.

## Verification

`flutter analyze` clean. Full suite **1628 passed, 4 skipped, 0 failed**.

Every test proved by reverting its implementation line — including the two added for the defects above: removing the emptiness check fails with *"told a user with drives that they have none"*, and moving the subscription back below the early return fails with *"the failure screen outlived the failure"*.

## Out of scope, from the same audit

Three states that render `const SizedBox()` — the anonymous share-link recipient who dismisses the attach dialog, a bookmarked drive URL when the list fails, and a returning ArConnect user whose extension never answers. All pre-existing, all needing a real screen. The share-link one is worth treating as urgent independently of this series: the address bar has already been rewritten, so reloading does not recover it.

Separately, the identity paths: biometric unlock stacking an undismissable dialog, an Ethereum signature rejection reported as a wrong password, and an ArConnect user with no extension being asked for a password that cannot work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ndA5nwUpt9hGLUx2TAFr
