### PR TITLE
PE-9205: Search on All Drives, and three things that read wrong

### DIFF
--- a/lib/app_shell.dart
+++ b/lib/app_shell.dart
@@ -315,7 +315,10 @@ const double mobileAppBarIconSize = _mobileAppBarIconSize;
 /// modal owns the text while it is open and there is nothing to remember once
 /// it closes.
 class _MobileSearchButton extends StatelessWidget {
-  const _MobileSearchButton();
+  const _MobileSearchButton({this.onNavigateToFolder});
+
+  /// See [MobileAppBar.onSearchNavigateToFolder].
+  final void Function(String driveId, String folderId)? onNavigateToFolder;
 
   @override
   Widget build(BuildContext context) {
@@ -334,6 +337,7 @@ class _MobileSearchButton extends StatelessWidget {
           driveDetailCubit: context.read<DriveDetailCubit>(),
           drivesCubit: context.read<DrivesCubit>(),
           controller: TextEditingController(),
+          onNavigateToFolder: onNavigateToFolder,
         );
       },
     );
@@ -346,6 +350,7 @@ class MobileAppBar extends StatelessWidget implements PreferredSizeWidget {
     this.leading,
     this.showDrawerButton = true,
     this.showSearch = false,
+    this.onSearchNavigateToFolder,
   });
 
   final Widget? leading;
