### PR TITLE
PE-9205: A sync you can read through, and choose the drives for

### DIFF
--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -593,6 +593,12 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
           }
 
           if (_activityTracker.isUploading) {
+            // Dropped, and owed back. An upload writes its file while this
+            // flag is up, so the tick carrying it is the one refused here -
+            // and nothing else is going to write that folder afterwards, so
+            // no later tick will carry it either. Remembering the debt is what
+            // lets the refresh at the end of the upload settle it.
+            _droppedFolderRedraw = true;
             return;
           }
 
@@ -984,8 +990,24 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
     );
   }
 
+  /// Redraws the table, re-reading the folder first if anything was missed.
+  ///
+  /// The re-read is the half this did not do, and an upload is where that
+  /// showed: the file is written while `isUploading` is up, the tick carrying
+  /// it is refused by the guard in the subscription, and nothing writes that
+  /// folder again afterwards - so there is no later tick to carry it. This
+  /// then re-emitted the state it already had with a new key, which rebuilds
+  /// the same rows. The file was uploaded, and was not on screen.
+  ///
+  /// Only when something was actually dropped, so the callers that use this
+  /// for a cosmetic rebuild after a rename or a hide still pay nothing.
   void refreshDriveDataTable() async {
     _refreshSelectedItem = true;
+
+    if (_droppedFolderRedraw) {
+      await _refreshAfterDroppedRedraws();
+      return;
+    }
 
     if (state is DriveDetailLoadSuccess) {
       await Future.delayed(const Duration(milliseconds: 100));

--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -1004,6 +1004,21 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
   void refreshDriveDataTable() async {
     _refreshSelectedItem = true;
 
+    // Something the reader did wrote to the drive, so something may now be
+    // waiting to be mined.
+    //
+    // An upload is not the only thing that leaves a pending transaction:
+    // creating a drive or a folder, renaming one, moving files, assigning a
+    // licence and taking a snapshot all write revisions the same way. Starting
+    // the watch only from the upload form would confirm uploads and leave
+    // every other write unconfirmed until the next login, which is the gap
+    // this exists to close. This is the one seam nearly all of them already
+    // pass through.
+    //
+    // Costs a single local read when nothing is pending, and stops - see
+    // [SyncCubit.watchForPendingConfirmations].
+    _syncCubit.watchForPendingConfirmations();
+
     if (_droppedFolderRedraw) {
       await _refreshAfterDroppedRedraws();
       return;

--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -587,8 +587,6 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
             _lastFolderRedraw = now;
           }
 
-          _lastFolderContents = folderContents;
-
           if (drive == null) {
             emit(DriveDetailLoadNotFound());
             return;
@@ -597,6 +595,17 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
           if (_activityTracker.isUploading) {
             return;
           }
+
+          // Recorded here, past every early return above it, because it means
+          // "this is what the reader is looking at" - and a tick dropped by
+          // one of those returns was never drawn.
+          //
+          // Recording it earlier was a real bug and the upload path was where
+          // it bit: an upload writes the new file, the tick carrying it is
+          // dropped by the guard just above, and the next identical tick then
+          // matched what had been recorded and was skipped as a no-op. The
+          // file did not appear until something else changed the folder.
+          _lastFolderContents = folderContents;
 
           final state = this.state is DriveDetailLoadSuccess
               ? this.state as DriveDetailLoadSuccess

--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -678,6 +678,30 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
             }
 
             if (rootFolderRevision == null) {
+              // Unless a sync is writing this drive right now, in which case
+              // the root revision has simply not landed *yet*.
+              //
+              // Reading no longer waits for the sync - which is the point -
+              // so this branch is now reached mid-walk, where it used not to
+              // be. Saying "Drive Not Synced" then is wrong twice over: it
+              // contradicts the ring still turning in the top bar, and it
+              // offers a Sync Now that the cubit will refuse because a sync is
+              // already running. Left on the loading panel, the drive opens by
+              // itself the moment its root revision is written.
+              if (SyncCubit.syncTouchesDrive(
+                state: _syncCubit.state,
+                syncingDriveId: _syncCubit.syncingDriveId,
+                completedDriveIds: _syncCubit.completedDriveIds,
+                runDriveIds: _syncCubit.syncingDriveIds,
+                driveId: driveId,
+              )) {
+                if (this.state is! DriveDetailLoadSuccess) {
+                  emit(DriveDetailLoadInProgress());
+                }
+
+                return;
+              }
+
               emit(DriveDetailLoadUnsynced(drive: drive));
               return;
             }

--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -67,6 +67,12 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
 
   /// What was last drawn, so a tick that changes nothing can be recognised.
   FolderWithContents? _lastFolderContents;
+
+  /// The drive whose root revision this screen is waiting on, if any.
+  ///
+  /// Only a sync writing that drive can end the wait, so a sync that ends
+  /// without doing it has to be noticed - see [_recoverIfStillWaiting].
+  String? _awaitingRootRevisionFor;
   bool _isExplicitSync = false;
 
   /// Bumped by every [openFolder]. Cancelling `_folderSubscription` does not
@@ -190,6 +196,41 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
     // (registered by _listenForSyncCompletion, above)
   }
 
+  /// Ends a wait for a root revision that is never going to arrive.
+  ///
+  /// The panel waits rather than claiming "Drive Not Synced" while a sync is
+  /// walking that drive, because the revision has probably not landed *yet*.
+  /// The wait is ended by the tick that writes it - and a run that fails, is
+  /// cancelled, or fails on this drive in particular writes nothing at all, so
+  /// no tick comes and the panel sits on "Opening..." for good.
+  ///
+  /// So a run reaching any terminal state re-reads the folder once. If the
+  /// revision did arrive, this draws it; if it did not, the same branch now
+  /// finds no sync in progress and says "Drive Not Synced", which is true and
+  /// offers a way out.
+  Future<void> _recoverIfStillWaiting() async {
+    final waitingFor = _awaitingRootRevisionFor;
+
+    if (waitingFor == null || isClosed) {
+      return;
+    }
+
+    _awaitingRootRevisionFor = null;
+
+    if (waitingFor != _driveId || state is! DriveDetailLoadInProgress) {
+      return;
+    }
+
+    final drive =
+        await _driveDao.driveById(driveId: waitingFor).getSingleOrNull();
+
+    if (isClosed || drive == null || waitingFor != _driveId) {
+      return;
+    }
+
+    openFolder(folderId: drive.rootFolderId, otherDriveId: waitingFor);
+  }
+
   /// Redraws once more if the throttle dropped the last tick of a run.
   ///
   /// The throttle is safe to drop ticks precisely because another is coming.
@@ -218,6 +259,7 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
   void _listenForSyncCompletion() {
     _syncSubscription = _syncCubit.stream.listen((syncState) {
       if (SyncCubit.syncHasFinished(syncState)) {
+        _recoverIfStillWaiting();
         _refreshAfterDroppedRedraws();
       }
 
@@ -711,11 +753,24 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
                 driveId: driveId,
               )) {
                 if (this.state is! DriveDetailLoadSuccess) {
+                  // Remembered, because waiting here is only safe if something
+                  // is going to end the wait. The tick that would resolve this
+                  // arrives only if the sync writes a row for this drive - and
+                  // a sync that fails, is cancelled, or fails on this drive
+                  // specifically writes nothing, so the stream never fires
+                  // again and the panel says "Opening..." until the reader
+                  // navigates away and back.
+                  //
+                  // Before reading stopped waiting for the sync this could not
+                  // happen: the check always ran after the sync had settled.
+                  _awaitingRootRevisionFor = driveId;
                   emit(DriveDetailLoadInProgress());
                 }
 
                 return;
               }
+
+              _awaitingRootRevisionFor = null;
 
               emit(DriveDetailLoadUnsynced(drive: drive));
               return;

--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -28,6 +28,18 @@ part 'drive_detail_state.dart';
 /// Sentinel used by copyWith to distinguish "not provided" from "explicitly null".
 const _driveDetailAbsent = Object();
 
+/// How often a folder may redraw while a sync is writing its drive.
+///
+/// A starting point, not a measured optimum. Each redraw parses the folder's
+/// rows and rebuilds its breadcrumb, so the cost scales with folder size while
+/// the tick rate scales with how fast revisions land - two things that are
+/// worst at the same time, on a big drive's first walk.
+///
+/// To tune it: watch redraws per second on a drive with thousands of revisions
+/// and raise this until the list stops feeling busy without feeling stale. The
+/// floor is set by how long a redraw takes, not by taste.
+const Duration _folderRedrawInterval = Duration(milliseconds: 500);
+
 class DriveDetailCubit extends Cubit<DriveDetailState> {
   String _driveId;
 
@@ -46,6 +58,12 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
   StreamSubscription? _folderSubscription;
   StreamSubscription? _syncSubscription;
   bool _initialLoadComplete = false;
+
+  /// When this folder last redrew while a sync was writing its drive.
+  DateTime? _lastFolderRedraw;
+
+  /// Whether a redraw was dropped by the throttle and not yet made good.
+  bool _droppedFolderRedraw = false;
   bool _isExplicitSync = false;
 
   /// Bumped by every [openFolder]. Cancelling `_folderSubscription` does not
@@ -123,6 +141,8 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
         if (SyncCubit.syncTouchesDrive(
           state: _syncCubit.state,
           syncingDriveId: _syncCubit.syncingDriveId,
+          completedDriveIds: _syncCubit.completedDriveIds,
+          runDriveIds: _syncCubit.syncingDriveIds,
           driveId: driveId,
         )) {
           await _syncCubit.waitCurrentSync();
@@ -167,8 +187,37 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
     // (registered by _listenForSyncCompletion, above)
   }
 
+  /// Redraws once more if the throttle dropped the last tick of a run.
+  ///
+  /// The throttle is safe to drop ticks precisely because another is coming.
+  /// The one tick that has nothing behind it is the last one of a sync, and
+  /// dropping that leaves the folder one batch short of what was written with
+  /// nothing else due to correct it. So a run that ends having dropped
+  /// anything re-reads the folder, once.
+  Future<void> _refreshAfterDroppedRedraws() async {
+    if (!_droppedFolderRedraw) {
+      return;
+    }
+
+    _droppedFolderRedraw = false;
+
+    final current = state;
+
+    if (isClosed || current is! DriveDetailLoadSuccess) {
+      return;
+    }
+
+    // The folder that is open, re-read. Not a loading state: the reader is
+    // looking at this list and nothing about it is being replaced.
+    openFolder(folderId: current.folderInView.folder.id);
+  }
+
   void _listenForSyncCompletion() {
     _syncSubscription = _syncCubit.stream.listen((syncState) {
+      if (SyncCubit.syncHasFinished(syncState)) {
+        _refreshAfterDroppedRedraws();
+      }
+
       // A drive list that has since been read means the failure screen is out
       // of date, wherever the retry came from. The top bar has its own Try
       // Again, and without this the body would go on saying the drives could
@@ -348,6 +397,8 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
       if (SyncCubit.syncTouchesDrive(
         state: _syncCubit.state,
         syncingDriveId: _syncCubit.syncingDriveId,
+        completedDriveIds: _syncCubit.completedDriveIds,
+        runDriveIds: _syncCubit.syncingDriveIds,
         driveId: driveId,
       )) {
         await _syncCubit.waitCurrentSync();
@@ -392,21 +443,23 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
     // previous folder is stale from here on even when the drive is unchanged.
     final loadGeneration = ++_folderLoadGeneration;
 
+    // A new folder redraws immediately whatever the last one did: the throttle
+    // exists to stop a folder flickering as it fills, not to delay one being
+    // opened.
+    _lastFolderRedraw = null;
+    _droppedFolderRedraw = false;
+
     if (isClosed) {
       return;
     }
 
-    // Before the wait, not after it. `changeDrive` has already cancelled the
-    // folder subscription and moved `_driveId` by the time it gets here, so
-    // until this emits, the screen still shows the drive the user just left.
-    // While a sync scrimmed the whole app that was unreachable; now that a
-    // background sync leaves the app usable, a click on a drive - or a
-    // double-click on a folder - would sit there doing nothing at all for as
-    // long as the sync ran, which on a large wallet is minutes.
+    // `changeDrive` has already cancelled the folder subscription and moved
+    // `_driveId` by the time it gets here, so until this emits, the screen
+    // still shows the drive the user just left. Saying so is what makes a
+    // click on a drive feel answered.
     //
-    // The wait itself stays: a folder must not be opened against a
-    // half-written database. What changes is that the app says it heard the
-    // click before it starts waiting.
+    // There is no wait behind it any more - see below - so this is a moment,
+    // not a screen anybody sits on.
     //
     // Except when the drive is already on screen. Navigating a folder inside a
     // drive that is syncing threw the reader out of the drive entirely and
@@ -423,19 +476,16 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
       emit(DriveDetailLoadInProgress());
     }
 
-    // Wait only for a sync that could be writing *this* drive - the same rule
-    // the initial load applies, and it has to be applied here too or it only
-    // ever holds for the very first drive opened in a session. Every later
-    // navigation goes through openFolder, so a blanket wait here meant a
-    // single-drive sync of B pinned drive A on "loading" until B finished,
-    // however long that took and however untouched A's rows were.
-    if (SyncCubit.syncTouchesDrive(
-      state: _syncCubit.state,
-      syncingDriveId: _syncCubit.syncingDriveId,
-      driveId: otherDriveId ?? _driveId,
-    )) {
-      await _syncCubit.waitCurrentSync();
-    }
+    // No wait. A folder is read from committed transactions, so what comes
+    // back mid-sync is consistent - it is simply less than the folder will
+    // eventually hold, and the subscription above fills the rest in as it
+    // lands. Waiting here bought nothing a reader wanted and cost them the
+    // drive for the length of the run.
+    //
+    // The one wait that stays is `changeDrive`'s, and it is a different
+    // question: there the drive is not in the local database at all, and only
+    // a sync will produce it. Waiting for a row that might arrive is worth
+    // doing; waiting to read rows that are already there is not.
 
     // A newer openFolder claimed the generation while this one waited - it
     // owns the subscription and the state now, so this one stops here rather
@@ -479,21 +529,40 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
             return;
           }
 
-          // Held, but only for a sync that could be writing *this* drive.
-          // This fires on every drift tick, so emitting a loading state here
-          // would blank the file list the user is browsing over and over for
-          // the length of a background sync; holding the folder already on
-          // screen until the database settles is the honest thing for a
-          // redraw nobody asked for. What it must not do is hold the *first*
-          // emission for a drive nothing is writing - that is the other half
-          // of the same bug openFolder had, and gating openFolder alone left
-          // the drive on "loading" here instead.
+          // Coalesced, not held.
+          //
+          // This used to await the whole sync, which is why a drive being
+          // synced could not be read: the folder on screen went as stale as
+          // the run was long. The reason for the hold was churn, not
+          // correctness - every batch commits in its own transaction, so a
+          // read mid-sync gets consistent data, just less of it than it will
+          // eventually have. So the fix is to redraw *less often*, not to stop
+          // redrawing: the folder fills in while the sync runs.
+          //
+          // The first tick after a folder opens is never dropped, so opening a
+          // drive mid-sync is immediate. After that, at most one redraw per
+          // [_folderRedrawInterval] for as long as a sync is writing this
+          // drive; once nothing is, every tick lands as before.
           if (SyncCubit.syncTouchesDrive(
             state: _syncCubit.state,
             syncingDriveId: _syncCubit.syncingDriveId,
+            completedDriveIds: _syncCubit.completedDriveIds,
+            runDriveIds: _syncCubit.syncingDriveIds,
             driveId: driveId,
           )) {
-            await _syncCubit.waitCurrentSync();
+            final last = _lastFolderRedraw;
+            final now = DateTime.now();
+
+            if (last != null && now.difference(last) < _folderRedrawInterval) {
+              // Dropped, and remembered as dropped. A run that ends on a
+              // dropped tick would otherwise leave the folder one batch short
+              // of what was written, with nothing else coming to correct it -
+              // see [_refreshAfterDroppedRedraws].
+              _droppedFolderRedraw = true;
+              return;
+            }
+
+            _lastFolderRedraw = now;
           }
 
           if (drive == null) {

--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -64,6 +64,9 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
 
   /// Whether a redraw was dropped by the throttle and not yet made good.
   bool _droppedFolderRedraw = false;
+
+  /// What was last drawn, so a tick that changes nothing can be recognised.
+  FolderWithContents? _lastFolderContents;
   bool _isExplicitSync = false;
 
   /// Bumped by every [openFolder]. Cancelling `_folderSubscription` does not
@@ -448,6 +451,7 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
     // opened.
     _lastFolderRedraw = null;
     _droppedFolderRedraw = false;
+    _lastFolderContents = null;
 
     if (isClosed) {
       return;
@@ -529,6 +533,24 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
             return;
           }
 
+          // Most ticks carry nothing new, so the cheapest question first.
+          //
+          // Drift re-runs a watched query when the *tables* it reads change,
+          // not when its own result does. A sync writing folder X therefore
+          // re-emits folder Y - the one on screen - with contents identical to
+          // what is already drawn, once per batch for the length of the run.
+          // Those redraws are pure waste: they parse the same rows, rebuild
+          // the same breadcrumb and emit the same list.
+          //
+          // FolderWithContents is Equatable, so this is exact rather than a
+          // heuristic: skip only when nothing a reader could see has changed.
+          // Unlike the interval below it, this never delays anything - a tick
+          // that carries a real change is never the one dropped here.
+          if (_lastFolderContents == folderContents &&
+              this.state is DriveDetailLoadSuccess) {
+            return;
+          }
+
           // Coalesced, not held.
           //
           // This used to await the whole sync, which is why a drive being
@@ -564,6 +586,8 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
 
             _lastFolderRedraw = now;
           }
+
+          _lastFolderContents = folderContents;
 
           if (drive == null) {
             emit(DriveDetailLoadNotFound());

--- a/lib/blocs/drives/drives_cubit.dart
+++ b/lib/blocs/drives/drives_cubit.dart
@@ -266,6 +266,31 @@ class DrivesCubit extends Cubit<DrivesState> {
   }
 
   Future<void> detachDrive(DriveID driveId) async {
+    // Stop a sync that is writing this drive before deleting its rows.
+    //
+    // Detaching used to delete the drive out from under a running sync, which
+    // then went on walking a drive that no longer existed - writing revisions
+    // against a deleted row, or throwing part way and reporting the drive as
+    // failed. The one-second wait below was the only thing between the two,
+    // and a wait is not a guarantee.
+    //
+    // This is also the case a reader most wants it for: a shared drive turns
+    // out to hold a million transactions, and the way out is to stop it and
+    // get rid of it. Stopping first makes that safe rather than lucky.
+    if (SyncCubit.syncTouchesDrive(
+      state: _syncCubit.state,
+      syncingDriveId: _syncCubit.syncingDriveId,
+      completedDriveIds: _syncCubit.completedDriveIds,
+      runDriveIds: _syncCubit.syncingDriveIds,
+      driveId: driveId,
+    )) {
+      _syncCubit.cancelSync();
+
+      // The repository notices at its next checkpoint, so this waits for the
+      // run to actually unwind rather than for the request to be made.
+      await _syncCubit.waitCurrentSync();
+    }
+
     _resetDriveSelection(driveId);
     await Future.delayed(const Duration(seconds: 1));
     await _driveDao.deleteDriveById(driveId: driveId);

--- a/lib/components/app_top_bar.dart
+++ b/lib/components/app_top_bar.dart
@@ -913,6 +913,24 @@ class _SyncButtonMenu extends StatelessWidget {
     // appears when there is something to report, so a menu of controls behind
     // it would be a second place to do what that page already does.
     final items = [
+      // The way out of a sync that is going to take longer than the reader is
+      // willing to wait.
+      //
+      // The engine has always been able to stop one - both entry points carry
+      // a cancellation token and both report SyncCancelled - but the only
+      // control that asked for it was the blocking modal, and that went when
+      // sync stopped taking the app away. So a drive with a million
+      // transactions could be started and not stopped, which is the one case
+      // the feature exists for. This is where a running sync is already
+      // reported, so it is where the way to stop it belongs.
+      if (isSyncing)
+        ArDriveDropdownItem(
+          onClick: () => context.read<SyncCubit>().cancelSync(),
+          content: ArDriveDropdownItemTile(
+            name: appLocalizationsOf(context).syncStopRunning,
+            icon: ArDriveIcons.x(color: iconColor),
+          ),
+        ),
       ArDriveDropdownItem(
         onClick: () => context.read<AppRouterDelegate>().showDrivesList(),
         content: ArDriveDropdownItemTile(

--- a/lib/components/drive_detach_dialog.dart
+++ b/lib/components/drive_detach_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:ardrive/blocs/drives/drives_cubit.dart';
+import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
 import 'package:ardrive/utils/app_localizations_wrapper.dart';
 import 'package:ardrive/utils/show_general_dialog.dart';
 import 'package:ardrive_ui/ardrive_ui.dart';
@@ -6,28 +7,112 @@ import 'package:ardrive_utils/ardrive_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+/// Confirming the detach of a drive somebody else owns.
+///
+/// Every path here is gated on `!isOwner`, so this is always a shared drive,
+/// and a shared drive detaches differently from one of your own. An owned
+/// drive is found again by the next drive-list refresh, because it is
+/// discovered from the transactions the wallet signed. A shared drive was
+/// never discovered at all: it is here only because a link was followed, and
+/// nothing will find it again. So detaching one is one-way unless the reader
+/// still has that link, and the dialog gave them no way to know that.
+///
+/// That is the only thing worth adding. Somebody who attached a drive
+/// belonging to somebody else does not need telling it stays on Arweave, and a
+/// dialog that explains what a reader already knows buys nothing and costs
+/// them the sentence that matters.
+///
+/// The sync line is said only while a sync is actually running, so the two are
+/// not left looking like a race.
 Future<void> showDetachDriveDialog({
   required BuildContext context,
   required DriveID driveID,
   required String driveName,
-}) =>
-    showArDriveDialog(
-      context,
-      content: ArDriveStandardModalNew(
-        title: appLocalizationsOf(context).detachDrive,
-        description: appLocalizationsOf(context).detachDriveQuestion(driveName),
-        actions: [
-          ModalAction(
-            action: () => Navigator.of(context).pop(null),
-            title: appLocalizationsOf(context).cancelEmphasized,
+}) {
+  // Read once, before the dialog opens. Inside it this is a static sentence
+  // about what pressing Detach will do, not a live report - a line that
+  // appeared or vanished under a reader deciding is worse than either.
+  final syncCubit = context.read<SyncCubit>();
+  final syncIsRunningOnIt = SyncCubit.syncTouchesDrive(
+    state: syncCubit.state,
+    syncingDriveId: syncCubit.syncingDriveId,
+    completedDriveIds: syncCubit.completedDriveIds,
+    runDriveIds: syncCubit.syncingDriveIds,
+    driveId: driveID,
+  );
+
+  return showArDriveDialog(
+    context,
+    content: _DetachDriveModal(
+      driveID: driveID,
+      driveName: driveName,
+      syncIsRunningOnIt: syncIsRunningOnIt,
+    ),
+  );
+}
+
+class _DetachDriveModal extends StatelessWidget {
+  const _DetachDriveModal({
+    required this.driveID,
+    required this.driveName,
+    required this.syncIsRunningOnIt,
+  });
+
+  final DriveID driveID;
+  final String driveName;
+  final bool syncIsRunningOnIt;
+
+  @override
+  Widget build(BuildContext context) {
+    final typography = ArDriveTypographyNew.of(context);
+    final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
+
+    Widget line(String text, {bool emphasised = false}) => Padding(
+          padding: const EdgeInsets.only(bottom: 12),
+          child: Text(
+            text,
+            style: typography.paragraphNormal(
+              // The question carries the drive's name and reads a step
+              // stronger than what follows it.
+              color: emphasised ? colorTokens.textHigh : colorTokens.textMid,
+              fontWeight:
+                  emphasised ? ArFontWeight.semiBold : ArFontWeight.book,
+            ),
           ),
-          ModalAction(
-            action: () {
-              context.read<DrivesCubit>().detachDrive(driveID);
-              Navigator.of(context).pop();
-            },
-            title: appLocalizationsOf(context).detachEmphasized,
+        );
+
+    return ArDriveStandardModalNew(
+      title: appLocalizationsOf(context).detachDrive,
+      // Everything in `content`, including the question. The modal renders
+      // `description` only when it has no `content`, so passing both drops the
+      // one carrying the drive's name - which is the single word a reader
+      // needs to be sure they are detaching the drive they meant.
+      content: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          line(
+            appLocalizationsOf(context).detachDriveQuestion(driveName),
+            emphasised: true,
           ),
+          line(appLocalizationsOf(context).detachDriveNeedsLinkAgain),
+          if (syncIsRunningOnIt)
+            line(appLocalizationsOf(context).detachDriveStopsSync),
         ],
       ),
+      actions: [
+        ModalAction(
+          action: () => Navigator.of(context).pop(null),
+          title: appLocalizationsOf(context).cancelEmphasized,
+        ),
+        ModalAction(
+          action: () {
+            context.read<DrivesCubit>().detachDrive(driveID);
+            Navigator.of(context).pop();
+          },
+          title: appLocalizationsOf(context).detachEmphasized,
+        ),
+      ],
     );
+  }
+}

--- a/lib/components/profile_card.dart
+++ b/lib/components/profile_card.dart
@@ -478,12 +478,25 @@ class _ProfileCardState extends State<ProfileCard> {
     DriveDao driveDao,
     String walletAddress,
   ) async {
-    // Only the drives this wallet owns. A drive shared with the account is
-    // somebody else's storage, readable here - counting it made this line
-    // describe what the reader can see rather than what they are keeping, and
-    // a shared drive of a million files would have dwarfed their own.
+    // Only the drives this wallet owns, and only the ones it is showing.
+    //
+    // A drive shared with the account is somebody else's storage, readable
+    // here - counting it made this line describe what the reader can see
+    // rather than what they are keeping, and a shared drive of a million files
+    // would have dwarfed their own.
+    //
+    // A hidden drive is left out because every other surface leaves it out:
+    // `allDrives()` is a plain `SELECT * FROM drives`, while the sidebar's
+    // scopes all exclude hidden drives, so this line could say seventeen
+    // drives beside an All drives that listed fifteen.
+    //
+    // Hidden *files* inside a drive still count, and the show-hidden toggle
+    // does not change these numbers. Hiding is a view preference: it frees
+    // nothing, and a figure for what somebody is keeping must not fall because
+    // they flipped a switch that changed nothing about what is stored.
     final drives = (await driveDao.allDrives().get())
-        .where((drive) => drive.ownerAddress == walletAddress)
+        .where(
+            (drive) => drive.ownerAddress == walletAddress && !drive.isHidden)
         .toList();
 
     final summaries = await driveDao.driveContentSummaries();

--- a/lib/components/profile_card.dart
+++ b/lib/components/profile_card.dart
@@ -52,6 +52,9 @@ class _ProfileCardState extends State<ProfileCard> {
   bool _showProfileCard = false;
   Future<_AccountStats>? _accountStatsFuture;
 
+  /// Whose statistics [_accountStatsFuture] holds.
+  String? _accountStatsForWallet;
+
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<ProfileCubit, ProfileState>(
@@ -429,7 +432,15 @@ class _ProfileCardState extends State<ProfileCard> {
     // account's storage - it is somebody else's, readable here.
     final walletAddress = context.read<ArDriveAuth>().currentUser.walletAddress;
 
-    _accountStatsFuture ??= _getAccountStats(driveDao, walletAddress);
+    // Keyed to the wallet, not merely computed once. This card stays mounted
+    // while the profile changes between logged-in and logged-out, so a plain
+    // `??=` let a second account read the first one's drive count, file count
+    // and size.
+    if (_accountStatsFuture == null ||
+        _accountStatsForWallet != walletAddress) {
+      _accountStatsForWallet = walletAddress;
+      _accountStatsFuture = _getAccountStats(driveDao, walletAddress);
+    }
 
     return FutureBuilder<_AccountStats>(
       future: _accountStatsFuture,

--- a/lib/components/profile_card.dart
+++ b/lib/components/profile_card.dart
@@ -424,7 +424,12 @@ class _ProfileCardState extends State<ProfileCard> {
     final typography = ArDriveTypographyNew.of(context);
     final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
     final driveDao = context.read<DriveDao>();
-    _accountStatsFuture ??= _getAccountStats(driveDao);
+
+    // Whose drives these are. A drive somebody else shared is not this
+    // account's storage - it is somebody else's, readable here.
+    final walletAddress = context.read<ArDriveAuth>().currentUser.walletAddress;
+
+    _accountStatsFuture ??= _getAccountStats(driveDao, walletAddress);
 
     return FutureBuilder<_AccountStats>(
       future: _accountStatsFuture,
@@ -447,19 +452,56 @@ class _ProfileCardState extends State<ProfileCard> {
     );
   }
 
-  Future<_AccountStats> _getAccountStats(DriveDao driveDao) async {
-    final drives = await driveDao.allDrives().get();
+  /// What this account holds locally, counted the way the drives list counts
+  /// it.
+  ///
+  /// This used `filesInDriveWithRevisionTransactions`, once per drive, and
+  /// added up the rows it returned. That query inner-joins each file to the
+  /// metadata and data transactions of its latest revision, so **a file whose
+  /// transaction rows have not synced yet is not in the result at all** - it is
+  /// dropped from the count and its bytes from the total. As a sync fills those
+  /// rows in, the same drive reports a larger total than it did before, which
+  /// is what a reader sees as "the same drive, a different number of GB in each
+  /// session".
+  ///
+  /// [DriveDao.driveContentSummaries] asks the question this line is actually
+  /// asking: how many files are in the local tables, and how big are they. One
+  /// aggregate query for every drive rather than one query per drive returning
+  /// every row, summed in SQL rather than in Dart - and, being the same source
+  /// the drives list reads, it cannot disagree with the per-drive figures shown
+  /// there.
+  ///
+  /// Both numbers still describe this device rather than Arweave: a drive that
+  /// has not been walked contributes nothing, because nothing about it is
+  /// known.
+  Future<_AccountStats> _getAccountStats(
+    DriveDao driveDao,
+    String walletAddress,
+  ) async {
+    // Only the drives this wallet owns. A drive shared with the account is
+    // somebody else's storage, readable here - counting it made this line
+    // describe what the reader can see rather than what they are keeping, and
+    // a shared drive of a million files would have dwarfed their own.
+    final drives = (await driveDao.allDrives().get())
+        .where((drive) => drive.ownerAddress == walletAddress)
+        .toList();
+
+    final summaries = await driveDao.driveContentSummaries();
+
     var fileCount = 0;
     var totalSize = 0;
+
     for (final drive in drives) {
-      final files = await driveDao
-          .filesInDriveWithRevisionTransactions(driveId: drive.id)
-          .get();
-      fileCount += files.length;
-      for (final file in files) {
-        totalSize += file.size;
+      final summary = summaries[drive.id];
+
+      if (summary == null) {
+        continue;
       }
+
+      fileCount += summary.fileCount;
+      totalSize += summary.totalSize;
     }
+
     return _AccountStats(
       driveCount: drives.length,
       fileCount: fileCount,

--- a/lib/components/upload_form.dart
+++ b/lib/components/upload_form.dart
@@ -7,6 +7,7 @@ import 'package:ardrive/turbo/topup/views/topup_modal.dart';
 import 'package:ardrive/arns/presentation/assign_name_modal.dart';
 import 'package:ardrive/authentication/ardrive_auth.dart';
 import 'package:ardrive/blocs/blocs.dart';
+import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
 import 'package:ardrive/blocs/create_manifest/create_manifest_cubit.dart';
 import 'package:ardrive/blocs/upload/enums/conflicting_files_actions.dart';
 import 'package:ardrive/blocs/upload/limits.dart';
@@ -215,8 +216,18 @@ class _UploadFormState extends State<UploadForm> {
               if (!_isShowingCancelDialog) {
                 Navigator.pop(context);
                 context.read<ActivityTracker>().setUploading(false);
-                // No sync needed — local DB already has the uploaded file.
-                // Background periodic sync will update lastBlockHeight naturally.
+
+                // The file is already in the local database, so nothing needs
+                // syncing for it to be *seen*. What it does need is
+                // confirming: this asks again every few minutes until the
+                // transaction is mined, and then stops.
+                //
+                // The comment that used to sit here said a background periodic
+                // sync would take care of it. It would not: that timer is
+                // gated on `autoSync`, which ships false in all three
+                // flavours, so an uploaded file stayed unconfirmed until the
+                // reader pressed sync or logged in again.
+                context.read<SyncCubit>().watchForPendingConfirmations();
               }
 
               widget.driveDetailCubit.refreshDriveDataTable();

--- a/lib/drives_list/presentation/drive_list_row.dart
+++ b/lib/drives_list/presentation/drive_list_row.dart
@@ -124,6 +124,8 @@ class DriveListHeader extends StatelessWidget {
     this.sort,
     this.sortAscending = true,
     this.onSort,
+    this.allSelected,
+    this.onToggleSelectAll,
   });
 
   /// Which column is ordering the list, if this header is sortable.
@@ -136,6 +138,12 @@ class DriveListHeader extends StatelessWidget {
   /// handler draws as plain text and takes no taps, which is what the tests
   /// that only care about layout get.
   final void Function(DriveListSort column)? onSort;
+
+  /// Whether every drive on screen is ticked, some are, or none - null when
+  /// the list is not offering selection.
+  final bool? allSelected;
+
+  final VoidCallback? onToggleSelectAll;
 
   @override
   Widget build(BuildContext context) {
@@ -209,6 +217,17 @@ class DriveListHeader extends StatelessWidget {
       ),
       child: Row(
         children: [
+          if (allSelected != null)
+            Padding(
+              padding: const EdgeInsets.only(
+                left: driveListRowHorizontalPadding,
+              ),
+              child: ArDriveCheckBox(
+                key: ValueKey('select-all-$allSelected'),
+                checked: allSelected!,
+                onChange: (_) => onToggleSelectAll?.call(),
+              ),
+            ),
           heading(appLocalizationsOf(context).name, _nameFlex,
               column: DriveListSort.name),
           const SizedBox(width: _columnGap),
@@ -239,6 +258,8 @@ class DriveListRow extends StatelessWidget {
     required this.onTap,
     required this.showsColumns,
     this.menu,
+    this.selected,
+    this.onSelectedChanged,
   });
 
   final DriveListItem drive;
@@ -257,6 +278,13 @@ class DriveListRow extends StatelessWidget {
   /// above these rows is drawn from the same answer, and the two disagreeing
   /// is a table header over a column of cards.
   final bool showsColumns;
+
+  /// Whether this drive is ticked, or null when the list is not offering
+  /// selection at all - which is how the checkbox disappears entirely rather
+  /// than being drawn disabled.
+  final bool? selected;
+
+  final void Function(String driveId)? onSelectedChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -288,6 +316,20 @@ class DriveListRow extends StatelessWidget {
         // the stacked card, which is taller than the target either way.
         child: Row(
           children: [
+            if (selected != null && showsColumns)
+              Padding(
+                padding: const EdgeInsets.only(
+                  left: driveListRowHorizontalPadding,
+                ),
+                child: ArDriveCheckBox(
+                  key: ValueKey('select-${drive.id}-$selected'),
+                  checked: selected!,
+                  // Its own target, beside the row's content rather than
+                  // inside it, so ticking a drive is never mistaken for
+                  // opening one.
+                  onChange: (_) => onSelectedChanged?.call(drive.id),
+                ),
+              ),
             Expanded(
               child: ArDriveClickArea(
                 child: Semantics(

--- a/lib/drives_list/presentation/drive_list_row.dart
+++ b/lib/drives_list/presentation/drive_list_row.dart
@@ -47,6 +47,14 @@ const double driveListMaxContentWidth = 1200;
 /// made on the width the row will actually lay out in.
 const double driveListRowHorizontalPadding = 16;
 
+/// The width of the selection column, header and rows alike.
+///
+/// One constant for both so the ticks line up down the table - the usual
+/// failure is a header drawn inside the table's own padding and rows drawn
+/// outside it, which offsets the two by exactly that padding. Wide enough to
+/// hold the box and the gap a checkbox needs from what it labels.
+const double driveListCheckboxColumn = 40;
+
 /// How big the per-row actions menu's tap target is.
 ///
 /// The touch minimum, and no larger: a row that draws columns is 48px tall -
@@ -218,14 +226,15 @@ class DriveListHeader extends StatelessWidget {
       child: Row(
         children: [
           if (allSelected != null)
-            Padding(
-              padding: const EdgeInsets.only(
-                left: driveListRowHorizontalPadding,
-              ),
-              child: ArDriveCheckBox(
-                key: ValueKey('select-all-$allSelected'),
-                checked: allSelected!,
-                onChange: (_) => onToggleSelectAll?.call(),
+            SizedBox(
+              width: driveListCheckboxColumn,
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: ArDriveCheckBox(
+                  key: ValueKey('select-all-$allSelected'),
+                  checked: allSelected!,
+                  onChange: (_) => onToggleSelectAll?.call(),
+                ),
               ),
             ),
           heading(appLocalizationsOf(context).name, _nameFlex,
@@ -321,13 +330,19 @@ class DriveListRow extends StatelessWidget {
                 padding: const EdgeInsets.only(
                   left: driveListRowHorizontalPadding,
                 ),
-                child: ArDriveCheckBox(
-                  key: ValueKey('select-${drive.id}-$selected'),
-                  checked: selected!,
-                  // Its own target, beside the row's content rather than
-                  // inside it, so ticking a drive is never mistaken for
-                  // opening one.
-                  onChange: (_) => onSelectedChanged?.call(drive.id),
+                child: SizedBox(
+                  width: driveListCheckboxColumn,
+                  child: Align(
+                    alignment: Alignment.centerLeft,
+                    // Its own target, beside the row's content rather than
+                    // inside it, so ticking a drive is never mistaken for
+                    // opening one.
+                    child: ArDriveCheckBox(
+                      key: ValueKey('select-${drive.id}-$selected'),
+                      checked: selected!,
+                      onChange: (_) => onSelectedChanged?.call(drive.id),
+                    ),
+                  ),
                 ),
               ),
             Expanded(
@@ -338,9 +353,16 @@ class DriveListRow extends StatelessWidget {
                   child: InkWell(
                     onTap: onTap,
                     child: Padding(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: driveListRowHorizontalPadding,
-                        vertical: _rowVerticalPadding,
+                      // The checkbox column already supplies the gutter on
+                      // its side, so the name would otherwise be indented one
+                      // padding further than the heading above it.
+                      padding: EdgeInsets.only(
+                        left: selected != null && showsColumns
+                            ? 0
+                            : driveListRowHorizontalPadding,
+                        right: driveListRowHorizontalPadding,
+                        top: _rowVerticalPadding,
+                        bottom: _rowVerticalPadding,
                       ),
                       child:
                           showsColumns ? _columns(context) : _stacked(context),

--- a/lib/drives_list/presentation/drives_list_cubit.dart
+++ b/lib/drives_list/presentation/drives_list_cubit.dart
@@ -136,7 +136,12 @@ class DrivesListCubit extends Cubit<DrivesListState> {
       // The drives themselves are in hand; only the per-drive numbers are not.
       // Draw the list without them rather than losing the page over a count.
       logger.e('Could not read the per-drive content summaries', e, stackTrace);
-      _emitDrives(drivesState, const {}, const {}, sequence);
+      // Null, not an empty map. An empty map is a true answer - "every drive
+      // was read and none of them has any files" - and passing one for a read
+      // that failed made every walked drive report 0 files and 0 B. A figure
+      // nobody could produce is exactly the confident wrong answer the dash
+      // exists to avoid.
+      _emitDrives(drivesState, null, const {}, sequence);
       return;
     }
 
@@ -170,7 +175,15 @@ class DrivesListCubit extends Cubit<DrivesListState> {
 
   void _emitDrives(
     DrivesLoadSuccess drivesState,
-    Map<String, DriveContentSummary> summaries,
+
+    /// What each drive holds locally, or null when that could not be read.
+    ///
+    /// The two are different answers and the row shows different things for
+    /// them: a drive missing from a map that *was* read has no files, and is
+    /// 0; a drive whose figures could not be read at all is unknown, and is a
+    /// dash. Collapsing them is how a failed local query turned into every
+    /// drive reporting itself as empty.
+    Map<String, DriveContentSummary>? summaries,
     Map<String, DateTime> lastSyncedAt,
     int sequence,
   ) {
@@ -209,7 +222,11 @@ class DrivesListCubit extends Cubit<DrivesListState> {
       final hasBeenWalked =
           (drive.lastBlockHeight ?? 0) > 0 || syncedAt != null;
 
-      final summary = summaries[drive.id] ?? DriveContentSummary.empty;
+      // Unknown when the read failed; empty when it succeeded and this drive
+      // simply has nothing in it.
+      final summary = summaries == null
+          ? null
+          : summaries[drive.id] ?? DriveContentSummary.empty;
 
       return DriveListItem(
         id: drive.id,
@@ -219,8 +236,8 @@ class DrivesListCubit extends Cubit<DrivesListState> {
         isHidden: drive.isHidden,
         dateCreated: drive.dateCreated,
         hasBeenWalked: hasBeenWalked,
-        fileCount: hasBeenWalked ? summary.fileCount : null,
-        totalSize: hasBeenWalked ? summary.totalSize : null,
+        fileCount: hasBeenWalked ? summary?.fileCount : null,
+        totalSize: hasBeenWalked ? summary?.totalSize : null,
         lastSyncedAt: syncedAt,
         // Says "Syncing..." only of a drive this run actually covers, and
         // stops saying it once the drive has been walked. A four-of-ten run

--- a/lib/drives_list/presentation/drives_list_cubit.dart
+++ b/lib/drives_list/presentation/drives_list_cubit.dart
@@ -230,7 +230,9 @@ class DrivesListCubit extends Cubit<DrivesListState> {
         isSyncing: syncState is SyncInProgress &&
             (syncingDriveId == null || syncingDriveId == drive.id) &&
             (runDriveIds == null || runDriveIds.contains(drive.id)) &&
-            !completedDriveIds.contains(drive.id),
+            // Same rule as the gate: a single-drive sync says so until it is
+            // over, because its walk finishing is not the run finishing.
+            (syncingDriveId != null || !completedDriveIds.contains(drive.id)),
         lastSyncFailed: failedDriveIds.contains(drive.id),
       );
     }).toList();
@@ -445,22 +447,27 @@ class DrivesListCubit extends Cubit<DrivesListState> {
   /// One run over four drives, not four runs: the engine has always walked an
   /// arbitrary subset concurrently. With nothing ticked this is a full sync,
   /// so the control behind it never has to be disabled.
-  void syncSelectedDrives() {
+  void syncSelectedDrives({bool deep = false}) {
     if (_selected.isEmpty) {
-      syncAllDrives();
+      unawaited(_syncCubit.startSync(deepSync: deep));
       return;
     }
 
-    unawaited(_syncSelected(_selected.toList()));
+    unawaited(_syncSelected(_selected.toList(), deep: deep));
   }
 
-  Future<void> _syncSelected(List<String> chosen) async {
+  /// Whether anything is ticked, so a control can say which it will act on.
+  bool get hasSelection => _selected.isNotEmpty;
+
+  int get selectionCount => _selected.length;
+
+  Future<void> _syncSelected(List<String> chosen, {bool deep = false}) async {
     // Only a run that actually started may take the selection away. A sync is
     // refused outright while another is going - one at a time, never queued -
     // and clearing first meant a press during a sync silently threw the ticks
     // away and did nothing with them. The reader would then have to find and
     // re-tick the same four drives to try again.
-    final started = await _syncCubit.syncDrives(chosen);
+    final started = await _syncCubit.syncDrives(chosen, deep: deep);
 
     if (isClosed || !started) {
       return;

--- a/lib/drives_list/presentation/drives_list_cubit.dart
+++ b/lib/drives_list/presentation/drives_list_cubit.dart
@@ -190,6 +190,8 @@ class DrivesListCubit extends Cubit<DrivesListState> {
 
     final syncState = _syncCubit.state;
     final syncingDriveId = _syncCubit.syncingDriveId;
+    final runDriveIds = _syncCubit.syncingDriveIds;
+    final completedDriveIds = _syncCubit.completedDriveIds.toSet();
 
     // The top bar says "1 of 5 drives failed" and the list is where a reader
     // goes to find out which. The state has always carried the ids; nothing on
@@ -220,8 +222,15 @@ class DrivesListCubit extends Cubit<DrivesListState> {
         fileCount: hasBeenWalked ? summary.fileCount : null,
         totalSize: hasBeenWalked ? summary.totalSize : null,
         lastSyncedAt: syncedAt,
+        // Says "Syncing..." only of a drive this run actually covers, and
+        // stops saying it once the drive has been walked. A four-of-ten run
+        // used to light up all ten rows, because a subset run carries no
+        // single drive id - and a row that finished went on claiming to be
+        // busy until the whole run did.
         isSyncing: syncState is SyncInProgress &&
-            (syncingDriveId == null || syncingDriveId == drive.id),
+            (syncingDriveId == null || syncingDriveId == drive.id) &&
+            (runDriveIds == null || runDriveIds.contains(drive.id)) &&
+            !completedDriveIds.contains(drive.id),
         lastSyncFailed: failedDriveIds.contains(drive.id),
       );
     }).toList();
@@ -232,12 +241,18 @@ class DrivesListCubit extends Cubit<DrivesListState> {
     final shown = items.where(_scope.matches).toList()
       ..sort(_sort.comparator(ascending: _sortAscending));
 
+    // A drive that has been detached or hidden since the tick was made is no
+    // longer selectable, and must not be carried into a sync as though it
+    // were.
+    _selected.retainAll(shown.map((drive) => drive.id).toSet());
+
     emit(DrivesListLoaded(
       drives: shown,
       scope: _scope,
       counts: DriveScopeCounts.of(items),
       sort: _sort,
       sortAscending: _sortAscending,
+      selected: Set.unmodifiable(_selected),
     ));
   }
 
@@ -296,6 +311,9 @@ class DrivesListCubit extends Cubit<DrivesListState> {
     }
 
     _scope = scope;
+    // Ticks in a scope that is no longer on screen cannot be reviewed or taken
+    // back, so they do not survive the change.
+    _selected.clear();
     _refresh();
   }
 
@@ -334,6 +352,121 @@ class DrivesListCubit extends Cubit<DrivesListState> {
   /// was simply wrong.
   void syncAllDrives() {
     unawaited(_syncCubit.startSync());
+  }
+
+  /// Which drives the reader has ticked, if any.
+  ///
+  /// Empty is not "none selected and therefore none" - it is "no selection",
+  /// and the controls read it that way: with nothing ticked the action is
+  /// still Sync All Drives.
+  final Set<String> _selected = {};
+
+  /// Ticks or unticks one drive.
+  void toggleSelected(String driveId) {
+    if (!_selected.remove(driveId)) {
+      _selected.add(driveId);
+    }
+
+    _emitSelection();
+  }
+
+  /// Ticks every drive in the scope on screen, or clears them if all are
+  /// already ticked - the behaviour of a header checkbox everywhere.
+  void toggleSelectAll() {
+    final current = state;
+
+    if (current is! DrivesListLoaded) {
+      return;
+    }
+
+    final shown = current.drives.map((drive) => drive.id).toSet();
+
+    if (shown.every(_selected.contains)) {
+      _selected.removeAll(shown);
+    } else {
+      _selected.addAll(shown);
+    }
+
+    _emitSelection();
+  }
+
+  /// Drops the selection - after a sync starts, and whenever the scope changes
+  /// under it, since a tick the reader can no longer see is a tick they cannot
+  /// take back.
+  void clearSelection() {
+    if (_selected.isEmpty) {
+      return;
+    }
+
+    _selected.clear();
+    _emitSelection();
+  }
+
+  void _emitSelection() {
+    final current = state;
+
+    if (current is! DrivesListLoaded) {
+      return;
+    }
+
+    emit(DrivesListLoaded(
+      drives: current.drives,
+      scope: current.scope,
+      counts: current.counts,
+      sort: current.sort,
+      sortAscending: current.sortAscending,
+      selected: Set.unmodifiable(_selected),
+    ));
+  }
+
+  /// Re-reads only the drives the last sync could not read.
+  ///
+  /// The same one-run subset walk a selection uses. Offered on the page rather
+  /// than only inside a menu because a partial failure is the moment a reader
+  /// most needs one button that fixes exactly the thing that broke.
+  void retryFailedDrives() {
+    final current = state;
+
+    if (current is! DrivesListLoaded) {
+      return;
+    }
+
+    final failed = current.failedDriveIds;
+
+    if (failed.isEmpty) {
+      return;
+    }
+
+    unawaited(_syncCubit.syncDrives(failed));
+  }
+
+  /// Syncs the ticked drives in one run, then drops the selection.
+  ///
+  /// One run over four drives, not four runs: the engine has always walked an
+  /// arbitrary subset concurrently. With nothing ticked this is a full sync,
+  /// so the control behind it never has to be disabled.
+  void syncSelectedDrives() {
+    if (_selected.isEmpty) {
+      syncAllDrives();
+      return;
+    }
+
+    unawaited(_syncSelected(_selected.toList()));
+  }
+
+  Future<void> _syncSelected(List<String> chosen) async {
+    // Only a run that actually started may take the selection away. A sync is
+    // refused outright while another is going - one at a time, never queued -
+    // and clearing first meant a press during a sync silently threw the ticks
+    // away and did nothing with them. The reader would then have to find and
+    // re-tick the same four drives to try again.
+    final started = await _syncCubit.syncDrives(chosen);
+
+    if (isClosed || !started) {
+      return;
+    }
+
+    clearSelection();
   }
 
   @override

--- a/lib/drives_list/presentation/drives_list_page.dart
+++ b/lib/drives_list/presentation/drives_list_page.dart
@@ -203,6 +203,11 @@ class _DrivesListChrome extends StatelessWidget {
           onTryAgain: cubit.retryLoadingDrives,
           onSyncAllDrives: cubit.syncAllDrives,
           onSort: cubit.sortBy,
+          onToggleSelected: cubit.toggleSelected,
+          onToggleSelectAll: cubit.toggleSelectAll,
+          onSyncSelected: cubit.syncSelectedDrives,
+          onClearSelection: cubit.clearSelection,
+          onRetryFailed: cubit.retryFailedDrives,
           buildMenu: (drive) => _menuFor(drivesState, drive),
           syncMenu: const DrivesSyncMenu(),
         );
@@ -263,6 +268,11 @@ class DrivesListBody extends StatelessWidget {
     required this.onTryAgain,
     required this.onSyncAllDrives,
     this.onSort,
+    this.onToggleSelected,
+    this.onToggleSelectAll,
+    this.onSyncSelected,
+    this.onClearSelection,
+    this.onRetryFailed,
     this.buildMenu,
     this.syncMenu,
   });
@@ -275,6 +285,14 @@ class DrivesListBody extends StatelessWidget {
   /// Called with the column whose heading was pressed. Optional so the tests
   /// that only draw the four states need not supply one.
   final void Function(DriveListSort column)? onSort;
+
+  /// Selection, threaded the same way [onSort] is - the page draws what it is
+  /// given so its tests need no providers.
+  final void Function(String driveId)? onToggleSelected;
+  final VoidCallback? onToggleSelectAll;
+  final VoidCallback? onSyncSelected;
+  final VoidCallback? onClearSelection;
+  final VoidCallback? onRetryFailed;
 
   /// Builds the actions menu for one row, or returns null for a row that has
   /// none.
@@ -318,6 +336,11 @@ class DrivesListBody extends StatelessWidget {
         buildMenu: buildMenu,
         syncMenu: syncMenu,
         onSort: onSort,
+        onToggleSelected: onToggleSelected,
+        onToggleSelectAll: onToggleSelectAll,
+        onSyncSelected: onSyncSelected,
+        onClearSelection: onClearSelection,
+        onRetryFailed: onRetryFailed,
       );
     }
 
@@ -493,12 +516,22 @@ class _DrivesListLoadedView extends StatelessWidget {
     required this.buildMenu,
     required this.syncMenu,
     this.onSort,
+    this.onToggleSelected,
+    this.onToggleSelectAll,
+    this.onSyncSelected,
+    this.onClearSelection,
+    this.onRetryFailed,
   });
 
   final DrivesListLoaded state;
   final void Function(DriveListItem drive) onOpenDrive;
   final VoidCallback onSyncAllDrives;
   final void Function(DriveListSort column)? onSort;
+  final void Function(String driveId)? onToggleSelected;
+  final VoidCallback? onToggleSelectAll;
+  final VoidCallback? onSyncSelected;
+  final VoidCallback? onClearSelection;
+  final VoidCallback? onRetryFailed;
   final Widget? Function(DriveListItem drive)? buildMenu;
 
   /// The drive-wide sync actions, passed in rather than reached for.
@@ -551,6 +584,37 @@ class _DrivesListLoadedView extends StatelessWidget {
                       ),
                     ),
                   const SliverToBoxAdapter(child: SizedBox(height: _blockGap)),
+                  // A partial failure, said once and fixable in one press.
+                  // Above the selection bar because it is the more urgent of
+                  // the two, and below the sync prompt because a wallet that
+                  // has never synced has no failures to report yet.
+                  if (state.failedDriveIds.isNotEmpty &&
+                      !state.isSyncing &&
+                      onRetryFailed != null)
+                    SliverToBoxAdapter(
+                      child: Padding(
+                        padding: const EdgeInsets.only(bottom: _blockGap),
+                        child: _PartialFailureBanner(
+                          failed: state.failedDriveIds.length,
+                          total: state.drives.length,
+                          onRetry: onRetryFailed!,
+                        ),
+                      ),
+                    ),
+                  // Present only while something is ticked. A bar that is
+                  // always there, with a count of zero and a disabled button,
+                  // is a control explaining that it cannot be used.
+                  if (state.selected.isNotEmpty && onSyncSelected != null)
+                    SliverToBoxAdapter(
+                      child: Padding(
+                        padding: const EdgeInsets.only(bottom: _blockGap),
+                        child: _SelectionBar(
+                          count: state.selected.length,
+                          onSyncSelected: onSyncSelected!,
+                          onClear: onClearSelection,
+                        ),
+                      ),
+                    ),
                   // The panel every other table in the app sits in.
                   //
                   // `ArDriveDataTable` wraps its header and rows in an
@@ -589,6 +653,15 @@ class _DrivesListLoadedView extends StatelessWidget {
                               sort: state.sort,
                               sortAscending: state.sortAscending,
                               onSort: onSort,
+                              // Offered only where there is room for a column
+                              // of checkboxes, and only when something can be
+                              // done with a selection.
+                              allSelected: onToggleSelectAll == null
+                                  ? null
+                                  : state.drives.isNotEmpty &&
+                                      state.drives.every((drive) =>
+                                          state.selected.contains(drive.id)),
+                              onToggleSelectAll: onToggleSelectAll,
                             ),
                           ),
                           _rows(state, showsColumns),
@@ -628,6 +701,10 @@ class _DrivesListLoadedView extends StatelessWidget {
             showsColumns: showsColumns,
             onTap: () => onOpenDrive(drive),
             menu: buildMenu?.call(drive),
+            selected: onToggleSelected == null
+                ? null
+                : state.selected.contains(drive.id),
+            onSelectedChanged: onToggleSelected,
           );
         },
         childCount: state.drives.length,
@@ -853,6 +930,169 @@ class _SyncEverythingPrompt extends StatelessWidget {
                   ),
           );
         },
+      ),
+    );
+  }
+}
+
+/// What the reader can do with the drives they have ticked.
+///
+/// Appears with the first tick and goes with the last, so the page is not
+/// carrying a disabled control around for the whole time nobody is selecting
+/// anything.
+class _SelectionBar extends StatelessWidget {
+  const _SelectionBar({
+    required this.count,
+    required this.onSyncSelected,
+    required this.onClear,
+  });
+
+  final int count;
+  final VoidCallback onSyncSelected;
+  final VoidCallback? onClear;
+
+  @override
+  Widget build(BuildContext context) {
+    final typography = ArDriveTypographyNew.of(context);
+    final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: _pagePadding),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+        decoration: BoxDecoration(
+          color: ArDriveTheme.of(context).themeData.tableTheme.backgroundColor,
+          borderRadius: BorderRadius.circular(cardDefaultBorderRadius),
+        ),
+        child: Wrap(
+          crossAxisAlignment: WrapCrossAlignment.center,
+          alignment: WrapAlignment.spaceBetween,
+          spacing: 12,
+          runSpacing: 8,
+          children: [
+            Text(
+              appLocalizationsOf(context).driveListSelectedCount(count),
+              style: typography.paragraphNormal(
+                color: colorTokens.textHigh,
+                fontWeight: ArFontWeight.semiBold,
+              ),
+            ),
+            Wrap(
+              crossAxisAlignment: WrapCrossAlignment.center,
+              spacing: 8,
+              children: [
+                if (onClear != null)
+                  ArDriveButtonNew(
+                    text: appLocalizationsOf(context).driveListClearSelection,
+                    typography: typography,
+                    variant: ButtonVariant.secondary,
+                    maxHeight: 36,
+                    onPressed: onClear,
+                  ),
+                ArDriveButtonNew(
+                  text: appLocalizationsOf(context).driveListSyncSelected,
+                  typography: typography,
+                  variant: ButtonVariant.primary,
+                  maxHeight: 36,
+                  onPressed: onSyncSelected,
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// A sync that read some drives and not others, and the one press that fixes
+/// it.
+///
+/// The failure was already on each row and in the sync menu; what was missing
+/// was the sentence that adds them up and the button that acts on exactly that
+/// set. A reader should not have to count red triangles to find out how bad it
+/// was, nor open a menu to retry what broke.
+class _PartialFailureBanner extends StatelessWidget {
+  const _PartialFailureBanner({
+    required this.failed,
+    required this.total,
+    required this.onRetry,
+  });
+
+  final int failed;
+  final int total;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final typography = ArDriveTypographyNew.of(context);
+    final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: _pagePadding),
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: ArDriveTheme.of(context).themeData.tableTheme.backgroundColor,
+          borderRadius: BorderRadius.circular(cardDefaultBorderRadius),
+          border: Border.all(color: colorTokens.strokeRed),
+        ),
+        child: Wrap(
+          crossAxisAlignment: WrapCrossAlignment.center,
+          alignment: WrapAlignment.spaceBetween,
+          spacing: 16,
+          runSpacing: 12,
+          children: [
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 520),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      ArDriveIcons.triangle(
+                        size: 16,
+                        color: colorTokens.strokeRed,
+                      ),
+                      const SizedBox(width: 8),
+                      Flexible(
+                        child: Text(
+                          appLocalizationsOf(context)
+                              .driveListSomeCouldNotBeRead(failed, total),
+                          style: typography.paragraphNormal(
+                            color: colorTokens.textHigh,
+                            fontWeight: ArFontWeight.semiBold,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 4),
+                  // Says what is still true as well as what went wrong: a
+                  // drive that could not be reached is not a drive that lost
+                  // anything, and a reader looking at red needs telling.
+                  Text(
+                    appLocalizationsOf(context)
+                        .driveListSomeCouldNotBeReadDetail,
+                    style: typography.paragraphSmall(
+                      color: colorTokens.textLow,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            ArDriveButtonNew(
+              text: appLocalizationsOf(context)
+                  .driveListSyncThoseThatFailed(failed),
+              typography: typography,
+              variant: ButtonVariant.primary,
+              maxHeight: 36,
+              onPressed: onRetry,
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/drives_list/presentation/drives_list_page.dart
+++ b/lib/drives_list/presentation/drives_list_page.dart
@@ -573,7 +573,11 @@ class _DrivesListLoadedView extends StatelessWidget {
               child: CustomScrollView(
                 slivers: [
                   SliverToBoxAdapter(child: _heading(context)),
-                  if (state.nothingHasEverBeenSynced)
+                  // Withdrawn while a selection exists. Two red buttons a
+                  // hundred pixels apart, offering different scopes, is the
+                  // reader having to work out which one they meant - and they
+                  // have just said which, by ticking rows.
+                  if (state.nothingHasEverBeenSynced && state.selected.isEmpty)
                     SliverToBoxAdapter(
                       child: Padding(
                         padding: const EdgeInsets.only(top: _blockGap),
@@ -634,12 +638,15 @@ class _DrivesListLoadedView extends StatelessWidget {
                           const SliverToBoxAdapter(
                             child: SizedBox(height: _panelPadding),
                           ),
-                          // While anything is ticked the heading row *is*
-                          // the selection bar, the way every table that has
-                          // both does it. A second bar above the panel cost a
-                          // block of vertical space on the one screen whose
-                          // job is to list drives, and repeated the column
-                          // headings underneath it for no reason.
+                          // Above the headings, never instead of them.
+                          //
+                          // Replacing them is what a mail client does, and it
+                          // works there because those rows describe
+                          // themselves. These read "Never synced", a dash, a
+                          // dash and a date: four terse columns with no labels
+                          // stop being a table. So the strip takes a line of
+                          // its own while a selection exists, and the headings
+                          // stay where they are.
                           if (state.selected.isNotEmpty &&
                               onSyncSelected != null)
                             SliverToBoxAdapter(
@@ -648,24 +655,23 @@ class _DrivesListLoadedView extends StatelessWidget {
                                 onSyncSelected: onSyncSelected!,
                                 onClear: onClearSelection,
                               ),
-                            )
-                          else
-                            SliverToBoxAdapter(
-                              child: DriveListHeader(
-                                sort: state.sort,
-                                sortAscending: state.sortAscending,
-                                onSort: onSort,
-                                // Offered only where there is room for a column
-                                // of checkboxes, and only when something can be
-                                // done with a selection.
-                                allSelected: onToggleSelectAll == null
-                                    ? null
-                                    : state.drives.isNotEmpty &&
-                                        state.drives.every((drive) =>
-                                            state.selected.contains(drive.id)),
-                                onToggleSelectAll: onToggleSelectAll,
-                              ),
                             ),
+                          SliverToBoxAdapter(
+                            child: DriveListHeader(
+                              sort: state.sort,
+                              sortAscending: state.sortAscending,
+                              onSort: onSort,
+                              // Offered only where there is room for a column
+                              // of checkboxes, and only when something can be
+                              // done with a selection.
+                              allSelected: onToggleSelectAll == null
+                                  ? null
+                                  : state.drives.isNotEmpty &&
+                                      state.drives.every((drive) =>
+                                          state.selected.contains(drive.id)),
+                              onToggleSelectAll: onToggleSelectAll,
+                            ),
+                          ),
                           _rows(state, showsColumns),
                           const SliverToBoxAdapter(
                             child: SizedBox(height: _panelPadding),
@@ -939,9 +945,11 @@ class _SyncEverythingPrompt extends StatelessWidget {
 
 /// What the reader can do with the drives they have ticked.
 ///
-/// Drawn in the heading row's place rather than above it, which is where a
-/// table that offers selection puts this - so choosing drives costs no
-/// vertical space and the columns are not labelled twice.
+/// A line of its own above the column headings, not instead of them: this
+/// table's cells are "Never synced", a dash, a dash and a date, and four terse
+/// columns with no labels stop being a table. It is drawn as a tinted band
+/// rather than another card, so it reads as part of the table it belongs to
+/// rather than a second panel stacked on the first.
 class _SelectionBar extends StatelessWidget {
   const _SelectionBar({
     required this.count,
@@ -958,12 +966,14 @@ class _SelectionBar extends StatelessWidget {
     final typography = ArDriveTypographyNew.of(context);
     final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
 
-    return Padding(
-      // The heading row's own padding, so the count sits where "Name" sat and
-      // the row beneath does not shift when a tick is made.
+    return Container(
+      // A step up from the panel it sits on, which is how a band says it is a
+      // state rather than a row - no border, no shadow, nothing that competes
+      // with the rows below it.
+      color: colorTokens.containerL2,
       padding: const EdgeInsets.symmetric(
         horizontal: driveListRowHorizontalPadding,
-        vertical: 4,
+        vertical: 8,
       ),
       child: Row(
         children: [
@@ -979,8 +989,9 @@ class _SelectionBar extends StatelessWidget {
           ),
           const Spacer(),
           if (onClear != null) ...[
-            // Text only. Two bordered buttons side by side read as equal
-            // choices, and these are not: one acts, the other undoes.
+            // Text, not a second button. Two bordered controls side by side
+            // read as equal choices and these are not: one acts, the other
+            // undoes.
             ArDriveClickArea(
               child: InkWell(
                 onTap: onClear,
@@ -1000,7 +1011,7 @@ class _SelectionBar extends StatelessWidget {
                 ),
               ),
             ),
-            const SizedBox(width: 4),
+            const SizedBox(width: 8),
           ],
           ArDriveButtonNew(
             text: appLocalizationsOf(context).driveListSyncSelected,

--- a/lib/drives_list/presentation/drives_list_page.dart
+++ b/lib/drives_list/presentation/drives_list_page.dart
@@ -601,20 +601,6 @@ class _DrivesListLoadedView extends StatelessWidget {
                         ),
                       ),
                     ),
-                  // Present only while something is ticked. A bar that is
-                  // always there, with a count of zero and a disabled button,
-                  // is a control explaining that it cannot be used.
-                  if (state.selected.isNotEmpty && onSyncSelected != null)
-                    SliverToBoxAdapter(
-                      child: Padding(
-                        padding: const EdgeInsets.only(bottom: _blockGap),
-                        child: _SelectionBar(
-                          count: state.selected.length,
-                          onSyncSelected: onSyncSelected!,
-                          onClear: onClearSelection,
-                        ),
-                      ),
-                    ),
                   // The panel every other table in the app sits in.
                   //
                   // `ArDriveDataTable` wraps its header and rows in an
@@ -648,22 +634,38 @@ class _DrivesListLoadedView extends StatelessWidget {
                           const SliverToBoxAdapter(
                             child: SizedBox(height: _panelPadding),
                           ),
-                          SliverToBoxAdapter(
-                            child: DriveListHeader(
-                              sort: state.sort,
-                              sortAscending: state.sortAscending,
-                              onSort: onSort,
-                              // Offered only where there is room for a column
-                              // of checkboxes, and only when something can be
-                              // done with a selection.
-                              allSelected: onToggleSelectAll == null
-                                  ? null
-                                  : state.drives.isNotEmpty &&
-                                      state.drives.every((drive) =>
-                                          state.selected.contains(drive.id)),
-                              onToggleSelectAll: onToggleSelectAll,
+                          // While anything is ticked the heading row *is*
+                          // the selection bar, the way every table that has
+                          // both does it. A second bar above the panel cost a
+                          // block of vertical space on the one screen whose
+                          // job is to list drives, and repeated the column
+                          // headings underneath it for no reason.
+                          if (state.selected.isNotEmpty &&
+                              onSyncSelected != null)
+                            SliverToBoxAdapter(
+                              child: _SelectionBar(
+                                count: state.selected.length,
+                                onSyncSelected: onSyncSelected!,
+                                onClear: onClearSelection,
+                              ),
+                            )
+                          else
+                            SliverToBoxAdapter(
+                              child: DriveListHeader(
+                                sort: state.sort,
+                                sortAscending: state.sortAscending,
+                                onSort: onSort,
+                                // Offered only where there is room for a column
+                                // of checkboxes, and only when something can be
+                                // done with a selection.
+                                allSelected: onToggleSelectAll == null
+                                    ? null
+                                    : state.drives.isNotEmpty &&
+                                        state.drives.every((drive) =>
+                                            state.selected.contains(drive.id)),
+                                onToggleSelectAll: onToggleSelectAll,
+                              ),
                             ),
-                          ),
                           _rows(state, showsColumns),
                           const SliverToBoxAdapter(
                             child: SizedBox(height: _panelPadding),
@@ -937,9 +939,9 @@ class _SyncEverythingPrompt extends StatelessWidget {
 
 /// What the reader can do with the drives they have ticked.
 ///
-/// Appears with the first tick and goes with the last, so the page is not
-/// carrying a disabled control around for the whole time nobody is selecting
-/// anything.
+/// Drawn in the heading row's place rather than above it, which is where a
+/// table that offers selection puts this - so choosing drives costs no
+/// vertical space and the columns are not labelled twice.
 class _SelectionBar extends StatelessWidget {
   const _SelectionBar({
     required this.count,
@@ -957,49 +959,60 @@ class _SelectionBar extends StatelessWidget {
     final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
 
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: _pagePadding),
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-        decoration: BoxDecoration(
-          color: ArDriveTheme.of(context).themeData.tableTheme.backgroundColor,
-          borderRadius: BorderRadius.circular(cardDefaultBorderRadius),
-        ),
-        child: Wrap(
-          crossAxisAlignment: WrapCrossAlignment.center,
-          alignment: WrapAlignment.spaceBetween,
-          spacing: 12,
-          runSpacing: 8,
-          children: [
-            Text(
+      // The heading row's own padding, so the count sits where "Name" sat and
+      // the row beneath does not shift when a tick is made.
+      padding: const EdgeInsets.symmetric(
+        horizontal: driveListRowHorizontalPadding,
+        vertical: 4,
+      ),
+      child: Row(
+        children: [
+          Flexible(
+            child: Text(
               appLocalizationsOf(context).driveListSelectedCount(count),
+              overflow: TextOverflow.ellipsis,
               style: typography.paragraphNormal(
                 color: colorTokens.textHigh,
                 fontWeight: ArFontWeight.semiBold,
               ),
             ),
-            Wrap(
-              crossAxisAlignment: WrapCrossAlignment.center,
-              spacing: 8,
-              children: [
-                if (onClear != null)
-                  ArDriveButtonNew(
-                    text: appLocalizationsOf(context).driveListClearSelection,
-                    typography: typography,
-                    variant: ButtonVariant.secondary,
-                    maxHeight: 36,
-                    onPressed: onClear,
+          ),
+          const Spacer(),
+          if (onClear != null) ...[
+            // Text only. Two bordered buttons side by side read as equal
+            // choices, and these are not: one acts, the other undoes.
+            ArDriveClickArea(
+              child: InkWell(
+                onTap: onClear,
+                borderRadius: BorderRadius.circular(4),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 10,
+                    vertical: 6,
                   ),
-                ArDriveButtonNew(
-                  text: appLocalizationsOf(context).driveListSyncSelected,
-                  typography: typography,
-                  variant: ButtonVariant.primary,
-                  maxHeight: 36,
-                  onPressed: onSyncSelected,
+                  child: Text(
+                    appLocalizationsOf(context).driveListClearSelection,
+                    style: typography.paragraphNormal(
+                      color: colorTokens.textLow,
+                      fontWeight: ArFontWeight.semiBold,
+                    ),
+                  ),
                 ),
-              ],
+              ),
             ),
+            const SizedBox(width: 4),
           ],
-        ),
+          ArDriveButtonNew(
+            text: appLocalizationsOf(context).driveListSyncSelected,
+            typography: typography,
+            variant: ButtonVariant.primary,
+            maxHeight: 32,
+            // Sized to its label rather than to whatever room is left, which
+            // is what stretched it across the panel.
+            maxWidth: 148,
+            onPressed: onSyncSelected,
+          ),
+        ],
       ),
     );
   }

--- a/lib/drives_list/presentation/drives_list_page.dart
+++ b/lib/drives_list/presentation/drives_list_page.dart
@@ -365,14 +365,38 @@ class _CentredMessage extends StatelessWidget {
         return SingleChildScrollView(
           child: ConstrainedBox(
             constraints: BoxConstraints(minHeight: constraints.maxHeight),
-            child: Center(
-              child: Padding(
-                padding: const EdgeInsets.all(_sectionGap),
-                child: ConstrainedBox(
-                  constraints: const BoxConstraints(maxWidth: 420),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: children,
+            child: Padding(
+              // The page's own margin, so this panel stops where the table's
+              // panel stops rather than running into the window edge.
+              padding: const EdgeInsets.fromLTRB(
+                _pagePadding,
+                _blockGap,
+                _pagePadding,
+                _sectionGap,
+              ),
+              child: Container(
+                // The ground every other full-panel state sits on. These two -
+                // the drives loading, and the drive list that could not be
+                // read - were drawn straight onto the page, so the words
+                // floated on black while the same states in the explorer had a
+                // card behind them.
+                decoration: BoxDecoration(
+                  color: ArDriveTheme.of(context)
+                      .themeData
+                      .tableTheme
+                      .backgroundColor,
+                  borderRadius: BorderRadius.circular(cardDefaultBorderRadius),
+                ),
+                child: Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(_sectionGap),
+                    child: ConstrainedBox(
+                      constraints: const BoxConstraints(maxWidth: 420),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: children,
+                      ),
+                    ),
                   ),
                 ),
               ),
@@ -975,6 +999,10 @@ class _SelectionBar extends StatelessWidget {
         horizontal: driveListRowHorizontalPadding,
         vertical: 8,
       ),
+      // The count and what to do about it, together. Right-aligning the
+      // actions put eight hundred pixels between "3 drives selected" and the
+      // button that acts on those three, which reads as two unrelated things
+      // sharing a line rather than one sentence.
       child: Row(
         children: [
           Flexible(
@@ -987,11 +1015,22 @@ class _SelectionBar extends StatelessWidget {
               ),
             ),
           ),
-          const Spacer(),
+          const SizedBox(width: 16),
+          ArDriveButtonNew(
+            text: appLocalizationsOf(context).driveListSyncSelected,
+            typography: typography,
+            variant: ButtonVariant.primary,
+            maxHeight: 32,
+            // Sized to its label rather than to whatever room is left, which
+            // is what stretched it across the panel.
+            maxWidth: 148,
+            onPressed: onSyncSelected,
+          ),
           if (onClear != null) ...[
-            // Text, not a second button. Two bordered controls side by side
-            // read as equal choices and these are not: one acts, the other
-            // undoes.
+            const SizedBox(width: 4),
+            // Text, not a second button, and after the action rather than
+            // before it: two bordered controls side by side read as equal
+            // choices and these are not - one acts, the other undoes.
             ArDriveClickArea(
               child: InkWell(
                 onTap: onClear,
@@ -1011,18 +1050,8 @@ class _SelectionBar extends StatelessWidget {
                 ),
               ),
             ),
-            const SizedBox(width: 8),
           ],
-          ArDriveButtonNew(
-            text: appLocalizationsOf(context).driveListSyncSelected,
-            typography: typography,
-            variant: ButtonVariant.primary,
-            maxHeight: 32,
-            // Sized to its label rather than to whatever room is left, which
-            // is what stretched it across the panel.
-            maxWidth: 148,
-            onPressed: onSyncSelected,
-          ),
+          const Spacer(),
         ],
       ),
     );

--- a/lib/drives_list/presentation/drives_list_state.dart
+++ b/lib/drives_list/presentation/drives_list_state.dart
@@ -47,6 +47,7 @@ class DrivesListLoaded extends DrivesListState {
     this.counts = const DriveScopeCounts({}),
     this.sort = DriveListSort.name,
     this.sortAscending = true,
+    this.selected = const {},
   });
 
   /// The drives this scope shows, already filtered.
@@ -65,6 +66,12 @@ class DrivesListLoaded extends DrivesListState {
   /// Which way that column is ordered.
   final bool sortAscending;
 
+  /// The drives the reader has ticked, if any.
+  ///
+  /// Empty means no selection rather than an empty one, and the controls read
+  /// it that way: with nothing ticked, the action is still Sync All Drives.
+  final Set<String> selected;
+
   /// Whether nothing here has ever been walked.
   ///
   /// With sync-on-login off this is the state a first login lands in, and it
@@ -74,9 +81,20 @@ class DrivesListLoaded extends DrivesListState {
   bool get nothingHasEverBeenSynced =>
       drives.isNotEmpty && drives.every((drive) => !drive.hasBeenWalked);
 
+  /// The drives the last sync could not read.
+  ///
+  /// Read off the rows rather than off a sync state, so it survives the sync
+  /// state moving on - the failure is a property of the drive until something
+  /// reads it successfully, not of the run that noticed.
+  List<String> get failedDriveIds => [
+        for (final drive in drives)
+          if (drive.lastSyncFailed) drive.id,
+      ];
+
   /// Whether a sync is running over these drives right now.
   bool get isSyncing => drives.any((drive) => drive.isSyncing);
 
   @override
-  List<Object?> get props => [drives, scope, counts, sort, sortAscending];
+  List<Object?> get props =>
+      [drives, scope, counts, sort, sortAscending, selected];
 }

--- a/lib/drives_list/presentation/drives_sync_menu.dart
+++ b/lib/drives_list/presentation/drives_sync_menu.dart
@@ -1,3 +1,4 @@
+import 'package:ardrive/drives_list/presentation/drives_list_cubit.dart';
 import 'package:ardrive/blocs/blocs.dart';
 import 'package:ardrive/pages/drive_detail/components/dropdown_item.dart';
 import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
@@ -32,6 +33,17 @@ class DrivesSyncMenu extends StatelessWidget {
         final errors = syncState is SyncCompleteWithErrors ? syncState : null;
         final nothingWalked = _nothingHasEverBeenWalked(context);
 
+        // How many drives are ticked, so both actions can say which set they
+        // will run over. Watched rather than read: ticking a drive has to
+        // relabel these the moment it happens.
+        //
+        // Nullable because selection belongs to the drives list and this menu
+        // does not: it needs SyncCubit to do its job and should not acquire a
+        // second hard dependency for a label. Without one it behaves exactly
+        // as it did before selection existed.
+        final drivesList = context.watch<DrivesListCubit?>();
+        final selection = drivesList?.selectionCount ?? 0;
+
         return ArDriveDropdown(
           anchor: const Aligned(
             follower: Alignment.topRight,
@@ -46,7 +58,14 @@ class DrivesSyncMenu extends StatelessWidget {
               onClick: isSyncing
                   ? null
                   : () {
-                      context.read<SyncCubit>().startSync(deepSync: false);
+                      // Acts on the ticked drives when there are any. A
+                      // control that quietly ignored a selection the reader
+                      // had just made would be the worst of both.
+                      if (drivesList != null) {
+                        drivesList.syncSelectedDrives(deep: false);
+                      } else {
+                        context.read<SyncCubit>().startSync(deepSync: false);
+                      }
                       context.read<ProfileNameBloc>().add(RefreshProfileName());
                       PlausibleEventTracker.trackResync(
                           type: ResyncType.resync);
@@ -54,9 +73,13 @@ class DrivesSyncMenu extends StatelessWidget {
               content: ArDriveDropdownItemTile(
                 // "Resync" is wrong before anything has ever synced. The word
                 // promises a repeat of something that has not happened.
-                name: nothingWalked
-                    ? appLocalizationsOf(context).syncAllDrives
-                    : appLocalizationsOf(context).resync,
+                name: selection > 0
+                    ? appLocalizationsOf(context)
+                        .driveListSyncSelectedCount(selection)
+                    // "Resync" is wrong before anything has ever synced.
+                    : nothingWalked
+                        ? appLocalizationsOf(context).syncAllDrives
+                        : appLocalizationsOf(context).resync,
                 icon: ArDriveIcons.refresh(color: iconColor),
                 isDisabled: isSyncing,
               ),
@@ -65,12 +88,19 @@ class DrivesSyncMenu extends StatelessWidget {
               onClick: isSyncing
                   ? null
                   : () {
-                      context.read<SyncCubit>().startSync(deepSync: true);
+                      if (drivesList != null) {
+                        drivesList.syncSelectedDrives(deep: true);
+                      } else {
+                        context.read<SyncCubit>().startSync(deepSync: true);
+                      }
                       PlausibleEventTracker.trackResync(
                           type: ResyncType.deepResync);
                     },
               content: ArDriveDropdownItemTile(
-                name: appLocalizationsOf(context).deepResync,
+                name: selection > 0
+                    ? appLocalizationsOf(context)
+                        .driveListDeepResyncSelectedCount(selection)
+                    : appLocalizationsOf(context).deepResync,
                 icon: ArDriveIcons.cloudSync(color: iconColor),
                 isDisabled: isSyncing,
               ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1590,6 +1590,36 @@
     "description": "The action of logging in. Imperative form"
   },
   "loginCheckingPassword": "Checking your password...",
+  "driveListSelectedCount": "{count, plural, =1{1 drive selected} other{{count} drives selected}}",
+  "@driveListSelectedCount": {
+    "description": "How many drives the reader has ticked on the drives list",
+    "placeholders": { "count": { "type": "num", "format": "compact" } }
+  },
+  "driveListSyncSelected": "Sync selected",
+  "@driveListSyncSelected": {
+    "description": "Button that syncs only the ticked drives, in one run"
+  },
+  "driveListClearSelection": "Clear",
+  "driveListSomeCouldNotBeRead": "{failed} of {total} drives could not be read",
+  "@driveListSomeCouldNotBeRead": {
+    "description": "Summary on the drives list after a sync that failed on some drives but not others",
+    "placeholders": {
+      "failed": { "type": "num", "format": "compact" },
+      "total": { "type": "num", "format": "compact" }
+    }
+  },
+  "driveListSomeCouldNotBeReadDetail": "The rest are up to date. Nothing was lost - a drive that could not be reached keeps whatever was read last time.",
+  "@driveListSomeCouldNotBeReadDetail": {
+    "description": "Reassurance under the partial-failure summary"
+  },
+  "driveListSyncThoseThatFailed": "{count, plural, =1{Sync that drive} other{Sync those {count}}}",
+  "@driveListSyncThoseThatFailed": {
+    "description": "Button that re-syncs only the drives that failed",
+    "placeholders": { "count": { "type": "num", "format": "compact" } }
+  },
+  "@driveListClearSelection": {
+    "description": "Button that unticks every selected drive"
+  },
   "@loginCheckingPassword": {
     "description": "Shown on the Continue button while the entered password is being proved against one of the wallet's private drives, which takes several network round trips"
   },

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1600,6 +1600,16 @@
     "description": "Button that syncs only the ticked drives, in one run"
   },
   "driveListClearSelection": "Clear",
+  "driveListSyncSelectedCount": "Sync {count} selected",
+  "@driveListSyncSelectedCount": {
+    "description": "Menu item that syncs only the ticked drives",
+    "placeholders": { "count": { "type": "num", "format": "compact" } }
+  },
+  "driveListDeepResyncSelectedCount": "Deep resync {count} selected",
+  "@driveListDeepResyncSelectedCount": {
+    "description": "Menu item that deep-resyncs only the ticked drives",
+    "placeholders": { "count": { "type": "num", "format": "compact" } }
+  },
   "driveListSomeCouldNotBeRead": "{failed} of {total} drives could not be read",
   "@driveListSomeCouldNotBeRead": {
     "description": "Summary on the drives list after a sync that failed on some drives but not others",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3086,9 +3086,9 @@
       }
     }
   },
-  "multiSelectPausedWhileSyncing": "Selecting several items is paused while syncing",
-  "@multiSelectPausedWhileSyncing": {
-    "description": "Why ctrl-click and ctrl-A do nothing in the file list while a sync is rewriting rows"
+  "syncStillReadingThisDrive": "Still reading this drive, so more items may appear. Selecting several is paused until it finishes.",
+  "@syncStillReadingThisDrive": {
+    "description": "Shown above the file list while a sync is walking the open drive. Leads with the fact that the list is incomplete - a reader who can now browse a drive mid-sync would otherwise take a short list for the whole of it - and explains the paused selection in the same breath, since both hold for exactly as long."
   },
   "syncElapsedTime": "{seconds}s elapsed",
   "@syncElapsedTime": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1600,6 +1600,10 @@
     "description": "Button that syncs only the ticked drives, in one run"
   },
   "driveListClearSelection": "Clear",
+  "syncStopRunning": "Stop syncing",
+  "@syncStopRunning": {
+    "description": "Menu item that stops the sync currently running"
+  },
   "driveListSyncSelectedCount": "Sync {count} selected",
   "@driveListSyncSelectedCount": {
     "description": "Menu item that syncs only the ticked drives",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1601,6 +1601,14 @@
   },
   "driveListClearSelection": "Clear",
   "syncStopRunning": "Stop syncing",
+  "detachDriveNeedsLinkAgain": "You will need its share link to add it back.",
+  "@detachDriveNeedsLinkAgain": {
+    "description": "The asymmetry that makes detaching a shared drive different from detaching your own: an owned drive is rediscovered by the next drive-list refresh, a shared one never is"
+  },
+  "detachDriveStopsSync": "The sync running on it will be stopped first.",
+  "@detachDriveStopsSync": {
+    "description": "Shown only while a sync is walking the drive being detached, so the reader knows the two do not race"
+  },
   "@syncStopRunning": {
     "description": "Menu item that stops the sync currently running"
   },
@@ -1622,7 +1630,7 @@
       "total": { "type": "num", "format": "compact" }
     }
   },
-  "driveListSomeCouldNotBeReadDetail": "The rest are up to date. Nothing was lost - a drive that could not be reached keeps whatever was read last time.",
+  "driveListSomeCouldNotBeReadDetail": "The rest are up to date. A drive that could not be reached keeps whatever was read last time.",
   "@driveListSomeCouldNotBeReadDetail": {
     "description": "Reassurance under the partial-failure summary"
   },

--- a/lib/pages/drive_detail/components/drive_detail_data_list.dart
+++ b/lib/pages/drive_detail/components/drive_detail_data_list.dart
@@ -125,6 +125,7 @@ Widget _buildDataListContent(
           lockMultiSelect: SyncingDriveNotice.locksMultiSelect(
                 context.watch<SyncCubit>().state,
                 syncingDriveId: context.watch<SyncCubit>().syncingDriveId,
+                syncingDriveIds: context.watch<SyncCubit>().syncingDriveIds,
                 driveId: folder.driveId,
               ) ||
               !context.watch<ActivityTracker>().isMultiSelectEnabled,

--- a/lib/pages/drive_detail/components/drive_detail_data_list.dart
+++ b/lib/pages/drive_detail/components/drive_detail_data_list.dart
@@ -120,9 +120,9 @@ Widget _buildDataListContent(
               '${folder.id}-${forceRebuildKey.toString()}${columns.length}-${hideState.toString()}'),
           initialPage: selectedPage,
           // The sync half of this lock is stated out loud rather than left as
-          // a silent no-op - see [MultiSelectPausedNotice], which is given the
+          // a silent no-op - see [SyncingDriveNotice], which is given the
           // same condition so the two cannot drift apart.
-          lockMultiSelect: MultiSelectPausedNotice.locksMultiSelect(
+          lockMultiSelect: SyncingDriveNotice.locksMultiSelect(
                 context.watch<SyncCubit>().state,
                 syncingDriveId: context.watch<SyncCubit>().syncingDriveId,
                 driveId: folder.driveId,
@@ -244,7 +244,7 @@ Widget _buildDataListContent(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             // Draws nothing unless a sync is holding multi-select shut.
-            MultiSelectPausedNotice(driveId: folder.driveId),
+            SyncingDriveNotice(driveId: folder.driveId),
             Expanded(child: table),
           ],
         );

--- a/lib/pages/drive_detail/components/drive_detail_syncing_card.dart
+++ b/lib/pages/drive_detail/components/drive_detail_syncing_card.dart
@@ -169,6 +169,14 @@ class _DriveDetailSyncingCardState extends State<DriveDetailSyncingCard> {
   /// The card the explorer's other full-panel states use on a wide screen, so
   /// the frame does not change shape when this becomes a folder listing, an
   /// unsynced drive, or the report that the drive list could not be read.
+  ///
+  /// On `tableTheme.backgroundColor`, which is what the tables and the unsynced
+  /// card already sit on. This used `containerL1` and the comment above was
+  /// therefore untrue: at `#0d0d0d` against a `#010905` page it lifted off the
+  /// background by twelve steps out of 255, so the panel read as no panel at
+  /// all - a card nobody can see is a card that is not there. The shared
+  /// ground is `#121212`, which is the difference between a black screen with
+  /// words on it and a surface holding them.
   Widget _frame(BuildContext context, Widget content) {
     return ScreenTypeLayout.builder(
       mobile: (context) => content,
@@ -179,7 +187,7 @@ class _DriveDetailSyncingCardState extends State<DriveDetailSyncingCard> {
           child: ArDriveCard(
             width: double.infinity,
             backgroundColor:
-                ArDriveTheme.of(context).themeData.colorTokens.containerL1,
+                ArDriveTheme.of(context).themeData.tableTheme.backgroundColor,
             content: content,
           ),
         ),

--- a/lib/pages/drive_detail/components/drive_detail_syncing_card.dart
+++ b/lib/pages/drive_detail/components/drive_detail_syncing_card.dart
@@ -148,6 +148,7 @@ class _DriveDetailSyncingCardState extends State<DriveDetailSyncingCard> {
                   syncState: syncState,
                   progress: reportsProgress ? snapshot.data : null,
                   driveName: _driveName(drivesState, snapshot.data),
+                  canBeStopped: syncState is SyncInProgress,
                   syncCoversThisDrive: _coversSelectedDrive(
                     drivesState,
                     syncState,
@@ -311,6 +312,7 @@ class _DriveDetailSyncingCardState extends State<DriveDetailSyncingCard> {
     required bool isLoadingDrives,
     required SyncState syncState,
     required bool syncCoversThisDrive,
+    required bool canBeStopped,
     required SyncProgress? progress,
     required String? driveName,
   }) {
@@ -445,7 +447,14 @@ class _DriveDetailSyncingCardState extends State<DriveDetailSyncingCard> {
       // decide the wait is not worth it. The top bar carries the same action;
       // this is where somebody staring at a drive that will not open looks
       // first, and a drive with a million transactions is exactly the case.
-      if (isSyncing) ...[
+      // Only while there is a sync that stopping can actually stop.
+      //
+      // `isSyncing` also covers SyncLoadingDrives, and `cancelSync` does
+      // nothing in that state - it cancels the token a running sync holds, and
+      // the drive-list refresh holds none. Offering the button there gave a
+      // reader a control that acknowledged the press and changed nothing,
+      // which is worse than not offering it.
+      if (canBeStopped) ...[
         const SizedBox(height: 16),
         ArDriveButtonNew(
           text: appLocalizationsOf(context).syncStopRunning,

--- a/lib/pages/drive_detail/components/drive_detail_syncing_card.dart
+++ b/lib/pages/drive_detail/components/drive_detail_syncing_card.dart
@@ -433,6 +433,21 @@ class _DriveDetailSyncingCardState extends State<DriveDetailSyncingCard> {
         const SizedBox(height: 4),
         const SyncElapsedTime(),
       ],
+      // The way out, on the screen a reader is actually sitting on while they
+      // decide the wait is not worth it. The top bar carries the same action;
+      // this is where somebody staring at a drive that will not open looks
+      // first, and a drive with a million transactions is exactly the case.
+      if (isSyncing) ...[
+        const SizedBox(height: 16),
+        ArDriveButtonNew(
+          text: appLocalizationsOf(context).syncStopRunning,
+          typography: typography,
+          variant: ButtonVariant.secondary,
+          maxHeight: 36,
+          maxWidth: 180,
+          onPressed: () => context.read<SyncCubit>().cancelSync(),
+        ),
+      ],
     ]);
   }
 }

--- a/lib/pages/drive_detail/components/syncing_drive_notice.dart
+++ b/lib/pages/drive_detail/components/syncing_drive_notice.dart
@@ -61,15 +61,30 @@ class SyncingDriveNotice extends StatelessWidget {
     SyncState state, {
     required String? syncingDriveId,
     required String driveId,
-  }) =>
-      state is SyncInProgress &&
-      (syncingDriveId == null || syncingDriveId == driveId);
+    Set<String>? syncingDriveIds,
+  }) {
+    if (state is! SyncInProgress) {
+      return false;
+    }
+
+    // A run over a chosen few also has no single drive id, so a null
+    // `syncingDriveId` means "every drive" only when the run has no scope
+    // either. Without this, syncing four drives told the other thirteen they
+    // were being written - the same mistake the rows made, in the one place
+    // that says so in words.
+    if (syncingDriveIds != null) {
+      return syncingDriveIds.contains(driveId);
+    }
+
+    return syncingDriveId == null || syncingDriveId == driveId;
+  }
 
   @override
   Widget build(BuildContext context) {
     if (!locksMultiSelect(
       context.watch<SyncCubit>().state,
       syncingDriveId: context.watch<SyncCubit>().syncingDriveId,
+      syncingDriveIds: context.watch<SyncCubit>().syncingDriveIds,
       driveId: driveId,
     )) {
       return const SizedBox.shrink();

--- a/lib/pages/drive_detail/components/syncing_drive_notice.dart
+++ b/lib/pages/drive_detail/components/syncing_drive_notice.dart
@@ -17,8 +17,19 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 ///
 /// One quiet line above the list, and no dialog: nothing is wrong and nothing
 /// is being asked, the app is briefly not offering something it usually does.
-class MultiSelectPausedNotice extends StatelessWidget {
-  const MultiSelectPausedNotice({super.key, required this.driveId});
+/// What is true of the file list while a sync is walking this drive.
+///
+/// Two facts, and they hold for exactly the same span, so they are said once:
+/// the list is still filling, and selecting several items is paused.
+///
+/// The first used to be unsayable because it was unreachable - a drive being
+/// synced could not be opened at all, so there was no partial list to warn
+/// about. Now that one can be read as it fills, a reader looking at four files
+/// has no way to tell four from four-so-far unless this says so, and a file
+/// list that quietly understates itself is the worst thing this surface could
+/// do.
+class SyncingDriveNotice extends StatelessWidget {
+  const SyncingDriveNotice({super.key, required this.driveId});
 
   /// The drive on screen, so the notice appears only when the sync running is
   /// one that actually holds this drive's selection shut.
@@ -76,7 +87,7 @@ class MultiSelectPausedNotice extends StatelessWidget {
           const SizedBox(width: 8),
           Flexible(
             child: Text(
-              appLocalizationsOf(context).multiSelectPausedWhileSyncing,
+              appLocalizationsOf(context).syncStillReadingThisDrive,
               style: typography.paragraphSmall(color: colorTokens.textLow),
             ),
           ),

--- a/lib/pages/drive_detail/drive_detail_page.dart
+++ b/lib/pages/drive_detail/drive_detail_page.dart
@@ -39,7 +39,7 @@ import 'package:ardrive/pages/drive_detail/components/drive_detail_syncing_card.
 import 'package:ardrive/pages/drive_detail/components/drive_file_drop_zone.dart';
 import 'package:ardrive/pages/drive_detail/components/dropdown_item.dart';
 import 'package:ardrive/pages/drive_detail/components/file_icon.dart';
-import 'package:ardrive/pages/drive_detail/components/multi_select_paused_notice.dart';
+import 'package:ardrive/pages/drive_detail/components/syncing_drive_notice.dart';
 import 'package:ardrive/pages/drive_detail/components/hover_widget.dart';
 import 'package:ardrive/pages/drive_detail/components/unpreviewable_content.dart';
 import 'package:ardrive/pages/drive_detail/components/document_preview_widget.dart';
@@ -1120,6 +1120,14 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
               ),
             ],
           ),
+        ),
+        // The same warning the wide table carries. A phone reads a
+        // half-walked drive exactly as a desktop does, and this is the
+        // surface with the least room to work out for itself that a short
+        // list is short because a sync is still running.
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: SyncingDriveNotice(driveId: state.currentDrive.id),
         ),
         Expanded(
           child: (hasSubfolders || hasFiles)

--- a/lib/pages/drive_detail/drive_detail_page.dart
+++ b/lib/pages/drive_detail/drive_detail_page.dart
@@ -205,7 +205,16 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
                         desktop: (context) => const Column(
                           children: [
                             AppTopBar(),
-                            Expanded(child: DriveDetailSyncingCard()),
+                            // The margin the unsynced card already has. Without
+                            // it this panel ran to the window's right edge
+                            // while every other full-panel state stopped short
+                            // of it.
+                            Expanded(
+                              child: Padding(
+                                padding: EdgeInsets.only(right: 16),
+                                child: DriveDetailSyncingCard(),
+                              ),
+                            ),
                           ],
                         ),
                       );
@@ -228,8 +237,11 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
                           children: [
                             AppTopBar(),
                             Expanded(
-                              child:
-                                  DriveDetailSyncingCard.driveListUnavailable(),
+                              child: Padding(
+                                padding: EdgeInsets.only(right: 16),
+                                child: DriveDetailSyncingCard
+                                    .driveListUnavailable(),
+                              ),
                             ),
                           ],
                         ),

--- a/lib/services/arweave/arweave_service.dart
+++ b/lib/services/arweave/arweave_service.dart
@@ -44,6 +44,25 @@ const byteCountPerChunk = 262144; // 256 KiB
 const defaultMaxRetries = 8;
 const kMaxNumberOfTransactionsPerPage = 100;
 
+/// How many transaction ids may go into one GraphQL query's `ids` argument.
+///
+/// Nine, because that is what the fallback endpoint accepts, and every query
+/// that chunks ids can end up there: `GraphQLRetry` falls back to Goldsky on a
+/// 429 or a 5xx, and Goldsky answers a longer list with
+/// `Too many ids in 'ids' argument: N provided, maximum 9 allowed`.
+///
+/// So a hundred was not merely wrong when Goldsky is configured as the primary
+/// endpoint. It made the fallback decorative for these queries on *every*
+/// configuration: the sync hits a rate limit on the primary, switches to the
+/// endpoint that exists to rescue it, and is refused for the shape of the
+/// request rather than for anything the endpoint could not answer.
+///
+/// The cost of the smaller batch is small where it is paid. Statuses are only
+/// asked for transactions not already known to be confirmed, so the list is
+/// short in an ordinary sync - the report that found this was 31 ids, which is
+/// four requests rather than one.
+const int maxGraphQLIdsPerQuery = 9;
+
 class ArweaveService {
   Arweave client;
   final ArDriveCrypto _crypto;
@@ -613,10 +632,9 @@ class ArweaveService {
     Iterable<String> licenseAssertionTxIds, {
     String? owner,
   }) async* {
-    const chunkSize = 100;
+    const chunkSize = maxGraphQLIdsPerQuery;
     final chunks = licenseAssertionTxIds.slices(chunkSize);
     for (final chunk in chunks) {
-      // Get a page of 100 transactions
       final licenseAssertionsQuery = await graphQLRetry.execute(
         LicenseAssertionsQuery(
           variables: LicenseAssertionsArguments(
@@ -639,10 +657,9 @@ class ArweaveService {
     Iterable<String> licenseComposedTxIds, {
     String? owner,
   }) async* {
-    const chunkSize = 100;
+    const chunkSize = maxGraphQLIdsPerQuery;
     final chunks = licenseComposedTxIds.slices(chunkSize);
     for (final chunk in chunks) {
-      // Get a page of 100 transactions
       final licenseComposedQuery = await graphQLRetry.execute(
         LicenseComposedQuery(
           variables: LicenseComposedArguments(
@@ -1710,7 +1727,6 @@ class ArweaveService {
     }
 
     while (true) {
-      // Get a page of 100 transactions
       final allFileEntitiesQuery = await graphQLRetry.execute(
         AllFileEntitiesWithIdQuery(
           variables: AllFileEntitiesWithIdArguments(
@@ -1874,7 +1890,7 @@ class ArweaveService {
     // [owner] is provided, the query is scoped to that owner so the gateway can
     // prune its search space.
     Future<void> queryConfirmations(List<String?> ids, {String? owner}) async {
-      const chunkSize = 100;
+      const chunkSize = maxGraphQLIdsPerQuery;
       // Cap how many chunk queries hit the gateway at once so a large page
       // doesn't fan out into a burst of concurrent GraphQL retries (and a
       // potential rate-limit storm), matching the throttling used by the other

--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -117,10 +117,22 @@ class SyncCubit extends Cubit<SyncState> {
       return false;
     }
 
-    // Not for SyncLoadingDrives: that phase writes the drives table itself,
-    // and a drive read in a previous run tells us nothing about whether this
-    // one is about to rewrite the row.
-    if (state is SyncInProgress && completedDriveIds.contains(driveId)) {
+    // Only for a run covering more than one drive.
+    //
+    // The point of releasing early is that a ten-drive run should not hold the
+    // drive it finished first. A single-drive sync has nothing to hold but the
+    // drive it was asked for, and it appends that drive to the completed list
+    // after its walk while the phases that follow are still running - so
+    // releasing there would have the row go quiet, and the panel open, while
+    // the sync the reader started is still going. Nothing is gained and the
+    // report contradicts itself.
+    //
+    // Not for SyncLoadingDrives either: that phase writes the drives table
+    // itself, and a drive read in a previous run tells us nothing about
+    // whether this one is about to rewrite the row.
+    if (state is SyncInProgress &&
+        syncingDriveId == null &&
+        completedDriveIds.contains(driveId)) {
       return false;
     }
 
@@ -1183,14 +1195,19 @@ class SyncCubit extends Cubit<SyncState> {
   /// only thing missing was a way to say which. One run, not several: the
   /// standing rule that a second sync is refused rather than queued is
   /// unchanged, and four drives in one run is one run.
-  Future<bool> syncDrives(List<String> driveIds) async {
+  Future<bool> syncDrives(List<String> driveIds, {bool deep = false}) async {
     if (driveIds.isEmpty) {
       return false;
     }
 
-    logger.i('Syncing ${driveIds.length} chosen drives');
+    logger.i('Syncing ${driveIds.length} chosen drives, deep: $deep');
 
-    return startSync(onlyDriveIds: driveIds);
+    // Deep composes with the subset because the two are independent: deep
+    // decides *how* a drive is walked - from block one, ignoring snapshots -
+    // and the subset decides *which* drives are walked at all. Neither changes
+    // the completion bookkeeping, so everything built on syncedDriveIds holds
+    // for a deep run too.
+    return startSync(onlyDriveIds: driveIds, deepSync: deep);
   }
 
   /// Get the current sync progress

--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -414,10 +414,83 @@ class SyncCubit extends Cubit<SyncState> {
 
     logger.i('Syncing on login: transactions are still pending');
 
-    startSync(
+    await startSync(
       skipTabVisibilityCheck: true,
       trigger: SyncTrigger.background,
     );
+
+    // One sync is not enough to confirm an upload. A transaction takes several
+    // blocks to mine, so the sync that runs the moment a login notices
+    // something pending will usually find it still pending.
+    watchForPendingConfirmations();
+  }
+
+  /// How long to leave between checks while an upload is waiting to be mined.
+  ///
+  /// An Arweave block is a couple of minutes and a transaction wants a few of
+  /// them, so anything much shorter is asking a question whose answer cannot
+  /// have changed - and asking it of a gateway that rate limits.
+  static const _pendingConfirmationInterval = Duration(minutes: 3);
+
+  Timer? _pendingConfirmationWatch;
+
+  /// Syncs until nothing is waiting to be mined, and then stops.
+  ///
+  /// The gap this closes: an upload writes its file locally and shows it
+  /// immediately, and nothing afterwards ever confirmed it. `autoSync` ships
+  /// `false` in all three flavours, so the periodic sync it gates never runs -
+  /// the comment in the upload form promising that "background periodic sync
+  /// will update lastBlockHeight naturally" describes a timer no shipped
+  /// configuration starts. So a file sat unconfirmed until the reader either
+  /// pressed sync or logged in again.
+  ///
+  /// Deliberately not a periodic sync with a pending check bolted on: it is a
+  /// pending check that syncs. With nothing pending it costs one local
+  /// database read and stops, so an app with no outstanding uploads is exactly
+  /// as quiet as it is today. That is the whole difference between this and
+  /// the `autoSync` flag, which is off precisely because it is unconditional.
+  void watchForPendingConfirmations() {
+    if (isClosed || _pendingConfirmationWatch != null) {
+      return;
+    }
+
+    _pendingConfirmationWatch =
+        Timer(_pendingConfirmationInterval, _confirmPendingTransactions);
+  }
+
+  Future<void> _confirmPendingTransactions() async {
+    _pendingConfirmationWatch = null;
+
+    if (isClosed) {
+      return;
+    }
+
+    bool stillPending;
+
+    try {
+      stillPending = await _syncRepository.hasPendingTransactions();
+    } catch (e, stackTrace) {
+      // A local read that failed is not a reason to keep asking. The next
+      // upload, or the next login, starts this again.
+      logger.e('Could not check for pending transactions', e, stackTrace);
+      return;
+    }
+
+    if (isClosed || !stillPending) {
+      logger.d('Nothing pending: the confirmation watch stops here');
+      return;
+    }
+
+    // Refused outright if a sync is already running, which is the standing
+    // rule and exactly right here: that sync will confirm them anyway.
+    await startSync(trigger: SyncTrigger.background);
+
+    if (isClosed) {
+      return;
+    }
+
+    // Round again. The check above is what ends this, not a counter.
+    watchForPendingConfirmations();
   }
 
   void restartSyncOnFocus() {
@@ -632,9 +705,13 @@ class SyncCubit extends Cubit<SyncState> {
 
       _initSync = DateTime.now();
 
-      // Every drive is covered, so no single drive owns this one.
+      // No *single* drive owns this run - which is a different question from
+      // which drives it covers. `_runDriveIds` is set above from the ids the
+      // caller asked for and must not be cleared here: doing so made a run
+      // over four drives indistinguishable from a run over all of them the
+      // instant it started, so every row said "Syncing" and the gate held
+      // every drive shut.
       _syncingDriveId = null;
-      _runDriveIds = null;
 
       _emitIfOpen(SyncInProgress(trigger: trigger));
       // Emit initial progress AFTER SyncInProgress so the indicator is
@@ -756,6 +833,11 @@ class SyncCubit extends Cubit<SyncState> {
         _currentSyncToken?.dispose();
         _currentSyncToken = null;
       }
+
+      // Released on every path out. A run over a chosen few that left this set
+      // behind would scope the *next* run to the same few - so syncing four
+      // drives once would quietly narrow every sync after it.
+      _runDriveIds = null;
     }
     _lastSync = DateTime.now();
 
@@ -1260,6 +1342,11 @@ class SyncCubit extends Cubit<SyncState> {
   @override
   Future<void> close() async {
     logger.i('Closing SyncCubit instance');
+
+    // A timer that fires after a logout would sync the previous wallet's
+    // drives into a database that has just been emptied.
+    _pendingConfirmationWatch?.cancel();
+    _pendingConfirmationWatch = null;
 
     // First, so the sync begins unwinding while the subscriptions below are
     // being torn down rather than after.

--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -65,6 +65,24 @@ class SyncCubit extends Cubit<SyncState> {
   /// print, and names are not identity.
   String? get syncingDriveId => _syncingDriveId;
 
+  /// Which drives this run covers at all, or null when it covers every one.
+  ///
+  /// A run over a chosen few is still `syncingDriveId == null` - that field
+  /// answers "is this a single-drive sync", not "what is in scope" - so
+  /// without this a four-of-ten run reads as an all-drives sync on every
+  /// surface: ten rows saying "Syncing...", and six drives held shut for a run
+  /// that was never going to touch them.
+  Set<String>? _runDriveIds;
+
+  Set<String>? get syncingDriveIds => _runDriveIds;
+
+  /// The drives this run has finished walking, in the order they finished.
+  ///
+  /// Appended per drive on the success path only - a drive that failed is not
+  /// in here - and live, so a surface can act on it while the run continues.
+  /// Reset with the progress at the start of every run.
+  List<String> get completedDriveIds => _syncProgress.syncedDriveIds;
+
   /// Whether a sync in [state] for [syncingDriveId] could be writing
   /// [driveId].
   ///
@@ -72,8 +90,19 @@ class SyncCubit extends Cubit<SyncState> {
   /// that nothing is writing should not be made to wait for one that is. This
   /// is what makes drive A openable while drive B syncs.
   ///
-  /// An all-drives sync (`syncingDriveId == null`) is treated as touching
-  /// everything, which is the conservative answer and the true one.
+  /// An all-drives sync (`syncingDriveId == null`) covers every drive it has
+  /// not yet finished. [completedDriveIds] is how it says which those are: a
+  /// drive whose history has been walked to the end is no longer being written
+  /// by this run, so a ten-drive sync stops holding the first drive shut for
+  /// the nine that follow it.
+  ///
+  /// **"Walked" is not "nothing will touch this again."** Two phases run after
+  /// every drive's walk: `createGhosts` writes the ghost folders accumulated
+  /// across all drives, and transaction statuses are resolved at the end. Both
+  /// are additive row writes that reach a reader through the Drift stream, so
+  /// what a reader sees is rows appearing - never a half-written folder - but
+  /// this predicate must not be read as a promise that the drive is finished
+  /// with. It says only that its history is read.
   ///
   /// Static, and reading only what callers already hold, so it adds no surface
   /// a test has to stub.
@@ -81,8 +110,22 @@ class SyncCubit extends Cubit<SyncState> {
     required SyncState state,
     required String? syncingDriveId,
     required String driveId,
+    Iterable<String> completedDriveIds = const [],
+    Set<String>? runDriveIds,
   }) {
     if (!(state is SyncInProgress || state is SyncLoadingDrives)) {
+      return false;
+    }
+
+    // Not for SyncLoadingDrives: that phase writes the drives table itself,
+    // and a drive read in a previous run tells us nothing about whether this
+    // one is about to rewrite the row.
+    if (state is SyncInProgress && completedDriveIds.contains(driveId)) {
+      return false;
+    }
+
+    // A run over a chosen few does not touch the rest, however it was started.
+    if (runDriveIds != null && !runDriveIds.contains(driveId)) {
       return false;
     }
 
@@ -527,7 +570,7 @@ class SyncCubit extends Cubit<SyncState> {
   Future<bool> startSync({
     bool deepSync = false,
     bool skipTabVisibilityCheck = false,
-    List<String>? driveIdsToRetry,
+    List<String>? onlyDriveIds,
     SyncTrigger trigger = SyncTrigger.userInitiated,
   }) async {
     logger.i('Starting Sync');
@@ -538,6 +581,12 @@ class SyncCubit extends Cubit<SyncState> {
     }
 
     _syncProgress = SyncProgress.initial();
+
+    // What this run covers, for every surface that has to tell a drive in the
+    // run from one merely sitting beside it. Null means all of them.
+    _runDriveIds = (onlyDriveIds != null && onlyDriveIds.isNotEmpty)
+        ? onlyDriveIds.toSet()
+        : null;
 
     /// Whether this sync actually ran to the end, for a logged-in profile.
     ///
@@ -573,6 +622,7 @@ class SyncCubit extends Cubit<SyncState> {
 
       // Every drive is covered, so no single drive owns this one.
       _syncingDriveId = null;
+      _runDriveIds = null;
 
       _emitIfOpen(SyncInProgress(trigger: trigger));
       // Emit initial progress AFTER SyncInProgress so the indicator is
@@ -640,7 +690,7 @@ class SyncCubit extends Cubit<SyncState> {
           password: password,
           cipherKey: cipherKey,
           syncDeep: deepSync,
-          driveIdsToRetry: driveIdsToRetry,
+          onlyDriveIds: onlyDriveIds,
           cancellationToken: _currentSyncToken,
           txFechedCallback: (driveId, txCount) {
             _promptToSnapshotBloc.add(
@@ -927,6 +977,7 @@ class SyncCubit extends Cubit<SyncState> {
       // Released on every path out, cancellation included: nothing is running
       // for this drive any more.
       _syncingDriveId = null;
+      _runDriveIds = null;
     }
 
     _lastSync = DateTime.now();
@@ -1122,7 +1173,24 @@ class SyncCubit extends Cubit<SyncState> {
     if (driveIds.isEmpty) return;
 
     logger.i('Retrying ${driveIds.length} failed drives');
-    await startSync(driveIdsToRetry: driveIds);
+    await startSync(onlyDriveIds: driveIds);
+  }
+
+  /// Sync a chosen few drives, in one run.
+  ///
+  /// The same operation as retrying failures over a different set - the engine
+  /// has always been able to walk an arbitrary subset concurrently, and the
+  /// only thing missing was a way to say which. One run, not several: the
+  /// standing rule that a second sync is refused rather than queued is
+  /// unchanged, and four drives in one run is one run.
+  Future<bool> syncDrives(List<String> driveIds) async {
+    if (driveIds.isEmpty) {
+      return false;
+    }
+
+    logger.i('Syncing ${driveIds.length} chosen drives');
+
+    return startSync(onlyDriveIds: driveIds);
   }
 
   /// Get the current sync progress

--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -427,10 +427,12 @@ class SyncCubit extends Cubit<SyncState> {
 
   /// How long to leave between checks while an upload is waiting to be mined.
   ///
-  /// An Arweave block is a couple of minutes and a transaction wants a few of
-  /// them, so anything much shorter is asking a question whose answer cannot
-  /// have changed - and asking it of a gateway that rate limits.
-  static const _pendingConfirmationInterval = Duration(minutes: 3);
+  /// An Arweave block is a couple of minutes and a transaction wants several
+  /// of them, so a short interval mostly asks a question whose answer cannot
+  /// have changed yet - of a gateway that rate limits. Fifteen minutes still
+  /// confirms an upload inside the window somebody would call "a while", and
+  /// costs four checks an hour rather than twenty.
+  static const _pendingConfirmationInterval = Duration(minutes: 15);
 
   Timer? _pendingConfirmationWatch;
 

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -260,7 +260,7 @@ abstract class SyncRepository {
     String? password,
     SecretKey? cipherKey,
     SyncCancellationToken? cancellationToken,
-    List<String>? driveIdsToRetry,
+    List<String>? onlyDriveIds,
 
     /// This was required because the usage of the `PromptToSnapshotBloc` in the
     /// `SyncCubit` and the `PromptToSnapshotBloc` is not available in the `SyncRepository`
@@ -412,7 +412,6 @@ class _SyncRepository implements SyncRepository {
   int _metadataFetchesScheduled = 0;
   int _metadataFetchesCompleted = 0;
 
-
   void _resetMetadataFetchCounts() {
     _metadataFetchesScheduled = 0;
     _metadataFetchesCompleted = 0;
@@ -499,7 +498,7 @@ class _SyncRepository implements SyncRepository {
     SecretKey? cipherKey,
     SyncCancellationToken? cancellationToken,
     Function(String driveId, int txCount)? txFechedCallback,
-    List<String>? driveIdsToRetry,
+    List<String>? onlyDriveIds,
   }) async* {
     final token = cancellationToken ?? SyncCancellationToken();
 
@@ -536,10 +535,12 @@ class _SyncRepository implements SyncRepository {
     // Sync the contents of each drive attached in the app.
     var drives = await _driveDao.allDrives().map((d) => d).get();
 
-    // If retrying specific drives, filter to only those
-    if (driveIdsToRetry != null && driveIdsToRetry.isNotEmpty) {
-      final retrySet = driveIdsToRetry.toSet();
-      drives = drives.where((d) => retrySet.contains(d.id)).toList();
+    // Narrowed to the drives asked for. Named for what it does rather
+    // than for its first caller: retrying the failures and syncing a chosen
+    // few are the same operation over a different set.
+    if (onlyDriveIds != null && onlyDriveIds.isNotEmpty) {
+      final only = onlyDriveIds.toSet();
+      drives = drives.where((d) => only.contains(d.id)).toList();
     }
 
     if (drives.isEmpty) {
@@ -2839,78 +2840,79 @@ class _SyncRepository implements SyncRepository {
           // [_pendingSyncedEntityIdsByDrive].
           var committed = false;
           try {
-          await _driveDao.runTransaction(() async {
-            final latestDriveRevision = await _addNewDriveEntityRevisions(
-              newEntities: newEntities.whereType<DriveEntity>(),
-            );
-            final latestFolderRevisions = await _addNewFolderEntityRevisions(
-              driveId: drive.id,
-              newEntities: newEntities.whereType<FolderEntity>(),
-              latestRevisionsCache: latestFolderRevisionsCache,
-            );
-            final latestFileRevisions = await _addNewFileEntityRevisions(
-              driveId: drive.id,
-              newEntities: newEntities.whereType<FileEntity>(),
-              latestRevisionsCache: latestFileRevisionsCache,
-            );
+            await _driveDao.runTransaction(() async {
+              final latestDriveRevision = await _addNewDriveEntityRevisions(
+                newEntities: newEntities.whereType<DriveEntity>(),
+              );
+              final latestFolderRevisions = await _addNewFolderEntityRevisions(
+                driveId: drive.id,
+                newEntities: newEntities.whereType<FolderEntity>(),
+                latestRevisionsCache: latestFolderRevisionsCache,
+              );
+              final latestFileRevisions = await _addNewFileEntityRevisions(
+                driveId: drive.id,
+                newEntities: newEntities.whereType<FileEntity>(),
+                latestRevisionsCache: latestFileRevisionsCache,
+              );
 
-            for (final entity in latestFileRevisions) {
-              if (!_folderIds.contains(entity.parentFolderId.value)) {
-                _ghostFolders.putIfAbsent(
-                  entity.parentFolderId.value,
-                  () => GhostFolder(
-                    driveId: drive.id,
-                    folderId: entity.parentFolderId.value,
-                    isHidden: false,
-                  ),
-                );
+              for (final entity in latestFileRevisions) {
+                if (!_folderIds.contains(entity.parentFolderId.value)) {
+                  _ghostFolders.putIfAbsent(
+                    entity.parentFolderId.value,
+                    () => GhostFolder(
+                      driveId: drive.id,
+                      folderId: entity.parentFolderId.value,
+                      isHidden: false,
+                    ),
+                  );
+                }
               }
-            }
 
-            // Check and handle cases where there's no more revisions
-            final updatedDrive = latestDriveRevision != null
-                ? await _computeRefreshedDriveFromRevision(
-                    driveDao: _driveDao,
-                    latestRevision: latestDriveRevision,
-                  )
-                : null;
+              // Check and handle cases where there's no more revisions
+              final updatedDrive = latestDriveRevision != null
+                  ? await _computeRefreshedDriveFromRevision(
+                      driveDao: _driveDao,
+                      latestRevision: latestDriveRevision,
+                    )
+                  : null;
 
-            final updatedFoldersById =
-                await _computeRefreshedFolderEntriesFromRevisions(
-              driveDao: _driveDao,
-              driveId: drive.id,
-              revisionsByFolderId: latestFolderRevisions,
-              oldestRevisionsCache: oldestFolderRevisionsCache,
-            );
-            final updatedFilesById =
-                await _computeRefreshedFileEntriesFromRevisions(
-              driveDao: _driveDao,
-              driveId: drive.id,
-              revisionsByFileId: latestFileRevisions,
-              oldestRevisionsCache: oldestFileRevisionsCache,
-            );
+              final updatedFoldersById =
+                  await _computeRefreshedFolderEntriesFromRevisions(
+                driveDao: _driveDao,
+                driveId: drive.id,
+                revisionsByFolderId: latestFolderRevisions,
+                oldestRevisionsCache: oldestFolderRevisionsCache,
+              );
+              final updatedFilesById =
+                  await _computeRefreshedFileEntriesFromRevisions(
+                driveDao: _driveDao,
+                driveId: drive.id,
+                revisionsByFileId: latestFileRevisions,
+                oldestRevisionsCache: oldestFileRevisionsCache,
+              );
 
-            numberOfDriveEntitiesParsed += newEntities.length;
+              numberOfDriveEntitiesParsed += newEntities.length;
 
-            numberOfDriveEntitiesParsed -=
-                updatedFoldersById.length + updatedFilesById.length;
+              numberOfDriveEntitiesParsed -=
+                  updatedFoldersById.length + updatedFilesById.length;
 
-            // Update the drive model, making sure to not overwrite the existing keys defined on the drive.
-            if (updatedDrive != null) {
-              await _driveDao.updateDrive(updatedDrive);
-            }
+              // Update the drive model, making sure to not overwrite the existing keys defined on the drive.
+              if (updatedDrive != null) {
+                await _driveDao.updateDrive(updatedDrive);
+              }
 
-            // Update the folder and file entries before generating their new paths.
-            await _driveDao
-                .updateFolderEntries(updatedFoldersById.values.toList());
-            await _driveDao.updateFileEntries(updatedFilesById.values.toList());
+              // Update the folder and file entries before generating their new paths.
+              await _driveDao
+                  .updateFolderEntries(updatedFoldersById.values.toList());
+              await _driveDao
+                  .updateFileEntries(updatedFilesById.values.toList());
 
-            numberOfDriveEntitiesParsed +=
-                updatedFoldersById.length + updatedFilesById.length;
+              numberOfDriveEntitiesParsed +=
+                  updatedFoldersById.length + updatedFilesById.length;
 
-            latestFolderRevisions.clear();
-            latestFileRevisions.clear();
-          });
+              latestFolderRevisions.clear();
+              latestFileRevisions.clear();
+            });
             committed = true;
           } finally {
             if (committed) {

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -663,6 +663,12 @@ class _SyncRepository implements SyncRepository {
             skippedDriveCount: skipped,
           );
         }
+      } on SyncCancelledException {
+        // A stop is not a probe failure. Without this the reader's cancel was
+        // swallowed here and the sync carried on into the walk - the phase
+        // this catch exists for is a best-effort optimisation, and being
+        // tolerant of its failure must not make it tolerant of being stopped.
+        rethrow;
       } catch (e) {
         logger.w('Drive activity probe failed, syncing all drives: $e');
         drivesToSync = drives;
@@ -778,6 +784,10 @@ class _SyncRepository implements SyncRepository {
             '${prefetchedSnapshots.values.expand((v) => v).length} '
             'for $withSnapshots of ${prefetchedSnapshots.length} drive(s); '
             'the rest are known to have none and will not be re-queried');
+      } on SyncCancelledException {
+        // Same again: failing to prefetch snapshots is recoverable, being
+        // stopped is not something to recover from.
+        rethrow;
       } catch (e) {
         logger.w('Snapshot prefetch failed, will fetch per-drive: $e');
         prefetchedSnapshots.clear();
@@ -2497,6 +2507,7 @@ class _SyncRepository implements SyncRepository {
             snapshotDriveHistory: snapshotDriveHistory,
             ownerAddress: ownerAddress,
             onMetadataFetchProgress: onMetadataFetchProgress,
+            cancellationToken: token,
           );
 
           totalTransactionsProcessed += transactionBuffer.length;
@@ -2537,6 +2548,7 @@ class _SyncRepository implements SyncRepository {
             snapshotDriveHistory: snapshotDriveHistory,
             ownerAddress: ownerAddress,
             onMetadataFetchProgress: onMetadataFetchProgress,
+            cancellationToken: token,
           );
 
           totalTransactionsProcessed += transactionBuffer.length;
@@ -2672,6 +2684,10 @@ class _SyncRepository implements SyncRepository {
     required int transactionParseBatchSize,
     required SnapshotDriveHistory snapshotDriveHistory,
     required String ownerAddress,
+
+    /// Read between the batches inside this chunk, so a stop is noticed
+    /// without waiting for the whole chunk to finish.
+    SyncCancellationToken? cancellationToken,
     void Function()? onMetadataFetchProgress,
   }) async {
     if (transactions.isEmpty) return;
@@ -2702,7 +2718,17 @@ class _SyncRepository implements SyncRepository {
       ownerAddress: ownerAddress,
       onMetadataFetchProgress: onMetadataFetchProgress,
     )) {
-      // Just consume the stream, progress is handled in main loop
+      // Progress is handled in the main loop; what this consumes it for is the
+      // chance to stop.
+      //
+      // The walk checks the token once per transaction *arriving*, which is
+      // fine - but a chunk already handed to this method used to run to the
+      // end whatever the reader asked for, and a chunk is up to
+      // `transactionParseBatchSize` metadata fetches. On a slow gateway that
+      // is the whole of the delay between pressing stop and stopping. This
+      // stream yields once per batch inside the chunk, so asking here moves
+      // the worst case from a chunk to a batch.
+      cancellationToken?.checkCancellation();
     }
   }
 

--- a/lib/utils/graphql_retry.dart
+++ b/lib/utils/graphql_retry.dart
@@ -4,6 +4,9 @@ import 'package:ardrive/utils/logger.dart';
 import 'package:artemis/client.dart';
 import 'package:artemis/schema/graphql_query.dart';
 import 'package:artemis/schema/graphql_response.dart';
+import 'package:flutter/foundation.dart';
+import 'package:gql_http_link/gql_http_link.dart';
+import 'package:gql_link/gql_link.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:retry/retry.dart';
 
@@ -13,11 +16,9 @@ import 'package:retry/retry.dart';
 /// index ArDrive L2 data.
 class GraphQLRetry {
   GraphQLRetry(this._client,
-      {required InternetChecker internetChecker,
-      String? fallbackGraphqlUrl})
+      {required InternetChecker internetChecker, String? fallbackGraphqlUrl})
       : _internetChecker = internetChecker,
-        _fallbackGraphqlUrl =
-            fallbackGraphqlUrl ?? defaultFallbackGraphqlUrl;
+        _fallbackGraphqlUrl = fallbackGraphqlUrl ?? defaultFallbackGraphqlUrl;
 
   /// Where a query goes when the primary endpoint will not serve it.
   ///
@@ -68,12 +69,7 @@ class GraphQLRetry {
           onRetry: onRetry, maxAttempts: maxAttempts);
     } catch (primaryError) {
       // If primary exhausted all retries, try fallback
-      final errorStr = primaryError.toString();
-      if (errorStr.contains('429') ||
-          errorStr.contains('500') ||
-          errorStr.contains('502') ||
-          errorStr.contains('503') ||
-          errorStr.contains('504')) {
+      if (deservesFallback(primaryError)) {
         logger.w(
           'GraphQL primary exhausted retries, '
           'trying fallback: $_fallbackGraphqlUrl',
@@ -116,6 +112,54 @@ class GraphQLRetry {
 
       throw GraphQLException(primaryError);
     }
+  }
+
+  /// Whether this failure is one another endpoint might not have.
+  ///
+  /// The status code is read off the exception rather than out of its text.
+  /// This used to string-match `error.toString()` for '429' and the 5xx codes,
+  /// and that never once matched an HTTP failure: a non-2xx from the gateway
+  /// arrives as `HttpLinkServerException`, whose `toString` prints
+  /// `originalException`, `originalStackTrace` and `parsedResponse` and *not*
+  /// the status - the one field the decision needed. So the fallback below has
+  /// never armed for a rate limit or a bad gateway, which is exactly what a
+  /// rate-limited primary looks like from the outside: retries against the
+  /// same host until the budget runs out, and no second endpoint ever tried.
+  ///
+  /// The string check stays underneath as a last resort, for anything that
+  /// does put a code in its message.
+  @visibleForTesting
+  static bool deservesFallback(Object error) {
+    final status = _statusCodeOf(error);
+
+    if (status != null) {
+      return status == 429 || (status >= 500 && status < 600);
+    }
+
+    final text = error.toString();
+
+    return text.contains('429') ||
+        text.contains('500') ||
+        text.contains('502') ||
+        text.contains('503') ||
+        text.contains('504');
+  }
+
+  /// The HTTP status behind a GraphQL failure, where there is one.
+  ///
+  /// `HttpLinkServerException` carries the whole `http.Response`;
+  /// `ServerException` carries a `statusCode` that the http link does not
+  /// currently populate. Both are read, so this keeps working if that changes.
+  static int? _statusCodeOf(Object error) {
+    if (error is HttpLinkServerException) {
+      return error.response.statusCode;
+    }
+
+    if (error is ServerException) {
+      return error.statusCode;
+    }
+
+    return null;
   }
 
   Future<GraphQLResponse<T>> _executeWithRetry<T, U extends JsonSerializable>(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1135,7 +1135,7 @@ packages:
     source: hosted
     version: "0.4.3"
   gql_http_link:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: gql_http_link
       sha256: "89ef87b32947acf4189f564c095f1148b0ab9bb9996fe518716dbad66708b834"
@@ -1143,7 +1143,7 @@ packages:
     source: hosted
     version: "0.4.5"
   gql_link:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: gql_link
       sha256: f7973279126bc922d465c4f4da6ed93d187085e597b3480f5e14e74d28fe14bd

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -603,7 +603,7 @@ packages:
     source: hosted
     version: "0.6.0"
   fake_async:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: fake_async
       sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
@@ -1127,7 +1127,7 @@ packages:
     source: hosted
     version: "2.0.3+1"
   gql_exec:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: gql_exec
       sha256: "0d1fdb2e4154efbfc1dcf3f35ec36d19c8428ff0d560eb4c45b354f8f871dc50"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,6 +53,12 @@ dependencies:
   ardrive_logger:
     path: ./packages/ardrive_logger
   artemis: ^7.0.0-beta.13
+  # Imported directly by `GraphQLRetry`, which reads the HTTP status off the
+  # exception artemis's transport throws rather than out of its toString.
+  # Already resolved as a transitive dependency of artemis; declared because
+  # it is used.
+  gql_http_link: ^0.4.5
+  gql_link: ^0.5.1
   pst:
     path: ./packages/pst
   arweave:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -192,6 +192,11 @@ dependency_overrides:
     path: ./packages/ardrive_ui
 
 dev_dependencies:
+  # Used by tests that drive a Timer without waiting for real time.
+  fake_async: ^1.3.1
+  # Used by the GraphQL fallback test to build the exception the transport
+  # throws on a non-2xx.
+  gql_exec: ^0.4.3
   integration_test:
     sdk: flutter
   flutter_test:

--- a/test/blocs/drive_detail/drive_detail_cubit_test.dart
+++ b/test/blocs/drive_detail/drive_detail_cubit_test.dart
@@ -187,6 +187,54 @@ void main() {
       },
     );
 
+    /// A drive whose root revision has not arrived *yet* is not a drive that
+    /// has never been synced.
+    ///
+    /// Reading no longer waits for the sync, which is the point - but it means
+    /// this branch is now reached mid-walk, where the wait used to keep it
+    /// away. Saying "Drive Not Synced" then contradicts the ring still turning
+    /// in the top bar, and offers a Sync Now the cubit refuses because a sync
+    /// is already running. Reported from the browser: the panel flipped to
+    /// Drive Not Synced part way through a sync, with both buttons greyed, and
+    /// came right when the sync finished.
+    blocTest<DriveDetailCubit, DriveDetailState>(
+      'waits rather than claiming "not synced" while that drive is syncing',
+      setUp: () async {
+        await insertDrive(lastBlockHeight: 0);
+
+        whenListen(syncCubit, syncStates.stream,
+            initialState: SyncInProgress(trigger: SyncTrigger.userInitiated));
+        when(() => syncCubit.syncingDriveId).thenReturn(driveId);
+      },
+      build: buildCubit,
+      wait: const Duration(milliseconds: 100),
+      verify: (cubit) {
+        expect(
+          cubit.state,
+          isNot(isA<DriveDetailLoadUnsynced>()),
+          reason: 'the root revision has not landed yet, which is not the same '
+              'as never landing',
+        );
+      },
+    );
+
+    /// And the claim is still made when nothing is running, because then it is
+    /// true and the offer to sync is one the cubit will honour.
+    blocTest<DriveDetailCubit, DriveDetailState>(
+      'and says it plainly once no sync is running',
+      setUp: () async {
+        await insertDrive(lastBlockHeight: 0);
+
+        whenListen(syncCubit, syncStates.stream, initialState: SyncIdle());
+        when(() => syncCubit.syncingDriveId).thenReturn(null);
+      },
+      build: buildCubit,
+      wait: const Duration(milliseconds: 100),
+      verify: (cubit) {
+        expect(cubit.state, isA<DriveDetailLoadUnsynced>());
+      },
+    );
+
     /// The mirror case, and the reason `lastBlockHeight` cannot be the signal:
     /// a drive created in-app writes a root revision but never advances its
     /// watermark, so gating on the watermark would tell someone who just made

--- a/test/blocs/drive_detail/drive_detail_cubit_test.dart
+++ b/test/blocs/drive_detail/drive_detail_cubit_test.dart
@@ -218,6 +218,46 @@ void main() {
       },
     );
 
+    /// A wait needs something that can end it.
+    ///
+    /// The panel waits rather than saying "Drive Not Synced" while a sync is
+    /// walking that drive, and the tick that writes the root revision is what
+    /// ends the wait. A run that fails, is cancelled, or fails on this drive
+    /// in particular writes nothing - so no tick comes, and the panel sat on
+    /// "Opening..." until the reader navigated away and back. Before reading
+    /// stopped waiting for the sync this could not happen: the check always
+    /// ran after the sync had settled.
+    blocTest<DriveDetailCubit, DriveDetailState>(
+      'a sync that ends without writing the drive does not strand the panel',
+      setUp: () async {
+        await insertDrive(lastBlockHeight: 0);
+
+        whenListen(syncCubit, syncStates.stream,
+            initialState: SyncInProgress(trigger: SyncTrigger.userInitiated));
+        when(() => syncCubit.syncingDriveId).thenReturn(driveId);
+      },
+      build: buildCubit,
+      act: (cubit) async {
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+
+        expect(cubit.state, isA<DriveDetailLoadInProgress>(),
+            reason: 'precondition: waiting for a revision that may still come');
+
+        // The sync ends having written nothing for this drive.
+        when(() => syncCubit.syncingDriveId).thenReturn(null);
+        syncStates.add(SyncFailure());
+        await Future<void>.delayed(const Duration(milliseconds: 300));
+      },
+      verify: (cubit) {
+        expect(
+          cubit.state,
+          isA<DriveDetailLoadUnsynced>(),
+          reason: 'the revision is not coming, so the panel has to say so and '
+              'offer a way out rather than spin for ever',
+        );
+      },
+    );
+
     /// And the claim is still made when nothing is running, because then it is
     /// true and the offer to sync is one the cubit will honour.
     blocTest<DriveDetailCubit, DriveDetailState>(

--- a/test/blocs/drive_detail/drive_detail_cubit_test.dart
+++ b/test/blocs/drive_detail/drive_detail_cubit_test.dart
@@ -642,6 +642,55 @@ void main() {
   /// is what a change to the drive row gives, since the subscription combines
   /// the drive and its contents and re-emits when either moves.
   group('a redraw dropped for an upload', () {
+    /// The report that found this: "I uploaded a file, it worked, and I do not
+    /// see it in the drive view."
+    ///
+    /// An upload writes its file while `isUploading` is up, so the tick
+    /// carrying it is refused by the guard in the subscription - and nothing
+    /// writes that folder again afterwards, so no later tick carries it
+    /// either. The upload form then calls `refreshDriveDataTable`, which
+    /// re-emitted the state it already had with a new key: the same rows,
+    /// rebuilt. The file was uploaded and was not on screen, and nothing short
+    /// of leaving the folder and coming back would show it.
+    test('is settled by the refresh the upload form calls', () async {
+      await insertDrive(lastBlockHeight: 100);
+      await insertRootFolderRevision();
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      expect(cubit.state, isA<DriveDetailLoadSuccess>(),
+          reason: 'precondition: the folder is on screen');
+
+      // The upload runs and writes into the folder being viewed.
+      when(() => activityTracker.isUploading).thenReturn(true);
+      await insertSubfolder('uploaded-during');
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      expect(
+        (cubit.state as DriveDetailLoadSuccess).folderInView.subfolders,
+        isEmpty,
+        reason: 'precondition: the upload guard refused that redraw',
+      );
+
+      // The upload finishes exactly as the form does it, and nothing else
+      // touches the database afterwards.
+      when(() => activityTracker.isUploading).thenReturn(false);
+      cubit.refreshDriveDataTable();
+      await Future<void>.delayed(const Duration(milliseconds: 400));
+
+      expect(
+        (cubit.state as DriveDetailLoadSuccess)
+            .folderInView
+            .subfolders
+            .map((f) => f.name),
+        contains('uploaded-during'),
+        reason: 'the uploaded file has to be on screen when the upload ends, '
+            'without the reader navigating away and back',
+      );
+    });
+
     test('does not make a later identical tick look like a no-op', () async {
       await insertDrive(lastBlockHeight: 100);
       await insertRootFolderRevision();

--- a/test/blocs/drive_detail/drive_detail_cubit_test.dart
+++ b/test/blocs/drive_detail/drive_detail_cubit_test.dart
@@ -146,6 +146,9 @@ void main() {
             )
             .watchSingleOrNull());
 
+    // The gate reads this alongside syncingDriveId; an empty list is "nothing
+    // has finished walking yet", which is true of every state these tests set.
+    when(() => syncCubit.completedDriveIds).thenReturn(const []);
     when(() => syncCubit.waitCurrentSync()).thenAnswer((_) async {});
     whenListen(syncCubit, syncStates.stream, initialState: SyncIdle());
 
@@ -467,33 +470,43 @@ void main() {
       expect(cubit.state, isA<DriveDetailLoadSuccess>(),
           reason: 'precondition: the first drive is on screen');
 
-      // A sync that is running and has not finished. Deliberately never
-      // completed: the point is what the app does *during* it. An all-drives
-      // background sync, which is the one that really does cover this drive -
-      // stubbing only waitCurrentSync left the cubit in SyncIdle, so the test
-      // described a sync that was not running.
+      // A sync that is running and never finishes. The point is what the app
+      // does *during* it - an all-drives background sync, which is the one
+      // that really does cover this drive.
       final syncing = Completer<void>();
       addTearDown(() => syncing.complete());
       when(() => syncCubit.waitCurrentSync()).thenAnswer((_) => syncing.future);
       whenListen(syncCubit, syncStates.stream,
           initialState: SyncInProgress(trigger: SyncTrigger.background));
       when(() => syncCubit.syncingDriveId).thenReturn(null);
+      // The run's own scope and what it has finished, read by every surface
+      // that tells a drive in the run from one beside it. Null scope is
+      // "every drive"; nothing finished yet.
+      when(() => syncCubit.syncingDriveIds).thenReturn(null);
+      when(() => syncCubit.completedDriveIds).thenReturn(const []);
 
       unawaited(cubit.changeDrive(otherDriveId));
-      await Future<void>.delayed(const Duration(milliseconds: 100));
+      await Future<void>.delayed(const Duration(milliseconds: 300));
 
+      final state = cubit.state;
       expect(
-        cubit.state,
-        isA<DriveDetailLoadInProgress>(),
-        reason: 'the click has to be answered before the wait, not after it - '
-            'otherwise the drive the user left stays on screen, with nothing '
-            'to say the app heard them, for the whole sync',
+        state,
+        isA<DriveDetailLoadSuccess>(),
+        reason: 'the drive opens during the sync rather than after it - the '
+            'sync here never finishes, so waiting for it would mean never '
+            'opening at all',
       );
+      expect((state as DriveDetailLoadSuccess).currentDrive.id, otherDriveId);
+      verifyNever(() => syncCubit.waitCurrentSync());
     });
 
-    /// The wait itself is not the bug and must survive: a folder opened
-    /// against a half-written database is the reason it is there.
-    test('the folder still waits for the sync before it is read', () async {
+    /// The wait this replaced was there to keep a folder from being read
+    /// against a half-written database. It was not needed for that: every
+    /// batch commits in its own transaction, so a read mid-sync gets
+    /// consistent data - just less of it than the folder will eventually hold,
+    /// with the subscription filling the rest in as it lands.
+    test('a folder is read during the sync of its own drive, not after it',
+        () async {
       await insertDrive(lastBlockHeight: 100);
       await insertRootFolderRevision();
       await insertSubfolder('subfolder-1');
@@ -504,26 +517,24 @@ void main() {
 
       await Future<void>.delayed(const Duration(milliseconds: 100));
 
+      // A sync of the very drive being opened, which never finishes.
       final syncing = Completer<void>();
+      addTearDown(() => syncing.complete());
       when(() => syncCubit.waitCurrentSync()).thenAnswer((_) => syncing.future);
-      // A sync that really is writing this drive. Without this the cubit is
-      // in SyncIdle, nothing is gated, and the test passes without ever
-      // reaching the wait it exists to protect.
       whenListen(syncCubit, syncStates.stream,
           initialState: SyncInProgress(trigger: SyncTrigger.userInitiated));
       when(() => syncCubit.syncingDriveId).thenReturn(otherDriveId);
 
       unawaited(cubit.changeDrive(otherDriveId));
-      await Future<void>.delayed(const Duration(milliseconds: 100));
-
-      expect(cubit.state, isA<DriveDetailLoadInProgress>(),
-          reason: 'precondition: the click was answered');
-
-      syncing.complete();
-      await Future<void>.delayed(const Duration(milliseconds: 200));
+      await Future<void>.delayed(const Duration(milliseconds: 300));
 
       final state = cubit.state;
-      expect(state, isA<DriveDetailLoadSuccess>());
+      expect(
+        state,
+        isA<DriveDetailLoadSuccess>(),
+        reason: 'the drive being synced is the one a reader most wants to '
+            'watch fill in',
+      );
       expect((state as DriveDetailLoadSuccess).currentDrive.id, otherDriveId);
     });
 
@@ -815,7 +826,7 @@ void main() {
             deepSync: any(named: 'deepSync'),
             trigger: any(named: 'trigger'),
             skipTabVisibilityCheck: any(named: 'skipTabVisibilityCheck'),
-            driveIdsToRetry: any(named: 'driveIdsToRetry'),
+            onlyDriveIds: any(named: 'onlyDriveIds'),
           )).thenAnswer((_) async => false);
       when(() => syncCubit.state).thenReturn(SyncIdle());
 
@@ -995,7 +1006,7 @@ void main() {
             deepSync: any(named: 'deepSync'),
             trigger: any(named: 'trigger'),
             skipTabVisibilityCheck: any(named: 'skipTabVisibilityCheck'),
-            driveIdsToRetry: any(named: 'driveIdsToRetry'),
+            onlyDriveIds: any(named: 'onlyDriveIds'),
           )).thenAnswer((_) async {
         when(() => syncCubit.state).thenReturn(SyncCompleteWithErrors(
           failedDrives: 1,

--- a/test/blocs/drive_detail/drive_detail_cubit_test.dart
+++ b/test/blocs/drive_detail/drive_detail_cubit_test.dart
@@ -628,6 +628,63 @@ void main() {
     });
   });
 
+  /// A tick that was never drawn must not count as drawn.
+  ///
+  /// The folder subscription skips a redraw while an upload is running, so the
+  /// file list does not churn under somebody watching a progress bar. The
+  /// change-detection added for sync then has to be careful *where* it records
+  /// what is on screen: recorded before that guard, the tick carrying the
+  /// newly uploaded file was marked as drawn and then dropped, and any later
+  /// tick carrying the same contents was skipped as a no-op. The file never
+  /// arrived.
+  ///
+  /// Reproducing it needs a second tick that carries the *same* folder - which
+  /// is what a change to the drive row gives, since the subscription combines
+  /// the drive and its contents and re-emits when either moves.
+  group('a redraw dropped for an upload', () {
+    test('does not make a later identical tick look like a no-op', () async {
+      await insertDrive(lastBlockHeight: 100);
+      await insertRootFolderRevision();
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      expect(cubit.state, isA<DriveDetailLoadSuccess>(),
+          reason: 'precondition: the folder is on screen');
+
+      // An upload runs, and writes a folder into the one on screen. The tick
+      // carrying it is dropped rather than drawn.
+      when(() => activityTracker.isUploading).thenReturn(true);
+      await insertSubfolder('arrived-during-upload');
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      expect(
+        (cubit.state as DriveDetailLoadSuccess).folderInView.subfolders,
+        isEmpty,
+        reason: 'precondition: the upload guard dropped that redraw',
+      );
+
+      // The upload ends, and something touches the drive row - a sync
+      // advancing its watermark, say. The folder itself is unchanged, so this
+      // tick carries exactly the contents the dropped one did.
+      when(() => activityTracker.isUploading).thenReturn(false);
+      await (db.update(db.drives)..where((d) => d.id.equals(driveId)))
+          .write(const DrivesCompanion(lastBlockHeight: Value(200)));
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+
+      expect(
+        (cubit.state as DriveDetailLoadSuccess)
+            .folderInView
+            .subfolders
+            .map((f) => f.name),
+        contains('arrived-during-upload'),
+        reason: 'nothing else is going to change this folder, so a tick '
+            'skipped as unchanged is the file never appearing',
+      );
+    });
+  });
+
   /// What an empty local database means, which is three different things.
   ///
   /// The app used to render all three as one: "Getting Started", two

--- a/test/components/drive_detach_dialog_test.dart
+++ b/test/components/drive_detach_dialog_test.dart
@@ -1,0 +1,150 @@
+import 'package:ardrive/blocs/blocs.dart';
+import 'package:ardrive/components/drive_detach_dialog.dart';
+import 'package:ardrive/core/activity_tracker.dart';
+import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
+import 'package:ardrive_ui/ardrive_ui.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:provider/provider.dart';
+
+class _MockSyncCubit extends MockBloc<dynamic, SyncState>
+    implements SyncCubit {}
+
+class _MockDrivesCubit extends MockBloc<dynamic, DrivesState>
+    implements DrivesCubit {}
+
+/// What a reader is told before detaching a drive somebody else owns.
+///
+/// Every path here is gated on `!isOwner`, so this is always a shared drive -
+/// and a shared drive does not come back on its own. An owned drive is
+/// rediscovered by the next drive-list refresh; a shared one was never
+/// discovered at all, only linked to. The dialog used to ask "are you sure?"
+/// and leave the reader to find that out afterwards.
+void main() {
+  late _MockSyncCubit syncCubit;
+  late _MockDrivesCubit drivesCubit;
+
+  setUp(() {
+    syncCubit = _MockSyncCubit();
+    drivesCubit = _MockDrivesCubit();
+
+    whenListen(syncCubit, const Stream<SyncState>.empty(),
+        initialState: SyncIdle());
+    when(() => syncCubit.syncingDriveId).thenReturn(null);
+    when(() => syncCubit.syncingDriveIds).thenReturn(null);
+    when(() => syncCubit.completedDriveIds).thenReturn(const []);
+    whenListen(drivesCubit, const Stream<DrivesState>.empty(),
+        initialState: DrivesLoadInProgress());
+  });
+
+  Future<void> openDialog(
+    WidgetTester tester, {
+    Size size = const Size(1200, 900),
+  }) async {
+    await tester.binding.setSurfaceSize(size);
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      // Providers above the MaterialApp, as they are in the real app: a
+      // dialog is pushed as its own route, so anything scoped inside `home`
+      // is not an ancestor of it.
+      MultiProvider(
+        providers: [
+          // `showArDriveDialog` reads it to hold sync off while a modal is up;
+          // nothing this test asserts depends on what it says.
+          ChangeNotifierProvider<ActivityTracker>(
+            create: (_) => ActivityTracker(),
+          ),
+          BlocProvider<SyncCubit>.value(value: syncCubit),
+          BlocProvider<DrivesCubit>.value(value: drivesCubit),
+        ],
+        child: ArDriveTheme(
+          themeData: lightTheme(),
+          child: MaterialApp(
+            localizationsDelegates: const [
+              AppLocalizations.delegate,
+              GlobalMaterialLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+              GlobalCupertinoLocalizations.delegate,
+            ],
+            supportedLocales: const [Locale('en', '')],
+            home: Builder(
+              builder: (context) => Scaffold(
+                body: Center(
+                  child: ElevatedButton(
+                    onPressed: () => showDetachDriveDialog(
+                      context: context,
+                      driveID: 'drive-a',
+                      driveName: 'Photos',
+                    ),
+                    child: const Text('open'),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('names the drive and says what getting it back costs',
+      (tester) async {
+    await openDialog(tester);
+
+    expect(find.textContaining('Photos'), findsOneWidget);
+    expect(
+      find.textContaining('share link'),
+      findsOneWidget,
+      reason: 'the one thing that makes this different from detaching a drive '
+          'you own, and the one thing a reader can act on beforehand',
+    );
+  });
+
+  testWidgets('and says nothing about a sync when none is running',
+      (tester) async {
+    await openDialog(tester);
+
+    expect(find.textContaining('will be stopped first'), findsNothing);
+  });
+
+  testWidgets('but does when one is', (tester) async {
+    whenListen(syncCubit, const Stream<SyncState>.empty(),
+        initialState: SyncInProgress(trigger: SyncTrigger.userInitiated));
+    when(() => syncCubit.syncingDriveId).thenReturn('drive-a');
+
+    await openDialog(tester);
+
+    expect(
+      find.textContaining('will be stopped first'),
+      findsOneWidget,
+      reason: 'detaching cancels the sync and waits for it - a reader watching '
+          'a ring turn should not have to guess whether the two race',
+    );
+  });
+
+  testWidgets('fits a 320px phone without overflowing', (tester) async {
+    await openDialog(tester, size: const Size(320, 640));
+
+    expect(tester.takeException(), isNull);
+    expect(find.textContaining('share link'), findsOneWidget);
+  });
+
+  testWidgets('detaching asks the cubit to do it', (tester) async {
+    when(() => drivesCubit.detachDrive(any())).thenAnswer((_) async {});
+
+    await openDialog(tester);
+    await tester.tap(find.text('DETACH'));
+    await tester.pumpAndSettle();
+
+    verify(() => drivesCubit.detachDrive('drive-a')).called(1);
+  });
+}

--- a/test/components/sync_button_test.dart
+++ b/test/components/sync_button_test.dart
@@ -60,6 +60,11 @@ void main() {
     // Null is "no single-drive sync is running", which is every case but the
     // ones that say otherwise.
     when(() => syncCubit.syncingDriveId).thenReturn(null);
+    // The run's own scope and what it has finished, read by every surface
+    // that tells a drive in the run from one beside it. Null scope is
+    // "every drive"; nothing finished yet.
+    when(() => syncCubit.syncingDriveIds).thenReturn(null);
+    when(() => syncCubit.completedDriveIds).thenReturn(const []);
     when(() => syncCubit.clearErrorState()).thenReturn(null);
     when(() => syncCubit.retryFailedDrives(any())).thenAnswer((_) async {});
     when(() => syncCubit.syncMetadataOnly()).thenAnswer((_) async {});
@@ -564,12 +569,10 @@ void main() {
     await tester.pump(const Duration(milliseconds: 300));
   }
 
-
   // The groups that tested Resync, Deep Resync, Retry and the record moved with
   // them: those actions now live on the drives list, and
   // `test/drives_list/drives_sync_menu_test.dart` covers them there. What is
   // left here is what this button still does - report, and get out of the way.
-
 
   group('a background sync that failed', () {
     testWidgets('says so at the top bar rather than over the app',
@@ -636,7 +639,6 @@ void main() {
       // the way to the page that carries it.
       expect(find.text('Retry Failed'), findsNothing);
       expect(find.text('All drives'), findsOneWidget);
-
 
       await tester.pumpWidget(const SizedBox());
     });
@@ -709,7 +711,6 @@ void main() {
 
       expect(find.text('All drives'), findsOneWidget);
 
-
       await tester.pumpWidget(const SizedBox());
     });
 
@@ -765,7 +766,6 @@ void main() {
       await tester.pumpWidget(const SizedBox());
     });
   });
-
 
   /// The two states the app used to emit and render nowhere at all.
   group('states that had no surface', () {

--- a/test/drives_list/drives_list_cubit_test.dart
+++ b/test/drives_list/drives_list_cubit_test.dart
@@ -560,6 +560,44 @@ void main() {
       );
     });
   });
+
+  /// What the row shows when the figures could not be read at all.
+  ///
+  /// Reported as drives showing a different total between sessions. The
+  /// arithmetic is sound - one row per file, `PRIMARY KEY (id, driveId)`, and
+  /// `size INTEGER NOT NULL` - but the failure path collapsed two different
+  /// answers into one. A drive missing from a summary map that *was* read has
+  /// no files and is 0; a drive whose figures could not be read is unknown and
+  /// is a dash. Passing an empty map for a read that failed made every walked
+  /// drive report itself as empty, which is the confident wrong answer this
+  /// whole series exists to remove - and it looks exactly like a total that
+  /// changed between sessions.
+  group('when the per-drive figures cannot be read', () {
+    test('a walked drive says it does not know, not that it is empty',
+        () async {
+      // Walked, or the figures would be withheld for that reason instead and
+      // the assertion below would hold whatever the failure path did.
+      await addDrive('drive-a', lastBlockHeight: 100);
+
+      // The real query, made to fail the way a real one would: the table it
+      // reads is not there.
+      await db.customStatement('DROP TABLE file_entries');
+
+      final state = await settle(loaded(await drivesNamed(['drive-a'])));
+
+      expect(state, isA<DrivesListLoaded>());
+
+      final drive = (state as DrivesListLoaded).drives.single;
+
+      expect(
+        drive.fileCount,
+        isNull,
+        reason: '0 files is a claim, and nothing here is in a position to '
+            'make it',
+      );
+      expect(drive.totalSize, isNull);
+    });
+  });
 }
 
 /// A sync doing nothing, which is what every test here starts from.

--- a/test/drives_list/drives_list_cubit_test.dart
+++ b/test/drives_list/drives_list_cubit_test.dart
@@ -47,6 +47,11 @@ void main() {
 
     when(() => syncCubit.driveListRefreshFailed).thenReturn(false);
     when(() => syncCubit.syncingDriveId).thenReturn(null);
+    // The run's own scope and what it has finished, read by every surface
+    // that tells a drive in the run from one beside it. Null scope is
+    // "every drive"; nothing finished yet.
+    when(() => syncCubit.syncingDriveIds).thenReturn(null);
+    when(() => syncCubit.completedDriveIds).thenReturn(const []);
     when(() => preferences.currentPreferences).thenReturn(prefs());
   });
 
@@ -116,6 +121,25 @@ void main() {
     await cubit.close();
 
     return state;
+  }
+
+  /// Like [settle], but hands back the live cubit so selection - which is
+  /// several calls, not one - can actually be exercised.
+  Future<DrivesListCubit> settleLive(
+    DrivesState drivesState, {
+    SyncState syncState = const _Idle(),
+  }) async {
+    whenListen(drivesCubit, const Stream<DrivesState>.empty(),
+        initialState: drivesState);
+    whenListen(syncCubit, const Stream<SyncState>.empty(),
+        initialState: syncState);
+
+    final cubit = buildCubit();
+    addTearDown(cubit.close);
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+
+    return cubit;
   }
 
   DrivesLoadSuccess loaded(List<Drive> userDrives,
@@ -449,6 +473,91 @@ void main() {
               as DrivesListLoaded;
 
       expect(state.nothingHasEverBeenSynced, isFalse);
+    });
+  });
+
+  /// Choosing drives to sync, and the one way a selection must never be lost.
+  group('selecting drives to sync', () {
+    setUp(() {
+      when(() => syncCubit.syncDrives(any())).thenAnswer((_) async => true);
+    });
+
+    test('ticks accumulate and reach the sync as one run', () async {
+      await addDrive('a');
+      await addDrive('b');
+      final cubit = await settleLive(loaded(await drivesNamed(['a', 'b'])));
+
+      cubit.toggleSelected('a');
+      cubit.toggleSelected('b');
+
+      expect((cubit.state as DrivesListLoaded).selected, {'a', 'b'});
+
+      cubit.syncSelectedDrives();
+      await Future<void>.delayed(Duration.zero);
+
+      final captured = verify(() => syncCubit.syncDrives(captureAny()))
+          .captured
+          .single as List<String>;
+      expect(captured, containsAll(<String>['a', 'b']));
+      expect(captured, hasLength(2),
+          reason: 'four drives chosen is one run over four, not four runs');
+    });
+
+    test('a second tick unticks', () async {
+      await addDrive('a');
+      final cubit = await settleLive(loaded(await drivesNamed(['a'])));
+
+      cubit.toggleSelected('a');
+      cubit.toggleSelected('a');
+
+      expect((cubit.state as DrivesListLoaded).selected, isEmpty);
+    });
+
+    test('nothing ticked syncs everything, rather than nothing', () async {
+      when(() => syncCubit.startSync()).thenAnswer((_) async => true);
+
+      await addDrive('a');
+      final cubit = await settleLive(loaded(await drivesNamed(['a'])));
+
+      cubit.syncSelectedDrives();
+      await Future<void>.delayed(Duration.zero);
+
+      verifyNever(() => syncCubit.syncDrives(any()));
+      verify(() => syncCubit.startSync()).called(1);
+    });
+
+    test('a run that started takes the selection away', () async {
+      await addDrive('a');
+      final cubit = await settleLive(loaded(await drivesNamed(['a'])));
+
+      cubit.toggleSelected('a');
+      cubit.syncSelectedDrives();
+      await Future<void>.delayed(Duration.zero);
+
+      expect((cubit.state as DrivesListLoaded).selected, isEmpty);
+    });
+
+    /// A sync is refused outright while another is running - one at a time,
+    /// never queued. Clearing anyway would make the reader find and re-tick
+    /// the same drives to try again.
+    test('a run that was refused leaves it alone', () async {
+      when(() => syncCubit.syncDrives(any())).thenAnswer((_) async => false);
+
+      await addDrive('a');
+      await addDrive('b');
+      final cubit = await settleLive(loaded(await drivesNamed(['a', 'b'])));
+
+      cubit.toggleSelected('a');
+      cubit.toggleSelected('b');
+      cubit.syncSelectedDrives();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        (cubit.state as DrivesListLoaded).selected,
+        {'a', 'b'},
+        reason: 'the press did nothing, so it must not also cost the reader '
+            'the selection they made',
+      );
     });
   });
 }

--- a/test/drives_list/drives_list_open_never_syncs_test.dart
+++ b/test/drives_list/drives_list_open_never_syncs_test.dart
@@ -67,6 +67,11 @@ void main() {
 
     when(() => syncCubit.driveListRefreshFailed).thenReturn(false);
     when(() => syncCubit.syncingDriveId).thenReturn(null);
+    // The run's own scope and what it has finished, read by every surface
+    // that tells a drive in the run from one beside it. Null scope is
+    // "every drive"; nothing finished yet.
+    when(() => syncCubit.syncingDriveIds).thenReturn(null);
+    when(() => syncCubit.completedDriveIds).thenReturn(const []);
     when(() => preferences.currentPreferences).thenReturn(prefs());
     when(() => syncCubit.startSyncForDrive(
           driveId: any(named: 'driveId'),
@@ -152,7 +157,7 @@ void main() {
     verifyNever(() => syncCubit.startSync(
           deepSync: any(named: 'deepSync'),
           skipTabVisibilityCheck: any(named: 'skipTabVisibilityCheck'),
-          driveIdsToRetry: any(named: 'driveIdsToRetry'),
+          onlyDriveIds: any(named: 'onlyDriveIds'),
           trigger: any(named: 'trigger'),
         ));
   });

--- a/test/drives_list/drives_list_selection_test.dart
+++ b/test/drives_list/drives_list_selection_test.dart
@@ -18,6 +18,7 @@ void main() {
     String id, {
     bool lastSyncFailed = false,
     bool isSyncing = false,
+    bool hasBeenWalked = true,
   }) =>
       DriveListItem(
         id: id,
@@ -26,10 +27,10 @@ void main() {
         isSharedWithMe: false,
         isHidden: false,
         dateCreated: DateTime(2024),
-        hasBeenWalked: true,
-        fileCount: 1,
-        totalSize: 1,
-        lastSyncedAt: DateTime(2024),
+        hasBeenWalked: hasBeenWalked,
+        fileCount: hasBeenWalked ? 1 : null,
+        totalSize: hasBeenWalked ? 1 : null,
+        lastSyncedAt: hasBeenWalked ? DateTime(2024) : null,
         isSyncing: isSyncing,
         lastSyncFailed: lastSyncFailed,
       );
@@ -196,6 +197,69 @@ void main() {
       await pump(tester, twoDrives);
 
       expect(find.textContaining('could not be read'), findsNothing);
+    });
+  });
+
+  /// The two things the first version of this got wrong, both visible in a
+  /// screenshot: the column headings vanished, and two red buttons offering
+  /// different scopes sat a hundred pixels apart.
+  group('a selection does not cost the table its headings', () {
+    final oneTicked = DrivesListLoaded(
+      drives: [drive('a'), drive('b')],
+      scope: DriveScope.all,
+      selected: const {'a'},
+    );
+
+    testWidgets('the columns are still labelled while selecting',
+        (tester) async {
+      await pump(tester, oneTicked);
+
+      for (final heading in ['Name', 'Last synced', 'Files', 'Size']) {
+        expect(
+          find.text(heading),
+          findsOneWidget,
+          reason: '"$heading" is what makes a column of dashes readable',
+        );
+      }
+    });
+
+    testWidgets('and only one action is offered at a time', (tester) async {
+      await pump(
+        tester,
+        DrivesListLoaded(
+          drives: [
+            drive('a', hasBeenWalked: false),
+            drive('b', hasBeenWalked: false),
+          ],
+          scope: DriveScope.all,
+          selected: const {'a'},
+        ),
+      );
+
+      expect(find.text('Sync selected'), findsOneWidget);
+      expect(
+        find.text('Sync All Drives'),
+        findsNothing,
+        reason: 'the reader has just said which drives they meant, so the '
+            'offer to sync every one of them is withdrawn rather than left to '
+            'compete with the one they asked for',
+      );
+    });
+
+    testWidgets('and it comes back when nothing is ticked', (tester) async {
+      await pump(
+        tester,
+        DrivesListLoaded(
+          drives: [
+            drive('a', hasBeenWalked: false),
+            drive('b', hasBeenWalked: false),
+          ],
+          scope: DriveScope.all,
+        ),
+      );
+
+      expect(find.text('Sync All Drives'), findsWidgets);
+      expect(find.text('Sync selected'), findsNothing);
     });
   });
 }

--- a/test/drives_list/drives_list_selection_test.dart
+++ b/test/drives_list/drives_list_selection_test.dart
@@ -1,0 +1,201 @@
+import 'package:ardrive/drives_list/domain/drive_list_item.dart';
+import 'package:ardrive/drives_list/domain/drive_scope.dart';
+import 'package:ardrive/drives_list/presentation/drives_list_cubit.dart';
+import 'package:ardrive/drives_list/presentation/drives_list_page.dart';
+import 'package:ardrive_ui/ardrive_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Choosing a few drives to sync, and being told when some could not be read.
+///
+/// The engine could always walk an arbitrary subset concurrently - the retry
+/// path has used it for as long as it has existed. What was missing was any
+/// way to say which, and any summary of what a partial failure actually cost.
+void main() {
+  DriveListItem drive(
+    String id, {
+    bool lastSyncFailed = false,
+    bool isSyncing = false,
+  }) =>
+      DriveListItem(
+        id: id,
+        name: id,
+        isPrivate: false,
+        isSharedWithMe: false,
+        isHidden: false,
+        dateCreated: DateTime(2024),
+        hasBeenWalked: true,
+        fileCount: 1,
+        totalSize: 1,
+        lastSyncedAt: DateTime(2024),
+        isSyncing: isSyncing,
+        lastSyncFailed: lastSyncFailed,
+      );
+
+  var toggled = <String>[];
+  var syncedSelected = 0;
+  var cleared = 0;
+  var retried = 0;
+
+  setUp(() {
+    toggled = <String>[];
+    syncedSelected = 0;
+    cleared = 0;
+    retried = 0;
+  });
+
+  Future<void> pump(
+    WidgetTester tester,
+    DrivesListLoaded state, {
+    double width = 1200,
+  }) async {
+    await tester.binding.setSurfaceSize(Size(width, 900));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      ArDriveTheme(
+        themeData: lightTheme(),
+        child: MaterialApp(
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: const [Locale('en', '')],
+          home: Scaffold(
+            body: DrivesListBody(
+              state: state,
+              onOpenDrive: (_) {},
+              onTryAgain: () {},
+              onSyncAllDrives: () {},
+              onToggleSelected: toggled.add,
+              onToggleSelectAll: () {},
+              onSyncSelected: () => syncedSelected++,
+              onClearSelection: () => cleared++,
+              onRetryFailed: () => retried++,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  final twoDrives = DrivesListLoaded(
+    drives: [drive('a'), drive('b')],
+    scope: DriveScope.all,
+  );
+
+  group('choosing drives', () {
+    testWidgets('every row offers a tick', (tester) async {
+      await pump(tester, twoDrives);
+
+      expect(find.byType(ArDriveCheckBox), findsNWidgets(3),
+          reason: 'one per row, plus the header select-all');
+    });
+
+    testWidgets('nothing is selected, so no bar is in the way', (tester) async {
+      await pump(tester, twoDrives);
+
+      expect(find.text('Sync selected'), findsNothing);
+      expect(find.textContaining('selected'), findsNothing);
+    });
+
+    testWidgets('a selection says how many and offers one run', (tester) async {
+      await pump(
+        tester,
+        DrivesListLoaded(
+          drives: [drive('a'), drive('b')],
+          scope: DriveScope.all,
+          selected: const {'a', 'b'},
+        ),
+      );
+
+      expect(find.text('2 drives selected'), findsOneWidget);
+      expect(find.text('Sync selected'), findsOneWidget);
+
+      await tester.tap(find.text('Sync selected'));
+      await tester.pump();
+
+      expect(syncedSelected, 1);
+    });
+
+    testWidgets('and clearing does not select everything instead',
+        (tester) async {
+      await pump(
+        tester,
+        DrivesListLoaded(
+          drives: [drive('a'), drive('b')],
+          scope: DriveScope.all,
+          selected: const {'a'},
+        ),
+      );
+
+      expect(find.text('1 drive selected'), findsOneWidget);
+
+      await tester.tap(find.text('Clear'));
+      await tester.pump();
+
+      expect(cleared, 1, reason: 'Clear must clear, not toggle-all');
+    });
+  });
+
+  group('a sync that read some drives and not others', () {
+    final partlyFailed = DrivesListLoaded(
+      drives: [drive('a'), drive('b', lastSyncFailed: true)],
+      scope: DriveScope.all,
+    );
+
+    testWidgets('adds up what failed and offers exactly that retry',
+        (tester) async {
+      await pump(tester, partlyFailed);
+
+      expect(find.text('1 of 2 drives could not be read'), findsOneWidget);
+
+      await tester.tap(find.text('Sync that drive'));
+      await tester.pump();
+
+      expect(retried, 1);
+    });
+
+    testWidgets('says nothing was lost, because nothing was', (tester) async {
+      await pump(tester, partlyFailed);
+
+      expect(
+        find.textContaining('keeps whatever was read last time'),
+        findsOneWidget,
+        reason: 'a reader looking at red needs telling what is still true',
+      );
+    });
+
+    testWidgets('and holds its tongue while a sync is running', (tester) async {
+      await pump(
+        tester,
+        DrivesListLoaded(
+          drives: [
+            drive('a', isSyncing: true),
+            drive('b', lastSyncFailed: true, isSyncing: true),
+          ],
+          scope: DriveScope.all,
+        ),
+      );
+
+      expect(
+        find.textContaining('could not be read'),
+        findsNothing,
+        reason: 'the run under way may well fix it; reporting the last one as '
+            'though it were the current answer is the error this whole series '
+            'exists to remove',
+      );
+    });
+
+    testWidgets('nothing is said when every drive was read', (tester) async {
+      await pump(tester, twoDrives);
+
+      expect(find.textContaining('could not be read'), findsNothing);
+    });
+  });
+}

--- a/test/drives_list/drives_sync_menu_test.dart
+++ b/test/drives_list/drives_sync_menu_test.dart
@@ -75,7 +75,7 @@ void main() {
     when(() => syncCubit.startSync(
           deepSync: any(named: 'deepSync'),
           skipTabVisibilityCheck: any(named: 'skipTabVisibilityCheck'),
-          driveIdsToRetry: any(named: 'driveIdsToRetry'),
+          onlyDriveIds: any(named: 'onlyDriveIds'),
           trigger: any(named: 'trigger'),
         )).thenAnswer((_) async => true);
 

--- a/test/models/drive_totals_agree_test.dart
+++ b/test/models/drive_totals_agree_test.dart
@@ -1,4 +1,5 @@
 import 'package:ardrive/models/models.dart';
+import 'package:drift/drift.dart' show Value;
 import 'package:ardrive_utils/ardrive_utils.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -18,7 +19,11 @@ void main() {
   setUp(() => db = Database(NativeDatabase.memory()));
   tearDown(() => db.close());
 
-  Future<void> addDrive(String id, {String owner = 'me'}) =>
+  Future<void> addDrive(
+    String id, {
+    String owner = 'me',
+    bool isHidden = false,
+  }) =>
       db.into(db.drives).insert(
             DrivesCompanion.insert(
               id: id,
@@ -26,6 +31,7 @@ void main() {
               ownerAddress: owner,
               name: id,
               privacy: DrivePrivacyTag.public,
+              isHidden: Value(isHidden),
             ),
           );
 
@@ -34,6 +40,7 @@ void main() {
     String fileId, {
     required int size,
     bool withTransactions = true,
+    bool isHidden = false,
   }) async {
     await db.into(db.fileEntries).insert(
           FileEntriesCompanion.insert(
@@ -45,6 +52,7 @@ void main() {
             size: size,
             lastModifiedDate: DateTime(2024),
             dataTxId: '$fileId-data',
+            isHidden: Value(isHidden),
           ),
         );
   }
@@ -117,6 +125,55 @@ void main() {
       totalSize,
       1000,
       reason: "the shared drive's bytes belong to whoever owns it",
+    );
+  });
+
+  /// A hidden drive is left out, because every other surface leaves it out.
+  ///
+  /// `allDrives()` is a plain `SELECT * FROM drives`, while every scope in the
+  /// sidebar excludes hidden drives - so this line could say seventeen drives
+  /// beside an All drives that listed fifteen.
+  test('a hidden drive is not in the account line either', () async {
+    await addDrive('shown');
+    await addDrive('tucked-away', isHidden: true);
+    await addFile('shown', 'file-1', size: 1000);
+    await addFile('tucked-away', 'file-2', size: 500);
+
+    final drives = await db.driveDao.allDrives().get();
+    final summaries = await db.driveDao.driveContentSummaries();
+
+    // The filter the account line applies.
+    final counted = drives
+        .where((drive) => drive.ownerAddress == 'me' && !drive.isHidden)
+        .toList();
+
+    var totalSize = 0;
+    for (final drive in counted) {
+      totalSize += summaries[drive.id]?.totalSize ?? 0;
+    }
+
+    expect(counted.map((d) => d.id), ['shown']);
+    expect(totalSize, 1000);
+  });
+
+  /// But a hidden *file* still counts, and the show-hidden toggle does not
+  /// move these numbers.
+  ///
+  /// Hiding is a view preference written as a revision: it frees nothing. A
+  /// figure for what somebody is keeping must not fall because they flipped a
+  /// switch that changed nothing about what is stored.
+  test('a hidden file inside a shown drive still counts', () async {
+    await addDrive('shown');
+    await addFile('shown', 'visible', size: 1000);
+    await addFile('shown', 'hidden-one', size: 500, isHidden: true);
+
+    final summaries = await db.driveDao.driveContentSummaries();
+
+    expect(summaries['shown']?.fileCount, 2);
+    expect(
+      summaries['shown']?.totalSize,
+      1500,
+      reason: 'the bytes are still stored and still paid for',
     );
   });
 }

--- a/test/models/drive_totals_agree_test.dart
+++ b/test/models/drive_totals_agree_test.dart
@@ -1,0 +1,122 @@
+import 'package:ardrive/models/models.dart';
+import 'package:ardrive_utils/ardrive_utils.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The two ways this app counts what a drive holds, and why they must agree.
+///
+/// Reported as a drive showing the same file count but a different total GB
+/// between sessions. The drives list counts `file_entries` directly; the
+/// profile dropdown used `filesInDriveWithRevisionTransactions`, which
+/// inner-joins each file to the metadata and data transactions of its latest
+/// revision. A file whose transaction rows have not synced yet is dropped from
+/// that join entirely - so the profile total omitted both the file and its
+/// bytes, and grew as those rows landed.
+void main() {
+  late Database db;
+
+  setUp(() => db = Database(NativeDatabase.memory()));
+  tearDown(() => db.close());
+
+  Future<void> addDrive(String id, {String owner = 'me'}) =>
+      db.into(db.drives).insert(
+            DrivesCompanion.insert(
+              id: id,
+              rootFolderId: '$id-root',
+              ownerAddress: owner,
+              name: id,
+              privacy: DrivePrivacyTag.public,
+            ),
+          );
+
+  Future<void> addFile(
+    String driveId,
+    String fileId, {
+    required int size,
+    bool withTransactions = true,
+  }) async {
+    await db.into(db.fileEntries).insert(
+          FileEntriesCompanion.insert(
+            id: fileId,
+            driveId: driveId,
+            name: fileId,
+            parentFolderId: '$driveId-root',
+            path: '/$fileId',
+            size: size,
+            lastModifiedDate: DateTime(2024),
+            dataTxId: '$fileId-data',
+          ),
+        );
+  }
+
+  test('a file whose transactions have not synced still counts', () async {
+    await addDrive('drive-a');
+    await addFile('drive-a', 'file-1', size: 1000, withTransactions: false);
+
+    final summaries = await db.driveDao.driveContentSummaries();
+
+    expect(
+      summaries['drive-a']?.fileCount,
+      1,
+      reason: 'the file is in the local tables, so it is one of the files this '
+          'device holds',
+    );
+    expect(
+      summaries['drive-a']?.totalSize,
+      1000,
+      reason: 'its bytes count whether or not its transaction rows have '
+          'arrived - dropping them is what made the same drive report a '
+          'different total between sessions',
+    );
+  });
+
+  /// And the query the profile total used to rely on drops it, which is the
+  /// whole of the bug: the file is really there, and that query cannot see it.
+  test('the revision-transaction join cannot see that file at all', () async {
+    await addDrive('drive-a');
+    await addFile('drive-a', 'file-1', size: 1000);
+
+    final joined = await db.driveDao
+        .filesInDriveWithRevisionTransactions(driveId: 'drive-a')
+        .get();
+
+    expect(
+      joined,
+      isEmpty,
+      reason: 'no revision rows, so the inner join matches nothing - counting '
+          'this way omits the file and its bytes until a sync fills those '
+          'rows in, and reports a larger total each time it does',
+    );
+  });
+
+  /// Whose storage the profile line is describing.
+  ///
+  /// A drive somebody else shared is readable here and is not this account's
+  /// storage. Counting it made the line describe what the reader can see
+  /// rather than what they are keeping - and one shared drive of a million
+  /// files would have dwarfed everything they own.
+  test('a drive somebody else owns is not this account\'s storage', () async {
+    await addDrive('mine');
+    await addDrive('theirs', owner: 'somebody-else');
+    await addFile('mine', 'file-1', size: 1000);
+    await addFile('theirs', 'file-2', size: 9999);
+
+    final drives = await db.driveDao.allDrives().get();
+    final summaries = await db.driveDao.driveContentSummaries();
+
+    // The filter the profile line applies.
+    final owned = drives.where((drive) => drive.ownerAddress == 'me').toList();
+
+    var totalSize = 0;
+    for (final drive in owned) {
+      totalSize += summaries[drive.id]?.totalSize ?? 0;
+    }
+
+    expect(owned.map((d) => d.id), ['mine']);
+    expect(
+      totalSize,
+      1000,
+      reason: "the shared drive's bytes belong to whoever owns it",
+    );
+  });
+}

--- a/test/models/drive_totals_agree_test.dart
+++ b/test/models/drive_totals_agree_test.dart
@@ -124,7 +124,7 @@ void main() {
     expect(
       totalSize,
       1000,
-      reason: "the shared drive's bytes belong to whoever owns it",
+      reason: 'the shared drive\'s bytes belong to whoever owns it',
     );
   });
 

--- a/test/pages/drive_detail/components/drive_detail_syncing_card_test.dart
+++ b/test/pages/drive_detail/components/drive_detail_syncing_card_test.dart
@@ -777,4 +777,25 @@ void main() {
 
     await tester.pumpWidget(const SizedBox());
   });
+
+  /// The panel has to look like a panel.
+  ///
+  /// It used `containerL1`, which in the dark theme is `#0d0d0d` against a
+  /// `#010905` page: twelve steps out of 255, so the card read as bare
+  /// background with words floating on it. The tables and the unsynced card
+  /// were already on `tableTheme.backgroundColor`, so this was the odd one out
+  /// as well as the invisible one.
+  testWidgets('sits on the same ground as every other panel', (tester) async {
+    final theme = lightTheme();
+
+    // The card is only drawn on a wide screen; a phone gets the bare content.
+    await pumpSyncing(tester, size: desktopSize, theme: theme);
+    final card = tester.widgetList<ArDriveCard>(find.byType(ArDriveCard));
+
+    expect(
+      card.map((c) => c.backgroundColor),
+      contains(theme.tableTheme.backgroundColor),
+      reason: 'one panel ground across the app, not one per surface',
+    );
+  });
 }

--- a/test/pages/drive_detail/components/syncing_drive_notice_test.dart
+++ b/test/pages/drive_detail/components/syncing_drive_notice_test.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:ardrive/pages/drive_detail/components/multi_select_paused_notice.dart';
+import 'package:ardrive/pages/drive_detail/components/syncing_drive_notice.dart';
 import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
 import 'package:ardrive_ui/ardrive_ui.dart';
 import 'package:bloc_test/bloc_test.dart';
@@ -37,13 +37,14 @@ void main() {
           home: Scaffold(
             body: BlocProvider<SyncCubit>.value(
               value: syncCubit,
-              child: const MultiSelectPausedNotice(driveId: 'drive-on-screen'),
+              child: const SyncingDriveNotice(driveId: 'drive-on-screen'),
             ),
           ),
         ),
       );
 
-  const line = 'Selecting several items is paused while syncing';
+  const line =
+      'Still reading this drive, so more items may appear. Selecting several is paused until it finishes.';
 
   testWidgets('a running sync says why several items cannot be selected',
       (tester) async {
@@ -78,12 +79,12 @@ void main() {
 
     expect(find.text(line), findsNothing);
     // And it leaves nothing behind in the layout it was sharing.
-    expect(tester.getSize(find.byType(MultiSelectPausedNotice)), Size.zero);
+    expect(tester.getSize(find.byType(SyncingDriveNotice)), Size.zero);
   });
 
   test('the notice and the lock read the same condition', () {
     bool locks(SyncState state, {String? syncingDriveId}) =>
-        MultiSelectPausedNotice.locksMultiSelect(
+        SyncingDriveNotice.locksMultiSelect(
           state,
           syncingDriveId: syncingDriveId,
           driveId: 'drive-on-screen',
@@ -111,8 +112,7 @@ void main() {
   /// The limitation this removes: syncing one drive used to disable selection
   /// in every other one, including drives that sync was never going to write.
   test('only a sync that could write this drive holds its selection', () {
-    bool locks(String? syncingDriveId) =>
-        MultiSelectPausedNotice.locksMultiSelect(
+    bool locks(String? syncingDriveId) => SyncingDriveNotice.locksMultiSelect(
           SyncInProgress(trigger: SyncTrigger.userInitiated),
           syncingDriveId: syncingDriveId,
           driveId: 'drive-on-screen',
@@ -151,5 +151,27 @@ void main() {
     expect(light, lightTheme().colorTokens.textLow);
     expect(dark, ArDriveColorTokens.darkMode().textLow);
     expect(light, isNot(dark));
+  });
+
+  /// The fact this notice exists for, kept honest by name.
+  ///
+  /// A reader can now open a drive while it is being walked - which is the
+  /// point - and a list that is four files long during a sync is four *so
+  /// far*. Nothing else on the screen says so: the ring in the top bar reports
+  /// that a sync is running, not that this list is short because of it.
+  testWidgets('says the list is still filling, not only that selection is off',
+      (tester) async {
+    await tester.pumpWidget(wrap());
+    stateController.add(SyncInProgress(trigger: SyncTrigger.background));
+    await tester.pump();
+
+    final text = tester.widget<Text>(find.byType(Text)).data!;
+
+    expect(
+      text.toLowerCase(),
+      contains('more items may appear'),
+      reason: 'a reader who cannot tell four from four-so-far will read a '
+          'half-walked drive as a drive that lost files',
+    );
   });
 }

--- a/test/pages/drive_detail/components/syncing_drive_notice_test.dart
+++ b/test/pages/drive_detail/components/syncing_drive_notice_test.dart
@@ -174,4 +174,36 @@ void main() {
           'half-walked drive as a drive that lost files',
     );
   });
+
+  /// A run over a chosen few does not write the drives it was not given.
+  ///
+  /// `syncingDriveId` is null for a subset run exactly as it is for an
+  /// all-drives one, so reading it alone told thirteen drives they were being
+  /// rewritten while four were. The rows had this fixed; the notice that says
+  /// so in words did not.
+  test('a subset run leaves the drives it does not cover alone', () {
+    bool locks(String driveId, {Set<String>? run}) =>
+        SyncingDriveNotice.locksMultiSelect(
+          SyncInProgress(trigger: SyncTrigger.userInitiated),
+          syncingDriveId: null,
+          syncingDriveIds: run,
+          driveId: driveId,
+        );
+
+    expect(
+      locks('in-the-run', run: {'in-the-run', 'also-in-it'}),
+      isTrue,
+    );
+    expect(
+      locks('not-in-the-run', run: {'in-the-run', 'also-in-it'}),
+      isFalse,
+      reason: 'nothing is rewriting this drive, so nothing should tell its '
+          'reader that the list is filling or that selection is paused',
+    );
+    expect(
+      locks('any-drive'),
+      isTrue,
+      reason: 'no scope at all is still an all-drives run',
+    );
+  });
 }

--- a/test/services/arweave/graphql_id_batch_limit_test.dart
+++ b/test/services/arweave/graphql_id_batch_limit_test.dart
@@ -1,0 +1,45 @@
+import 'package:ardrive/services/arweave/arweave_service.dart';
+import 'package:ardrive/utils/graphql_retry.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// How many transaction ids may go into one query's `ids` argument.
+///
+/// Reported from the browser with Goldsky configured as the GraphQL endpoint:
+///
+///   Too many ids in 'ids' argument: 31 provided, maximum 9 allowed
+///
+/// The number matters beyond that configuration, which is why it is asserted
+/// rather than left as a constant somebody may later "optimise". Every query
+/// that chunks ids can be served by Goldsky whether or not it was asked for:
+/// [GraphQLRetry] falls back there on a 429 or a 5xx. A batch the fallback
+/// cannot accept therefore makes the fallback useless for these queries on
+/// every configuration - the sync hits a rate limit, switches to the endpoint
+/// that exists to rescue it, and is refused for the shape of the request.
+void main() {
+  test('a batch fits what the fallback endpoint accepts', () {
+    expect(
+      maxGraphQLIdsPerQuery,
+      lessThanOrEqualTo(9),
+      reason: 'Goldsky refuses more than nine, and any of these queries can '
+          'land on Goldsky through the fallback',
+    );
+  });
+
+  test('and the fallback really is the endpoint with that limit', () {
+    expect(
+      GraphQLRetry.defaultFallbackGraphqlUrl,
+      contains('goldsky'),
+      reason: 'if the fallback moves, the cap above should be re-derived from '
+          'whatever the new one accepts rather than left at nine by accident',
+    );
+  });
+
+  test('and the batch is still worth batching', () {
+    expect(
+      maxGraphQLIdsPerQuery,
+      greaterThan(1),
+      reason: 'one id per request is not a batch, and these run in a loop over '
+          'every unconfirmed transaction in a sync',
+    );
+  });
+}

--- a/test/sync/domain/cubit/sync_complete_test.dart
+++ b/test/sync/domain/cubit/sync_complete_test.dart
@@ -54,7 +54,7 @@ void main() {
           password: any(named: 'password'),
           cipherKey: any(named: 'cipherKey'),
           syncDeep: any(named: 'syncDeep'),
-          driveIdsToRetry: any(named: 'driveIdsToRetry'),
+          onlyDriveIds: any(named: 'onlyDriveIds'),
           cancellationToken: any(named: 'cancellationToken'),
           txFechedCallback: any(named: 'txFechedCallback'),
         )).thenAnswer((_) => Stream.value(progress));

--- a/test/sync/domain/cubit/sync_history_recording_test.dart
+++ b/test/sync/domain/cubit/sync_history_recording_test.dart
@@ -60,7 +60,7 @@ void main() {
           password: any(named: 'password'),
           cipherKey: any(named: 'cipherKey'),
           syncDeep: any(named: 'syncDeep'),
-          driveIdsToRetry: any(named: 'driveIdsToRetry'),
+          onlyDriveIds: any(named: 'onlyDriveIds'),
           cancellationToken: any(named: 'cancellationToken'),
           txFechedCallback: any(named: 'txFechedCallback'),
         )).thenAnswer((_) => progress);

--- a/test/sync/domain/cubit/sync_only_when_needed_test.dart
+++ b/test/sync/domain/cubit/sync_only_when_needed_test.dart
@@ -99,7 +99,7 @@ void main() {
           password: any(named: 'password'),
           cipherKey: any(named: 'cipherKey'),
           syncDeep: any(named: 'syncDeep'),
-          driveIdsToRetry: any(named: 'driveIdsToRetry'),
+          onlyDriveIds: any(named: 'onlyDriveIds'),
           cancellationToken: any(named: 'cancellationToken'),
           txFechedCallback: any(named: 'txFechedCallback'),
         )).thenAnswer((_) => Stream.value(SyncProgress.emptySyncCompleted()));
@@ -188,7 +188,7 @@ void main() {
           password: any(named: 'password'),
           cipherKey: any(named: 'cipherKey'),
           syncDeep: any(named: 'syncDeep'),
-          driveIdsToRetry: any(named: 'driveIdsToRetry'),
+          onlyDriveIds: any(named: 'onlyDriveIds'),
           cancellationToken: any(named: 'cancellationToken'),
           txFechedCallback: any(named: 'txFechedCallback'),
         ));
@@ -220,7 +220,7 @@ void main() {
           password: any(named: 'password'),
           cipherKey: any(named: 'cipherKey'),
           syncDeep: any(named: 'syncDeep'),
-          driveIdsToRetry: any(named: 'driveIdsToRetry'),
+          onlyDriveIds: any(named: 'onlyDriveIds'),
           cancellationToken: any(named: 'cancellationToken'),
           txFechedCallback: any(named: 'txFechedCallback'),
         )).called(1);
@@ -244,7 +244,7 @@ void main() {
           password: any(named: 'password'),
           cipherKey: any(named: 'cipherKey'),
           syncDeep: any(named: 'syncDeep'),
-          driveIdsToRetry: any(named: 'driveIdsToRetry'),
+          onlyDriveIds: any(named: 'onlyDriveIds'),
           cancellationToken: any(named: 'cancellationToken'),
           txFechedCallback: any(named: 'txFechedCallback'),
         )).called(1);
@@ -273,7 +273,7 @@ void main() {
           password: any(named: 'password'),
           cipherKey: any(named: 'cipherKey'),
           syncDeep: any(named: 'syncDeep'),
-          driveIdsToRetry: any(named: 'driveIdsToRetry'),
+          onlyDriveIds: any(named: 'onlyDriveIds'),
           cancellationToken: any(named: 'cancellationToken'),
           txFechedCallback: any(named: 'txFechedCallback'),
         ));
@@ -307,7 +307,7 @@ void main() {
           password: any(named: 'password'),
           cipherKey: any(named: 'cipherKey'),
           syncDeep: any(named: 'syncDeep'),
-          driveIdsToRetry: any(named: 'driveIdsToRetry'),
+          onlyDriveIds: any(named: 'onlyDriveIds'),
           cancellationToken: any(named: 'cancellationToken'),
           txFechedCallback: any(named: 'txFechedCallback'),
         ));

--- a/test/sync/domain/cubit/sync_shutdown_test.dart
+++ b/test/sync/domain/cubit/sync_shutdown_test.dart
@@ -183,7 +183,7 @@ void main() {
           password: any(named: 'password'),
           cipherKey: any(named: 'cipherKey'),
           syncDeep: any(named: 'syncDeep'),
-          driveIdsToRetry: any(named: 'driveIdsToRetry'),
+          onlyDriveIds: any(named: 'onlyDriveIds'),
           cancellationToken: any(named: 'cancellationToken'),
           txFechedCallback: any(named: 'txFechedCallback'),
         )).thenAnswer((invocation) {

--- a/test/sync/domain/cubit/sync_shutdown_test.dart
+++ b/test/sync/domain/cubit/sync_shutdown_test.dart
@@ -193,6 +193,64 @@ void main() {
     });
   }
 
+  /// Which drives a run over a chosen few reports itself as covering.
+  ///
+  /// Reported from the browser: ticking one drive and pressing Sync selected
+  /// made every row say "Syncing". The scope was set from the ids the caller
+  /// asked for and then cleared two lines later, immediately before the state
+  /// was emitted - so from the moment it started, a run over one drive was
+  /// indistinguishable from a run over all of them, and the gate held every
+  /// drive shut on top of it. The clear was meant for `_syncingDriveId`, which
+  /// answers a different question: which *single* drive owns this run.
+  group('a run over a chosen few', () {
+    test('reports the drives it covers, not all of them', () async {
+      anAllDrivesSyncThatRunsUntilCancelled();
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      await settled();
+
+      unawaited(cubit.syncDrives(['drive-a', 'drive-b']));
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+
+      expect(
+        cubit.syncingDriveIds,
+        {'drive-a', 'drive-b'},
+        reason: 'every surface that tells a drive in the run from one beside '
+            'it reads this',
+      );
+      expect(
+        cubit.syncingDriveId,
+        isNull,
+        reason: 'no single drive owns a run over several - that is the field '
+            'whose clearing wiped the scope',
+      );
+    });
+
+    test('and lets go of it when the run is over', () async {
+      anAllDrivesSyncThatRunsUntilCancelled();
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      await settled();
+
+      final sync = cubit.syncDrives(['drive-a']);
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      expect(cubit.syncingDriveIds, isNotNull);
+
+      cubit.cancelSync();
+      nextCheckpoint.complete();
+      await sync;
+      await settled();
+
+      expect(
+        cubit.syncingDriveIds,
+        isNull,
+        reason: 'a scope left behind would quietly narrow every sync after it',
+      );
+    });
+  });
+
   group('closing the cubit stops the sync', () {
     /// Pressing Stop, as against logging out.
     ///

--- a/test/sync/domain/cubit/sync_shutdown_test.dart
+++ b/test/sync/domain/cubit/sync_shutdown_test.dart
@@ -194,6 +194,106 @@ void main() {
   }
 
   group('closing the cubit stops the sync', () {
+    /// Pressing Stop, as against logging out.
+    ///
+    /// Reported as never having worked, and the report is worth taking
+    /// seriously: for most of this app's life the only control that called
+    /// `cancelSync` was a modal that no longer exists, so nothing was
+    /// exercising the path a user actually takes. These four assert the whole
+    /// of it - the token is cancelled, the run unwinds, the outcome is
+    /// reported, and the app is left able to sync again.
+    test('pressing stop cancels the token the repository was given', () async {
+      aSingleDriveSyncThatRunsUntilCancelled();
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      await settled();
+
+      unawaited(cubit.startSyncForDrive(driveId: 'drive-a'));
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+
+      expect(cubit.state, isA<SyncInProgress>(),
+          reason: 'precondition: a sync is running');
+      expect(issuedToken!.isCancelled, isFalse);
+
+      cubit.cancelSync();
+
+      expect(issuedToken!.isCancelled, isTrue);
+    });
+
+    test('and the run really does unwind rather than carry on', () async {
+      aSingleDriveSyncThatRunsUntilCancelled();
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      await settled();
+
+      final sync = cubit.startSyncForDrive(driveId: 'drive-a');
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+
+      cubit.cancelSync();
+      // The repository notices at its next checkpoint, exactly as the real one
+      // does - the token is read between progress events, not mid-request.
+      nextCheckpoint.complete();
+
+      await sync.timeout(
+        const Duration(seconds: 2),
+        onTimeout: () => fail('the sync went on after it was cancelled'),
+      );
+    });
+
+    test('and says so, rather than going quiet', () async {
+      aSingleDriveSyncThatRunsUntilCancelled();
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      await settled();
+
+      final sync = cubit.startSyncForDrive(driveId: 'drive-a');
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+
+      cubit.cancelSync();
+      nextCheckpoint.complete();
+      await sync;
+      await settled();
+
+      expect(
+        cubit.state,
+        isA<SyncCancelled>(),
+        reason: 'a stop the app does not report is indistinguishable from a '
+            'stop that did not happen, which is how this was described',
+      );
+    });
+
+    /// The half that makes a cancel worth pressing: it has to leave the app
+    /// able to sync again. A run that is stopped but never releases the slot
+    /// refuses every sync afterwards, which reads exactly like a cancel that
+    /// did nothing.
+    test('and leaves the app able to start another sync', () async {
+      aSingleDriveSyncThatRunsUntilCancelled();
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      await settled();
+
+      final first = cubit.startSyncForDrive(driveId: 'drive-a');
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+
+      cubit.cancelSync();
+      nextCheckpoint.complete();
+      await first;
+      await settled();
+
+      // A second run is accepted, which it would not be if the first had left
+      // SyncInProgress standing or held the token.
+      unawaited(cubit.startSyncForDrive(driveId: 'drive-a'));
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+
+      expect(cubit.state, isA<SyncInProgress>());
+      expect(issuedToken!.isCancelled, isFalse,
+          reason: 'the second run must get a token of its own');
+    });
+
     test('the running sync is cancelled, not abandoned', () async {
       aSingleDriveSyncThatRunsUntilCancelled();
 

--- a/test/sync/domain/cubit/sync_trigger_test.dart
+++ b/test/sync/domain/cubit/sync_trigger_test.dart
@@ -66,7 +66,7 @@ void main() {
           password: any(named: 'password'),
           cipherKey: any(named: 'cipherKey'),
           syncDeep: any(named: 'syncDeep'),
-          driveIdsToRetry: any(named: 'driveIdsToRetry'),
+          onlyDriveIds: any(named: 'onlyDriveIds'),
           cancellationToken: any(named: 'cancellationToken'),
           txFechedCallback: any(named: 'txFechedCallback'),
         )).thenAnswer(

--- a/test/sync/pending_confirmation_watch_test.dart
+++ b/test/sync/pending_confirmation_watch_test.dart
@@ -1,0 +1,221 @@
+import 'dart:async';
+
+import 'package:fake_async/fake_async.dart';
+
+import 'package:ardrive/blocs/activity/activity_cubit.dart';
+import 'package:ardrive/blocs/blocs.dart';
+import 'package:ardrive/core/activity_tracker.dart';
+import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
+import 'package:ardrive/sync/domain/repositories/sync_repository.dart';
+import 'package:ardrive/sync/domain/sync_progress.dart';
+import 'package:ardrive/user/repositories/user_preferences_repository.dart';
+import 'package:ardrive/user/user_preferences.dart';
+import 'package:ardrive_ui/ardrive_ui.dart';
+import 'package:arweave/arweave.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:cryptography/cryptography.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../test_utils/utils.dart';
+
+class MockSyncRepository extends Mock implements SyncRepository {}
+
+class MockUserPreferencesRepository extends Mock
+    implements UserPreferencesRepository {}
+
+class MockActivityCubit extends MockCubit<ActivityState>
+    implements ActivityCubit {}
+
+class MockActivityTracker extends Mock implements ActivityTracker {}
+
+class _FakeWallet extends Fake implements Wallet {}
+
+class _FakeSecretKey extends Fake implements SecretKey {}
+
+/// Logging in should not walk every drive's whole history unasked - but it
+/// must still notice new drives, and it must still finish the job when an
+/// upload is left unresolved. These drive the real [SyncCubit]; only the
+/// repository underneath it is a mock.
+
+/// Confirming an upload, without turning the app into a polling client.
+///
+/// An upload writes its file locally and shows it at once, and nothing
+/// afterwards ever confirmed it. `autoSync` ships false in all three flavours,
+/// so the periodic sync it gates never runs - the comment promising that
+/// "background periodic sync will update lastBlockHeight naturally" described
+/// a timer nothing starts. A file therefore sat unconfirmed until the reader
+/// pressed sync or logged in again.
+///
+/// The rule this must not break while fixing that: with nothing pending, the
+/// app stays exactly as quiet as it is now. This is a pending check that
+/// syncs, not a periodic sync with a pending check bolted on - which is the
+/// whole difference between it and the `autoSync` flag that is off precisely
+/// because it is unconditional.
+void main() {
+  late MockProfileCubit profileCubit;
+  late MockActivityCubit activityCubit;
+  late MockPromptToSnapshotBloc promptToSnapshotBloc;
+  late MockTabVisibilitySingleton tabVisibility;
+  late MockConfigService configService;
+  late MockConfig config;
+  late MockActivityTracker activityTracker;
+  late MockSyncRepository syncRepository;
+  late MockUserPreferencesRepository userPreferencesRepository;
+
+  setUpAll(() {
+    registerFallbackValue(false);
+    registerFallbackValue(_FakeWallet());
+    registerFallbackValue(_FakeSecretKey());
+  });
+
+  setUp(() {
+    profileCubit = MockProfileCubit();
+    activityCubit = MockActivityCubit();
+    promptToSnapshotBloc = MockPromptToSnapshotBloc();
+    tabVisibility = MockTabVisibilitySingleton();
+    configService = MockConfigService();
+    config = MockConfig();
+    activityTracker = MockActivityTracker();
+    syncRepository = MockSyncRepository();
+    userPreferencesRepository = MockUserPreferencesRepository();
+
+    // Logged in, so the metadata refresh really reaches updateUserDrives and a
+    // full sync really reaches syncAllDrives. A logged-out cubit would take
+    // neither path and every assertion below would pass on an absence.
+    when(() => profileCubit.state).thenReturn(
+      ProfileLoggedIn(user: getTestUser(), useTurbo: false),
+    );
+    when(() => profileCubit.isCurrentProfileArConnect())
+        .thenAnswer((_) async => false);
+    when(() => profileCubit.refreshBalance()).thenAnswer((_) async {});
+    when(() => activityCubit.state).thenReturn(ActivityNotRunning());
+    when(() => tabVisibility.isTabFocused()).thenReturn(true);
+    when(() => tabVisibility.onTabGetsFocused(any()))
+        .thenAnswer((_) => const Stream<void>.empty().listen((_) {}));
+    when(() => configService.config).thenReturn(config);
+    // No timer and no focus event may fire a sync of its own: the only sync
+    // any test here can see is the one the login path decided on.
+    when(() => config.autoSync).thenReturn(false);
+    when(() => config.autoSyncIntervalInSeconds).thenReturn(3600);
+    when(() => syncRepository.updateUserDrives(
+          wallet: any(named: 'wallet'),
+          password: any(named: 'password'),
+          cipherKey: any(named: 'cipherKey'),
+          onDriveRead: any(named: 'onDriveRead'),
+          onDriveUnlocked: any(named: 'onDriveUnlocked'),
+        )).thenAnswer((_) async {});
+    when(() => syncRepository.syncAllDrives(
+          wallet: any(named: 'wallet'),
+          password: any(named: 'password'),
+          cipherKey: any(named: 'cipherKey'),
+          syncDeep: any(named: 'syncDeep'),
+          onlyDriveIds: any(named: 'onlyDriveIds'),
+          cancellationToken: any(named: 'cancellationToken'),
+          txFechedCallback: any(named: 'txFechedCallback'),
+        )).thenAnswer((_) => Stream.value(SyncProgress.emptySyncCompleted()));
+    when(() => syncRepository.numberOfFilesInWallet())
+        .thenAnswer((_) async => 0);
+    when(() => syncRepository.numberOfFoldersInWallet())
+        .thenAnswer((_) async => 0);
+    // Default: the drives here have been walked before, so the only question
+    // left is whether an upload is unresolved.
+  });
+
+  /// What the local database says about unresolved uploads.
+
+  SyncCubit buildCubit({required bool syncAllDrivesOnLogin}) {
+    when(() => userPreferencesRepository.load()).thenAnswer(
+      (_) async => UserPreferences(
+        currentTheme: ArDriveThemes.dark,
+        lastSelectedDriveId: null,
+        syncAllDrivesOnLogin: syncAllDrivesOnLogin,
+      ),
+    );
+
+    return SyncCubit(
+      profileCubit: profileCubit,
+      activityCubit: activityCubit,
+      promptToSnapshotBloc: promptToSnapshotBloc,
+      tabVisibility: tabVisibility,
+      configService: configService,
+      activityTracker: activityTracker,
+      syncRepository: syncRepository,
+      userPreferencesRepository: userPreferencesRepository,
+    );
+  }
+
+  test('nothing pending means nothing is asked of the network', () async {
+    when(() => syncRepository.hasPendingTransactions())
+        .thenAnswer((_) async => false);
+
+    final cubit = buildCubit(syncAllDrivesOnLogin: false);
+    addTearDown(cubit.close);
+
+    fakeAsync((async) {
+      cubit.watchForPendingConfirmations();
+      async.elapse(const Duration(minutes: 30));
+      async.flushMicrotasks();
+    });
+
+    verifyNever(
+      () => syncRepository.syncAllDrives(
+        wallet: any(named: 'wallet'),
+        password: any(named: 'password'),
+        cipherKey: any(named: 'cipherKey'),
+      ),
+    );
+  });
+
+  test('and the watch stops rather than asking again', () async {
+    when(() => syncRepository.hasPendingTransactions())
+        .thenAnswer((_) async => false);
+
+    final cubit = buildCubit(syncAllDrivesOnLogin: false);
+    addTearDown(cubit.close);
+
+    fakeAsync((async) {
+      cubit.watchForPendingConfirmations();
+      async.elapse(const Duration(minutes: 30));
+      async.flushMicrotasks();
+    });
+
+    // Ten intervals would have passed. One local read is the whole cost of an
+    // app with no outstanding uploads.
+    verify(() => syncRepository.hasPendingTransactions()).called(1);
+  });
+
+  test('starting it twice does not double the checking', () async {
+    when(() => syncRepository.hasPendingTransactions())
+        .thenAnswer((_) async => false);
+
+    final cubit = buildCubit(syncAllDrivesOnLogin: false);
+    addTearDown(cubit.close);
+
+    fakeAsync((async) {
+      cubit.watchForPendingConfirmations();
+      cubit.watchForPendingConfirmations();
+      cubit.watchForPendingConfirmations();
+      async.elapse(const Duration(minutes: 10));
+      async.flushMicrotasks();
+    });
+
+    verify(() => syncRepository.hasPendingTransactions()).called(1);
+  });
+
+  test('a failed local read stops it rather than spinning', () async {
+    when(() => syncRepository.hasPendingTransactions())
+        .thenThrow(Exception('database is gone'));
+
+    final cubit = buildCubit(syncAllDrivesOnLogin: false);
+    addTearDown(cubit.close);
+
+    fakeAsync((async) {
+      cubit.watchForPendingConfirmations();
+      async.elapse(const Duration(minutes: 30));
+      async.flushMicrotasks();
+    });
+
+    verify(() => syncRepository.hasPendingTransactions()).called(1);
+  });
+}

--- a/test/sync/pending_confirmation_watch_test.dart
+++ b/test/sync/pending_confirmation_watch_test.dart
@@ -196,7 +196,8 @@ void main() {
       cubit.watchForPendingConfirmations();
       cubit.watchForPendingConfirmations();
       cubit.watchForPendingConfirmations();
-      async.elapse(const Duration(minutes: 10));
+      // Comfortably past one interval, so a second timer would have shown.
+      async.elapse(const Duration(minutes: 20));
       async.flushMicrotasks();
     });
 

--- a/test/sync/presentation/sync_status_header_test.dart
+++ b/test/sync/presentation/sync_status_header_test.dart
@@ -67,6 +67,11 @@ void main() {
     when(() => syncCubit.syncProgress).thenReturn(SyncProgress.initial());
     when(() => syncCubit.syncStartTime).thenReturn(DateTime.now());
     when(() => syncCubit.syncingDriveId).thenReturn(null);
+    // The run's own scope and what it has finished, read by every surface
+    // that tells a drive in the run from one beside it. Null scope is
+    // "every drive"; nothing finished yet.
+    when(() => syncCubit.syncingDriveIds).thenReturn(null);
+    when(() => syncCubit.completedDriveIds).thenReturn(const []);
     when(() => syncCubit.clearCancelledState()).thenReturn(null);
   });
 
@@ -746,7 +751,6 @@ void main() {
   // The record moved to the drives list with the rest of the sync actions, and
   // `test/drives_list/drives_sync_menu_test.dart` covers it there. This
   // indicator reports; it no longer carries controls.
-
 }
 
 /// A drive row as `DrivesCubit` hands them over, with only the two fields the

--- a/test/sync/sync_can_be_stopped_test.dart
+++ b/test/sync/sync_can_be_stopped_test.dart
@@ -1,0 +1,114 @@
+import 'dart:async';
+
+import 'package:ardrive/components/app_top_bar.dart';
+import 'package:ardrive/pages/app_router_delegate.dart';
+import 'package:ardrive/blocs/blocs.dart';
+import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
+import 'package:ardrive/sync/domain/sync_progress.dart';
+import 'package:ardrive_ui/ardrive_ui.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:flutter_portal/flutter_portal.dart';
+import 'package:provider/provider.dart';
+
+import '../test_utils/mocks.dart';
+
+class _MockSyncCubit extends MockBloc<dynamic, SyncState>
+    implements SyncCubit {}
+
+/// A sync you can get out of.
+///
+/// The engine has always been able to stop one - both entry points carry a
+/// cancellation token and both report SyncCancelled - but the only control
+/// that ever asked for it was the blocking modal, and that went when sync
+/// stopped taking the app away. A drive with a million transactions could then
+/// be started and not stopped, which is the one case the feature exists for.
+void main() {
+  late _MockSyncCubit syncCubit;
+  late MockDrivesCubit drivesCubit;
+  late StreamController<SyncProgress> progress;
+
+  setUp(() {
+    syncCubit = _MockSyncCubit();
+    drivesCubit = MockDrivesCubit();
+    progress = StreamController<SyncProgress>.broadcast();
+
+    when(() => syncCubit.syncProgressController).thenReturn(progress);
+    when(() => syncCubit.syncProgress).thenReturn(SyncProgress.initial());
+    when(() => syncCubit.syncStartTime).thenReturn(DateTime(2024));
+    when(() => syncCubit.cancelSync()).thenReturn(null);
+    whenListen(drivesCubit, const Stream<DrivesState>.empty(),
+        initialState: DrivesLoadInProgress());
+  });
+
+  tearDown(() => progress.close());
+
+  Future<void> pumpBar(WidgetTester tester, SyncState state) async {
+    whenListen(syncCubit, const Stream<SyncState>.empty(), initialState: state);
+
+    await tester.pumpWidget(
+      ArDriveTheme(
+        themeData: lightTheme(),
+        child: MaterialApp(
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: const [Locale('en', '')],
+          home: MultiProvider(
+            providers: [
+              ListenableProvider<AppRouterDelegate>.value(
+                value: AppRouterDelegate(),
+              ),
+              BlocProvider<SyncCubit>.value(value: syncCubit),
+              BlocProvider<DrivesCubit>.value(value: drivesCubit),
+            ],
+            child: const Portal(
+              child: Scaffold(body: Center(child: SyncButton())),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  testWidgets('a running sync can be stopped from where it is reported',
+      (tester) async {
+    await pumpBar(tester, SyncInProgress(trigger: SyncTrigger.userInitiated));
+
+    await tester.tap(find.byType(SyncButton));
+    // The ring rotates forever, so the tree never settles - and the menu
+    // reveals through an offstage transition, so one pump is not enough for it
+    // to accept a tap. Several fixed pumps get it fully open without waiting
+    // on an animation that never ends.
+    for (var i = 0; i < 8; i++) {
+      await tester.pump(const Duration(milliseconds: 150));
+    }
+
+    expect(find.text('Stop syncing'), findsOneWidget);
+
+    await tester.tap(find.text('Stop syncing'));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    verify(() => syncCubit.cancelSync()).called(1);
+  });
+
+  testWidgets('and nothing offers to stop one that is not running',
+      (tester) async {
+    await pumpBar(tester, SyncIdle());
+
+    expect(
+      find.text('Stop syncing'),
+      findsNothing,
+      reason: 'an idle indicator is not even drawn, let alone its menu',
+    );
+  });
+}

--- a/test/sync/sync_touches_drive_test.dart
+++ b/test/sync/sync_touches_drive_test.dart
@@ -43,6 +43,18 @@ void main() {
     test('and no other', () {
       expect(touches(running, syncingDriveId: 'B'), isFalse);
     });
+
+    /// Its walk finishing is not the run finishing - ghost folders and the
+    /// transaction statuses come after it. Releasing there would open the
+    /// panel and quiet the row while the sync the reader pressed for is still
+    /// going, which is a report contradicting itself for no gain: there is no
+    /// other drive waiting on this one.
+    test('holds it until the run is over, not until its walk is', () {
+      expect(
+        touches(running, syncingDriveId: 'A', completed: ['A']),
+        isTrue,
+      );
+    });
   });
 
   group('an all-drives sync', () {

--- a/test/sync/sync_touches_drive_test.dart
+++ b/test/sync/sync_touches_drive_test.dart
@@ -1,0 +1,127 @@
+import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Which drives a running sync is allowed to hold shut.
+///
+/// The rule a reader feels: a sync of one drive must not lock the others, and
+/// a ten-drive sync must not go on locking the drive it finished nine drives
+/// ago.
+void main() {
+  bool touches(
+    SyncState state, {
+    String? syncingDriveId,
+    String driveId = 'A',
+    List<String> completed = const [],
+    Set<String>? run,
+  }) =>
+      SyncCubit.syncTouchesDrive(
+        state: state,
+        syncingDriveId: syncingDriveId,
+        driveId: driveId,
+        completedDriveIds: completed,
+        runDriveIds: run,
+      );
+
+  final running = SyncInProgress(trigger: SyncTrigger.userInitiated);
+
+  group('nothing is held when nothing is running', () {
+    test('idle holds nothing', () {
+      expect(touches(SyncIdle()), isFalse);
+    });
+
+    test('a finished run holds nothing, whatever it completed', () {
+      expect(touches(SyncIdle(), completed: ['A']), isFalse);
+      expect(touches(SyncIdle(), completed: const []), isFalse);
+    });
+  });
+
+  group('a single-drive sync', () {
+    test('holds the drive it is walking', () {
+      expect(touches(running, syncingDriveId: 'A'), isTrue);
+    });
+
+    test('and no other', () {
+      expect(touches(running, syncingDriveId: 'B'), isFalse);
+    });
+  });
+
+  group('an all-drives sync', () {
+    test('holds a drive it has not reached yet', () {
+      expect(touches(running, syncingDriveId: null), isTrue);
+    });
+
+    test('releases a drive it has finished walking', () {
+      expect(
+        touches(running, syncingDriveId: null, completed: ['A']),
+        isFalse,
+        reason: 'the first of ten drives must not stay shut for the other '
+            'nine - its history has been read',
+      );
+    });
+
+    test('and goes on holding the ones it has not', () {
+      expect(
+        touches(running, syncingDriveId: null, completed: ['B', 'C']),
+        isTrue,
+      );
+    });
+  });
+
+  /// The drives table itself is what this phase writes, so a drive read by an
+  /// earlier run says nothing about whether this one is about to rewrite it.
+  group('while the drive list is being read', () {
+    test('every drive is held', () {
+      expect(touches(SyncLoadingDrives()), isTrue);
+    });
+
+    test('including one an earlier run completed', () {
+      expect(
+        touches(SyncLoadingDrives(), completed: ['A']),
+        isTrue,
+        reason: 'this phase rewrites the drive rows themselves',
+      );
+    });
+  });
+
+  /// A run over a chosen few carries no single drive id - it is started the
+  /// same way an all-drives sync is - so without the run's own scope it would
+  /// read as covering everything.
+  group('a run over a chosen few', () {
+    test('holds a drive it is going to walk', () {
+      expect(
+        touches(running, syncingDriveId: null, run: {'A', 'B'}),
+        isTrue,
+      );
+    });
+
+    test('and leaves the rest of the wallet alone', () {
+      expect(
+        touches(running, syncingDriveId: null, run: {'B', 'C'}),
+        isFalse,
+        reason: 'six drives must not be shut for a run over the other four',
+      );
+    });
+
+    test('releases one it has already finished', () {
+      expect(
+        touches(
+          running,
+          syncingDriveId: null,
+          run: {'A', 'B'},
+          completed: ['A'],
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  /// A drive that failed is never appended to the completed list, so it stays
+  /// held for the rest of the run rather than being read as done.
+  test('a failed drive is not released', () {
+    expect(
+      touches(running, syncingDriveId: null, completed: ['B']),
+      isTrue,
+      reason: 'A failed and is absent from the completed list',
+    );
+  });
+}

--- a/test/utils/graphql_fallback_arming_test.dart
+++ b/test/utils/graphql_fallback_arming_test.dart
@@ -1,0 +1,72 @@
+import 'package:ardrive/utils/graphql_retry.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gql_exec/gql_exec.dart' as gql;
+import 'package:gql_http_link/gql_http_link.dart';
+import 'package:gql_link/gql_link.dart';
+import 'package:http/http.dart' as http;
+
+/// Whether a failure sends the query to the other endpoint.
+///
+/// Reported from the browser: repeated retries against one gateway and never a
+/// fallback, on a host known to rate-limit. The reason was that the decision
+/// read `error.toString()` looking for '429' or a 5xx, and the exception a
+/// non-2xx actually produces does not print its status code - it prints
+/// originalException, originalStackTrace and parsedResponse. So the check was
+/// false for every HTTP failure there is, and the fallback existed without
+/// ever arming.
+void main() {
+  HttpLinkServerException serverError(int status) => HttpLinkServerException(
+        response: http.Response('', status),
+        parsedResponse: const gql.Response(response: {}),
+      );
+
+  group('an HTTP failure is read by its status, not its text', () {
+    test('a rate limit sends the query elsewhere', () {
+      expect(GraphQLRetry.deservesFallback(serverError(429)), isTrue);
+    });
+
+    test('so does a bad gateway', () {
+      expect(GraphQLRetry.deservesFallback(serverError(502)), isTrue);
+      expect(GraphQLRetry.deservesFallback(serverError(500)), isTrue);
+      expect(GraphQLRetry.deservesFallback(serverError(503)), isTrue);
+      expect(GraphQLRetry.deservesFallback(serverError(504)), isTrue);
+    });
+
+    test('and the whole 5xx range, not the four codes once listed', () {
+      expect(GraphQLRetry.deservesFallback(serverError(507)), isTrue);
+      expect(GraphQLRetry.deservesFallback(serverError(599)), isTrue);
+    });
+
+    /// None of these is fixed by asking a different endpoint the same thing.
+    test('a bad request is not sent elsewhere to fail again', () {
+      expect(GraphQLRetry.deservesFallback(serverError(400)), isFalse);
+      expect(GraphQLRetry.deservesFallback(serverError(404)), isFalse);
+    });
+
+    test('nor is a status the exception did not carry', () {
+      expect(
+        GraphQLRetry.deservesFallback(
+          const ServerException(statusCode: 404),
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  /// The old behaviour, kept for anything that does put a code in its message.
+  group('and by its text when there is no status to read', () {
+    test('a message naming a rate limit still arms it', () {
+      expect(
+        GraphQLRetry.deservesFallback(Exception('HTTP 429 Too Many Requests')),
+        isTrue,
+      );
+    });
+
+    test('an ordinary failure does not', () {
+      expect(
+        GraphQLRetry.deservesFallback(Exception('Connection closed')),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Stacked on #2214. The five steps from `docs/SYNC_PROGRESSIVE_READABILITY.md`, executed end to end.

## What changes for a user

- **A drive the sync has finished can be opened**, while the rest of the run continues. A ten-drive sync no longer holds the first drive shut for the nine that follow.
- **A drive being synced can be read, and fills in as it goes**, instead of sitting behind a panel until the run ends.
- **Navigating a folder mid-sync just works.** No wait, no loading card.
- **Sync the four drives you care about**, not all ten. One run over four, not four runs.
- **A partial failure says what it cost and fixes itself in one press** — "1 of 2 drives could not be read", plus what is still true, plus a button over exactly the drives that failed.

## Fault tolerance

Each claim rests on a property, not a hope:

- `syncedDriveIds` is appended **only** on the path that reached the end, so the widened gate can never release a drive that failed or was cancelled.
- Dropping redraw ticks is safe only because another is coming. The tick with nothing behind it is a run's last, so a run that ends having dropped anything **re-reads the folder once**.
- A folder is read from committed transactions either way, so what comes back mid-sync is consistent — just less than the folder will eventually hold.
- Choosing drives is one run, not several. A second sync is still refused rather than queued.

## Three faults found while building it

1. A four-of-ten run carries no single drive id, so it read as an all-drives sync — ten rows claiming to sync, ten drives held for a run over four.
2. Pressing **Sync selected** during a sync cleared the ticks and was then refused, costing a selection for nothing.
3. **Clear** was wired to toggle-select-all, which selects everything when some are unticked.

## Verification

2012 tests (up 29), `flutter analyze` clean on `lib` and `test`.

## Known gap

The 500ms redraw interval is a **starting point, not a measured optimum** — the tuning method is in the doc comment. Measuring it needs a browser and a wallet with thousands of revisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ndA5nwUpt9hGLUx2TAFr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Select multiple drives to sync, deep-resync, or clear selection.
  - Stop active syncs from the sync menu and drive detail view.
  - Retry drives that fail during a multi-drive sync.
  - Pending upload confirmations are monitored automatically.
- **Bug Fixes**
  - Drive contents remain available while syncing, with clearer loading status.
  - Sync updates are smoother and more reliable during uploads.
  - Storage totals now exclude hidden and unrelated drives and include accurate file counts.
  - GraphQL requests recover more reliably from rate limits and server errors.
  - Detaching a syncing drive now stops its sync and explains recovery steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->