### PR TITLE
PE-9205: What a returning or brand-new user is told about their drives

### DIFF
--- a/lib/app_shell.dart
+++ b/lib/app_shell.dart
@@ -7,10 +7,12 @@ import 'package:ardrive/components/side_bar.dart';
 import 'package:ardrive/components/sync_failure_test_panel.dart';
 import 'package:ardrive/misc/misc.dart';
 import 'package:ardrive/pages/drive_detail/components/hover_widget.dart';
+import 'package:ardrive/search/search_modal.dart';
 import 'package:ardrive/shared/blocs/banner/app_banner_bloc.dart';
 import 'package:ardrive/shared/blocs/private_drive_migration/private_drive_migration_bloc.dart';
 import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
 import 'package:ardrive/sync/presentation/sync_overlay.dart';
+import 'package:ardrive/utils/app_localizations_wrapper.dart';
 import 'package:ardrive/utils/logger.dart';
 import 'package:ardrive/utils/show_general_dialog.dart';
 import 'package:ardrive_ui/ardrive_ui.dart';
@@ -302,15 +304,62 @@ const double _mobileAppBarIconSize = 24;
 const double mobileAppBarIconSize = _mobileAppBarIconSize;
 
 // TODO: add the gift icon
+/// Search, as an icon that opens the sheet the field used to open.
+///
+/// The field it replaces did nothing until it was submitted - it opened this
+/// same modal and handed the typed query over - so nothing is lost by starting
+/// from the modal instead. What is gained is the band it occupied, on the one
+/// layout where vertical space is the scarce thing.
+///
+/// A controller per press rather than one held for the life of the bar: the
+/// modal owns the text while it is open and there is nothing to remember once
+/// it closes.
+class _MobileSearchButton extends StatelessWidget {
+  const _MobileSearchButton();
+
+  @override
+  Widget build(BuildContext context) {
+    return ArDriveIconButton(
+      // The same glyph the field carried, at the size every other control in
+      // this bar uses.
+      icon: ArDriveIcon(
+        icon: Icons.search,
+        size: _mobileAppBarIconSize,
+        color: ArDriveTheme.of(context).themeData.colors.themeFgDefault,
+      ),
+      tooltip: appLocalizationsOf(context).searchFiles,
+      onPressed: () {
+        showSearchModalBottomSheet(
+          context: context,
+          driveDetailCubit: context.read<DriveDetailCubit>(),
+          drivesCubit: context.read<DrivesCubit>(),
+          controller: TextEditingController(),
+        );
+      },
+    );
+  }
+}
+
 class MobileAppBar extends StatelessWidget implements PreferredSizeWidget {
   const MobileAppBar({
     super.key,
     this.leading,
     this.showDrawerButton = true,
+    this.showSearch = false,
   });
 
   final Widget? leading;
   final bool showDrawerButton;
+
+  /// Whether this screen offers search from the bar.
+  ///
+  /// Off by default and asked for explicitly, because the modal reads a
+  /// `DriveDetailCubit` and not every screen wearing this bar has a meaningful
+  /// one. The drives list has a cubit built against the root path rather than
+  /// a chosen drive, and the no-drives page has nothing to search - so a bar
+  /// that offered search everywhere would be offering it where it could only
+  /// disappoint.
+  final bool showSearch;
 
   @override
   // Its own row and nothing else. Nothing about a sync is laid out here: a
@@ -368,6 +417,16 @@ class MobileAppBar extends StatelessWidget implements PreferredSizeWidget {
                   ),
                 ),
               const Spacer(),
+              // Search sits with the other controls that are about the whole
+              // view rather than one item in it - the hide toggle beside it is
+              // the same kind of thing. As a field it took a 60px band above
+              // the file list on the screen with the least vertical room to
+              // give; as an icon it takes the space that was already empty
+              // here.
+              if (showSearch) ...[
+                const _MobileSearchButton(),
+                const SizedBox(width: 8),
+              ],
               const GlobalHideToggleButton(),
               const SizedBox(width: 8),
               const SyncButton(),

