### PR TITLE
PE-9205: Cut the pipeline from change to preview roughly in half

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,7 +18,10 @@ jobs:
     uses: ./.github/workflows/test.yml
 
   build-web:
-    needs: pre-build
+    # Deliberately no `needs:`. This job shares nothing with the test job but a
+    # checkout, so making it wait only added the tests' runtime to the wall
+    # clock. The one thing that must not happen over a red test run is the
+    # deploy, and that is now its own job below.
     runs-on: ubuntu-latest
     steps:
       # Checkout
@@ -49,6 +52,31 @@ jobs:
         run: |
           sed -i 's/main.dart.js/main.dart.js?version='"$GITHUB_SHA"'/' build/web/index.html
           sed -i 's/flutter_service_worker.js/flutter_service_worker.js?version='"$GITHUB_SHA"'/' build/web/index.html
+
+      - name: Upload the built web app
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-build
+          path: build/web
+          retention-days: 1
+
+  deploy-web:
+    # The only job that waits for the tests, because publishing a preview is
+    # the only step whose cost is not paid purely in CI minutes.
+    needs: [pre-build, build-web]
+    runs-on: ubuntu-latest
+    steps:
+      # `firebase.json` decides what is served and with which headers, so the
+      # deploy needs the repo as well as the build output.
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Download the built web app
+        uses: actions/download-artifact@v4
+        with:
+          name: web-build
+          path: build/web
 
       # Disribute to Firebase
       - uses: FirebaseExtended/action-hosting-deploy@v0

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,6 +23,9 @@ jobs:
     # clock. The one thing that must not happen over a red test run is the
     # deploy, and that is now its own job below.
     runs-on: ubuntu-latest
+    # The repository default is write. This job only reads the source.
+    permissions:
+      contents: read
     steps:
       # Checkout
       - uses: actions/checkout@v3
@@ -65,6 +68,12 @@ jobs:
     # the only step whose cost is not paid purely in CI minutes.
     needs: [pre-build, build-web]
     runs-on: ubuntu-latest
+    # Least privilege for the Firebase preview deploy: it reads the source, adds
+    # the preview URL as a pull request comment, and reports a check run.
+    permissions:
+      contents: read
+      pull-requests: write
+      checks: write
     steps:
       # `firebase.json` decides what is served and with which headers, so the
       # deploy needs the repo as well as the build output.

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -27,6 +27,9 @@ jobs:
     # clock. The one thing that must not happen over a red test run is the
     # deploy, and that is now its own job below.
     runs-on: ubuntu-latest
+    # The repository default is write. This job only reads the source.
+    permissions:
+      contents: read
     steps:
       # Checkout
       - uses: actions/checkout@v3
@@ -63,6 +66,10 @@ jobs:
     # the only step whose cost is not paid purely in CI minutes.
     needs: [pre-build, build-web]
     runs-on: ubuntu-latest
+    # This deploy pushes the built app to the gh-pages branch, so it needs to
+    # write the repository contents. It needs nothing else.
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -22,7 +22,10 @@ jobs:
     uses: ./.github/workflows/test.yml
 
   build-web:
-    needs: pre-build
+    # Deliberately no `needs:`. This job shares nothing with the test job but a
+    # checkout, so making it wait only added the tests' runtime to the wall
+    # clock. The one thing that must not happen over a red test run is the
+    # deploy, and that is now its own job below.
     runs-on: ubuntu-latest
     steps:
       # Checkout
@@ -47,6 +50,29 @@ jobs:
           scr setup
           flutter config --enable-web
           flutter build web --dart-define=environment=staging --release --pwa-strategy=none --no-web-resources-cdn --source-maps --dart2js-optimization=O1
+
+      - name: Upload the built web app
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-build
+          path: build/web
+          retention-days: 1
+
+  deploy-web:
+    # The only job that waits for the tests, because publishing the build is
+    # the only step whose cost is not paid purely in CI minutes.
+    needs: [pre-build, build-web]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Download the built web app
+        uses: actions/download-artifact@v4
+        with:
+          name: web-build
+          path: build/web
 
       # Deploy to github pages
       - uses: JamesIves/github-pages-deploy-action@4.1.1