@@ -360,6 +365,15 @@ class MobileAppBar extends StatelessWidget implements PreferredSizeWidget {
   /// that offered search everywhere would be offering it where it could only
   /// disappoint.
   final bool showSearch;
+
+  /// How a search result reaches its folder from this screen.
+  ///
+  /// Null on the explorer, where the modal's own `DriveDetailCubit` is
+  /// long-lived and can be told to open a folder in another drive. The drives
+  /// list passes one, because selecting a drive there replaces the subtree and
+  /// tears that cubit down mid-navigation. See [FileSearchModal.onNavigateToFolder].
+  final void Function(String driveId, String folderId)?
+      onSearchNavigateToFolder;
 
   @override
   // Its own row and nothing else. Nothing about a sync is laid out here: a
@@ -424,7 +438,9 @@ class MobileAppBar extends StatelessWidget implements PreferredSizeWidget {
               // give; as an icon it takes the space that was already empty
               // here.
               if (showSearch) ...[
-                const _MobileSearchButton(),
+                _MobileSearchButton(
+                  onNavigateToFolder: onSearchNavigateToFolder,
+                ),
                 const SizedBox(width: 8),
               ],
               const GlobalHideToggleButton(),

--- a/lib/components/side_bar.dart
+++ b/lib/components/side_bar.dart
@@ -572,7 +572,10 @@ class DriveListTile extends StatelessWidget {
     final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
 
     return GestureDetector(
-      key: key,
+      // Not `key: key`. The widget already carries its own key through
+      // `super.key`, so forwarding it here put the same key on two elements -
+      // harmless for a ValueKey, and an outright duplicate-GlobalKey assertion
+      // the moment anything needs to find this tile in the tree.
       onTap: onTap,
       child: Container(
         decoration: isSelected
@@ -899,14 +902,83 @@ Future<void> showSupportModal({
   );
 }
 
-class _Accordion extends StatelessWidget {
+/// The drive list, and the one piece of behaviour it owes a reader: when the
+/// selection moves, show them where it went.
+///
+/// Both sections ship expanded, so a wallet with a long public list pushes the
+/// private one below the fold. Opening a private drive from the drives list then
+/// highlighted a row nobody could see, which reads as nothing having happened.
+///
+/// Scrolling to it rather than collapsing the other section, deliberately: a
+/// reader who wanted their public drives hidden would have collapsed that
+/// section themselves, and closing it for them is the app moving furniture
+/// around while they are using it. Nothing is hidden; the selection is simply
+/// brought into view.
+class _Accordion extends StatefulWidget {
   const _Accordion({required this.state, required this.isMobile});
 
   final DrivesLoadSuccess state;
   final bool isMobile;
 
   @override
+  State<_Accordion> createState() => _AccordionState();
+}
+
+class _AccordionState extends State<_Accordion> {
+  /// Carried by whichever tile is selected, so it can be scrolled to.
+  final GlobalKey _selectedTileKey = GlobalKey();
+
+  /// What the last scroll was for.
+  ///
+  /// The selection is read on every rebuild - a sync tick alone causes several -
+  /// and scrolling on each of those would drag the list back under a reader who
+  /// was scrolling it themselves. Only a *change* is worth moving for.
+  String? _scrolledFor;
+
+  @override
+  void initState() {
+    super.initState();
+    // The selection a reader arrives with is not one they watched move, so
+    // there is nothing to show them about it.
+    _scrolledFor = widget.state.selectedDriveId;
+  }
+
+  @override
+  void didUpdateWidget(_Accordion oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    final selected = widget.state.selectedDriveId;
+
+    if (selected == null || selected == _scrolledFor) {
+      return;
+    }
+
+    _scrolledFor = selected;
+
+    // After the frame, because the tile for a newly selected drive may not be
+    // laid out yet - and it has no context at all if the reader has collapsed
+    // the section holding it, which is the one case where doing nothing is
+    // right.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final context = _selectedTileKey.currentContext;
+
+      if (context == null || !mounted) {
+        return;
+      }
+
+      Scrollable.ensureVisible(
+        context,
+        alignment: 0.5,
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeOut,
+      );
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final state = widget.state;
+    final isMobile = widget.isMobile;
     final typography = ArDriveTypographyNew.of(context);
     final colorTokens = ArDriveTheme.of(context).themeData.colorTokens;
 
@@ -935,6 +1007,9 @@ class _Accordion extends StatelessWidget {
                     })
                     .map(
                       (d) => DriveListTile(
+                        key: state.selectedDriveId == d.id
+                            ? _selectedTileKey
+                            : null,
                         hasAlert: state.drivesWithAlerts.contains(d.id),
                         drive: d,
                         onTap: () {
@@ -977,6 +1052,9 @@ class _Accordion extends StatelessWidget {
                     })
                     .map(
                       (d) => DriveListTile(
+                        key: state.selectedDriveId == d.id
+                            ? _selectedTileKey
+                            : null,
                         hasAlert: state.drivesWithAlerts.contains(d.id),
                         drive: d,
                         onTap: () {
@@ -1004,6 +1082,9 @@ class _Accordion extends StatelessWidget {
                 state.sharedDrives
                     .map(
                       (d) => DriveListTile(
+                        key: state.selectedDriveId == d.id
+                            ? _selectedTileKey
+                            : null,
                         hasAlert: state.drivesWithAlerts.contains(d.id),
                         drive: d,
                         onTap: () {

--- a/lib/drives_list/presentation/drives_list_page.dart
+++ b/lib/drives_list/presentation/drives_list_page.dart
@@ -1,3 +1,7 @@
+import 'package:ardrive/blocs/drive_detail/drive_detail_cubit.dart';
+import 'package:ardrive/pages/app_router_delegate.dart';
+import 'package:ardrive/search/search_modal.dart';
+import 'package:ardrive/search/search_text_field.dart';
 import 'package:ardrive/drives_list/domain/drive_list_sort.dart';
 import 'package:ardrive/drives_list/presentation/drive_scope_empty.dart';
 import 'package:ardrive/drives_list/presentation/drives_sync_menu.dart';
@@ -227,7 +231,12 @@ class _DrivesListChrome extends StatelessWidget {
                 .themeBgSurface
                 .withOpacity(0.5),
             drawer: const AppSideBar(),
-            appBar: const MobileAppBar(),
+            appBar: MobileAppBar(
+              showSearch: true,
+              onSearchNavigateToFolder: (driveId, folderId) => context
+                  .read<AppRouterDelegate>()
+                  .requestFolder(driveId, folderId),
+            ),
             body: body,
           ),
           desktop: (context) => Padding(
@@ -235,13 +244,27 @@ class _DrivesListChrome extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                const Row(
+                Row(
                   mainAxisAlignment: MainAxisAlignment.end,
                   children: [
-                    SyncButton(),
-                    SizedBox(width: 8),
-                    SizedBox(width: 8),
-                    ProfileCard(),
+                    // Search is global - `DriveDao.search` takes no drive id -
+                    // so this page had no business being the one screen without
+                    // it. Capped and pushed left of the controls, the same shape
+                    // the explorer's top bar gives it.
+                    Expanded(
+                      child: Align(
+                        alignment: Alignment.centerLeft,
+                        child: ConstrainedBox(
+                          constraints: const BoxConstraints(maxWidth: 400),
+                          child: const _DrivesListSearchField(),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 24),
+                    const SyncButton(),
+                    const SizedBox(width: 8),
+                    const SizedBox(width: 8),
+                    const ProfileCard(),
                   ],
                 ),
                 const SizedBox(height: _sectionGap),
@@ -249,6 +272,53 @@ class _DrivesListChrome extends StatelessWidget {
               ],
             ),
           ),
+        );
+      },
+    );
+  }
+}
+
+/// Global search, on the one page that did not have it.
+///
+/// The field is the explorer's, and so is the sheet it opens. What differs is
+/// how a result is reached: the explorer hands the modal its own long-lived
+/// `DriveDetailCubit`, which can be told to open a folder in another drive. Here
+/// selecting a drive replaces the whole subtree, so that cubit is torn down
+/// mid-navigation - hence [AppRouterDelegate.requestFolder], which asks for the
+/// folder before the selection that carries it.
+class _DrivesListSearchField extends StatefulWidget {
+  const _DrivesListSearchField();
+
+  @override
+  State<_DrivesListSearchField> createState() => _DrivesListSearchFieldState();
+}
+
+class _DrivesListSearchFieldState extends State<_DrivesListSearchField> {
+  final TextEditingController _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SearchTextField(
+      controller: _controller,
+      onFieldSubmitted: (query) {
+        if (query.isEmpty) {
+          return;
+        }
+
+        showSearchModalDesktop(
+          context: context,
+          driveDetailCubit: context.read<DriveDetailCubit>(),
+          drivesCubit: context.read<DrivesCubit>(),
+          controller: _controller,
+          onNavigateToFolder: (driveId, folderId) => context
+              .read<AppRouterDelegate>()
+              .requestFolder(driveId, folderId),
         );
       },
     );

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -795,9 +795,9 @@
   "@nothingSyncedYetSyncingTitle": {
     "description": "Replaces nothingSyncedYetTitle while a sync is actually running, so the card does not offer work that is already under way beside a strip reporting it"
   },
-  "nothingSyncedYetSyncingDescription": "Each row will say what it holds as it arrives.",
+  "nothingSyncedYetSyncingDescription": "Large drives can take a few minutes.",
   "@nothingSyncedYetSyncingDescription": {
-    "description": "Replaces nothingSyncedYetDescription while a sync is running. It also explains the disabled button beside it"
+    "description": "Replaces nothingSyncedYetDescription while a sync is running. It also explains the disabled button beside it. Sets the expectation rather than narrating the interface: it read 'Each row will say what it holds as it arrives', which told the reader to go and watch something instead of saying the one thing the screen could not - how long this takes"
   },
   "nothingSyncedYetDescription": "Their contents have not been fetched yet.",
   "@nothingSyncedYetDescription": {
@@ -2622,7 +2622,7 @@
   "@sharedFileVersionLatest": {
     "description": "Chip marking the newest version in the recipient's version list"
   },
-  "sharedFileVersionPinned": "Pinned",
+  "sharedFileVersionPinned": "This version",
   "@sharedFileVersionPinned": {
     "description": "Chip marking the version a pinned share link deliberately points at, as opposed to merely the version the link carried"
   },

--- a/lib/pages/app_router_delegate.dart
+++ b/lib/pages/app_router_delegate.dart
@@ -395,8 +395,8 @@ class AppRouterDelegate extends RouterDelegate<AppRoutePath>
                                         driveDetailCubitState.currentDrive,
                                         (_) => null,
                                         0,
-                                        driveDetailCubitState.currentDrive
-                                                .ownerAddress ==
+                                        driveDetailCubitState
+                                                .currentDrive.ownerAddress ==
                                             context
                                                 .read<ArDriveAuth>()
                                                 .currentUser
@@ -615,6 +615,24 @@ class AppRouterDelegate extends RouterDelegate<AppRoutePath>
   /// before the selection rather than threaded through it.
   void requestDriveInfo(String driveId) {
     _pendingInfoDriveId = driveId;
+  }
+
+  /// Asks for a drive to open at a particular folder, once it is selected.
+  ///
+  /// The road a search result takes off the drives list. The explorer navigates
+  /// a result by calling `openFolder` on its own `DriveDetailCubit`, which works
+  /// there because that cubit is long-lived and switches drives underneath the
+  /// page. On the drives list it is not: selecting a drive replaces the whole
+  /// subtree, so the cubit the modal was handed is torn down mid-navigation and
+  /// the reader lands at the drive root instead of the file they searched for.
+  ///
+  /// Set before the selection, like [requestDriveInfo], and honoured by
+  /// [onDriveSelected] when that drive arrives. One shot, so navigating away and
+  /// back lands at the root rather than jumping to a folder somebody visited
+  /// once.
+  void requestFolder(String driveId, String folderId) {
+    _pendingFolderDriveId = driveId;
+    _pendingFolderId = folderId;
   }
 
   @visibleForTesting

--- a/lib/pages/shared_file/shared_file_ready_view.dart
+++ b/lib/pages/shared_file/shared_file_ready_view.dart
@@ -1277,10 +1277,16 @@ class _SharedFileVersionRow extends StatelessWidget {
 
     final hasDate = !SharedFileCubit.isUnknownDate(revision.dateCreated);
 
-    // "Pinned" says the sharer chose this version; "This link" says only that
-    // the link carried it. On a pinned link the first is the fact worth
-    // knowing, and it is what makes the way back obvious after selecting
+    // "This version" says the sharer aimed the link at this one; "Shared" says
+    // only that the link carried it. On a pinned link the first is the fact
+    // worth knowing, and it is what makes the way back obvious after selecting
     // something else.
+    //
+    // It read "Pinned" until this was the third meaning of that word in one
+    // product: ArDrive's own File Pin brings a permaweb file into a drive, IPFS
+    // pinning is what many readers arrive already knowing, and neither is this.
+    // A link fixed to one version is best described as the version you are
+    // looking at.
     final label = isFromLink
         ? (isPinned
             ? appLocalizationsOf(context).sharedFileVersionPinned
@@ -1351,7 +1357,13 @@ class _SharedFileVersionRow extends StatelessWidget {
               // same thing, and on a phone that is what pushes it over.
               if (hasDate && label != null) ...[
                 const SizedBox(width: 8),
-                _VersionChip(label),
+                // Flexible, because the chip is the only thing in this row that
+                // could not give. The date is Expanded and the size is short and
+                // numeric, so a longer label pushed the row straight over the
+                // edge - renaming "Pinned" to "This version" overflowed it by
+                // eleven pixels. Any translation would have done the same, so
+                // this is the fix rather than a shorter word.
+                Flexible(child: _VersionChip(label)),
               ],
             ],
           ),
@@ -1408,6 +1420,8 @@ class _VersionChip extends StatelessWidget {
       ),
       child: Text(
         label,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
         style: ArDriveTypography.body.captionBold(
           color: SharedFileColors.subtle(context),
         ),

--- a/lib/search/search_modal.dart
+++ b/lib/search/search_modal.dart
@@ -32,6 +32,9 @@ Future<void> showSearchModalBottomSheet({
   required DrivesCubit drivesCubit,
   required TextEditingController controller,
   String? query,
+
+  /// See [FileSearchModal.onNavigateToFolder].
+  void Function(String driveId, String folderId)? onNavigateToFolder,
 }) {
   PlausibleEventTracker.trackPageview(page: PlausiblePageView.searchPage);
 
@@ -58,6 +61,7 @@ Future<void> showSearchModalBottomSheet({
             driveDetailCubit: context.read<DriveDetailCubit>(),
             controller: controller,
             drivesCubit: drivesCubit,
+            onNavigateToFolder: onNavigateToFolder,
           ),
         ),
       ),
@@ -71,6 +75,9 @@ Future<void> showSearchModalDesktop({
   required DrivesCubit drivesCubit,
   required TextEditingController controller,
   String? query,
+
+  /// See [FileSearchModal.onNavigateToFolder].
+  void Function(String driveId, String folderId)? onNavigateToFolder,
 }) {
   PlausibleEventTracker.trackPageview(page: PlausiblePageView.searchPage);
 
@@ -83,6 +90,7 @@ Future<void> showSearchModalDesktop({
       driveDetailCubit: context.read<DriveDetailCubit>(),
       controller: controller,
       drivesCubit: drivesCubit,
+      onNavigateToFolder: onNavigateToFolder,
     ),
     barrierColor: colorTokens.containerL1.withOpacity(0.8),
   );
@@ -93,12 +101,24 @@ class FileSearchModal extends StatelessWidget {
     super.key,
     required this.driveDetailCubit,
     required this.drivesCubit,
+    this.onNavigateToFolder,
     this.initialQuery,
     required this.controller,
   });
 
   final DriveDetailCubit driveDetailCubit;
   final DrivesCubit drivesCubit;
+
+  /// How to reach a folder, when calling `openFolder` on [driveDetailCubit] will
+  /// not get there.
+  ///
+  /// The explorer's cubit is long-lived and switches drives underneath the page,
+  /// so it can simply be told to open a folder in another drive. The drives
+  /// list's is not: selecting a drive there replaces the whole subtree, and the
+  /// cubit this modal was handed is torn down mid-navigation - leaving the
+  /// reader at the drive root rather than the file they searched for. Callers in
+  /// that position pass this and the navigation goes through the router instead.
+  final void Function(String driveId, String folderId)? onNavigateToFolder;
   final String? initialQuery;
   final TextEditingController controller;
 
@@ -125,6 +145,7 @@ class FileSearchModal extends StatelessWidget {
         initialQuery: initialQuery,
         controller: controller,
         drivesCubit: drivesCubit,
+        onNavigateToFolder: onNavigateToFolder,
       ),
     );
   }
@@ -136,12 +157,16 @@ class _FileSearchModal extends StatefulWidget {
     required this.drivesCubit,
     this.initialQuery,
     required this.controller,
+    this.onNavigateToFolder,
   });
 
   final String? initialQuery;
   final DriveDetailCubit driveDetailCubit;
   final DrivesCubit drivesCubit;
   final TextEditingController controller;
+
+  /// See [FileSearchModal.onNavigateToFolder].
+  final void Function(String driveId, String folderId)? onNavigateToFolder;
 
   @override
   _FileSearchModalState createState() => _FileSearchModalState();
@@ -442,11 +467,23 @@ class _FileSearchModalState extends State<_FileSearchModal> {
     if (searchResult.result is FileEntry) {
       _navigateToFile(context, searchResult.result as FileEntry);
     } else if (searchResult.result is FolderEntry) {
-      context.read<DrivesCubit>().selectDrive(searchResult.drive.id);
-
       final otherDriveId = (searchResult.parentFolder == null)
           ? searchResult.drive.id
           : searchResult.parentFolder!.driveId;
+
+      final navigate = widget.onNavigateToFolder;
+
+      if (navigate != null) {
+        // Asked for before the selection, because the selection is what carries
+        // it - see [FileSearchModal.onNavigateToFolder].
+        navigate(otherDriveId, searchResult.result.id);
+        context.read<DrivesCubit>().selectDrive(searchResult.drive.id);
+        Navigator.of(context).pop();
+
+        return;
+      }
+
+      context.read<DrivesCubit>().selectDrive(searchResult.drive.id);
 
       widget.driveDetailCubit.openFolder(
         otherDriveId: otherDriveId,
@@ -469,6 +506,23 @@ class _FileSearchModalState extends State<_FileSearchModal> {
     final file = DriveDataTableItemMapper.fromFileEntryForSearchModal(
       result,
     );
+
+    final navigate = widget.onNavigateToFolder;
+
+    if (navigate != null) {
+      // The folder the file is in, not the file itself: the router opens a
+      // drive at a folder, and has nowhere to put an item to select. Landing in
+      // the right folder with the file in the list is the substance of it; the
+      // explorer's own path below additionally opens the file's details.
+      navigate(file.driveId, file.parentFolderId);
+      widget.drivesCubit.selectDrive(file.driveId);
+
+      if (mounted) {
+        Navigator.of(context).pop();
+      }
+
+      return;
+    }
 
     await Future.delayed(const Duration(milliseconds: 100));
 

--- a/test/components/side_bar_loading_test.dart
+++ b/test/components/side_bar_loading_test.dart
@@ -44,8 +44,8 @@ void main() {
         initialState: const HiddingItems(userHasHiddenDrive: false));
   });
 
-  Widget wrap(DrivesState drivesState) {
-    whenListen(drivesCubit, const Stream<DrivesState>.empty(),
+  Widget wrap(DrivesState drivesState, {Stream<DrivesState>? updates}) {
+    whenListen(drivesCubit, updates ?? const Stream<DrivesState>.empty(),
         initialState: drivesState);
 
     return ArDriveTheme(
@@ -83,6 +83,17 @@ void main() {
         ownerAddress: 'me',
         name: id,
         privacy: DrivePrivacyTag.public,
+        isHidden: false,
+        dateCreated: DateTime(2024, 3, 4),
+        lastUpdated: DateTime(2024, 3, 4),
+      );
+
+  Drive privateDrive(String id) => Drive(
+        id: id,
+        rootFolderId: '$id-root',
+        ownerAddress: 'me',
+        name: id,
+        privacy: DrivePrivacyTag.private,
         isHidden: false,
         dateCreated: DateTime(2024, 3, 4),
         lastUpdated: DateTime(2024, 3, 4),
@@ -299,5 +310,92 @@ void main() {
     expect(find.text('Loading your drives...'), findsNothing);
 
     await tester.pumpWidget(const SizedBox());
+  });
+
+  /// Opening a private drive used to highlight a row nobody could see.
+  ///
+  /// Both sections ship expanded, so a wallet with a long public list pushes the
+  /// private section past the bottom of the window. Selecting a drive down there
+  /// - from the drives list, say - marked it and left the reader looking at an
+  /// unchanged screen, which reads as the click having done nothing.
+  group('when the selection moves somewhere off screen', () {
+    late StreamController<DrivesState> states;
+
+    setUp(() => states = StreamController<DrivesState>.broadcast());
+    tearDown(() => states.close());
+
+    /// Twenty public drives above one private drive, on a window far too short
+    /// for them, so the private row starts well below the fold.
+    List<Drive> manyDrives() => [
+          for (var i = 0; i < 20; i++) publicDrive('public-$i'),
+          privateDrive('the-private-one'),
+        ];
+
+    testWidgets('the sidebar scrolls it into view', (tester) async {
+      tester.view.physicalSize = const Size(1200, 700);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      final drives = manyDrives();
+
+      await tester.pumpWidget(
+        wrap(
+          withDrives(drives, selected: 'public-0'),
+          updates: states.stream,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final target = find.text('the-private-one');
+
+      // Precondition, asserted rather than assumed: if it were already on
+      // screen this test would pass without the behaviour it is about.
+      expect(
+        tester.getRect(target).top,
+        greaterThan(700),
+        reason: 'the private drive has to start below the fold for this to '
+            'be testing anything',
+      );
+
+      states.add(withDrives(drives, selected: 'the-private-one'));
+      await tester.pumpAndSettle();
+
+      final rect = tester.getRect(target);
+
+      expect(rect.top, greaterThanOrEqualTo(0.0));
+      expect(
+        rect.bottom,
+        lessThanOrEqualTo(700.0),
+        reason: 'the drive that was just selected has to be somewhere the '
+            'reader can see it',
+      );
+    });
+
+    /// A sync tick alone rebuilds this several times. Scrolling on each would
+    /// drag the list back under a reader who was scrolling it themselves.
+    testWidgets('and leaves the list alone when nothing was selected',
+        (tester) async {
+      tester.view.physicalSize = const Size(1200, 700);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      final drives = manyDrives();
+
+      await tester.pumpWidget(
+        wrap(
+          withDrives(drives, selected: 'public-0'),
+          updates: states.stream,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final before = tester.getRect(find.text('the-private-one'));
+
+      // The same selection arriving again, which is what a rebuild looks like.
+      states.add(withDrives(drives, selected: 'public-0'));
+      await tester.pumpAndSettle();
+
+      expect(tester.getRect(find.text('the-private-one')), before);
+    });
   });
 }

--- a/test/drives_list/drives_list_search_test.dart
+++ b/test/drives_list/drives_list_search_test.dart
@@ -1,0 +1,57 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Search on the one page that did not have it.
+///
+/// `DriveDao.search` takes no drive id - it is global across every drive, plus
+/// ARNS names - so All Drives had no reason to be the single screen without a
+/// way in. Desktop search lived in `AppTopBar`, which only the explorer mounts,
+/// and the drives list builds its own chrome; mobile search was opt-in on
+/// `MobileAppBar` and this page did not opt in.
+///
+/// Read as source rather than pumped, for the same reason the item-menu parity
+/// test is: the failure mode is a surface *missing* the control, and the two
+/// surfaces are different widget trees behind a `ScreenTypeLayout`. A widget
+/// test proves whichever branch it rendered, which is exactly the half that was
+/// never the problem.
+void main() {
+  final page = File(
+    'lib/drives_list/presentation/drives_list_page.dart',
+  ).readAsStringSync();
+
+  test('the desktop chrome carries a search field', () {
+    expect(page.contains('_DrivesListSearchField()'), isTrue);
+  });
+
+  test('the mobile bar opts into search', () {
+    expect(page.contains('showSearch: true'), isTrue);
+  });
+
+  /// Both surfaces have to route results through the router, not the modal's
+  /// own cubit. Selecting a drive here replaces the subtree, so that cubit is
+  /// torn down mid-navigation and the reader lands at the drive root instead of
+  /// the file they searched for.
+  test('both routes a result through requestFolder', () {
+    expect(
+      'requestFolder('.allMatches(page).length,
+      2,
+      reason: 'one for the desktop field, one for the mobile bar; a surface '
+          'without it navigates to the wrong place',
+    );
+  });
+
+  test('and the explorer keeps its own path', () {
+    final shell = File('lib/app_shell.dart').readAsStringSync();
+
+    // `MobileAppBar` is worn by the explorer, the drives list and the no-drives
+    // page. The callback is optional so the explorer keeps calling `openFolder`
+    // on its own long-lived cubit, which is correct there.
+    expect(
+      shell.contains('this.onSearchNavigateToFolder,'),
+      isTrue,
+      reason: 'forcing every screen to supply one would make the explorer take '
+          'a slower road to the same place',
+    );
+  });
+}

--- a/test/pages/app_router_delegate_test.dart
+++ b/test/pages/app_router_delegate_test.dart
@@ -198,7 +198,6 @@ void main() {
       expect(delegate.isViewingRawTransaction, isFalse);
       expect(delegate.showingDrivesList, isTrue);
     });
-
   });
 
   group('ordinary navigation', () {
@@ -264,6 +263,48 @@ void main() {
       delegate.requestDriveInfo('drive-2');
 
       expect(delegate.pendingInfoDriveId, 'drive-2');
+    });
+  });
+
+  /// A search result opened from the drives list.
+  ///
+  /// The explorer navigates a result by calling `openFolder` on its own
+  /// `DriveDetailCubit`, which works because that cubit is long-lived and
+  /// switches drives underneath the page. On the drives list it is not:
+  /// selecting a drive replaces the whole subtree, so the cubit the modal was
+  /// handed is torn down mid-navigation and the reader lands at the drive root
+  /// instead of the file they searched for. [AppRouterDelegate.requestFolder]
+  /// is the road that survives that.
+  group('a folder asked for before its drive is selected', () {
+    test('opens when that drive arrives', () {
+      delegate.requestFolder(driveId, folderId);
+      delegate.onDriveSelected(driveId);
+
+      expect(delegate.driveFolderId, folderId);
+      expect(delegate.driveId, driveId);
+    });
+
+    /// One shot, for the same reason a folder link is: navigating away and back
+    /// should land at the root rather than jumping to a folder visited once.
+    test('is not honoured a second time', () {
+      delegate.requestFolder(driveId, folderId);
+      delegate.onDriveSelected(driveId);
+
+      delegate.onDriveSelected(otherDriveId);
+      delegate.onDriveSelected(driveId);
+
+      expect(delegate.driveFolderId, isNull);
+    });
+
+    test('is ignored when a different drive is selected instead', () {
+      delegate.requestFolder(driveId, folderId);
+      delegate.onDriveSelected(otherDriveId);
+
+      expect(
+        delegate.driveFolderId,
+        isNull,
+        reason: 'a folder from one drive must not open inside another',
+      );
     });
   });
 }

--- a/test/pages/shared_file/shared_file_page_test.dart
+++ b/test/pages/shared_file/shared_file_page_test.dart
@@ -1009,8 +1009,13 @@ void main() {
       await tester.tap(find.text('Version history'));
       await tester.pumpAndSettle();
 
-      expect(find.text('Pinned'), findsOneWidget);
+      expect(find.text('This version'), findsOneWidget);
       expect(find.text('Shared'), findsNothing);
+
+      // Not "Pinned", which was the third meaning of that word in one product:
+      // an ArDrive File Pin brings a permaweb file into a drive, IPFS pinning is
+      // what many readers arrive already knowing, and neither is this.
+      expect(find.text('Pinned'), findsNothing);
 
       // And the newer one is still selectable.
       await tester.tap(find.text('Latest'));


### PR DESCRIPTION
Closes the four items raised against staging.

## Search on All Drives

`DriveDao.search` takes **no drive id** — it is global across every drive plus ARNS names — so this page had no business being the one screen without a way in. Desktop search lived in `AppTopBar`, which only the explorer mounts; mobile search was opt-in on `MobileAppBar` and this page had not opted in.

Adding the field was the easy half. **The explorer navigates a result by calling `openFolder` on its own `DriveDetailCubit`**, which works there because that cubit is long-lived and switches drives underneath the page. On the drives list it is not: selecting a drive replaces the whole subtree, so the cubit the modal was handed is torn down mid-navigation and the reader lands at the drive root instead of the file they searched for.

`AppRouterDelegate.requestFolder` is the road that survives that — asked for before the selection, honoured by `onDriveSelected` when the drive arrives, and one shot so navigating away and back lands at the root rather than jumping to a folder somebody visited once.

The callback is **optional**, so the explorer keeps its own path rather than taking a slower road to the same place.

**Known gap, stated rather than papered over:** from the drives list a *file* result opens its containing folder but does not pre-select the file the way the explorer does. The router opens a drive at a folder and has nowhere to put an item to select. Landing in the right folder is the substance; closing this properly means widening `DriveDetailCubit`, which is not this PR's business.

## "Pinned" was the third meaning of that word

An ArDrive **File Pin** brings a permaweb file into a drive. **IPFS pinning** is what many readers arrive already knowing. Neither is what this chip meant — a link aimed at one fixed version. It reads **"This version"** now.

That rename then overflowed the version row by 11px, because the chip was the only thing in it that could not give: the date is `Expanded` and the size is short and numeric. **Any longer translation would have done the same**, so the row is the fix rather than a shorter word.

## A selection nobody could see

Both sidebar sections ship expanded, so a long public list pushes the private one below the fold — and opening a private drive highlighted a row off screen, which reads as the click having done nothing.

It scrolls to the selection now, **only when the selection actually changes**: a sync tick alone rebuilds that widget several times, and scrolling on each would drag the list out from under somebody reading it. Scrolling rather than collapsing the other section, because a reader who wanted their public drives hidden would have collapsed it themselves.

Doing that turned up a real bug underneath: **`DriveListTile` forwarded its own `key` to an inner `GestureDetector`**, putting one key on two elements. Harmless for a `ValueKey`, an outright duplicate-`GlobalKey` assertion the moment anything needs to find the tile — which is why an existing test started failing the moment this one did.

## "Each row will say what it holds as it arrives"

Told the reader to go and watch something, and narrated the interface rather than answering the question they actually have during a wait. Now: **"Large drives can take a few minutes."**

## Testing

Full suite green (**2102 passing**), `flutter analyze lib test` clean.

Each fix verified by removal — the scroll, the router hook and the search surfaces all fail their tests when the code is taken out. The sidebar test asserts its own precondition first (that the tile really does start below the fold), so it cannot pass for the wrong reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ndA5nwUpt9hGLUx2TAFr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added global search to the drives list on desktop and mobile.
  - Search results can navigate directly to folders, including results from files.
  - The sidebar now scrolls selected drives into view automatically.

- **Bug Fixes**
  - Improved shared-file version rows to prevent text and chip overflow on smaller screens.

- **Style**
  - Updated synchronization guidance for large drives.
  - Renamed the shared-file version label from “Pinned” to “This version” for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->