--- a/lib/drives_list/domain/drive_list_item.dart
+++ b/lib/drives_list/domain/drive_list_item.dart
@@ -16,6 +16,7 @@ class DriveListItem extends Equatable {
     required this.isHidden,
     required this.dateCreated,
     required this.hasBeenWalked,
+    this.hasUnreadChanges = false,
     required this.fileCount,
     required this.totalSize,
     required this.lastSyncedAt,
@@ -53,6 +54,18 @@ class DriveListItem extends Equatable {
   /// flag that tells the two apart, and everything derived from row counts is
   /// withheld when it is false.
   final bool hasBeenWalked;
+
+  /// Whether the network has activity for this drive that the device has not
+  /// read.
+  ///
+  /// Only ever true of a drive that *has* been walked: an unread drive is
+  /// already described by [hasBeenWalked], and one row cannot usefully say both
+  /// "never read" and "changed since it was read".
+  ///
+  /// False until the probe answers, and false forever if it never does, so this
+  /// only ever adds a claim - it never withdraws one the row was already
+  /// making.
+  final bool hasUnreadChanges;
 
   /// Files stored locally for this drive, or null when the drive has never
   /// been walked and the number would therefore be a guess dressed as a count.
@@ -93,6 +106,7 @@ class DriveListItem extends Equatable {
         isHidden,
         dateCreated,
         hasBeenWalked,
+        hasUnreadChanges,
         fileCount,
         totalSize,
         lastSyncedAt,

--- a/lib/drives_list/presentation/drives_list_cubit.dart
+++ b/lib/drives_list/presentation/drives_list_cubit.dart
@@ -236,6 +236,24 @@ class DrivesListCubit extends Cubit<DrivesListState> {
           ? null
           : summaries[drive.id] ?? DriveContentSummary.empty;
 
+      // Whether the local tables know anything about this drive's contents.
+      //
+      // This is the question [hasBeenWalked] was being asked to answer as well
+      // as its own, and the two are not the same. A drive created on this
+      // device and uploaded to has a block height of zero - nothing has read it
+      // from chain - but its files are right here in `fileEntries`, written by
+      // the upload that put them there. Treating that as "we have not looked"
+      // meant a user who had just made their first drive and uploaded five
+      // files was shown `Never synced`, a dash for files and a dash for size:
+      // not a cautious label over correct figures, but the figures withheld.
+      //
+      // A zero from a walked drive still means empty, and a zero from an
+      // unwalked one still means unknown. Only a non-zero count proves the
+      // device knows something, which is why this asks for one.
+      final hasLocalContent = (summary?.fileCount ?? 0) > 0;
+
+      final figuresAreKnown = hasBeenWalked || hasLocalContent;
+
       return DriveListItem(
         id: drive.id,
         name: drive.name,
@@ -249,8 +267,8 @@ class DrivesListCubit extends Cubit<DrivesListState> {
         // a row claiming both would be saying it has never been read and has
         // changed since.
         hasUnreadChanges: hasBeenWalked && unreadChanges.contains(drive.id),
-        fileCount: hasBeenWalked ? summary?.fileCount : null,
-        totalSize: hasBeenWalked ? summary?.totalSize : null,
+        fileCount: figuresAreKnown ? summary?.fileCount : null,
+        totalSize: figuresAreKnown ? summary?.totalSize : null,
         lastSyncedAt: syncedAt,
         // Says "Syncing..." only of a drive this run actually covers, and
         // stops saying it once the drive has been walked. A four-of-ten run

--- a/lib/drives_list/presentation/drives_list_cubit.dart
+++ b/lib/drives_list/presentation/drives_list_cubit.dart
@@ -34,10 +34,17 @@ class DrivesListCubit extends Cubit<DrivesListState> {
         _driveDao = driveDao,
         _userPreferencesRepository = userPreferencesRepository,
         super(const DrivesListLoading()) {
-    _subscription = Rx.combineLatest2<DrivesState, SyncState, void>(
+    // Three sources, one refresh. The third is the unread-changes probe, which
+    // answers long after the other two have settled and must repaint the rows
+    // when it does - it is the whole reason a returning reader is told anything
+    // at all.
+    _subscription =
+        Rx.combineLatest3<DrivesState, SyncState, Set<String>, void>(
       drivesCubit.stream.startWith(drivesCubit.state),
       syncCubit.stream.startWith(syncCubit.state),
-      (_, __) {},
+      syncCubit.unreadChangesStream
+          .startWith(syncCubit.drivesWithUnreadChanges),
+      (_, __, ___) {},
     ).listen((_) => unawaited(_refresh()));
   }
 
@@ -205,6 +212,7 @@ class DrivesListCubit extends Cubit<DrivesListState> {
     final syncingDriveId = _syncCubit.syncingDriveId;
     final runDriveIds = _syncCubit.syncingDriveIds;
     final completedDriveIds = _syncCubit.completedDriveIds.toSet();
+    final unreadChanges = _syncCubit.drivesWithUnreadChanges;
 
     // The top bar says "1 of 5 drives failed" and the list is where a reader
     // goes to find out which. The state has always carried the ids; nothing on
@@ -236,6 +244,11 @@ class DrivesListCubit extends Cubit<DrivesListState> {
         isHidden: drive.isHidden,
         dateCreated: drive.dateCreated,
         hasBeenWalked: hasBeenWalked,
+        // Guarded on `hasBeenWalked` as well as the probe. The probe only ever
+        // returns walked drives, but the two facts are read a moment apart and
+        // a row claiming both would be saying it has never been read and has
+        // changed since.
+        hasUnreadChanges: hasBeenWalked && unreadChanges.contains(drive.id),
         fileCount: hasBeenWalked ? summary?.fileCount : null,
         totalSize: hasBeenWalked ? summary?.totalSize : null,
         lastSyncedAt: syncedAt,
@@ -443,6 +456,27 @@ class DrivesListCubit extends Cubit<DrivesListState> {
   /// The same one-run subset walk a selection uses. Offered on the page rather
   /// than only inside a menu because a partial failure is the moment a reader
   /// most needs one button that fixes exactly the thing that broke.
+  /// Syncs only the drives the probe found had changed.
+  ///
+  /// A subset, not everything: the reader was told a number and pressed a
+  /// button naming it, so syncing more than that would be doing something they
+  /// did not ask for and were not warned about.
+  void syncDrivesWithUnreadChanges() {
+    final current = state;
+
+    if (current is! DrivesListLoaded) {
+      return;
+    }
+
+    final changed = current.drivesWithUnreadChanges;
+
+    if (changed.isEmpty) {
+      return;
+    }
+
+    unawaited(_syncCubit.syncDrives(changed));
+  }
+
   void retryFailedDrives() {
     final current = state;
 

--- a/lib/drives_list/presentation/drives_list_page.dart
+++ b/lib/drives_list/presentation/drives_list_page.dart
@@ -208,6 +208,7 @@ class _DrivesListChrome extends StatelessWidget {
           onSyncSelected: cubit.syncSelectedDrives,
           onClearSelection: cubit.clearSelection,
           onRetryFailed: cubit.retryFailedDrives,
+          onSyncChanged: cubit.syncDrivesWithUnreadChanges,
           buildMenu: (drive) => _menuFor(drivesState, drive),
           syncMenu: const DrivesSyncMenu(),
         );
@@ -273,6 +274,7 @@ class DrivesListBody extends StatelessWidget {
     this.onSyncSelected,
     this.onClearSelection,
     this.onRetryFailed,
+    this.onSyncChanged,
     this.buildMenu,
     this.syncMenu,
   });
@@ -293,6 +295,7 @@ class DrivesListBody extends StatelessWidget {
   final VoidCallback? onSyncSelected;
   final VoidCallback? onClearSelection;
   final VoidCallback? onRetryFailed;
+  final VoidCallback? onSyncChanged;
 
   /// Builds the actions menu for one row, or returns null for a row that has
   /// none.
@@ -341,6 +344,7 @@ class DrivesListBody extends StatelessWidget {
         onSyncSelected: onSyncSelected,
         onClearSelection: onClearSelection,
         onRetryFailed: onRetryFailed,
+        onSyncChanged: onSyncChanged,
       );
     }
 
@@ -545,6 +549,7 @@ class _DrivesListLoadedView extends StatelessWidget {
     this.onSyncSelected,
     this.onClearSelection,
     this.onRetryFailed,
+    this.onSyncChanged,
   });
 
   final DrivesListLoaded state;
@@ -556,6 +561,7 @@ class _DrivesListLoadedView extends StatelessWidget {
   final VoidCallback? onSyncSelected;
   final VoidCallback? onClearSelection;
   final VoidCallback? onRetryFailed;
+  final VoidCallback? onSyncChanged;
   final Widget? Function(DriveListItem drive)? buildMenu;
 
   /// The drive-wide sync actions, passed in rather than reached for.
@@ -612,6 +618,30 @@ class _DrivesListLoadedView extends StatelessWidget {
                       ),
                     ),
                   const SliverToBoxAdapter(child: SizedBox(height: _blockGap)),
+                  // What the network says changed while the reader was away.
+                  //
+                  // Below the never-synced prompt and above the failure banner
+                  // because it sits between them in urgency: a wallet that has
+                  // never synced is not owed this news, and a drive that could
+                  // not be read at all is worse than one that is merely behind.
+                  //
+                  // Withdrawn during a sync and while a selection exists, on
+                  // the same argument as the prompt above: it offers a scope,
+                  // and two offers of different scopes on one screen is the
+                  // reader having to work out which one they meant.
+                  if (state.drivesWithUnreadChanges.isNotEmpty &&
+                      !state.isSyncing &&
+                      state.selected.isEmpty &&
+                      onSyncChanged != null)
+                    SliverToBoxAdapter(
+                      child: Padding(
+                        padding: const EdgeInsets.only(bottom: _blockGap),
+                        child: _UnreadChangesBanner(
+                          changed: state.drivesWithUnreadChanges.length,
+                          onSync: onSyncChanged!,
+                        ),
+                      ),
+                    ),
                   // A partial failure, said once and fixable in one press.
                   // Above the selection bar because it is the more urgent of
                   // the two, and below the sync prompt because a wallet that
@@ -1065,6 +1095,105 @@ class _SelectionBar extends StatelessWidget {
 /// was the sentence that adds them up and the button that acts on exactly that
 /// set. A reader should not have to count red triangles to find out how bad it
 /// was, nor open a menu to retry what broke.
+/// Tells a returning reader that the drives on screen have moved on.
+///
+/// The whole point of this page is that its figures come from the local
+/// database and nothing else, which is what makes it instant - and also what
+/// makes it silently old. A reader who closed the tab on Tuesday and came back
+/// on Friday sees Tuesday's file counts rendered with exactly the confidence of
+/// current ones, and the only cue is a `Last synced` cell they have to read and
+/// do arithmetic on.
+///
+/// So this says the one thing the table cannot: not that the numbers are old -
+/// they always are - but that they are *wrong*, because the drives themselves
+/// have changed. That is a fact worth interrupting for, and it is only ever
+/// shown when the network has confirmed it. Nothing changed means nothing said.
+///
+/// Deliberately quieter than [_PartialFailureBanner]: nothing here has gone
+/// wrong, and neutral is what separates news from an alarm.
+class _UnreadChangesBanner extends StatelessWidget {
+  const _UnreadChangesBanner({
+    required this.changed,
+    required this.onSync,
+  });
+
+  final int changed;
+  final VoidCallback onSync;
+
+  @override
+  Widget build(BuildContext context) {
+    final typography = ArDriveTypographyNew.of(context);
+    final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: _pagePadding),
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: ArDriveTheme.of(context).themeData.tableTheme.backgroundColor,
+          borderRadius: BorderRadius.circular(cardDefaultBorderRadius),
+          border: Border.all(color: colorTokens.strokeLow),
+        ),
+        child: Wrap(
+          crossAxisAlignment: WrapCrossAlignment.center,
+          alignment: WrapAlignment.spaceBetween,
+          spacing: 16,
+          runSpacing: 12,
+          children: [
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 520),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      ArDriveIcons.cloudSync(
+                        size: 16,
+                        color: colorTokens.iconHigh,
+                      ),
+                      const SizedBox(width: 8),
+                      Flexible(
+                        child: Text(
+                          appLocalizationsOf(context)
+                              .driveListDrivesHaveChanges(changed),
+                          style: typography.paragraphNormal(
+                            color: colorTokens.textHigh,
+                            fontWeight: ArFontWeight.semiBold,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 4),
+                  // Says what the figures below still are, rather than leaving
+                  // a reader to wonder whether they are looking at nothing.
+                  Text(
+                    appLocalizationsOf(context)
+                        .driveListDrivesHaveChangesDetail,
+                    style: typography.paragraphSmall(
+                      color: colorTokens.textLow,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            ArDriveButtonNew(
+              text: appLocalizationsOf(context)
+                  .driveListSyncThoseWithChanges(changed),
+              typography: typography,
+              variant: ButtonVariant.primary,
+              maxHeight: 36,
+              onPressed: onSync,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 class _PartialFailureBanner extends StatelessWidget {
   const _PartialFailureBanner({
     required this.failed,

--- a/lib/drives_list/presentation/drives_list_state.dart
+++ b/lib/drives_list/presentation/drives_list_state.dart
@@ -81,6 +81,17 @@ class DrivesListLoaded extends DrivesListState {
   bool get nothingHasEverBeenSynced =>
       drives.isNotEmpty && drives.every((drive) => !drive.hasBeenWalked);
 
+  /// The drives the network has moved on without.
+  ///
+  /// Read off the rows for the same reason [failedDriveIds] is, and scoped for
+  /// the same reason too: this is a claim about the list on screen, so filtering
+  /// to Private must not leave a notice up about a public drive that is no
+  /// longer in view.
+  List<String> get drivesWithUnreadChanges => [
+        for (final drive in drives)
+          if (drive.hasUnreadChanges) drive.id,
+      ];
+
   /// The drives the last sync could not read.
   ///
   /// Read off the rows rather than off a sync state, so it survives the sync

--- a/lib/drives_list/presentation/drives_list_state.dart
+++ b/lib/drives_list/presentation/drives_list_state.dart
@@ -72,14 +72,24 @@ class DrivesListLoaded extends DrivesListState {
   /// it that way: with nothing ticked, the action is still Sync All Drives.
   final Set<String> selected;
 
-  /// Whether nothing here has ever been walked.
+  /// Whether nothing here has ever been walked *and* nothing is known about
+  /// what any of it holds.
   ///
   /// With sync-on-login off this is the state a first login lands in, and it
   /// is the one moment where offering to sync everything at once is a service
   /// rather than a nag. Once a single drive has been synced the offer goes
   /// away, because the per-drive answer is on the row.
+  ///
+  /// The second half of that is why a file count is consulted as well as a
+  /// block height. A brand new user creates one drive, uploads to it and lands
+  /// here: every drive they own is unwalked, so `every` was trivially true and
+  /// the card announced "Nothing has been synced yet - their contents have not
+  /// been fetched yet" over a drive whose contents they had just put there
+  /// themselves. The card's own words are the test: a drive whose figures are
+  /// on screen has had its contents fetched, whoever fetched them.
   bool get nothingHasEverBeenSynced =>
-      drives.isNotEmpty && drives.every((drive) => !drive.hasBeenWalked);
+      drives.isNotEmpty &&
+      drives.every((drive) => !drive.hasBeenWalked && drive.fileCount == null);
 
   /// The drives the network has moved on without.
   ///

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1639,6 +1639,20 @@
     "description": "Button that re-syncs only the drives that failed",
     "placeholders": { "count": { "type": "num", "format": "compact" } }
   },
+  "driveListDrivesHaveChanges": "{count, plural, =1{1 drive has changed since it was last read} other{{count} drives have changed since they were last read}}",
+  "@driveListDrivesHaveChanges": {
+    "description": "Heading of the notice offering to sync drives the network has activity for",
+    "placeholders": { "count": { "type": "num", "format": "compact" } }
+  },
+  "driveListDrivesHaveChangesDetail": "The files and sizes below were read earlier. Syncing brings them up to date.",
+  "@driveListDrivesHaveChangesDetail": {
+    "description": "Explains that the figures on screen are still the last ones read"
+  },
+  "driveListSyncThoseWithChanges": "{count, plural, =1{Sync that drive} other{Sync those {count}}}",
+  "@driveListSyncThoseWithChanges": {
+    "description": "Button that syncs only the drives that have changed",
+    "placeholders": { "count": { "type": "num", "format": "compact" } }
+  },
   "@driveListClearSelection": {
     "description": "Button that unticks every selected drive"
   },

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1644,6 +1644,18 @@
     "description": "Heading of the notice offering to sync drives the network has activity for",
     "placeholders": { "count": { "type": "num", "format": "compact" } }
   },
+  "checkUploadStatus": "Check upload status",
+  "@checkUploadStatus": {
+    "description": "Menu item on a file whose upload has not been confirmed yet"
+  },
+  "checkedUploadStatus": "Upload status checked",
+  "@checkedUploadStatus": {
+    "description": "Confirmation shown after re-checking a pending upload"
+  },
+  "searchFiles": "Search files",
+  "@searchFiles": {
+    "description": "Tooltip on the mobile app bar's search control"
+  },
   "driveListDrivesHaveChangesDetail": "The files and sizes below were read earlier. Syncing brings them up to date.",
   "@driveListDrivesHaveChangesDetail": {
     "description": "Explains that the figures on screen are still the last ones read"

--- a/lib/pages/drive_detail/components/drive_detail_folder_empty_card.dart
+++ b/lib/pages/drive_detail/components/drive_detail_folder_empty_card.dart
@@ -276,13 +276,17 @@ class _NewUserEmptyRootFolder extends StatelessWidget {
                 driveId: driveId,
                 parentFolderId: parentFolderId,
                 page: PlausiblePageView.newUserDriveEmptyPage,
+                variant: ButtonVariant.primary,
+                compact: true,
               ),
-              const SizedBox(height: 20),
+              const SizedBox(height: 12),
               _ActionCard.createFolder(
                 context,
                 driveId: driveId,
                 parentFolderId: parentFolderId,
                 page: PlausiblePageView.newUserDriveEmptyPage,
+                variant: ButtonVariant.primary,
+                compact: true,
               ),
             ],
           ),
@@ -330,11 +334,13 @@ class _NewUserEmptyRootFolder extends StatelessWidget {
                 _ActionCard.uploadFile(context,
                     driveId: driveId,
                     parentFolderId: parentFolderId,
-                    page: PlausiblePageView.newUserDriveEmptyPage),
+                    page: PlausiblePageView.newUserDriveEmptyPage,
+                    variant: ButtonVariant.primary),
                 _ActionCard.createFolder(context,
                     driveId: driveId,
                     parentFolderId: parentFolderId,
-                    page: PlausiblePageView.newUserDriveEmptyPage),
+                    page: PlausiblePageView.newUserDriveEmptyPage,
+                    variant: ButtonVariant.primary),
               ],
             )
           ],
@@ -524,8 +530,12 @@ class _ActionCard {
     required String driveId,
     required String parentFolderId,
     required PlausiblePageView page,
+    ButtonVariant variant = ButtonVariant.secondary,
+    bool compact = false,
   }) {
     return _buildActionCard(
+      variant: variant,
+      compact: compact,
       context: context,
       title: 'Upload Files',
       description:
@@ -550,8 +560,12 @@ class _ActionCard {
     required String driveId,
     required String parentFolderId,
     required PlausiblePageView page,
+    ButtonVariant variant = ButtonVariant.secondary,
+    bool compact = false,
   }) {
     return _buildActionCard(
+      variant: variant,
+      compact: compact,
       context: context,
       title: 'Create a Folder',
       description: 'Create folders to keep your drive organized.',
@@ -614,9 +628,61 @@ class _ActionCard {
     required String buttonText,
     required Function() onPressed,
     required ArDriveIcon icon,
+    ButtonVariant variant = ButtonVariant.secondary,
+    bool compact = false,
   }) {
     final typography = ArDriveTypographyNew.of(context);
     final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
+
+    // A phone gets the same card lying down.
+    //
+    // Two 283px squares stacked, under a heading and a paragraph, is about
+    // 800px of content on a screen that has around 600 - so the one page in
+    // the product whose job is to say "well done, now do one of these two
+    // things" put both of those things below the fold. Laid on its side the
+    // pair takes roughly 260px and the whole page is visible at once.
+    if (compact) {
+      return ArDriveCard(
+        backgroundColor: colorTokens.containerL2,
+        contentPadding: const EdgeInsets.all(16),
+        content: Row(
+          children: [
+            icon.copyWith(size: 20),
+            const SizedBox(width: 14),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    title,
+                    style: typography.paragraphNormal(
+                        fontWeight: ArFontWeight.semiBold),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    description,
+                    style:
+                        typography.paragraphSmall(color: colorTokens.textMid),
+                  ),
+                  const SizedBox(height: 12),
+                  // Under the words rather than beside them: at this width a
+                  // third column leaves the description about ten characters
+                  // to work with.
+                  ArDriveButtonNew(
+                    text: buttonText,
+                    typography: typography,
+                    onPressed: onPressed,
+                    variant: variant,
+                    maxHeight: 36,
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      );
+    }
 
     return ArDriveCard(
       width: 283,
@@ -644,7 +710,7 @@ class _ActionCard {
             text: buttonText,
             typography: typography,
             onPressed: onPressed,
-            variant: ButtonVariant.secondary,
+            variant: variant,
           ),
         ],
       ),

--- a/lib/pages/drive_detail/components/drive_explorer_item_tile.dart
+++ b/lib/pages/drive_detail/components/drive_explorer_item_tile.dart
@@ -579,6 +579,39 @@ class _DriveExplorerItemTileTrailingState
             height: height,
           ),
         ),
+      // Only on a file that is actually waiting on something. A confirmed file
+      // has nothing to check, and an item that is present but does nothing is
+      // worse than one that is absent.
+      if (item.fileStatusFromTransactions == TransactionStatus.pending)
+        ArDriveDropdownItem(
+          onClick: () async {
+            // Both read before the await: the tile can be gone by the time the
+            // gateway answers - the row it sits in redraws whenever the folder
+            // does - and a context read afterwards is a context that may no
+            // longer be mounted.
+            final messenger = ScaffoldMessenger.of(context);
+            final checked = appLocalizationsOf(context).checkedUploadStatus;
+
+            final refreshed =
+                await context.read<SyncCubit>().refreshPendingStatuses();
+
+            // Refused because a sync is already running, or it failed. Either
+            // way the row keeps the status it had and says nothing it cannot
+            // stand behind.
+            if (!refreshed) {
+              return;
+            }
+
+            messenger.showSnackBar(SnackBar(content: Text(checked)));
+          },
+          content: _buildItem(
+            appLocalizationsOf(context).checkUploadStatus,
+            ArDriveIcons.refresh(
+              size: defaultIconSize,
+            ),
+            height: height,
+          ),
+        ),
       if (isOwner) ...[
         if (item is FileDataTableItem)
           ArDriveDropdownItem(

--- a/lib/pages/drive_detail/drive_detail_page.dart
+++ b/lib/pages/drive_detail/drive_detail_page.dart
@@ -47,8 +47,6 @@ import 'package:ardrive/pages/drive_detail/components/email_preview_widget.dart'
 import 'package:ardrive/pages/drive_detail/components/pdf_preview_widget.dart';
 import 'package:ardrive/pages/drive_detail/models/data_table_item.dart';
 import 'package:ardrive/pages/no_drives/no_drives_page.dart';
-import 'package:ardrive/search/search_modal.dart';
-import 'package:ardrive/search/search_text_field.dart';
 import 'package:ardrive/services/services.dart';
 import 'package:ardrive/shared/components/plausible_page_view_wrapper.dart';
 import 'package:ardrive/sharing/sharing_file_listener.dart';
@@ -100,7 +98,6 @@ class DriveDetailPage extends StatefulWidget {
 class _DriveDetailPageState extends State<DriveDetailPage> {
   bool checkboxEnabled = false;
   final _scrollController = ScrollController();
-  final controller = TextEditingController();
 
   @override
   void initState() {
@@ -1025,6 +1022,7 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
           .withOpacity(0.5),
       drawer: const AppSideBar(),
       appBar: MobileAppBar(
+        showSearch: true,
         leading: (driveDetailLoadSuccessState.showSelectedItemDetails &&
                 context.read<DriveDetailCubit>().selectedItem != null)
             ? ArDriveIconButton(
@@ -1077,48 +1075,13 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
       filteredItems = items.where((item) => item.isHidden == false).toList();
     }
 
-    final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
     return Column(
       children: [
-        Padding(
-          padding: const EdgeInsets.all(16.0),
-          child: SearchTextField(
-            controller: controller,
-            onFieldSubmitted: (query) {
-              if (query.isEmpty) {
-                return;
-              }
-
-              showModalBottomSheet(
-                isScrollControlled: true,
-                context: context,
-                backgroundColor: Colors.transparent,
-                builder: (_) => Container(
-                  height: MediaQuery.of(context).size.height * 0.85,
-                  decoration: BoxDecoration(
-                    color: colorTokens.containerL2,
-                    borderRadius: const BorderRadius.only(
-                      topLeft: Radius.circular(6.0),
-                      topRight: Radius.circular(6.0),
-                    ),
-                  ),
-                  child: Padding(
-                    padding: MediaQuery.of(context).viewInsets,
-                    child: BlocProvider.value(
-                      value: context.read<DriveDetailCubit>(),
-                      child: FileSearchModal(
-                        initialQuery: query,
-                        driveDetailCubit: context.read<DriveDetailCubit>(),
-                        controller: controller,
-                        drivesCubit: context.read<DrivesCubit>(),
-                      ),
-                    ),
-                  ),
-                ),
-              );
-            },
-          ),
-        ),
+        // The search field used to sit here, 16px of padding either side of it,
+        // and did nothing until it was submitted - at which point it opened the
+        // same sheet the bar's search icon now opens. Nothing was lost by
+        // moving it; a 60px band above the file list was gained, on the layout
+        // with the least height to spare. See [MobileAppBar.showSearch].
         Padding(
           padding: const EdgeInsets.only(top: 8),
           child: Row(

--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -253,6 +253,16 @@ class SyncCubit extends Cubit<SyncState> {
     // the next few seconds writing the previous wallet's transaction statuses
     // into a database that has just been cleared. The same hazard the sync
     // itself carries a token for, and the same answer.
+    // Cancelled *then* disposed, and in that order for two reasons.
+    //
+    // `dispose` only closes the stream controller - it does not set
+    // `isCancelled` - so a token that was disposed without being cancelled
+    // reports false forever and `checkCancellation` never throws. The refresh
+    // it belonged to would go on writing statuses underneath the newer one.
+    //
+    // And the reverse order throws: `cancel` adds to the controller `dispose`
+    // has already closed.
+    _statusRefreshToken?.cancel();
     _statusRefreshToken?.dispose();
     final token = _statusRefreshToken = SyncCancellationToken();
 

--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -215,6 +215,18 @@ class SyncCubit extends Cubit<SyncState> {
   final BehaviorSubject<Set<String>> _unreadChanges =
       BehaviorSubject.seeded(const <String>{});
 
+  /// How many sync runs this cubit has accepted.
+  ///
+  /// The probe is un-awaited and slow enough to be overtaken. A sync can both
+  /// start *and finish* while it is in flight, and that sync's completion
+  /// retires the very ids the probe is about to report - so the late answer put
+  /// them back, and the list offered to sync drives it had just synced.
+  ///
+  /// Checking [state] again after the await does not catch it, because by then
+  /// the sync is over and the state is idle again. Only something that counts
+  /// runs can tell "no sync happened" from "a whole sync happened".
+  int _syncGeneration = 0;
+
   /// See [_unreadChanges].
   Stream<Set<String>> get unreadChangesStream => _unreadChanges.stream;
 
@@ -263,6 +275,9 @@ class SyncCubit extends Cubit<SyncState> {
       return;
     }
 
+    // Read before the await, compared after it. See [_syncGeneration].
+    final generation = _syncGeneration;
+
     final Set<String> changed;
     try {
       changed = await _syncRepository.probeDrivesWithChanges();
@@ -280,7 +295,9 @@ class SyncCubit extends Cubit<SyncState> {
     // its way to `super.close()`, so there is a window where `isClosed` is
     // still false and adding here throws `Cannot add new events after calling
     // close` - out of an un-awaited future, where nothing catches it.
-    if (isClosed || _unreadChanges.isClosed) {
+    // A sync ran while this was in flight, so its answer is about a state that
+    // no longer exists - and the run it raced has already said what it read.
+    if (isClosed || _unreadChanges.isClosed || generation != _syncGeneration) {
       return;
     }
 
@@ -783,6 +800,7 @@ class SyncCubit extends Cubit<SyncState> {
     }
 
     _syncProgress = SyncProgress.initial();
+    _syncGeneration++;
 
     // What this run covers, for every surface that has to tell a drive in the
     // run from one merely sitting beside it. Null means all of them.
@@ -1079,6 +1097,7 @@ class SyncCubit extends Cubit<SyncState> {
       SecretKey? cipherKey;
 
       _initSync = DateTime.now();
+      _syncGeneration++;
 
       // Which drive this sync is for, so a surface listing drives can say
       // "Syncing..." on that row alone.

--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -221,6 +221,38 @@ class SyncCubit extends Cubit<SyncState> {
   /// See [_unreadChanges].
   Set<String> get drivesWithUnreadChanges => _unreadChanges.value;
 
+  /// Re-asks the gateway about pending transactions, and nothing else.
+  ///
+  /// For the reader who has just uploaded and wants to know now rather than
+  /// within twenty minutes. It walks no history, so it cannot find anything
+  /// new - it can only settle what is already known to be waiting, which is
+  /// exactly the question a pending file raises.
+  ///
+  /// Refused while a sync runs, on the standing one-at-a-time rule: that sync
+  /// ends with this very pass, so starting a second one would ask the same
+  /// question twice and race its own answer.
+  Future<bool> refreshPendingStatuses() async {
+    if (isClosed || state is SyncInProgress) {
+      return false;
+    }
+
+    try {
+      await _syncRepository.refreshTransactionStatuses(
+        ownerAddress: _profileCubit.state is ProfileLoggedIn
+            ? (_profileCubit.state as ProfileLoggedIn).user.walletAddress
+            : null,
+      );
+
+      return true;
+    } catch (e, stackTrace) {
+      // The status a file already shows stays showing. Nothing is lost by this
+      // failing except the answer the reader asked for early.
+      logger.e('Could not refresh pending transaction statuses', e, stackTrace);
+
+      return false;
+    }
+  }
+
   /// Asks the network which already-read drives have moved on, once.
   ///
   /// Deliberately not awaited by anything and deliberately not run while a sync

--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -248,22 +248,51 @@ class SyncCubit extends Cubit<SyncState> {
       return false;
     }
 
+    // This writes rows, and `ArDriveAuth.logout()` empties every table *before*
+    // this cubit closes - so without a token an in-flight refresh would spend
+    // the next few seconds writing the previous wallet's transaction statuses
+    // into a database that has just been cleared. The same hazard the sync
+    // itself carries a token for, and the same answer.
+    _statusRefreshToken?.dispose();
+    final token = _statusRefreshToken = SyncCancellationToken();
+
     try {
       await _syncRepository.refreshTransactionStatuses(
         ownerAddress: _profileCubit.state is ProfileLoggedIn
             ? (_profileCubit.state as ProfileLoggedIn).user.walletAddress
             : null,
+        cancellationToken: token,
       );
 
+      // Cancelled out from under us while the gateway was answering: the wallet
+      // this was about is gone, so there is nothing to report to anybody.
+      if (token.isCancelled) {
+        return false;
+      }
+
       return true;
+    } on SyncCancelledException {
+      return false;
     } catch (e, stackTrace) {
       // The status a file already shows stays showing. Nothing is lost by this
       // failing except the answer the reader asked for early.
       logger.e('Could not refresh pending transaction statuses', e, stackTrace);
 
       return false;
+    } finally {
+      if (identical(_statusRefreshToken, token)) {
+        _statusRefreshToken?.dispose();
+        _statusRefreshToken = null;
+      }
     }
   }
+
+  /// The token for the standalone status refresh above.
+  ///
+  /// Its own, not [_currentSyncToken]: that one is cancelled and replaced by
+  /// every sync, and a refresh must not be torn down by a sync starting - nor
+  /// survive one that cancelled it.
+  SyncCancellationToken? _statusRefreshToken;
 
   /// Asks the network which already-read drives have moved on, once.
   ///
@@ -1485,6 +1514,12 @@ class SyncCubit extends Cubit<SyncState> {
     // drives into a database that has just been emptied.
     _pendingConfirmationWatch?.cancel();
     _pendingConfirmationWatch = null;
+
+    // Same argument as the sync token below: logout empties the tables before
+    // this runs, so anything still writing has to be told to stop.
+    _statusRefreshToken?.cancel();
+    _statusRefreshToken?.dispose();
+    _statusRefreshToken = null;
 
     // First, so the sync begins unwinding while the subscriptions below are
     // being torn down rather than after.

--- a/lib/sync/domain/cubit/sync_cubit.dart
+++ b/lib/sync/domain/cubit/sync_cubit.dart
@@ -22,6 +22,7 @@ import 'package:cryptography/cryptography.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:rxdart/rxdart.dart';
 
 /// Re-exported so every surface that already imports this cubit keeps seeing
 /// [SyncTrigger] - it moved to its own file because the persisted sync history
@@ -201,6 +202,79 @@ class SyncCubit extends Cubit<SyncState> {
   /// Counts the results this cubit has reported, so each one is a state of its
   /// own. See [SyncComplete.sequence] for why a timestamp will not do.
   int _completedSyncCount = 0;
+
+  /// Drives with activity on chain this device has not read yet.
+  ///
+  /// Kept off [SyncState] on purpose. Every state in that hierarchy describes a
+  /// sync that is being run; this describes one that has not been asked for and
+  /// may never be. Folding it in would mean every reader of a sync state having
+  /// to ignore a field about a sync that is not happening.
+  ///
+  /// Seeded empty, so a page that subscribes before the probe answers - or when
+  /// it never does - renders exactly as it did before this existed.
+  final BehaviorSubject<Set<String>> _unreadChanges =
+      BehaviorSubject.seeded(const <String>{});
+
+  /// See [_unreadChanges].
+  Stream<Set<String>> get unreadChangesStream => _unreadChanges.stream;
+
+  /// See [_unreadChanges].
+  Set<String> get drivesWithUnreadChanges => _unreadChanges.value;
+
+  /// Asks the network which already-read drives have moved on, once.
+  ///
+  /// Deliberately not awaited by anything and deliberately not run while a sync
+  /// is: a sync answers this question far better than a probe can, and asking
+  /// during one races the answer it is about to produce.
+  Future<void> checkForUnreadChanges() async {
+    if (isClosed || state is SyncInProgress) {
+      return;
+    }
+
+    final Set<String> changed;
+    try {
+      changed = await _syncRepository.probeDrivesWithChanges();
+    } catch (e) {
+      // Caught here as well as in the repository, because this is the boundary
+      // that matters: nothing awaits this call, so an exception escaping it is
+      // an unhandled async error rather than a failed request. The cost of it
+      // failing is that a reader is not offered a sync they were never
+      // promised.
+      logger.w('Could not ask what changed while away: $e');
+      return;
+    }
+
+    // The subject, not the cubit. [close] shuts this down *before* it awaits
+    // its way to `super.close()`, so there is a window where `isClosed` is
+    // still false and adding here throws `Cannot add new events after calling
+    // close` - out of an un-awaited future, where nothing catches it.
+    if (isClosed || _unreadChanges.isClosed) {
+      return;
+    }
+
+    _unreadChanges.add(changed);
+
+    if (changed.isNotEmpty) {
+      logger.i('${changed.length} drives have changes that have not been read');
+    }
+  }
+
+  /// Forgets the drives a finished run has just read.
+  ///
+  /// Reading a drive is the one thing that makes its unread changes read, so a
+  /// completed run retires exactly the ids it covered and leaves the rest -
+  /// syncing three of eight drives must not clear the offer on the other five.
+  void _forgetUnreadChangesFor(Iterable<String> driveIds) {
+    if (_unreadChanges.isClosed) {
+      return;
+    }
+
+    final remaining = _unreadChanges.value.difference(driveIds.toSet());
+
+    if (remaining.length != _unreadChanges.value.length) {
+      _unreadChanges.add(remaining);
+    }
+  }
 
   SyncComplete _syncComplete(SyncTrigger trigger) => SyncComplete(
         entitiesSynced: _syncProgress.entitiesSynced,
@@ -409,6 +483,14 @@ class SyncCubit extends Cubit<SyncState> {
 
     if (isClosed || !thereIsWork) {
       logger.d('Nothing owed: leaving the login sync skipped');
+
+      // Nothing owed is not the same as nothing to say. This is the returning
+      // reader's moment: the drive list has just been refreshed from the
+      // network, every row is about to render counts and a last-read time from
+      // the local database, and none of those numbers knows whether the drives
+      // have moved on since. One query answers that, and the answer is only
+      // ever offered - see [checkForUnreadChanges].
+      unawaited(checkForUnreadChanges());
       return;
     }
 
@@ -874,6 +956,7 @@ class SyncCubit extends Cubit<SyncState> {
       ));
       unawaited(_recordSyncRun(SyncRunOutcome.completedWithErrors, trigger));
     } else if (ranToCompletion) {
+      _forgetUnreadChangesFor(_syncProgress.syncedDriveIds);
       _emitIfOpen(_syncComplete(trigger));
       unawaited(_recordSyncRun(SyncRunOutcome.completed, trigger));
     } else if (threw) {
@@ -1103,6 +1186,7 @@ class SyncCubit extends Cubit<SyncState> {
       ));
       unawaited(_recordSyncRun(SyncRunOutcome.completedWithErrors, trigger));
     } else if (ranToCompletion) {
+      _forgetUnreadChangesFor(_syncProgress.syncedDriveIds);
       _emitIfOpen(_syncComplete(trigger));
       unawaited(_recordSyncRun(SyncRunOutcome.completed, trigger));
     } else if (threw) {
@@ -1356,6 +1440,10 @@ class SyncCubit extends Cubit<SyncState> {
     _currentSyncToken?.cancel();
     _currentSyncToken?.dispose();
     _currentSyncToken = null;
+
+    // The subject outlives no wallet: its ids name drives that are about to be
+    // dropped from the database.
+    await _unreadChanges.close();
 
     await _syncSub?.cancel();
     await _arconnectSyncSub?.cancel();

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -334,6 +334,22 @@ abstract class SyncRepository {
   /// runs the other way.
   Future<Set<String>> probeDrivesWithChanges();
 
+  /// Re-asks the gateway about every transaction still recorded as pending.
+  ///
+  /// The status pass a sync ends with, on its own. That pass is already
+  /// wallet-wide and independent of which drives the run covered - it reads the
+  /// pending transactions out of the local tables rather than out of the walk -
+  /// so nothing about it needs a sync around it.
+  ///
+  /// This exists because there was no way to ask "did my upload land?" without
+  /// starting one. A confirmation is owed within twenty minutes either way; the
+  /// point of this is the twenty minutes.
+  ///
+  /// It walks no history and moves no block-height watermark, so it cannot find
+  /// a file somebody else uploaded - only resolve the state of one already
+  /// known about.
+  Future<void> refreshTransactionStatuses({String? ownerAddress});
+
   factory SyncRepository({
     required ArweaveService arweave,
     required DriveDao driveDao,
@@ -3149,6 +3165,15 @@ class _SyncRepository implements SyncRepository {
   @override
   Future<bool> hasPendingTransactions() {
     return _driveDao.hasPendingTransactions();
+  }
+
+  @override
+  Future<void> refreshTransactionStatuses({String? ownerAddress}) {
+    return _updateTransactionStatuses(
+      driveDao: _driveDao,
+      arweave: _arweave,
+      ownerAddress: ownerAddress,
+    );
   }
 
   @override

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -313,6 +313,27 @@ abstract class SyncRepository {
   /// knows it and it is past [kRequiredTxConfirmationPendingThreshold].
   Future<bool> hasPendingTransactions();
 
+  /// Which already-read drives have activity on chain the device has not read.
+  ///
+  /// Read-only. It writes nothing, touches no sync state and starts no sync -
+  /// it runs the same per-owner query [syncAllDrives] uses to skip unchanged
+  /// drives, and hands back the answer instead of acting on it. That is the
+  /// whole point: a returning reader gets told what is stale and decides for
+  /// themselves, rather than having a sync begun on their behalf.
+  ///
+  /// Drives that have never been read are **not** included. Their rows already
+  /// say `Never synced`, and folding them in here would make one number mean
+  /// two different things.
+  ///
+  /// An empty set means "nothing to say", and that deliberately covers three
+  /// situations at once: nothing changed, the probe could not confirm it had
+  /// checked everything, and the probe failed outright. Inside a sync an
+  /// unanswerable probe means *sync everything*, because the cost of guessing
+  /// wrong is a slower sync. Here the cost of guessing wrong is a banner
+  /// claiming changes that may not exist, which is a nag - so the fallback
+  /// runs the other way.
+  Future<Set<String>> probeDrivesWithChanges();
+
   factory SyncRepository({
     required ArweaveService arweave,
     required DriveDao driveDao,
@@ -3128,6 +3149,64 @@ class _SyncRepository implements SyncRepository {
   @override
   Future<bool> hasPendingTransactions() {
     return _driveDao.hasPendingTransactions();
+  }
+
+  @override
+  Future<Set<String>> probeDrivesWithChanges() async {
+    try {
+      final drives = await _driveDao.allDrives().get();
+
+      // Only drives with a watermark to compare against. A never-read drive
+      // has a block height of zero, which would drag its owner's floor down to
+      // genesis - the same poisoning [syncAllDrives] partitions to avoid, and
+      // there it costs a slow query. Here it would also make the probe answer
+      // a question nobody asked, since those rows already say `Never synced`.
+      final readDrives =
+          drives.where((d) => (d.lastBlockHeight ?? 0) > 0).toList();
+
+      if (readDrives.isEmpty) {
+        return const {};
+      }
+
+      final drivesByOwner = <String, List<Drive>>{};
+      for (final drive in readDrives) {
+        drivesByOwner.putIfAbsent(drive.ownerAddress, () => []).add(drive);
+      }
+
+      final changed = <String>{};
+
+      for (final entry in drivesByOwner.entries) {
+        final ownerDrives = entry.value;
+        final minBlock = ownerDrives
+            .map((d) => _calculateSyncLastBlockHeight(d.lastBlockHeight ?? 0))
+            .reduce(min);
+
+        final result = await _arweave.probeActiveDriveIds(
+          driveIds: ownerDrives.map((d) => d.id).toList(),
+          minBlockHeight: minBlock,
+          ownerAddress: entry.key,
+        );
+
+        // An incomplete answer is dropped rather than widened. The probe
+        // reports `isComplete: false` when it could not see far enough to be
+        // sure, and the honest reading of that is "unknown" - which is not
+        // something to put in front of a reader as though it were news.
+        if (!result.isComplete) {
+          continue;
+        }
+
+        changed.addAll(result.activeDriveIds);
+      }
+
+      return changed;
+    } catch (e) {
+      // Nothing downstream of this is load-bearing: the drives list still
+      // shows every drive and its last-read time, and Sync still works. A
+      // failure here costs the reader a prompt, so it is logged and swallowed
+      // rather than surfaced.
+      logger.w('Could not probe for unread drive changes: $e');
+      return const {};
+    }
   }
 }
 

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -348,7 +348,17 @@ abstract class SyncRepository {
   /// It walks no history and moves no block-height watermark, so it cannot find
   /// a file somebody else uploaded - only resolve the state of one already
   /// known about.
-  Future<void> refreshTransactionStatuses({String? ownerAddress});
+  ///
+  /// Takes a cancellation token for the same reason [syncAllDrives] does, and it
+  /// is not optional in practice: this writes rows, `ArDriveAuth.logout()`
+  /// empties every table *before* the cubit closes, and this repository is an
+  /// app-level singleton above the auth gate. Without a token an in-flight
+  /// refresh spends the next few seconds writing the previous wallet's
+  /// transaction statuses into a database that has just been cleared.
+  Future<void> refreshTransactionStatuses({
+    String? ownerAddress,
+    SyncCancellationToken? cancellationToken,
+  });
 
   factory SyncRepository({
     required ArweaveService arweave,
@@ -3168,11 +3178,15 @@ class _SyncRepository implements SyncRepository {
   }
 
   @override
-  Future<void> refreshTransactionStatuses({String? ownerAddress}) {
+  Future<void> refreshTransactionStatuses({
+    String? ownerAddress,
+    SyncCancellationToken? cancellationToken,
+  }) {
     return _updateTransactionStatuses(
       driveDao: _driveDao,
       arweave: _arweave,
       ownerAddress: ownerAddress,
+      cancellationToken: cancellationToken,
     );
   }
 

--- a/lib/sync/domain/repositories/sync_repository.dart
+++ b/lib/sync/domain/repositories/sync_repository.dart
@@ -3212,12 +3212,17 @@ class _SyncRepository implements SyncRepository {
           ownerAddress: entry.key,
         );
 
-        // An incomplete answer is dropped rather than widened. The probe
-        // reports `isComplete: false` when it could not see far enough to be
-        // sure, and the honest reading of that is "unknown" - which is not
-        // something to put in front of a reader as though it were news.
+        // One unconfirmable owner ends the whole probe, rather than dropping
+        // that owner and reporting the rest.
+        //
+        // `continue` here would have returned a partial answer through an
+        // interface documented to return none: a count that reads as "these are
+        // the drives that changed" when it is really "these are the ones we
+        // could confirm, out of some number we cannot state". Silence is the
+        // fallback this whole method is built around, and it has to hold for a
+        // partial failure too, or the contract means nothing.
         if (!result.isComplete) {
-          continue;
+          return const {};
         }
 
         changed.addAll(result.activeDriveIds);

--- a/test/components/drive_detach_dialog_test.dart
+++ b/test/components/drive_detach_dialog_test.dart
@@ -38,6 +38,12 @@ void main() {
     when(() => syncCubit.syncingDriveId).thenReturn(null);
     when(() => syncCubit.syncingDriveIds).thenReturn(null);
     when(() => syncCubit.completedDriveIds).thenReturn(const []);
+    // The probe never answers in these tests, which is the state the page is in
+    // for the whole of a real session until it does - and forever when it
+    // cannot. Every one of these expectations must hold in that state.
+    when(() => syncCubit.drivesWithUnreadChanges).thenReturn(const {});
+    when(() => syncCubit.unreadChangesStream)
+        .thenAnswer((_) => const Stream<Set<String>>.empty());
     whenListen(drivesCubit, const Stream<DrivesState>.empty(),
         initialState: DrivesLoadInProgress());
   });

--- a/test/drives_list/drives_list_cubit_test.dart
+++ b/test/drives_list/drives_list_cubit_test.dart
@@ -52,6 +52,12 @@ void main() {
     // "every drive"; nothing finished yet.
     when(() => syncCubit.syncingDriveIds).thenReturn(null);
     when(() => syncCubit.completedDriveIds).thenReturn(const []);
+    // The probe never answers in these tests, which is the state the page is in
+    // for the whole of a real session until it does - and forever when it
+    // cannot. Every one of these expectations must hold in that state.
+    when(() => syncCubit.drivesWithUnreadChanges).thenReturn(const {});
+    when(() => syncCubit.unreadChangesStream)
+        .thenAnswer((_) => const Stream<Set<String>>.empty());
     when(() => preferences.currentPreferences).thenReturn(prefs());
   });
 

--- a/test/drives_list/drives_list_cubit_test.dart
+++ b/test/drives_list/drives_list_cubit_test.dart
@@ -604,6 +604,74 @@ void main() {
       expect(drive.totalSize, isNull);
     });
   });
+
+  /// A drive this device made and filled, before anything has read it back.
+  ///
+  /// `createDrive` inserts with no block height and the schema defaults it to
+  /// zero, so nothing has walked this drive - but the upload wrote its files
+  /// into `fileEntries`, and those rows are as true as any sync would make
+  /// them. The list used to withhold them and say `Never synced`, which told a
+  /// user who had just uploaded that nothing had happened.
+  group('a drive the device filled itself', () {
+    test('shows what was uploaded to it, unwalked or not', () async {
+      await addDrive('drive-new');
+      await addFile('drive-new', 'photo-1', 1024);
+      await addFile('drive-new', 'photo-2', 2048);
+
+      final state = await settle(
+        DrivesLoadSuccess(
+          selectedDriveId: 'drive-new',
+          userDrives: await drivesNamed(['drive-new']),
+          sharedDrives: const [],
+          drivesWithAlerts: const [],
+          canCreateNewDrive: true,
+        ),
+      ) as DrivesListLoaded;
+
+      expect(state.drives.single.fileCount, 2);
+      expect(state.drives.single.totalSize, 3072);
+
+      // Still true, and still said: nothing has read this drive from chain.
+      // It is the figures that were wrong to withhold, not the label.
+      expect(state.drives.single.hasBeenWalked, isFalse);
+    });
+
+    test('withholds figures for an unwalked drive it knows nothing about',
+        () async {
+      // No local files. A zero here would be a guess dressed as a fact.
+      await addDrive('drive-unread');
+
+      final state = await settle(
+        DrivesLoadSuccess(
+          selectedDriveId: 'drive-unread',
+          userDrives: await drivesNamed(['drive-unread']),
+          sharedDrives: const [],
+          drivesWithAlerts: const [],
+          canCreateNewDrive: true,
+        ),
+      ) as DrivesListLoaded;
+
+      expect(state.drives.single.fileCount, isNull);
+      expect(state.drives.single.totalSize, isNull);
+    });
+
+    test('reports a walked drive that really is empty as empty', () async {
+      await addDrive('drive-empty', lastBlockHeight: 42);
+
+      final state = await settle(
+        DrivesLoadSuccess(
+          selectedDriveId: 'drive-empty',
+          userDrives: await drivesNamed(['drive-empty']),
+          sharedDrives: const [],
+          drivesWithAlerts: const [],
+          canCreateNewDrive: true,
+        ),
+      ) as DrivesListLoaded;
+
+      expect(state.drives.single.fileCount, 0);
+      expect(state.drives.single.totalSize, 0);
+    });
+  });
 }
 
 /// A sync doing nothing, which is what every test here starts from.

--- a/test/drives_list/drives_list_open_never_syncs_test.dart
+++ b/test/drives_list/drives_list_open_never_syncs_test.dart
@@ -72,6 +72,12 @@ void main() {
     // "every drive"; nothing finished yet.
     when(() => syncCubit.syncingDriveIds).thenReturn(null);
     when(() => syncCubit.completedDriveIds).thenReturn(const []);
+    // The probe never answers in these tests, which is the state the page is in
+    // for the whole of a real session until it does - and forever when it
+    // cannot. Every one of these expectations must hold in that state.
+    when(() => syncCubit.drivesWithUnreadChanges).thenReturn(const {});
+    when(() => syncCubit.unreadChangesStream)
+        .thenAnswer((_) => const Stream<Set<String>>.empty());
     when(() => preferences.currentPreferences).thenReturn(prefs());
     when(() => syncCubit.startSyncForDrive(
           driveId: any(named: 'driveId'),

--- a/test/drives_list/drives_list_unread_changes_test.dart
+++ b/test/drives_list/drives_list_unread_changes_test.dart
@@ -1,0 +1,167 @@
+import 'package:ardrive/drives_list/domain/drive_list_item.dart';
+import 'package:ardrive/drives_list/presentation/drives_list_cubit.dart';
+import 'package:ardrive/drives_list/presentation/drives_list_page.dart';
+import 'package:ardrive_ui/ardrive_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// What a returning reader is told.
+///
+/// Everything on this page comes from the local database, which is what makes
+/// it instant and also what makes it silently old: a reader who closed the tab
+/// on Tuesday sees Tuesday's file counts drawn with exactly the confidence of
+/// current ones. The notice under test is the only thing that says otherwise,
+/// and it is only ever shown when the network has confirmed there is something
+/// to say.
+void main() {
+  DriveListItem drive(
+    String id, {
+    bool hasUnreadChanges = false,
+    bool isSyncing = false,
+    bool lastSyncFailed = false,
+  }) =>
+      DriveListItem(
+        id: id,
+        name: id,
+        isPrivate: false,
+        isSharedWithMe: false,
+        isHidden: false,
+        dateCreated: DateTime(2026, 3, 4),
+        hasBeenWalked: true,
+        hasUnreadChanges: hasUnreadChanges,
+        fileCount: 12,
+        totalSize: 4096,
+        lastSyncedAt: DateTime(2026, 3, 1),
+        isSyncing: isSyncing,
+        lastSyncFailed: lastSyncFailed,
+      );
+
+  Widget host(Widget child) => ArDriveTheme(
+        themeData: lightTheme(),
+        child: MaterialApp(
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: const [Locale('en', '')],
+          home: Scaffold(body: child),
+        ),
+      );
+
+  Future<void> pump(
+    WidgetTester tester,
+    DrivesListLoaded state, {
+    VoidCallback? onSyncChanged,
+    VoidCallback? onRetryFailed,
+  }) async {
+    await tester.binding.setSurfaceSize(const Size(1200, 900));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      host(
+        DrivesListBody(
+          state: state,
+          onOpenDrive: (_) {},
+          onTryAgain: () {},
+          onSyncAllDrives: () {},
+          onSyncChanged: onSyncChanged ?? () {},
+          onRetryFailed: onRetryFailed,
+        ),
+      ),
+    );
+  }
+
+  testWidgets('names how many drives moved on, and offers only those',
+      (tester) async {
+    await pump(
+      tester,
+      DrivesListLoaded(drives: [
+        drive('a', hasUnreadChanges: true),
+        drive('b', hasUnreadChanges: true),
+        drive('c'),
+      ]),
+    );
+
+    expect(
+      find.text('2 drives have changed since they were last read'),
+      findsOneWidget,
+    );
+    // The button names the same number the sentence does. A reader who is told
+    // two and offered "Sync All Drives" has been told two different things.
+    expect(find.text('Sync those 2'), findsOneWidget);
+  });
+
+  testWidgets('says nothing when every drive is current', (tester) async {
+    await pump(tester, DrivesListLoaded(drives: [drive('a'), drive('b')]));
+
+    expect(find.textContaining('have changed since'), findsNothing);
+  });
+
+  testWidgets('syncs the drives it named and nothing else', (tester) async {
+    var pressed = 0;
+    await pump(
+      tester,
+      DrivesListLoaded(drives: [
+        drive('a', hasUnreadChanges: true),
+        drive('b'),
+      ]),
+      onSyncChanged: () => pressed++,
+    );
+
+    await tester.tap(find.text('Sync that drive'));
+    await tester.pump();
+
+    expect(pressed, 1);
+  });
+
+  /// The offer is only an offer while it can be taken - the same rule the
+  /// never-synced card follows one block up.
+  testWidgets('withdraws itself while a sync is running', (tester) async {
+    await pump(
+      tester,
+      DrivesListLoaded(drives: [
+        drive('a', hasUnreadChanges: true, isSyncing: true),
+      ]),
+    );
+
+    expect(find.textContaining('have changed since'), findsNothing);
+    expect(find.textContaining('has changed since'), findsNothing);
+  });
+
+  /// Two red-adjacent offers of different scopes on one screen is the reader
+  /// having to work out which one they meant, and they have just said which by
+  /// ticking rows.
+  testWidgets('withdraws itself while rows are ticked', (tester) async {
+    await pump(
+      tester,
+      DrivesListLoaded(
+        drives: [drive('a', hasUnreadChanges: true)],
+        selected: const {'a'},
+      ),
+    );
+
+    expect(find.textContaining('has changed since'), findsNothing);
+  });
+
+  /// A drive that could not be read at all is worse news than one that is
+  /// merely behind, and the two notices say different things about different
+  /// drives - so both stand.
+  testWidgets('stands alongside a failure notice', (tester) async {
+    await pump(
+      tester,
+      DrivesListLoaded(drives: [
+        drive('a', hasUnreadChanges: true),
+        drive('b', lastSyncFailed: true),
+      ]),
+      onRetryFailed: () {},
+    );
+
+    expect(find.text('1 drive has changed since it was last read'),
+        findsOneWidget);
+    expect(find.textContaining('could not be read'), findsOneWidget);
+  });
+}

--- a/test/drives_list/new_drive_figures_test.dart
+++ b/test/drives_list/new_drive_figures_test.dart
@@ -1,0 +1,75 @@
+import 'package:ardrive/drives_list/domain/drive_list_item.dart';
+import 'package:ardrive/drives_list/presentation/drives_list_cubit.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// What the list says about a drive this device made and filled.
+///
+/// The user creates their first drive, uploads a few files, and opens Your
+/// Drives. Nothing has read that drive from chain - `createDrive` inserts with
+/// no block height and the schema defaults it to zero - but the files are in
+/// `fileEntries`, written by the upload. Treating "never walked" as "nothing
+/// known" showed them `Never synced`, a dash, and a dash, over work they had
+/// just done.
+void main() {
+  DriveListItem drive({
+    required bool hasBeenWalked,
+    int? fileCount,
+    int? totalSize,
+  }) =>
+      DriveListItem(
+        id: 'drive-a',
+        name: 'My Drive',
+        isPrivate: false,
+        isSharedWithMe: false,
+        isHidden: false,
+        dateCreated: DateTime(2026, 3, 1),
+        hasBeenWalked: hasBeenWalked,
+        fileCount: fileCount,
+        totalSize: totalSize,
+        lastSyncedAt: null,
+        isSyncing: false,
+        lastSyncFailed: false,
+      );
+
+  group('the sync-everything card', () {
+    test('is offered when nothing is known about anything', () {
+      final state = DrivesListLoaded(
+        drives: [drive(hasBeenWalked: false)],
+      );
+
+      expect(state.nothingHasEverBeenSynced, isTrue);
+    });
+
+    /// The card says "their contents have not been fetched yet". They have.
+    test('is withdrawn once a drive has figures to show', () {
+      final state = DrivesListLoaded(
+        drives: [drive(hasBeenWalked: false, fileCount: 5, totalSize: 2048)],
+      );
+
+      expect(
+        state.nothingHasEverBeenSynced,
+        isFalse,
+        reason: 'a brand new drive the user has already uploaded to is not a '
+            'wallet with nothing in it',
+      );
+    });
+
+    test('is still offered beside a drive that is known to be empty', () {
+      // Walked, and genuinely holds nothing. Zero here is a fact, not a gap -
+      // but this drive *has* been read, so the card goes anyway.
+      final state = DrivesListLoaded(
+        drives: [drive(hasBeenWalked: true, fileCount: 0, totalSize: 0)],
+      );
+
+      expect(state.nothingHasEverBeenSynced, isFalse);
+    });
+
+    test('is still offered when one unread drive sits beside another', () {
+      final state = DrivesListLoaded(
+        drives: [drive(hasBeenWalked: false), drive(hasBeenWalked: false)],
+      );
+
+      expect(state.nothingHasEverBeenSynced, isTrue);
+    });
+  });
+}

--- a/test/pages/drive_detail/components/new_drive_empty_card_test.dart
+++ b/test/pages/drive_detail/components/new_drive_empty_card_test.dart
@@ -1,0 +1,129 @@
+import 'package:ardrive/blocs/drives/drives_cubit.dart';
+import 'package:ardrive/models/models.dart';
+import 'package:ardrive/pages/drive_detail/drive_detail_page.dart';
+import 'package:ardrive_ui/ardrive_ui.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _MockDrivesCubit extends MockCubit<DrivesState> implements DrivesCubit {}
+
+/// The page a brand new drive opens on: "You're on chain!".
+///
+/// It has one job - say well done, then offer the two things worth doing next -
+/// and on a phone it was doing that job below the fold, because both offers
+/// were 283px squares stacked under a heading and a paragraph.
+void main() {
+  late _MockDrivesCubit drivesCubit;
+
+  setUp(() {
+    drivesCubit = _MockDrivesCubit();
+
+    // Exactly one drive is what makes this the new-user page rather than the
+    // existing-user one.
+    whenListen(
+      drivesCubit,
+      const Stream<DrivesState>.empty(),
+      initialState: DrivesLoadSuccess(
+        selectedDriveId: 'drive-a',
+        userDrives: [
+          Drive(
+            id: 'drive-a',
+            rootFolderId: 'root',
+            ownerAddress: 'owner',
+            name: 'My Drive',
+            privacy: 'public',
+            dateCreated: DateTime(2026, 3, 1),
+            lastUpdated: DateTime(2026, 3, 1),
+            isHidden: false,
+          ),
+        ],
+        sharedDrives: const [],
+        drivesWithAlerts: const [],
+        canCreateNewDrive: true,
+      ),
+    );
+  });
+
+  Future<void> pumpAt(WidgetTester tester, Size size) async {
+    await tester.binding.setSurfaceSize(size);
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      ArDriveTheme(
+        themeData: lightTheme(),
+        child: MaterialApp(
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: const [Locale('en', '')],
+          home: Scaffold(
+            body: BlocProvider<DrivesCubit>.value(
+              value: drivesCubit,
+              child: const DriveDetailFolderEmptyCard(
+                driveId: 'drive-a',
+                parentFolderId: 'root',
+                isRootFolder: true,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  /// The measurement that matters, taken rather than assumed: a scroll view
+  /// whose content is shorter than its viewport has nowhere to scroll to.
+  double scrollableExtent(WidgetTester tester) {
+    final position = tester
+        .state<ScrollableState>(find.byType(Scrollable).first)
+        .position;
+
+    return position.maxScrollExtent;
+  }
+
+  testWidgets('fits on a phone without scrolling', (tester) async {
+    // A small-but-real phone viewport: iPhone SE is 375x667.
+    await pumpAt(tester, const Size(375, 667));
+
+    expect(find.textContaining("You're on chain!"), findsOneWidget);
+    expect(
+      scrollableExtent(tester),
+      0,
+      reason: 'the whole page has to be visible at once - both offers included',
+    );
+  });
+
+  testWidgets('both offers are on screen, not below the fold', (tester) async {
+    await pumpAt(tester, const Size(375, 667));
+
+    for (final label in ['Upload', 'Create Folder']) {
+      final rect = tester.getRect(find.widgetWithText(ArDriveButtonNew, label));
+      expect(rect.bottom, lessThanOrEqualTo(667),
+          reason: '"$label" is off the bottom of the screen');
+    }
+  });
+
+  /// Grey on grey read as disabled: the secondary token is `solidGrey700` and
+  /// the card it sits on is `solidGrey800`, while the *disabled* token is
+  /// `solidGrey600` - so the button that worked was less prominent than one
+  /// that would not.
+  testWidgets('the two offers are drawn as the actions they are',
+      (tester) async {
+    await pumpAt(tester, const Size(375, 667));
+
+    for (final label in ['Upload', 'Create Folder']) {
+      final button = tester.widget<ArDriveButtonNew>(
+        find.widgetWithText(ArDriveButtonNew, label),
+      );
+      expect(button.variant, ButtonVariant.primary, reason: label);
+    }
+  });
+}

--- a/test/sync/domain/cubit/sync_complete_test.dart
+++ b/test/sync/domain/cubit/sync_complete_test.dart
@@ -112,6 +112,11 @@ void main() {
     // would make it sync on its own.
     when(() => syncRepository.hasPendingTransactions())
         .thenAnswer((_) async => false);
+    // The returning-reader probe fires on the same "nothing owed" branch these
+    // tests exercise. It answers nothing here, which is the honest default:
+    // none of these tests is about what the network says changed.
+    when(() => syncRepository.probeDrivesWithChanges())
+        .thenAnswer((_) async => const <String>{});
     repositoryReports(SyncProgress.emptySyncCompleted());
   });
 

--- a/test/sync/domain/cubit/sync_history_recording_test.dart
+++ b/test/sync/domain/cubit/sync_history_recording_test.dart
@@ -114,6 +114,11 @@ void main() {
         .thenAnswer((_) async => 0);
     when(() => syncRepository.hasPendingTransactions())
         .thenAnswer((_) async => false);
+    // The returning-reader probe fires on the same "nothing owed" branch these
+    // tests exercise. It answers nothing here, which is the honest default:
+    // none of these tests is about what the network says changed.
+    when(() => syncRepository.probeDrivesWithChanges())
+        .thenAnswer((_) async => const <String>{});
     when(() => userPreferencesRepository.saveDrivesLastSynced(any()))
         .thenAnswer((_) async {});
     when(() => userPreferencesRepository.recordSyncRun(any()))

--- a/test/sync/domain/cubit/sync_one_at_a_time_test.dart
+++ b/test/sync/domain/cubit/sync_one_at_a_time_test.dart
@@ -84,6 +84,11 @@ void main() {
         .thenAnswer((_) async => 0);
     when(() => syncRepository.hasPendingTransactions())
         .thenAnswer((_) async => false);
+    // The returning-reader probe fires on the same "nothing owed" branch these
+    // tests exercise. It answers nothing here, which is the honest default:
+    // none of these tests is about what the network says changed.
+    when(() => syncRepository.probeDrivesWithChanges())
+        .thenAnswer((_) async => const <String>{});
     when(() => userPreferencesRepository.saveDrivesLastSynced(any()))
         .thenAnswer((_) async {});
   });

--- a/test/sync/domain/cubit/sync_only_when_needed_test.dart
+++ b/test/sync/domain/cubit/sync_only_when_needed_test.dart
@@ -418,16 +418,44 @@ void main() {
   /// leaves the figures on screen as old as whenever the drives were last read.
   /// The probe is the one thing that turns that silence into a fact.
   group('coming back to a session that is already set up', () {
+    /// Completed by the probe stub itself, so a test waits for the thing it is
+    /// about rather than for a duration. A fixed delay here was a race: if the
+    /// probe had not answered inside it, the assertion read the seeded empty
+    /// set and the test failed for no reason anybody could reproduce.
+    late Completer<void> probed;
+
+    setUp(() => probed = Completer<void>());
+
+    /// Wraps a probe answer so it reports when it was asked for.
+    void probeAnswers(Set<String> changed) {
+      when(() => syncRepository.probeDrivesWithChanges()).thenAnswer((_) async {
+        if (!probed.isCompleted) probed.complete();
+        return changed;
+      });
+    }
+
+    void probeThrows(Object error) {
+      when(() => syncRepository.probeDrivesWithChanges()).thenAnswer((_) async {
+        if (!probed.isCompleted) probed.complete();
+        throw error;
+      });
+    }
+
+    /// The probe has answered *and* the cubit has had a turn to publish it.
+    Future<void> published() async {
+      await probed.future.timeout(const Duration(seconds: 10));
+      await Future<void>.delayed(Duration.zero);
+    }
+
     test('asks what changed once nothing else is owed', () async {
       nothingIsPending();
-      when(() => syncRepository.probeDrivesWithChanges())
-          .thenAnswer((_) async => {'drive-b', 'drive-c'});
+      probeAnswers({'drive-b', 'drive-c'});
 
       final cubit = buildCubit(syncAllDrivesOnLogin: false);
       addTearDown(cubit.close);
 
       await pendingWasChecked.future.timeout(const Duration(seconds: 10));
-      await _settle();
+      await published();
 
       expect(cubit.drivesWithUnreadChanges, {'drive-b', 'drive-c'});
 
@@ -445,14 +473,13 @@ void main() {
 
     test('says nothing when the drives have not moved', () async {
       nothingIsPending();
-      when(() => syncRepository.probeDrivesWithChanges())
-          .thenAnswer((_) async => const <String>{});
+      probeAnswers(const <String>{});
 
       final cubit = buildCubit(syncAllDrivesOnLogin: false);
       addTearDown(cubit.close);
 
       await pendingWasChecked.future.timeout(const Duration(seconds: 10));
-      await _settle();
+      await published();
 
       expect(cubit.drivesWithUnreadChanges, isEmpty);
     });
@@ -462,16 +489,51 @@ void main() {
     /// claiming changes nobody has confirmed.
     test('a probe that fails is not news', () async {
       nothingIsPending();
-      when(() => syncRepository.probeDrivesWithChanges())
-          .thenThrow(Exception('gateway said no'));
+      probeThrows(Exception('gateway said no'));
 
       final cubit = buildCubit(syncAllDrivesOnLogin: false);
       addTearDown(cubit.close);
 
       await pendingWasChecked.future.timeout(const Duration(seconds: 10));
-      await _settle();
+      await published();
 
       expect(cubit.drivesWithUnreadChanges, isEmpty);
+    });
+
+    /// The race the generation counter exists for.
+    ///
+    /// The probe is un-awaited, so a sync can start *and finish* while it is in
+    /// flight. That sync's completion retires the ids it just read; a late
+    /// probe answer then put them straight back, and the list offered to sync
+    /// drives it had only just synced. Re-checking the state after the await
+    /// does not catch this - by then the sync is over and the state is idle.
+    test('a probe overtaken by a whole sync is thrown away', () async {
+      nothingIsPending();
+
+      // Held open so the sync can begin and end inside the probe's await.
+      final releaseProbe = Completer<Set<String>>();
+      when(() => syncRepository.probeDrivesWithChanges()).thenAnswer((_) {
+        if (!probed.isCompleted) probed.complete();
+        return releaseProbe.future;
+      });
+
+      final cubit = buildCubit(syncAllDrivesOnLogin: false);
+      addTearDown(cubit.close);
+
+      await probed.future.timeout(const Duration(seconds: 10));
+
+      // A whole sync, start to finish, while the probe is still waiting.
+      await cubit.startSync(trigger: SyncTrigger.userInitiated);
+
+      releaseProbe.complete({'drive-b'});
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        cubit.drivesWithUnreadChanges,
+        isEmpty,
+        reason: 'the sync that just ran is a better answer than the probe that '
+            'started before it',
+      );
     });
 
     test('an upload still waiting is asked about instead', () async {
@@ -483,13 +545,9 @@ void main() {
       addTearDown(cubit.close);
 
       await pendingWasChecked.future.timeout(const Duration(seconds: 10));
-      await _settle();
+      await Future<void>.delayed(Duration.zero);
 
       verifyNever(() => syncRepository.probeDrivesWithChanges());
     });
   });
 }
-
-/// Lets the un-awaited probe future complete.
-Future<void> _settle() =>
-    Future<void>.delayed(const Duration(milliseconds: 50));

--- a/test/sync/domain/cubit/sync_only_when_needed_test.dart
+++ b/test/sync/domain/cubit/sync_only_when_needed_test.dart
@@ -107,6 +107,8 @@ void main() {
         .thenAnswer((_) async => 0);
     when(() => syncRepository.numberOfFoldersInWallet())
         .thenAnswer((_) async => 0);
+    when(() => syncRepository.probeDrivesWithChanges())
+        .thenAnswer((_) async => const <String>{});
     // Default: the drives here have been walked before, so the only question
     // left is whether an upload is unresolved.
   });
@@ -408,4 +410,86 @@ void main() {
       expect(cubit.driveListRefreshFailed, isTrue);
     });
   });
+
+  /// The returning reader.
+  ///
+  /// Coming back to an existing session restores everything from the local
+  /// database and syncs nothing, which is exactly right and also silently
+  /// leaves the figures on screen as old as whenever the drives were last read.
+  /// The probe is the one thing that turns that silence into a fact.
+  group('coming back to a session that is already set up', () {
+    test('asks what changed once nothing else is owed', () async {
+      nothingIsPending();
+      when(() => syncRepository.probeDrivesWithChanges())
+          .thenAnswer((_) async => {'drive-b', 'drive-c'});
+
+      final cubit = buildCubit(syncAllDrivesOnLogin: false);
+      addTearDown(cubit.close);
+
+      await pendingWasChecked.future.timeout(const Duration(seconds: 10));
+      await _settle();
+
+      expect(cubit.drivesWithUnreadChanges, {'drive-b', 'drive-c'});
+
+      // Told, not acted on. The reader decides.
+      verifyNever(() => syncRepository.syncAllDrives(
+            wallet: any(named: 'wallet'),
+            password: any(named: 'password'),
+            cipherKey: any(named: 'cipherKey'),
+            syncDeep: any(named: 'syncDeep'),
+            onlyDriveIds: any(named: 'onlyDriveIds'),
+            cancellationToken: any(named: 'cancellationToken'),
+            txFechedCallback: any(named: 'txFechedCallback'),
+          ));
+    });
+
+    test('says nothing when the drives have not moved', () async {
+      nothingIsPending();
+      when(() => syncRepository.probeDrivesWithChanges())
+          .thenAnswer((_) async => const <String>{});
+
+      final cubit = buildCubit(syncAllDrivesOnLogin: false);
+      addTearDown(cubit.close);
+
+      await pendingWasChecked.future.timeout(const Duration(seconds: 10));
+      await _settle();
+
+      expect(cubit.drivesWithUnreadChanges, isEmpty);
+    });
+
+    /// The fallback runs the opposite way to the one inside a sync, where an
+    /// unanswerable probe means sync everything. Here it would mean a banner
+    /// claiming changes nobody has confirmed.
+    test('a probe that fails is not news', () async {
+      nothingIsPending();
+      when(() => syncRepository.probeDrivesWithChanges())
+          .thenThrow(Exception('gateway said no'));
+
+      final cubit = buildCubit(syncAllDrivesOnLogin: false);
+      addTearDown(cubit.close);
+
+      await pendingWasChecked.future.timeout(const Duration(seconds: 10));
+      await _settle();
+
+      expect(cubit.drivesWithUnreadChanges, isEmpty);
+    });
+
+    test('an upload still waiting is asked about instead', () async {
+      // Something is owed, so the sync that resolves it runs - and that answers
+      // the probe's question far better than the probe could.
+      somethingIsPending();
+
+      final cubit = buildCubit(syncAllDrivesOnLogin: false);
+      addTearDown(cubit.close);
+
+      await pendingWasChecked.future.timeout(const Duration(seconds: 10));
+      await _settle();
+
+      verifyNever(() => syncRepository.probeDrivesWithChanges());
+    });
+  });
 }
+
+/// Lets the un-awaited probe future complete.
+Future<void> _settle() =>
+    Future<void>.delayed(const Duration(milliseconds: 50));

--- a/test/sync/domain/cubit/sync_shutdown_test.dart
+++ b/test/sync/domain/cubit/sync_shutdown_test.dart
@@ -108,6 +108,11 @@ void main() {
         .thenAnswer((_) async => 0);
     when(() => syncRepository.hasPendingTransactions())
         .thenAnswer((_) async => false);
+    // The returning-reader probe fires on the same "nothing owed" branch these
+    // tests exercise. It answers nothing here, which is the honest default:
+    // none of these tests is about what the network says changed.
+    when(() => syncRepository.probeDrivesWithChanges())
+        .thenAnswer((_) async => const <String>{});
     when(() => userPreferencesRepository.saveDrivesLastSynced(any()))
         .thenAnswer((_) async {});
 

--- a/test/sync/domain/cubit/sync_trigger_test.dart
+++ b/test/sync/domain/cubit/sync_trigger_test.dart
@@ -80,6 +80,11 @@ void main() {
     // would make it sync on its own.
     when(() => syncRepository.hasPendingTransactions())
         .thenAnswer((_) async => false);
+    // The returning-reader probe fires on the same "nothing owed" branch these
+    // tests exercise. It answers nothing here, which is the honest default:
+    // none of these tests is about what the network says changed.
+    when(() => syncRepository.probeDrivesWithChanges())
+        .thenAnswer((_) async => const <String>{});
   });
 
   SyncCubit buildCubit({required bool syncAllDrivesOnLogin}) {

--- a/test/sync/pending_confirmation_watch_test.dart
+++ b/test/sync/pending_confirmation_watch_test.dart
@@ -78,6 +78,11 @@ void main() {
     config = MockConfig();
     activityTracker = MockActivityTracker();
     syncRepository = MockSyncRepository();
+    // The returning-reader probe fires on the same "nothing owed" branch these
+    // tests exercise. It answers nothing here, which is the honest default:
+    // none of these tests is about what the network says changed.
+    when(() => syncRepository.probeDrivesWithChanges())
+        .thenAnswer((_) async => const <String>{});
     userPreferencesRepository = MockUserPreferencesRepository();
 
     // Logged in, so the metadata refresh really reaches updateUserDrives and a

--- a/test/sync/refresh_pending_statuses_test.dart
+++ b/test/sync/refresh_pending_statuses_test.dart
@@ -1,0 +1,158 @@
+import 'dart:async';
+
+import 'package:ardrive/blocs/activity/activity_cubit.dart';
+import 'package:ardrive/blocs/blocs.dart';
+import 'package:ardrive/core/activity_tracker.dart';
+import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
+import 'package:ardrive/sync/domain/repositories/sync_repository.dart';
+import 'package:ardrive/user/repositories/user_preferences_repository.dart';
+import 'package:ardrive/user/user_preferences.dart';
+import 'package:ardrive_ui/ardrive_ui.dart';
+import 'package:arweave/arweave.dart';
+import 'package:cryptography/cryptography.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../test_utils/utils.dart';
+
+class _MockSyncRepository extends Mock implements SyncRepository {}
+
+class _MockUserPreferencesRepository extends Mock
+    implements UserPreferencesRepository {}
+
+class _MockActivityCubit extends MockCubit<ActivityState>
+    implements ActivityCubit {}
+
+class _MockActivityTracker extends Mock implements ActivityTracker {}
+
+class _FakeWallet extends Fake implements Wallet {}
+
+class _FakeSecretKey extends Fake implements SecretKey {}
+
+/// Asking "did my upload land?" without starting a sync.
+///
+/// The status pass a sync ends with is already wallet-wide, and reads its
+/// pending transactions out of the local tables rather than out of the walk -
+/// so nothing about it needs a sync around it. Until now there was no way to
+/// reach it: a reader watching a pending file either waited up to twenty
+/// minutes for the confirmation watch, or ran a whole sync to ask one question.
+void main() {
+  late MockProfileCubit profileCubit;
+  late _MockActivityCubit activityCubit;
+  late MockPromptToSnapshotBloc promptToSnapshotBloc;
+  late MockTabVisibilitySingleton tabVisibility;
+  late MockConfigService configService;
+  late MockConfig config;
+  late _MockActivityTracker activityTracker;
+  late _MockSyncRepository syncRepository;
+  late _MockUserPreferencesRepository preferences;
+
+  setUpAll(() {
+    registerFallbackValue(_FakeWallet());
+    registerFallbackValue(_FakeSecretKey());
+  });
+
+  setUp(() {
+    profileCubit = MockProfileCubit();
+    activityCubit = _MockActivityCubit();
+    promptToSnapshotBloc = MockPromptToSnapshotBloc();
+    tabVisibility = MockTabVisibilitySingleton();
+    configService = MockConfigService();
+    config = MockConfig();
+    activityTracker = _MockActivityTracker();
+    syncRepository = _MockSyncRepository();
+    preferences = _MockUserPreferencesRepository();
+
+    when(() => profileCubit.state).thenReturn(ProfileLoggingOut());
+    when(() => profileCubit.isCurrentProfileArConnect())
+        .thenAnswer((_) async => false);
+    when(() => activityCubit.state).thenReturn(ActivityNotRunning());
+    when(() => tabVisibility.isTabFocused()).thenReturn(true);
+    when(() => tabVisibility.onTabGetsFocused(any()))
+        .thenAnswer((_) => StreamController<void>().stream.listen((_) {}));
+    when(() => configService.config).thenReturn(config);
+    when(() => config.autoSync).thenReturn(false);
+    when(() => config.autoSyncIntervalInSeconds).thenReturn(3600);
+    when(() => syncRepository.updateUserDrives(
+          wallet: any(named: 'wallet'),
+          password: any(named: 'password'),
+          cipherKey: any(named: 'cipherKey'),
+          onDriveRead: any(named: 'onDriveRead'),
+          onDriveUnlocked: any(named: 'onDriveUnlocked'),
+        )).thenAnswer((_) async {});
+    when(() => syncRepository.hasPendingTransactions())
+        .thenAnswer((_) async => false);
+    when(() => syncRepository.probeDrivesWithChanges())
+        .thenAnswer((_) async => const <String>{});
+    when(() => syncRepository.refreshTransactionStatuses(
+        ownerAddress: any(named: 'ownerAddress'))).thenAnswer((_) async {});
+    when(() => preferences.load()).thenAnswer(
+      (_) async => const UserPreferences(
+        currentTheme: ArDriveThemes.dark,
+        lastSelectedDriveId: null,
+        syncAllDrivesOnLogin: false,
+      ),
+    );
+  });
+
+  SyncCubit buildCubit() => SyncCubit(
+        profileCubit: profileCubit,
+        activityCubit: activityCubit,
+        promptToSnapshotBloc: promptToSnapshotBloc,
+        tabVisibility: tabVisibility,
+        configService: configService,
+        activityTracker: activityTracker,
+        syncRepository: syncRepository,
+        userPreferencesRepository: preferences,
+      );
+
+  test('asks the gateway, and walks no history to do it', () async {
+    final cubit = buildCubit();
+    addTearDown(cubit.close);
+
+    expect(await cubit.refreshPendingStatuses(), isTrue);
+
+    verify(() => syncRepository.refreshTransactionStatuses(
+        ownerAddress: any(named: 'ownerAddress'))).called(1);
+
+    // The whole point: it cannot invent a drive state, only settle one already
+    // recorded. A sync here would be the sledgehammer this exists to avoid.
+    verifyNever(() => syncRepository.syncAllDrives(
+          wallet: any(named: 'wallet'),
+          password: any(named: 'password'),
+          cipherKey: any(named: 'cipherKey'),
+          syncDeep: any(named: 'syncDeep'),
+          onlyDriveIds: any(named: 'onlyDriveIds'),
+          cancellationToken: any(named: 'cancellationToken'),
+          txFechedCallback: any(named: 'txFechedCallback'),
+        ));
+  });
+
+  test('a gateway that refuses leaves the file showing what it showed',
+      () async {
+    when(() => syncRepository.refreshTransactionStatuses(
+            ownerAddress: any(named: 'ownerAddress')))
+        .thenThrow(Exception('gateway said no'));
+
+    final cubit = buildCubit();
+    addTearDown(cubit.close);
+
+    // Answered, not thrown: the menu item reads this to decide whether it may
+    // claim the check happened.
+    expect(await cubit.refreshPendingStatuses(), isFalse);
+  });
+
+  /// The standing one-at-a-time rule. That sync ends with this very pass, so a
+  /// second one would ask the same question twice and race its own answer.
+  test('declines while a sync is already running', () async {
+    final cubit = buildCubit();
+    addTearDown(cubit.close);
+
+    cubit.emit(SyncInProgress());
+
+    expect(await cubit.refreshPendingStatuses(), isFalse);
+    verifyNever(() => syncRepository.refreshTransactionStatuses(
+        ownerAddress: any(named: 'ownerAddress')));
+  });
+}

--- a/test/sync/refresh_pending_statuses_test.dart
+++ b/test/sync/refresh_pending_statuses_test.dart
@@ -206,4 +206,50 @@ void main() {
     // And it reports nothing, because the wallet it was about is gone.
     expect(await refreshing, isFalse);
   });
+
+  /// `dispose` closes the token's stream controller and nothing else - it does
+  /// not set `isCancelled`. A token disposed without being cancelled therefore
+  /// answers false forever and `checkCancellation` never throws, so the refresh
+  /// it belonged to goes on writing statuses underneath the one that replaced
+  /// it.
+  test('a second refresh cancels the first rather than orphaning it', () async {
+    final tokens = <SyncCancellationToken>[];
+    final release = <Completer<void>>[];
+
+    when(() => syncRepository.refreshTransactionStatuses(
+          ownerAddress: any(named: 'ownerAddress'),
+          cancellationToken: any(named: 'cancellationToken'),
+        )).thenAnswer((invocation) {
+      tokens.add(invocation.namedArguments[#cancellationToken]
+          as SyncCancellationToken);
+      release.add(Completer<void>());
+
+      return release.last.future;
+    });
+
+    final cubit = buildCubit();
+    addTearDown(cubit.close);
+
+    final first = cubit.refreshPendingStatuses();
+    await Future<void>.delayed(Duration.zero);
+
+    final second = cubit.refreshPendingStatuses();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(tokens, hasLength(2), reason: 'both refreshes reached the gateway');
+    expect(
+      tokens.first.isCancelled,
+      isTrue,
+      reason: 'the refresh that was replaced has to be able to notice',
+    );
+    expect(tokens.last.isCancelled, isFalse);
+
+    for (final completer in release) {
+      completer.complete();
+    }
+
+    // The replaced one reports nothing; the live one reports its result.
+    expect(await first, isFalse);
+    expect(await second, isTrue);
+  });
 }

--- a/test/sync/refresh_pending_statuses_test.dart
+++ b/test/sync/refresh_pending_statuses_test.dart
@@ -5,6 +5,7 @@ import 'package:ardrive/blocs/blocs.dart';
 import 'package:ardrive/core/activity_tracker.dart';
 import 'package:ardrive/sync/domain/cubit/sync_cubit.dart';
 import 'package:ardrive/sync/domain/repositories/sync_repository.dart';
+import 'package:ardrive/sync/domain/sync_cancellation_token.dart';
 import 'package:ardrive/user/repositories/user_preferences_repository.dart';
 import 'package:ardrive/user/user_preferences.dart';
 import 'package:ardrive_ui/ardrive_ui.dart';
@@ -86,7 +87,9 @@ void main() {
     when(() => syncRepository.probeDrivesWithChanges())
         .thenAnswer((_) async => const <String>{});
     when(() => syncRepository.refreshTransactionStatuses(
-        ownerAddress: any(named: 'ownerAddress'))).thenAnswer((_) async {});
+          ownerAddress: any(named: 'ownerAddress'),
+          cancellationToken: any(named: 'cancellationToken'),
+        )).thenAnswer((_) async {});
     when(() => preferences.load()).thenAnswer(
       (_) async => const UserPreferences(
         currentTheme: ArDriveThemes.dark,
@@ -114,7 +117,9 @@ void main() {
     expect(await cubit.refreshPendingStatuses(), isTrue);
 
     verify(() => syncRepository.refreshTransactionStatuses(
-        ownerAddress: any(named: 'ownerAddress'))).called(1);
+          ownerAddress: any(named: 'ownerAddress'),
+          cancellationToken: any(named: 'cancellationToken'),
+        )).called(1);
 
     // The whole point: it cannot invent a drive state, only settle one already
     // recorded. A sync here would be the sledgehammer this exists to avoid.
@@ -132,8 +137,9 @@ void main() {
   test('a gateway that refuses leaves the file showing what it showed',
       () async {
     when(() => syncRepository.refreshTransactionStatuses(
-            ownerAddress: any(named: 'ownerAddress')))
-        .thenThrow(Exception('gateway said no'));
+          ownerAddress: any(named: 'ownerAddress'),
+          cancellationToken: any(named: 'cancellationToken'),
+        )).thenThrow(Exception('gateway said no'));
 
     final cubit = buildCubit();
     addTearDown(cubit.close);
@@ -153,6 +159,51 @@ void main() {
 
     expect(await cubit.refreshPendingStatuses(), isFalse);
     verifyNever(() => syncRepository.refreshTransactionStatuses(
-        ownerAddress: any(named: 'ownerAddress')));
+          ownerAddress: any(named: 'ownerAddress'),
+          cancellationToken: any(named: 'cancellationToken'),
+        ));
+  });
+
+  /// The hazard `sync_shutdown_test.dart` describes, reached by a new door.
+  ///
+  /// `ArDriveAuth.logout()` empties every table *before* this cubit closes, and
+  /// `SyncRepository` is an app-level singleton above the auth gate - so an
+  /// in-flight refresh would otherwise spend the next few seconds writing the
+  /// previous wallet's transaction statuses into a database that has just been
+  /// cleared.
+  test('a refresh still in flight is cancelled when the cubit closes',
+      () async {
+    late SyncCancellationToken given;
+    final released = Completer<void>();
+
+    when(() => syncRepository.refreshTransactionStatuses(
+          ownerAddress: any(named: 'ownerAddress'),
+          cancellationToken: any(named: 'cancellationToken'),
+        )).thenAnswer((invocation) {
+      given = invocation.namedArguments[#cancellationToken]
+          as SyncCancellationToken;
+
+      return released.future;
+    });
+
+    final cubit = buildCubit();
+
+    final refreshing = cubit.refreshPendingStatuses();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(given.isCancelled, isFalse, reason: 'nothing has happened yet');
+
+    await cubit.close();
+
+    expect(
+      given.isCancelled,
+      isTrue,
+      reason: 'the write has to be told to stop before the tables are emptied',
+    );
+
+    released.complete();
+
+    // And it reports nothing, because the wallet it was about is gone.
+    expect(await refreshing, isFalse);
   });
 }


### PR DESCRIPTION
Two independent things a returning or brand-new user sees, both found in staging.

## Telling a returning reader what changed

Coming back to an existing session restores everything from the local database and syncs nothing, which is right - IndexedDB survives a closed tab, so counts, sizes and block heights are all still there, and `autoSync` is false in every flavour. The cost is that nothing on the page says how old any of it is. Close the tab on Tuesday, come back on Friday, and Tuesday's file counts are drawn with exactly the confidence of current ones. The only cue is a `Last synced` cell you have to read and do arithmetic on.

The one prompt this page has is gated on `nothingHasEverBeenSynced` - *every* drive unwalked - so it only ever fires on a first login. Returning readers get silence.

So: one query, at the exact moment the app currently goes quiet (the "nothing owed" branch of `_syncOnlyIfThereIsWork`). `probeActiveDriveIds` already exists and the sync already uses it to skip unchanged drives; the new `probeDrivesWithChanges` runs the same per-owner query read-only - it writes nothing, touches no sync state and starts no sync. If drives have moved, a neutral notice above the table names how many and offers to sync **only those**. If nothing moved, nothing is said.

An unanswerable probe also says nothing. That is deliberately the opposite of the fallback inside a sync, where `isComplete: false` means *sync everything*: there the cost of guessing wrong is a slower sync, here it would be a banner claiming changes nobody has confirmed, which is a nag.

Two bugs surfaced while testing it, both mine:

- `close()` shuts the subject down before it awaits its way to `super.close()`, so there is a window where `isClosed` is still false and adding throws `Cannot add new events after calling close` - out of an un-awaited future, where nothing catches it. Now guarded on the subject, not the cubit.
- The failure swallow lived in the repository, leaving the cubit's fire-and-forget call unprotected: an exception there was an unhandled async error rather than a failed request. Now caught at the boundary that is actually un-awaited.

## The new drive's two offers

On "You're on chain!" the buttons were `ButtonVariant.secondary`, which on the dark card is `solidGrey700` against a `solidGrey800` background - while the **disabled** token is `solidGrey600`. The button that worked was less prominent than one that would not, which is a fair description of "doesn't look clickable". Both are primary now. This page has exactly two cards and its whole job is to get one of them pressed, so two primaries is the design rather than a competition.

On a phone those two offers were 283px squares stacked under a heading and a paragraph: **239px of scroll on a 375x667 screen, with Create Folder at y=866** - two hundred pixels below the fold, on the one page whose job is to say "well done, now do one of these two things". Laid on their side they take about 130px each and the whole page is visible at once.

The `SingleChildScrollView` stays: at a large enough text scale something has to give, and a page that scrolls degrades better than one that overflows.

The four-card empty states are deliberately left alone. They have the same grey-on-grey problem, but four red buttons is a wall rather than a fix.

## Testing

13 new tests. The phone layout is *measured* rather than asserted - `maxScrollExtent` is 0 and both buttons are proven on screen; removing the fix puts the numbers back to 239px and y=866. The two withdrawal guards on the notice were each checked by deleting them and confirming the matching test fails.

Full suite green (2075 passing), `flutter analyze lib test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ndA5nwUpt9hGLUx2TAFr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Drives now show unread network changes and offer targeted syncing.
  - Drive lists display available file counts and sizes before a full scan completes.
  - Pending uploads can be rechecked from the file menu.
  - Mobile drive search is now accessed from the app bar.
  - Sync status is refreshed when no other sync is running.

- **Style**
  - Improved new-drive empty states with compact mobile actions and clearer primary buttons.

- **Tests**
  - Added coverage for unread changes, targeted syncing, upload status refreshes, search access, and responsive layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->