### PR TITLE
PE-9205: A search result from All Drives never actually opened its folder

### DIFF
--- a/lib/app_shell.dart
+++ b/lib/app_shell.dart
@@ -318,7 +318,8 @@ class _MobileSearchButton extends StatelessWidget {
   const _MobileSearchButton({this.onNavigateToFolder});
 
   /// See [MobileAppBar.onSearchNavigateToFolder].
-  final void Function(String driveId, String folderId)? onNavigateToFolder;
+  final void Function(String driveId, String folderId, {String? itemId})?
+      onNavigateToFolder;
 
   @override
   Widget build(BuildContext context) {
@@ -372,7 +373,7 @@ class MobileAppBar extends StatelessWidget implements PreferredSizeWidget {
   /// long-lived and can be told to open a folder in another drive. The drives
   /// list passes one, because selecting a drive there replaces the subtree and
   /// tears that cubit down mid-navigation. See [FileSearchModal.onNavigateToFolder].
-  final void Function(String driveId, String folderId)?
+  final void Function(String driveId, String folderId, {String? itemId})?
       onSearchNavigateToFolder;
 
   @override

--- a/lib/blocs/drive_detail/drive_detail_cubit.dart
+++ b/lib/blocs/drive_detail/drive_detail_cubit.dart
@@ -95,6 +95,14 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
   DriveDetailCubit({
     required String driveId,
     String? initialFolderId,
+
+    /// The item to pick out once [initialFolderId] has opened.
+    ///
+    /// For a search result reached from the drives list. The explorer's own
+    /// search calls `openFolder(selectedItemId: ...)` on a cubit that already
+    /// exists; there is no such cubit to call when the drives list is what is on
+    /// screen, so the file to highlight has to arrive with the drive.
+    String? initialSelectedItemId,
     required ProfileCubit profileCubit,
     required DriveDao driveDao,
     required ConfigService configService,
@@ -134,7 +142,12 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
         if (_driveId != driveId) return;
 
         // Open the root folder if the deep-linked folder could not be found.
-        openFolder(folderId: folder?.id);
+        // The item is only meaningful inside the folder that was asked for: if
+        // that folder is gone, so is any claim about what was in it.
+        openFolder(
+          folderId: folder?.id,
+          selectedItemId: folder == null ? null : initialSelectedItemId,
+        );
         // The empty string here is required to open the root folder
       }).whenComplete(() {
         _initialLoadComplete = true;
@@ -783,9 +796,14 @@ class DriveDetailCubit extends Cubit<DriveDetailState> {
           );
 
           if (selectedItemId != null) {
-            _selectedItem = currentFolderContents.firstWhere(
-              (element) => element.id == selectedItemId,
-            );
+            // `firstWhere` without `orElse` throws when it finds nothing, and
+            // there are ordinary reasons for it to find nothing here: the file
+            // was moved or deleted between the search and the tap, or hidden
+            // items are being filtered out. Failing to highlight a row is a
+            // disappointment; throwing out of a folder load is a broken screen.
+            _selectedItem = currentFolderContents
+                .where((element) => element.id == selectedItemId)
+                .firstOrNull;
           }
 
           final List<BreadCrumbRowInfo> pathSegments =

--- a/lib/drives_list/presentation/drives_list_page.dart
+++ b/lib/drives_list/presentation/drives_list_page.dart
@@ -233,9 +233,12 @@ class _DrivesListChrome extends StatelessWidget {
             drawer: const AppSideBar(),
             appBar: MobileAppBar(
               showSearch: true,
-              onSearchNavigateToFolder: (driveId, folderId) => context
-                  .read<AppRouterDelegate>()
-                  .requestFolder(driveId, folderId),
+              onSearchNavigateToFolder: (driveId, folderId, {itemId}) =>
+                  context.read<AppRouterDelegate>().requestFolder(
+                        driveId,
+                        folderId,
+                        itemId: itemId,
+                      ),
             ),
             body: body,
           ),
@@ -316,9 +319,12 @@ class _DrivesListSearchFieldState extends State<_DrivesListSearchField> {
           driveDetailCubit: context.read<DriveDetailCubit>(),
           drivesCubit: context.read<DrivesCubit>(),
           controller: _controller,
-          onNavigateToFolder: (driveId, folderId) => context
-              .read<AppRouterDelegate>()
-              .requestFolder(driveId, folderId),
+          onNavigateToFolder: (driveId, folderId, {itemId}) =>
+              context.read<AppRouterDelegate>().requestFolder(
+                    driveId,
+                    folderId,
+                    itemId: itemId,
+                  ),
         );
       },
     );

--- a/lib/pages/app_router_delegate.dart
+++ b/lib/pages/app_router_delegate.dart
@@ -760,9 +760,20 @@ class AppRouterDelegate extends RouterDelegate<AppRoutePath>
     showingDrivesList = true;
     signingIn = false;
     gettingStarted = false;
-    // Going back to the list abandons whatever a search asked for. Without
-    // this, a request honoured in a frame where the explorer never built would
-    // sit here and highlight a stale file the next time that drive was opened.
+    // Going back to the list abandons whatever a search asked for - all of it,
+    // in both the states it can be in. A request honoured in a frame where the
+    // explorer never built would otherwise sit here and highlight a stale file
+    // the next time that drive opened; one never honoured at all would sit in
+    // the other three fields and jump a later, unrelated row tap into a folder
+    // somebody searched for once.
+    //
+    // No live path is known to reach the second - `requestFolder` is always
+    // followed immediately by the selection that spends it. This is here
+    // because clearing half the state and describing it as all of it is how
+    // the first case got missed.
+    _requestedFolderDriveId = null;
+    _requestedFolderId = null;
+    _requestedItemId = null;
     _selectedItemForFolder = null;
     _selectedItemForFolderDriveId = null;
     sharedFileId = null;

--- a/lib/pages/app_router_delegate.dart
+++ b/lib/pages/app_router_delegate.dart
@@ -78,6 +78,28 @@ class AppRouterDelegate extends RouterDelegate<AppRoutePath>
   /// drive's name.
   String? _pendingFolderId;
 
+  /// A folder asked for by a search result, and the file to pick out of it.
+  ///
+  /// Deliberately *not* [_pendingFolderId]. That one is a folder deep link, and
+  /// a link is not an instruction to resume: tapping a drive on the list after
+  /// arriving through `/drives/X/folders/Y` opens X at its root, which
+  /// `drives_list_routing_test` pins. A search result is the opposite - the
+  /// reader picked a folder out of a list of them - so it has to survive the
+  /// same call that discards the link.
+  String? _requestedFolderDriveId;
+  String? _requestedFolderId;
+  String? _requestedItemId;
+
+  /// The selection waiting for the cubit that is about to be built, and the
+  /// drive it belongs to.
+  ///
+  /// Keyed by drive because [_driveDetailCubit] builds twice over: once for the
+  /// drives list, against the root path, and once for the explorer against the
+  /// chosen drive. Unkeyed, the list's cubit would swallow a selection meant for
+  /// the explorer and the file would never be highlighted.
+  String? _selectedItemForFolder;
+  String? _selectedItemForFolderDriveId;
+
   /// The drive whose info panel should open once that drive has loaded.
   ///
   /// The drives list can only ask; it cannot open the panel itself. The panel
@@ -580,6 +602,7 @@ class AppRouterDelegate extends RouterDelegate<AppRoutePath>
       activityTracker: context.read<ActivityTracker>(),
       driveId: driveId,
       initialFolderId: driveFolderId,
+      initialSelectedItemId: _takeSelectedItemFor(driveId),
       profileCubit: context.read<ProfileCubit>(),
       driveDao: context.read<DriveDao>(),
       configService: context.read<ConfigService>(),
@@ -607,6 +630,28 @@ class AppRouterDelegate extends RouterDelegate<AppRoutePath>
   /// to fetch it, and a drive with nothing local lands on the card that says
   /// so and carries its own Sync button.
   /// `drives_list_open_never_syncs_test.dart` holds that.
+  /// Hands the waiting selection to the cubit being built, if it is that
+  /// cubit's, and only once.
+  ///
+  /// Read at construction rather than kept as route state: a file to highlight
+  /// describes one arrival at one folder, not where the reader currently is.
+  String? _takeSelectedItemFor(String driveId) {
+    if (_selectedItemForFolderDriveId != driveId) {
+      return null;
+    }
+
+    final itemId = _selectedItemForFolder;
+    _selectedItemForFolder = null;
+    _selectedItemForFolderDriveId = null;
+
+    return itemId;
+  }
+
+  /// [_takeSelectedItemFor], for tests. The real caller is the cubit factory.
+  @visibleForTesting
+  String? takeSelectedItemForTest(String driveId) =>
+      _takeSelectedItemFor(driveId);
+
   /// Asks for a drive's info panel to open once that drive has loaded.
   ///
   /// Separate from [openDriveFromList] so the drives list keeps one way in: a
@@ -630,17 +675,41 @@ class AppRouterDelegate extends RouterDelegate<AppRoutePath>
   /// [onDriveSelected] when that drive arrives. One shot, so navigating away and
   /// back lands at the root rather than jumping to a folder somebody visited
   /// once.
-  void requestFolder(String driveId, String folderId) {
-    _pendingFolderDriveId = driveId;
-    _pendingFolderId = folderId;
+  void requestFolder(String driveId, String folderId, {String? itemId}) {
+    _requestedFolderDriveId = driveId;
+    _requestedFolderId = folderId;
+    _requestedItemId = itemId;
   }
 
   @visibleForTesting
   void openDriveFromList(String driveId) {
     showingDrivesList = false;
     this.driveId = driveId;
-    // The list has no folder in view, and the drive opens at its root.
-    driveFolderId = null;
+
+    // A row tap has no folder in view and opens the drive at its root. A search
+    // result does have one, and asked for it through [requestFolder] a moment
+    // ago - so clearing unconditionally, as this did, threw that away and landed
+    // the reader at the root of the right drive rather than at the file they
+    // searched for.
+    //
+    // This is the road that actually runs from the list: `OpenDriveOnSelection`
+    // hears the selection and calls here. `onDriveSelected` honours the same
+    // request for the explorer, but it is only mounted on the explorer's branch,
+    // so it never sees a drive opened from the list.
+    if (_requestedFolderDriveId == driveId) {
+      driveFolderId = _requestedFolderId;
+      _selectedItemForFolder = _requestedItemId;
+      _selectedItemForFolderDriveId = driveId;
+    } else {
+      driveFolderId = null;
+    }
+
+    // One shot either way, honoured or not. The folder *link* is discarded
+    // here too, which is the older rule this must not disturb: a row tap opens
+    // a drive at its root, whatever link the reader arrived through.
+    _requestedFolderDriveId = null;
+    _requestedFolderId = null;
+    _requestedItemId = null;
     _pendingFolderDriveId = null;
     _pendingFolderId = null;
     // Not the info request: opening the drive is how it reaches somewhere it
@@ -691,6 +760,11 @@ class AppRouterDelegate extends RouterDelegate<AppRoutePath>
     showingDrivesList = true;
     signingIn = false;
     gettingStarted = false;
+    // Going back to the list abandons whatever a search asked for. Without
+    // this, a request honoured in a frame where the explorer never built would
+    // sit here and highlight a stale file the next time that drive was opened.
+    _selectedItemForFolder = null;
+    _selectedItemForFolderDriveId = null;
     sharedFileId = null;
     sharedFileKey = null;
     sharedRawFileKey = null;
@@ -736,6 +810,14 @@ class AppRouterDelegate extends RouterDelegate<AppRoutePath>
     _pendingFolderDriveId = null;
     _pendingFolderId = null;
     _pendingInfoDriveId = null;
+    // A search somebody ran before logging out is not an instruction to the
+    // next person to sign in on this device. Every other pending field here is
+    // cleared for the same reason.
+    _requestedFolderDriveId = null;
+    _requestedFolderId = null;
+    _requestedItemId = null;
+    _selectedItemForFolder = null;
+    _selectedItemForFolderDriveId = null;
     sharedDriveKey = null;
     sharedRawDriveKey = null;
     sharedFileId = null;

--- a/lib/search/search_modal.dart
+++ b/lib/search/search_modal.dart
@@ -34,7 +34,8 @@ Future<void> showSearchModalBottomSheet({
   String? query,
 
   /// See [FileSearchModal.onNavigateToFolder].
-  void Function(String driveId, String folderId)? onNavigateToFolder,
+  void Function(String driveId, String folderId, {String? itemId})?
+      onNavigateToFolder,
 }) {
   PlausibleEventTracker.trackPageview(page: PlausiblePageView.searchPage);
 
@@ -77,7 +78,8 @@ Future<void> showSearchModalDesktop({
   String? query,
 
   /// See [FileSearchModal.onNavigateToFolder].
-  void Function(String driveId, String folderId)? onNavigateToFolder,
+  void Function(String driveId, String folderId, {String? itemId})?
+      onNavigateToFolder,
 }) {
   PlausibleEventTracker.trackPageview(page: PlausiblePageView.searchPage);
 
@@ -118,7 +120,8 @@ class FileSearchModal extends StatelessWidget {
   /// cubit this modal was handed is torn down mid-navigation - leaving the
   /// reader at the drive root rather than the file they searched for. Callers in
   /// that position pass this and the navigation goes through the router instead.
-  final void Function(String driveId, String folderId)? onNavigateToFolder;
+  final void Function(String driveId, String folderId, {String? itemId})?
+      onNavigateToFolder;
   final String? initialQuery;
   final TextEditingController controller;
 
@@ -166,7 +169,8 @@ class _FileSearchModal extends StatefulWidget {
   final TextEditingController controller;
 
   /// See [FileSearchModal.onNavigateToFolder].
-  final void Function(String driveId, String folderId)? onNavigateToFolder;
+  final void Function(String driveId, String folderId, {String? itemId})?
+      onNavigateToFolder;
 
   @override
   _FileSearchModalState createState() => _FileSearchModalState();
@@ -510,11 +514,11 @@ class _FileSearchModalState extends State<_FileSearchModal> {
     final navigate = widget.onNavigateToFolder;
 
     if (navigate != null) {
-      // The folder the file is in, not the file itself: the router opens a
-      // drive at a folder, and has nowhere to put an item to select. Landing in
-      // the right folder with the file in the list is the substance of it; the
-      // explorer's own path below additionally opens the file's details.
-      navigate(file.driveId, file.parentFolderId);
+      // The folder the file is in, and the file to pick out of it once it
+      // opens - the same thing the explorer's path below does with
+      // `selectedItemId`, taking the long way round because the cubit that
+      // could be told directly is about to be torn down.
+      navigate(file.driveId, file.parentFolderId, itemId: file.id);
       widget.drivesCubit.selectDrive(file.driveId);
 
       if (mounted) {

--- a/test/pages/app_router_delegate_test.dart
+++ b/test/pages/app_router_delegate_test.dart
@@ -266,45 +266,102 @@ void main() {
     });
   });
 
-  /// A search result opened from the drives list.
+  /// A search result opened from the drives list, by the road that actually
+  /// runs.
   ///
-  /// The explorer navigates a result by calling `openFolder` on its own
-  /// `DriveDetailCubit`, which works because that cubit is long-lived and
-  /// switches drives underneath the page. On the drives list it is not:
-  /// selecting a drive replaces the whole subtree, so the cubit the modal was
-  /// handed is torn down mid-navigation and the reader lands at the drive root
-  /// instead of the file they searched for. [AppRouterDelegate.requestFolder]
-  /// is the road that survives that.
-  group('a folder asked for before its drive is selected', () {
-    test('opens when that drive arrives', () {
-      delegate.requestFolder(driveId, folderId);
-      delegate.onDriveSelected(driveId);
+  /// This is the group that was missing, and its absence shipped a broken
+  /// feature. The first version tested `requestFolder` followed by
+  /// [AppRouterDelegate.onDriveSelected] - which passes, and proves nothing,
+  /// because `onDriveSelected` is only mounted on the explorer's branch of the
+  /// router and never sees a drive opened from the list.
+  ///
+  /// From the list, `OpenDriveOnSelection` hears the selection and calls
+  /// [AppRouterDelegate.openDriveFromList] - which cleared the pending folder
+  /// outright, so the reader landed at the root of the right drive instead of at
+  /// the file they searched for.
+  group('a search result opened from the drives list', () {
+    const itemId = 'd5eaed3d-6e5d-7f4e-bd50-9a4d3e6f7081';
+
+    test('opens the folder it asked for', () {
+      delegate.requestFolder(driveId, folderId, itemId: itemId);
+      delegate.openDriveFromList(driveId);
 
       expect(delegate.driveFolderId, folderId);
       expect(delegate.driveId, driveId);
+      expect(delegate.showingDrivesList, isFalse);
     });
 
-    /// One shot, for the same reason a folder link is: navigating away and back
-    /// should land at the root rather than jumping to a folder visited once.
-    test('is not honoured a second time', () {
-      delegate.requestFolder(driveId, folderId);
-      delegate.onDriveSelected(driveId);
+    test('and hands the file to highlight to that drive, once', () {
+      delegate.requestFolder(driveId, folderId, itemId: itemId);
+      delegate.openDriveFromList(driveId);
 
-      delegate.onDriveSelected(otherDriveId);
-      delegate.onDriveSelected(driveId);
-
-      expect(delegate.driveFolderId, isNull);
+      expect(delegate.takeSelectedItemForTest(driveId), itemId);
+      expect(
+        delegate.takeSelectedItemForTest(driveId),
+        isNull,
+        reason: 'coming back to this drive later must not re-select a file '
+            'somebody searched for once',
+      );
     });
 
-    test('is ignored when a different drive is selected instead', () {
-      delegate.requestFolder(driveId, folderId);
-      delegate.onDriveSelected(otherDriveId);
+    /// `_driveDetailCubit` is built twice over - once for the drives list
+    /// against the root path, once for the explorer against the chosen drive.
+    /// Unkeyed, the list's cubit swallows the selection and the file is never
+    /// highlighted.
+    test('and not to a cubit built for some other drive', () {
+      delegate.requestFolder(driveId, folderId, itemId: itemId);
+      delegate.openDriveFromList(driveId);
+
+      expect(delegate.takeSelectedItemForTest(otherDriveId), isNull);
+      expect(delegate.takeSelectedItemForTest(driveId), itemId);
+    });
+
+    /// A row tap, which is what this method was written for: no folder is in
+    /// view and the drive opens at its root.
+    test('a plain row tap still opens the drive at its root', () {
+      delegate.requestFolder(otherDriveId, folderId, itemId: itemId);
+      delegate.openDriveFromList(driveId);
 
       expect(
         delegate.driveFolderId,
         isNull,
-        reason: 'a folder from one drive must not open inside another',
+        reason: 'a folder asked for in one drive must not open inside another',
       );
+      expect(delegate.takeSelectedItemForTest(driveId), isNull);
+    });
+
+    /// Every other pending field is cleared on logout, and these are no
+    /// different: a search somebody ran before signing out is not an
+    /// instruction to whoever signs in next on the same device.
+    test('and does not survive a logout', () {
+      delegate.requestFolder(driveId, folderId, itemId: itemId);
+
+      delegate.clearState();
+      delegate.openDriveFromList(driveId);
+
+      expect(delegate.driveFolderId, isNull);
+      expect(delegate.takeSelectedItemForTest(driveId), isNull);
+    });
+
+    /// Honoured, but the explorer never built and the reader went back to the
+    /// list. The selection dies with the navigation it belonged to.
+    test('and is abandoned by going back to the list', () {
+      delegate.requestFolder(driveId, folderId, itemId: itemId);
+      delegate.openDriveFromList(driveId);
+
+      delegate.showDrivesList();
+
+      expect(delegate.takeSelectedItemForTest(driveId), isNull);
+    });
+
+    test('and a request is spent even when it is not honoured', () {
+      delegate.requestFolder(otherDriveId, folderId, itemId: itemId);
+      delegate.openDriveFromList(driveId);
+
+      // The stale request must not fire the next time its own drive is opened.
+      delegate.openDriveFromList(otherDriveId);
+
+      expect(delegate.driveFolderId, isNull);
     });
   });
 }

--- a/test/pages/app_router_delegate_test.dart
+++ b/test/pages/app_router_delegate_test.dart
@@ -354,6 +354,19 @@ void main() {
       expect(delegate.takeSelectedItemForTest(driveId), isNull);
     });
 
+    /// The other half of abandoning: a request that was never honoured at all,
+    /// because the reader went back to the list before it was spent. It must
+    /// not jump a later, unrelated row tap into that folder.
+    test('and an unspent request does not ambush a later row tap', () {
+      delegate.requestFolder(driveId, folderId, itemId: itemId);
+
+      delegate.showDrivesList();
+      delegate.openDriveFromList(driveId);
+
+      expect(delegate.driveFolderId, isNull);
+      expect(delegate.takeSelectedItemForTest(driveId), isNull);
+    });
+
     test('and a request is spent even when it is not honoured', () {
       delegate.requestFolder(otherDriveId, folderId, itemId: itemId);
       delegate.openDriveFromList(driveId);


### PR DESCRIPTION
**#2221 shipped search on the drives list with navigation that does not work.** A file or folder result lands at the root of the right drive rather than at the thing that was searched for. This fixes that, and adds the file highlighting.

## The bug

`requestFolder` set a pending folder and `onDriveSelected` honoured it — but **`onDriveSelected` is only mounted on the explorer's branch of the router** and never sees a drive opened from the list. The road that actually runs is `OpenDriveOnSelection`, which hears the selection and calls `openDriveFromList` — and that cleared the pending folder outright.

**Why the tests passed:** they called `requestFolder` then `onDriveSelected` directly. A path that exists, and not the one a reader takes. The new group goes through `openDriveFromList`, and **three of its tests fail against what is live on staging right now**.

## A first attempt broke an existing test, correctly

Making `openDriveFromList` honour *any* pending folder broke `drives_list_routing_test`: *"opening a drive from the list opens it at its root rather than at whatever folder was last seen."*

That test is right. A folder deep link and a search request were sharing one pair of fields, and they are **not the same intent**:

- Arriving through `/drives/X/folders/Y` and later tapping X on the list should open X at its **root**. A link is not an instruction to resume.
- A search result is the opposite — the reader picked that folder out of a list of them.

Search requests now have their own fields, so `openDriveFromList` honours one and discards the other. The existing test needed no changes, which is what says the invariant was real and the shortcut was the problem.

## Highlighting the file

`DriveDetailCubit` takes an `initialSelectedItemId`, carried on the same one-shot road, so a file result arrives selected the way it does from inside a drive.

It is **keyed by drive id**: `_driveDetailCubit` is built twice over — once for the drives list against `rootPath`, once for the explorer against the chosen drive — and unkeyed, the list's cubit would swallow a selection meant for the explorer.

## A crash that was already there

`openFolder`'s `firstWhere` had no `orElse`, so a selection that is not in the folder **threw out of the folder load**. There are ordinary reasons for that: the file moved or was deleted between the search and the tap, or hidden items are being filtered out. Failing to highlight a row is a disappointment; throwing is a broken screen.

## Two more found by attacking this before shipping

Neither would have been caught by CI or by the happy path working:

1. **`clearState` did not clear the new fields.** Every sibling pending field is cleared on logout; a search from one session could have reached the next person to sign in on that device.
2. **A stale highlight window.** A request honoured in a frame where the explorer never built sat waiting, and would have highlighted a stale file the next time that drive opened. `showDrivesList` abandons it now.

## Testing

Full suite green (**2106 passing**), `flutter analyze lib test` clean.

Every guard verified by removal: the folder fix, the logout clear and the abandon-on-return all fail their tests when the code is taken out. The stale test group from #2221 was deleted rather than repaired — it was the one that gave false confidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ndA5nwUpt9hGLUx2TAFr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results now open the containing folder and automatically select the specific matching item.
  * Item selection is preserved while navigating from the drives list to the requested folder.

* **Bug Fixes**
  * Opening a search result no longer fails when the item is unavailable or filtered out; the folder opens without an item selected.
  * Pending search selections are cleared when leaving the drives list or signing out, preventing stale selections from affecting later navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->