### PR TITLE
PE-9205: chore(version): bump version to 2.88.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Secure, permanent storage
 
 publish_to: 'none'
 
-version: 2.87.1
+version: 2.88.0
 
 environment:
   sdk: '>=3.2.0 <4.0.0'


### PR DESCRIPTION
Routine version bump ahead of the release to production.

**2.87.1 → 2.88.0.** Minor rather than patch: 95 commits since the last release, and most of them are user-visible.

Pre-flight checks against `master`, all clean:

| | |
|---|---|
| `schemaVersion` | 29 both sides, no `.drift` changes — nothing for the migration fixtures (which only cover v17–v19) to miss |
| `configVersion` | 3 both sides, no asset changes — no stale-config surprise for existing users |
| Uploads / crypto | `ardrive_uploader`, `ardrive_crypto`, `lib/core/upload`, `lib/core/crypto`, `lib/blocs/upload` — **zero lines changed** |
| Staging | Green through #2223 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ndA5nwUpt9hGLUx2TAFr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 2.88.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->