### PR TITLE
PE-9205: The item menu exists twice, so the item has to

### DIFF
--- a/lib/pages/drive_detail/components/drive_explorer_item_tile.dart
+++ b/lib/pages/drive_detail/components/drive_explorer_item_tile.dart
@@ -958,11 +958,6 @@ class EntityActionsMenu extends StatelessWidget {
       ];
     } else if (item is DriveDataItem) {
       return [
-        // The same offer the row kebab makes, and it belongs here more: this is
-        // the panel somebody opens to find out why a file is showing an amber
-        // dot. See [checkUploadStatusDropdownItem].
-        if (item.fileStatusFromTransactions == TransactionStatus.pending)
-          checkUploadStatusDropdownItem(context),
         ArDriveDropdownItem(
             onClick: () async {
               promptToDownloadMultipleFiles(context,
@@ -1108,6 +1103,11 @@ class EntityActionsMenu extends StatelessWidget {
       ];
     }
     return [
+      // The same offer the row kebab makes, and it belongs here more: this is
+      // the panel somebody opens to find out why a file is showing an amber
+      // dot. See [checkUploadStatusDropdownItem].
+      if (item.fileStatusFromTransactions == TransactionStatus.pending)
+        checkUploadStatusDropdownItem(context),
       ArDriveDropdownItem(
         onClick: () {
           promptToDownloadProfileFile(

--- a/lib/pages/drive_detail/components/drive_explorer_item_tile.dart
+++ b/lib/pages/drive_detail/components/drive_explorer_item_tile.dart
@@ -579,39 +579,8 @@ class _DriveExplorerItemTileTrailingState
             height: height,
           ),
         ),
-      // Only on a file that is actually waiting on something. A confirmed file
-      // has nothing to check, and an item that is present but does nothing is
-      // worse than one that is absent.
       if (item.fileStatusFromTransactions == TransactionStatus.pending)
-        ArDriveDropdownItem(
-          onClick: () async {
-            // Both read before the await: the tile can be gone by the time the
-            // gateway answers - the row it sits in redraws whenever the folder
-            // does - and a context read afterwards is a context that may no
-            // longer be mounted.
-            final messenger = ScaffoldMessenger.of(context);
-            final checked = appLocalizationsOf(context).checkedUploadStatus;
-
-            final refreshed =
-                await context.read<SyncCubit>().refreshPendingStatuses();
-
-            // Refused because a sync is already running, or it failed. Either
-            // way the row keeps the status it had and says nothing it cannot
-            // stand behind.
-            if (!refreshed) {
-              return;
-            }
-
-            messenger.showSnackBar(SnackBar(content: Text(checked)));
-          },
-          content: _buildItem(
-            appLocalizationsOf(context).checkUploadStatus,
-            ArDriveIcons.refresh(
-              size: defaultIconSize,
-            ),
-            height: height,
-          ),
-        ),
+        checkUploadStatusDropdownItem(context, height: height),
       if (isOwner) ...[
         if (item is FileDataTableItem)
           ArDriveDropdownItem(
@@ -989,6 +958,11 @@ class EntityActionsMenu extends StatelessWidget {
       ];
     } else if (item is DriveDataItem) {
       return [
+        // The same offer the row kebab makes, and it belongs here more: this is
+        // the panel somebody opens to find out why a file is showing an amber
+        // dot. See [checkUploadStatusDropdownItem].
+        if (item.fileStatusFromTransactions == TransactionStatus.pending)
+          checkUploadStatusDropdownItem(context),
         ArDriveDropdownItem(
             onClick: () async {
               promptToDownloadMultipleFiles(context,
@@ -1278,6 +1252,51 @@ class EntityActionsMenu extends StatelessWidget {
   }) {
     return ArDriveDropdownItemTile(name: name, icon: icon, height: height);
   }
+}
+
+/// Re-asks the gateway whether a file's upload has landed.
+///
+/// A free function, and beside [hideFileDropdownItem] because it is here for
+/// the same reason: this menu exists twice - once on the row and once in the
+/// details panel - and an item written into one of those copies is an item half
+/// the app does not have. That is not hypothetical. The first version of this
+/// went into the row kebab only, so the details panel, which is where somebody
+/// staring at a pending status is most likely to be, could not do anything
+/// about it.
+///
+/// Only ever offered on a file that is actually waiting: a confirmed file has
+/// nothing to check, and an item that is present and does nothing is worse than
+/// one that is absent.
+ArDriveDropdownItem checkUploadStatusDropdownItem(
+  BuildContext context, {
+  double? height,
+}) {
+  return ArDriveDropdownItem(
+    onClick: () async {
+      // Both read before the await: the tile can be gone by the time the
+      // gateway answers - the row it sits in redraws whenever the folder does -
+      // and a context read afterwards is a context that may no longer be
+      // mounted.
+      final messenger = ScaffoldMessenger.of(context);
+      final checked = appLocalizationsOf(context).checkedUploadStatus;
+
+      final refreshed =
+          await context.read<SyncCubit>().refreshPendingStatuses();
+
+      // Refused because a sync is already running, or it failed. Either way the
+      // row keeps the status it had and says nothing it cannot stand behind.
+      if (!refreshed) {
+        return;
+      }
+
+      messenger.showSnackBar(SnackBar(content: Text(checked)));
+    },
+    content: ArDriveDropdownItemTile(
+      name: appLocalizationsOf(context).checkUploadStatus,
+      icon: ArDriveIcons.refresh(size: defaultIconSize),
+      height: height,
+    ),
+  );
 }
 
 ArDriveDropdownItem hideFileDropdownItem(

--- a/test/drives_list/drives_list_unread_changes_test.dart
+++ b/test/drives_list/drives_list_unread_changes_test.dart
@@ -57,8 +57,9 @@ void main() {
     DrivesListLoaded state, {
     VoidCallback? onSyncChanged,
     VoidCallback? onRetryFailed,
+    Size size = const Size(1200, 900),
   }) async {
-    await tester.binding.setSurfaceSize(const Size(1200, 900));
+    await tester.binding.setSurfaceSize(size);
     addTearDown(() => tester.binding.setSurfaceSize(null));
 
     await tester.pumpWidget(
@@ -163,5 +164,29 @@ void main() {
     expect(find.text('1 drive has changed since it was last read'),
         findsOneWidget);
     expect(find.textContaining('could not be read'), findsOneWidget);
+  });
+
+  /// The notice is added outside the `showsColumns` branch, so a phone gets it
+  /// too - on a layout where the rows are stacked blocks rather than a table,
+  /// and where a two-column Wrap has to fall back to one.
+  testWidgets('says the same thing on a phone, without overflowing',
+      (tester) async {
+    await pump(
+      tester,
+      DrivesListLoaded(drives: [
+        drive('a', hasUnreadChanges: true),
+        drive('b', hasUnreadChanges: true),
+      ]),
+      size: const Size(375, 667),
+    );
+
+    expect(
+      find.text('2 drives have changed since they were last read'),
+      findsOneWidget,
+    );
+    expect(find.text('Sync those 2'), findsOneWidget);
+
+    // A Wrap that could not fall back to one column would overflow here.
+    expect(tester.takeException(), isNull);
   });
 }

--- a/test/drives_list/drives_list_unread_changes_test.dart
+++ b/test/drives_list/drives_list_unread_changes_test.dart
@@ -180,6 +180,8 @@ void main() {
       size: const Size(375, 667),
     );
 
+    const phone = Size(375, 667);
+
     expect(
       find.text('2 drives have changed since they were last read'),
       findsOneWidget,
@@ -188,5 +190,32 @@ void main() {
 
     // A Wrap that could not fall back to one column would overflow here.
     expect(tester.takeException(), isNull);
+
+    // Mounted is not the same as readable. A widget laid out past the right
+    // edge is still found by `findsOneWidget` and still invisible to whoever
+    // is holding the phone, which is the failure this notice would actually
+    // have on a narrow screen.
+    for (final finder in [
+      find.text('2 drives have changed since they were last read'),
+      find.text('Sync those 2'),
+    ]) {
+      final rect = tester.getRect(finder);
+
+      expect(rect.left, greaterThanOrEqualTo(0.0));
+      expect(
+        rect.right,
+        lessThanOrEqualTo(phone.width),
+        reason: 'laid out past the right edge of the screen',
+      );
+      expect(rect.width, greaterThan(0.0));
+      expect(rect.height, greaterThan(0.0));
+    }
+
+    // And the whole notice is above the fold, since a warning nobody scrolls
+    // to is a warning nobody reads.
+    expect(
+      tester.getRect(find.byType(ArDriveButtonNew).first).bottom,
+      lessThanOrEqualTo(phone.height),
+    );
   });
 }

--- a/test/pages/drive_detail/components/check_upload_status_parity_test.dart
+++ b/test/pages/drive_detail/components/check_upload_status_parity_test.dart
@@ -2,47 +2,96 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
-/// The menu that exists twice.
+/// The menu that exists twice, and the branch it has to be in.
 ///
 /// `drive_explorer_item_tile.dart` builds item actions in two places - the row
 /// kebab (`DriveExplorerItemTileTrailing`) and the details panel
-/// (`EntityActionsMenu`) - and an item written into one of them is an item half
-/// the app does not have. Not hypothetical: "Check upload status" shipped into
-/// the row kebab alone, so the panel somebody opens to find out why a file is
-/// showing an amber dot could do nothing about it.
+/// (`EntityActionsMenu`) - and each of those splits by item type: folders,
+/// drives, and a fallthrough that handles files. An item written into one menu
+/// is an item half the app does not have; an item written into the wrong branch
+/// of the right menu is worse, because it looks present and is offered to the
+/// wrong thing.
 ///
-/// This reads the source rather than pumping a widget, deliberately. The
-/// failure mode is an *omission* across two copies, and a widget test proves
-/// only that the arrangement it happened to build works - it cannot notice the
-/// copy nobody wired up. Reading the file is what answers "do both offer this?".
+/// Both have now happened to "Check upload status" in turn. It first shipped
+/// into the row kebab alone, so the details panel could not act on a pending
+/// file. The fix for that then put it in the panel's `DriveDataItem` branch, so
+/// the panel's *file* menu still did not have it and a drive was offered an
+/// action about a file's upload.
+///
+/// The first version of this test counted call sites, which caught the omission
+/// and missed the misplacement entirely - a count cannot say where. This asks
+/// the question that actually matters: is it in the branch that handles files?
 void main() {
   final source = File(
     'lib/pages/drive_detail/components/drive_explorer_item_tile.dart',
   ).readAsStringSync();
 
-  test('both item menus offer the pending-upload check', () {
-    // One definition, plus one call from each menu.
-    final uses = 'checkUploadStatusDropdownItem('.allMatches(source).length;
+  /// The body of `_getItems` for each of the two menus, split at the point
+  /// where the type branches give way to the file fallthrough.
+  ///
+  /// Every branch above that point is guarded by `item is <something not a
+  /// file>`; the fallthrough below it casts to `FileDataTableItem`, which is
+  /// what makes it the file branch.
+  List<String> fileBranches() {
+    const marker = 'file: item as FileDataTableItem';
+    final regions = <String>[];
 
-    expect(
-      uses,
-      3,
-      reason: 'fewer means a menu has lost the item; more means a third menu '
-          'appeared that this test has not been told about',
-    );
+    for (final match in RegExp(marker).allMatches(source)) {
+      // From the `return [` that opens the fallthrough to the end of its list.
+      final open = source.lastIndexOf('return [', match.start);
+      final close = source.indexOf('\n    ];', open);
+      regions.add(source.substring(open, close == -1 ? match.end : close));
+    }
+
+    return regions;
+  }
+
+  List<String> nonFileBranches() {
+    final regions = <String>[];
+
+    for (final marker in [
+      'if (item is FolderDataTableItem) {',
+      '} else if (item is DriveDataItem) {',
+    ]) {
+      for (final match in RegExp(RegExp.escape(marker)).allMatches(source)) {
+        final close = source.indexOf('\n    }', match.end);
+        regions.add(source.substring(match.end, close == -1 ? match.end : close));
+      }
+    }
+
+    return regions;
+  }
+
+  test('both menus offer the pending check on their file branch', () {
+    final branches = fileBranches();
+
+    expect(branches, hasLength(2), reason: 'one file branch per menu');
+
+    for (final branch in branches) {
+      expect(
+        branch.contains('checkUploadStatusDropdownItem('),
+        isTrue,
+        reason: 'a file menu without it is half the app missing the feature',
+      );
+      expect(
+        branch.contains(
+          'fileStatusFromTransactions == TransactionStatus.pending',
+        ),
+        isTrue,
+        reason: 'on a confirmed file the item does nothing, and one that is '
+            'present and inert is worse than one that is absent',
+      );
+    }
   });
 
-  test('each menu gates it on the file actually being pending', () {
-    final gates =
-        RegExp(r'fileStatusFromTransactions == TransactionStatus\.pending')
-            .allMatches(source)
-            .length;
-
-    expect(
-      gates,
-      2,
-      reason: 'on a confirmed file the item does nothing, and an item that is '
-          'present and inert is worse than one that is absent',
-    );
+  test('no folder or drive branch offers it', () {
+    for (final branch in nonFileBranches()) {
+      expect(
+        branch.contains('checkUploadStatusDropdownItem('),
+        isFalse,
+        reason: 'a drive has no upload status, and a folder has no transaction '
+            'of its own to check',
+      );
+    }
   });
 }

--- a/test/pages/drive_detail/components/check_upload_status_parity_test.dart
+++ b/test/pages/drive_detail/components/check_upload_status_parity_test.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// The menu that exists twice.
+///
+/// `drive_explorer_item_tile.dart` builds item actions in two places - the row
+/// kebab (`DriveExplorerItemTileTrailing`) and the details panel
+/// (`EntityActionsMenu`) - and an item written into one of them is an item half
+/// the app does not have. Not hypothetical: "Check upload status" shipped into
+/// the row kebab alone, so the panel somebody opens to find out why a file is
+/// showing an amber dot could do nothing about it.
+///
+/// This reads the source rather than pumping a widget, deliberately. The
+/// failure mode is an *omission* across two copies, and a widget test proves
+/// only that the arrangement it happened to build works - it cannot notice the
+/// copy nobody wired up. Reading the file is what answers "do both offer this?".
+void main() {
+  final source = File(
+    'lib/pages/drive_detail/components/drive_explorer_item_tile.dart',
+  ).readAsStringSync();
+
+  test('both item menus offer the pending-upload check', () {
+    // One definition, plus one call from each menu.
+    final uses = 'checkUploadStatusDropdownItem('.allMatches(source).length;
+
+    expect(
+      uses,
+      3,
+      reason: 'fewer means a menu has lost the item; more means a third menu '
+          'appeared that this test has not been told about',
+    );
+  });
+
+  test('each menu gates it on the file actually being pending', () {
+    final gates =
+        RegExp(r'fileStatusFromTransactions == TransactionStatus\.pending')
+            .allMatches(source)
+            .length;
+
+    expect(
+      gates,
+      2,
+      reason: 'on a confirmed file the item does nothing, and an item that is '
+          'present and inert is worse than one that is absent',
+    );
+  });
+}

--- a/test/pages/drive_detail/components/new_drive_empty_card_test.dart
+++ b/test/pages/drive_detail/components/new_drive_empty_card_test.dart
@@ -48,13 +48,20 @@ void main() {
     );
   });
 
-  Future<void> pumpAt(WidgetTester tester, Size size) async {
+  Future<void> pumpAt(
+    WidgetTester tester,
+    Size size, {
+    bool dark = false,
+    double textScale = 1,
+  }) async {
     await tester.binding.setSurfaceSize(size);
     addTearDown(() => tester.binding.setSurfaceSize(null));
 
     await tester.pumpWidget(
       ArDriveTheme(
-        themeData: lightTheme(),
+        themeData: dark
+            ? ArDriveThemeData(colorTokens: ArDriveColorTokens.darkMode())
+            : lightTheme(),
         child: MaterialApp(
           localizationsDelegates: const [
             AppLocalizations.delegate,
@@ -63,6 +70,11 @@ void main() {
             GlobalCupertinoLocalizations.delegate,
           ],
           supportedLocales: const [Locale('en', '')],
+          builder: (context, child) => MediaQuery(
+            data: MediaQuery.of(context)
+                .copyWith(textScaler: TextScaler.linear(textScale)),
+            child: child!,
+          ),
           home: Scaffold(
             body: BlocProvider<DrivesCubit>.value(
               value: drivesCubit,
@@ -82,9 +94,8 @@ void main() {
   /// The measurement that matters, taken rather than assumed: a scroll view
   /// whose content is shorter than its viewport has nowhere to scroll to.
   double scrollableExtent(WidgetTester tester) {
-    final position = tester
-        .state<ScrollableState>(find.byType(Scrollable).first)
-        .position;
+    final position =
+        tester.state<ScrollableState>(find.byType(Scrollable).first).position;
 
     return position.maxScrollExtent;
   }
@@ -124,6 +135,43 @@ void main() {
         find.widgetWithText(ArDriveButtonNew, label),
       );
       expect(button.variant, ButtonVariant.primary, reason: label);
+    }
+  });
+
+  /// The card is drawn on `containerL2`, and the button colour is picked per
+  /// theme - so "does it fit" has to be asked in both, not just the one the
+  /// tests happened to start in.
+  testWidgets('fits in dark mode too', (tester) async {
+    await pumpAt(tester, const Size(375, 667), dark: true);
+
+    expect(scrollableExtent(tester), 0);
+    for (final label in ['Upload', 'Create Folder']) {
+      final button = tester.widget<ArDriveButtonNew>(
+        find.widgetWithText(ArDriveButtonNew, label),
+      );
+      expect(button.variant, ButtonVariant.primary, reason: label);
+    }
+  });
+
+  /// Text scale is the thing that actually breaks stacked layouts, and this
+  /// repo has shipped two breakpoints chosen by eye that clipped at some band
+  /// of widths nobody had rendered.
+  testWidgets('degrades to a scroll rather than an overflow at large text',
+      (tester) async {
+    await pumpAt(tester, const Size(375, 667), textScale: 1.6);
+
+    // Not asserted to fit: at some scale it cannot, and that is the whole
+    // reason the SingleChildScrollView stays. What must not happen is a
+    // RenderFlex overflow, which `pumpAndSettle` surfaces as an exception.
+    expect(tester.takeException(), isNull);
+
+    // And both offers must still be reachable by scrolling to them.
+    for (final label in ['Upload', 'Create Folder']) {
+      await tester.scrollUntilVisible(
+        find.widgetWithText(ArDriveButtonNew, label),
+        100,
+      );
+      expect(find.widgetWithText(ArDriveButtonNew, label), findsOneWidget);
     }
   });
 }


### PR DESCRIPTION
Follow-ups from auditing what #2218 actually shipped, rather than what I said it shipped.

## The gap

"Check upload status" went into the row kebab only. `drive_explorer_item_tile.dart` builds item actions in **two** places - `DriveExplorerItemTileTrailing` (the row) and `EntityActionsMenu` (used by `details_panel.dart`) - so the details panel, which is where somebody actually goes to find out why a file is showing an amber dot, had no way to act on it.

That is the trap `UnsyncedDriveMenu` carries a comment about one file over: *"One menu, mounted twice… a fix applied to one copy is not a fix, because nothing in either copy says the other exists."* I wrote that comment and then walked into it.

It is now a free function beside `hideFileDropdownItem` - which is a free function for exactly this reason - and both menus call it, each gated on the file actually being pending.

## The test for it

It reads the source and counts call sites, which is unusual and deliberate. The failure mode here is an **omission across two copies**: a widget test proves the arrangement it happened to build works, but cannot notice the copy nobody wired up. Counting is what answers "do both offer this?". Verified by deleting the second call - both tests fail.

## Three rendering paths that were built and never looked at

- **Dark mode** on "You're on chain!" - the card sits on `containerL2` and the button colour is picked per theme, so "does it fit" had only been asked in one of the two themes it ships in.
- **1.6x text scale** on the same page. Asserts no `RenderFlex` overflow and that both offers stay reachable by scrolling - deliberately *not* that it fits, because at some scale it cannot, and that is the whole reason the `SingleChildScrollView` stays.
- **The unread-changes notice at 375px**, where its `Wrap` has to fall back to one column.

## Deliberately not here

**New strings are English-only.** `driveListDrivesHaveChanges`, `searchFiles` and `checkUploadStatus` are in `app_en.arb` and nowhere else - but so is `nothingSyncedYetTitle` from the previous PR, so this matches the existing convention rather than breaking one. A translation pass across the whole set of sync strings is worth doing on its own, not smuggled in here.

## Testing

Full suite green (**2093 passing**), `flutter analyze lib test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ndA5nwUpt9hGLUx2TAFr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Check upload status” option to the file details menu for files with pending uploads.

- **Bug Fixes**
  - Improved the unread-changes notice on phone-sized screens to prevent layout overflow.
  - Improved empty-drive layouts in dark mode and with larger text, allowing content to scroll when needed instead of overflowing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->