--- a/firebase.json
+++ b/firebase.json
@@ -32,6 +32,15 @@
         ]
       },
       {
+        "source": "/",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache, no-store, must-revalidate"
+          }
+        ]
+      },
+      {
         "source": "**/index.html",
         "headers": [
           {

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -8,17 +8,30 @@
 # and test runner start-up, twelve times over, in sequence.
 #
 # The app's own suite deliberately stays outside the pool. `flutter test`
-# already spreads it across cores, and some of its bloc tests wait on real
-# debounce timers, so they start failing when other test processes compete for
-# the CPU. Running it alone costs a little wall clock and buys a stable signal.
+# already runs its suites concurrently, so it uses the cores it is given;
+# putting it in the pool adds contention without adding parallelism.
+#
+# Note that the app suite has at least one pre-existing flaky test that does not
+# depend on this script: prompt_to_snapshot_bloc_test.dart waits 250ms for a
+# 200ms debounce, and loses the race under load. Keeping the suite out of the
+# pool does not fix it.
 #
 # `TEST_JOBS` sets the width of the pool. `TEST_JOBS=1` restores the old
-# strictly-sequential behaviour, which is worth reaching for when interleaved
-# output makes a failure hard to read.
+# strictly-sequential behaviour.
 
 set -euo pipefail
 
 JOBS="${TEST_JOBS:-3}"
+
+# `xargs -P 0` means "as many processes as possible", which is the opposite of a
+# bounded pool, so a bad value must not reach it.
+case "$JOBS" in
+  '' | *[!0-9]*) echo "TEST_JOBS must be a positive integer, got '$JOBS'" >&2; exit 1 ;;
+esac
+if [ "$JOBS" -lt 1 ]; then
+  echo "TEST_JOBS must be at least 1, got '$JOBS'" >&2
+  exit 1
+fi
 
 packages=()
 for dir in packages/*; do
@@ -45,9 +58,10 @@ LOG_DIR="$(mktemp -d)"
 trap 'rm -rf "$LOG_DIR"' EXIT
 export LOG_DIR
 
-# Each package's output is buffered and printed in one piece, so that packages
-# running side by side cannot interleave halfway through a suite and leave the
-# log unreadable.
+# A worker writes only to its own files. Nothing goes to the shared stdout while
+# the pool is running: `cat` of a multi-kilobyte log is many writes, not one, so
+# two workers printing at once would interleave mid-suite whatever order they
+# started in. The logs are replayed below instead, in a fixed order.
 run_package() {
   local dir="$1"
   local name status=0
@@ -55,16 +69,27 @@ run_package() {
 
   (cd "$dir" && flutter analyze && flutter test) >"$LOG_DIR/$name.log" 2>&1 || status=$?
 
-  echo "===== $name (exit $status) ====="
-  cat "$LOG_DIR/$name.log"
+  echo "$status" >"$LOG_DIR/$name.status"
   return $status
 }
 export -f run_package
 
 echo "Running ${#packages[@]} packages, $JOBS at a time"
 
-# xargs exits non-zero when any invocation does, and `set -e` turns that into a
-# failed step - so one broken package still fails the build.
-printf '%s\n' "${packages[@]}" | xargs -P "$JOBS" -I{} bash -c 'run_package "$@"' _ {}
+# xargs exits non-zero when any invocation does. The failure is held rather than
+# thrown, so that every package's log still gets printed before the script ends.
+pool_status=0
+printf '%s\n' "${packages[@]}" | xargs -P "$JOBS" -I{} bash -c 'run_package "$@"' _ {} || pool_status=$?
+
+for dir in "${packages[@]}"; do
+  name="$(basename "$dir")"
+  echo "===== $name (exit $(cat "$LOG_DIR/$name.status" 2>/dev/null || echo '?')) ====="
+  cat "$LOG_DIR/$name.log" 2>/dev/null || echo '(no output - the package did not run)'
+done
+
+if [ "$pool_status" -ne 0 ]; then
+  echo "At least one package failed. Look for a non-zero exit in the headers above."
+  exit "$pool_status"
+fi
 
 echo "The app and all ${#packages[@]} packages passed"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,24 +1,70 @@
 #!/bin/bash
 
-set -e
+# Runs the app's tests, then every package's analyze + tests.
+#
+# The packages are independent of each other, so they run in a bounded pool
+# rather than one after another. Serially, that step spent a large share of its
+# wall clock on work that does not use the CPU it was given - analyzer start-up
+# and test runner start-up, twelve times over, in sequence.
+#
+# The app's own suite deliberately stays outside the pool. `flutter test`
+# already spreads it across cores, and some of its bloc tests wait on real
+# debounce timers, so they start failing when other test processes compete for
+# the CPU. Running it alone costs a little wall clock and buys a stable signal.
+#
+# `TEST_JOBS` sets the width of the pool. `TEST_JOBS=1` restores the old
+# strictly-sequential behaviour, which is worth reaching for when interleaved
+# output makes a failure hard to read.
 
-echo "Running tests in main app"
-flutter pub get
-flutter test
+set -euo pipefail
 
-echo "Searching for packages..."
+JOBS="${TEST_JOBS:-3}"
+
+packages=()
 for dir in packages/*; do
-  if [ -d "$dir" ]; then
-    echo "Checking $dir"
-    if [ -d "$dir/test" ]; then
-      echo "Running tests in $dir"
-      cd $dir
-      flutter pub get
-      flutter analyze
-      flutter test
-      cd ../..
-    else
-      echo "No test directory found in $dir, skipping tests"
-    fi
+  if [ -d "$dir/test" ]; then
+    packages+=("$dir")
+  else
+    echo "No test directory in $dir, skipping"
   fi
 done
+
+# Dependencies are resolved up front and in sequence: concurrent `pub get` runs
+# contend for one lock on the shared pub cache, which costs back what the pool
+# wins.
+echo "Resolving dependencies for the app and ${#packages[@]} packages"
+flutter pub get >/dev/null
+for dir in "${packages[@]}"; do
+  (cd "$dir" && flutter pub get >/dev/null)
+done
+
+echo "===== app ====="
+flutter test
+
+LOG_DIR="$(mktemp -d)"
+trap 'rm -rf "$LOG_DIR"' EXIT
+export LOG_DIR
+
+# Each package's output is buffered and printed in one piece, so that packages
+# running side by side cannot interleave halfway through a suite and leave the
+# log unreadable.
+run_package() {
+  local dir="$1"
+  local name status=0
+  name="$(basename "$dir")"
+
+  (cd "$dir" && flutter analyze && flutter test) >"$LOG_DIR/$name.log" 2>&1 || status=$?
+
+  echo "===== $name (exit $status) ====="
+  cat "$LOG_DIR/$name.log"
+  return $status
+}
+export -f run_package
+
+echo "Running ${#packages[@]} packages, $JOBS at a time"
+
+# xargs exits non-zero when any invocation does, and `set -e` turns that into a
+# failed step - so one broken package still fails the build.
+printf '%s\n' "${packages[@]}" | xargs -P "$JOBS" -I{} bash -c 'run_package "$@"' _ {}
+
+echo "The app and all ${#packages[@]} packages passed"


### PR DESCRIPTION
## Why

A change took 15 to 18 minutes to reach a preview URL, and then the browser
served the previous bundle for up to an hour. Three separate causes, all cheap
to fix.

## 1. The web build no longer waits for the tests

`build-web` declared `needs: pre-build`, so the build sat idle for the whole
test run before it started. The two jobs share nothing but a checkout.

The build now starts immediately and uploads `build/web` as an artifact. A new
`deploy-web` job waits for both and does the publish. The rule that mattered is
kept: a red test run still publishes nothing.

Measured: `pre-build` ~12 min, `build-web` ~5.5 min. Serial that is ~17.5 min.
In parallel it is ~12 min plus the artifact round trip.

Applied to `pr.yaml` and `staging.yaml`. `production.yaml` has the same shape
and is left alone - a release is not a feedback loop.

## 2. Package tests run in a pool

`scripts/run_tests.sh` walked twelve packages in sequence, paying `pub get`,
analyzer start-up and test runner start-up each time. That step measured 460s.

The packages now run through a bounded pool. `TEST_JOBS` sets the width and
defaults to 3; `TEST_JOBS=1` restores the old sequential run.

Two details worth knowing:

- `pub get` still runs up front and in sequence. Concurrent runs contend for one
  lock on the shared pub cache.
- The app's own suite stays outside the pool. `flutter test` already runs its
  suites concurrently, so it uses the cores it is given; pooling it would add
  contention without adding parallelism.

Each package's output is buffered and printed in one piece, so parallel
packages cannot interleave mid-suite. A failing package still fails the build.

Local wall clock for the whole `scr test` step: 8m40s before, 4m11s after -
roughly half. The second figure had a warm pub cache, so treat it as the good
case rather than a guarantee. CI measured the old step at 460s.

## 3. The no-cache header never applied to a page load

`firebase.json` set `no-cache` on `**/index.html`. Nobody requests that path.
The app loads from `/`, and its routes are hash fragments that resolve to `/`
as well. Those requests fell through to the default:

```
/                    cache-control: max-age=3600
/index.html          cache-control: no-cache, no-store, must-revalidate
/#/drives/<id>       cache-control: max-age=3600
```

So every deploy stayed invisible for up to an hour, and the `?version=$SHA`
busting on `main.dart.js` was moot - the document holding that pointer was
itself cached. Adding a `/` source fixes it.

This one is outside the two items asked for. It is here because without it the
other two speed up a pipeline whose output nobody sees for an hour.

## Testing

`./scripts/run_tests.sh` run end to end locally twice. The final run: app plus
twelve packages, every unit exit 0, script exit 0, 4m11s.

The pool's failure handling was tested separately with a synthetic package that
exits non-zero: every package still ran, every log still printed, the headers
kept their declared order, and the script exited non-zero.

## A pre-existing flake this PR does not fix

`prompt_to_snapshot_bloc_test.dart` - "will prompt to snapshot after enough
txs" - fails intermittently. Measured at four failures in six full app-suite
runs on a developer machine. CI is green in every run observed.

It is not caused by this change. It fails with the app suite running alone, and
the mechanism is in the test itself: it waits 250ms for a 200ms debounce, and
inside that 50ms margin the bloc still has to run a Drift query. `blocTest`
closes the bloc when `act` returns, and closing cancels the pending timer - the
`Debuncer cancelled` line in the failure output. A machine with more cores runs
more suites at once and loses the race more often, which is why it shows up
locally and not on a 4-vCPU runner.

Flagged rather than fixed, because the fix is in app test code and this is a
pipeline change. It is worth its own small PR.

## What is not proven

The workflow changes cannot be fully proven before merge. The artifact hand-off
between `build-web` and `deploy-web` did work on this PR's first run: build-web
5m9s, deploy-web 42s, Deploy Preview green in 35s, whole run 659s against a
912-1137s baseline over the last seven successful runs.

The cache-control fix cannot be verified from CI at all. It only takes effect
once this merges and a deploy carries the new `firebase.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3CbaePfsFZsPqijauuBrD